### PR TITLE
fix: resolve build errors, deny clippy::all, add pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+set -e
+cargo clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,6 @@ path = "src/main.rs"
 
 [build-dependencies]
 serde_json = "1"
+
+[lints.clippy]
+all = "deny"


### PR DESCRIPTION
## Summary

- Fix `lib.rs`: add missing `mod cron_jobs` + `mod error` declarations (required by `server.rs` in lib crate context)
- Fix `main.rs`: remove phantom `config`/`handlers`/`static_handler` modules (files don't exist), guard `mod wasm` with `#[cfg(target_arch = "wasm32")]` to stop WASM-only code compiling on native
- Add `[lints.clippy] all = "deny"` to `Cargo.toml` — enforced at compile time across all targets
- Add `.githooks/pre-push` — runs `cargo clippy` before every push

## Setup

New contributors need to activate the hook once:

```sh
git config core.hooksPath .githooks
```

(Already configured in this repo via `git config`.)

## Test plan

- [ ] `cargo clippy` passes with no errors
- [ ] Push blocked if clippy::all violations introduced
- [ ] `cargo build` succeeds for native target