### PR TITLE
feat: expose filesystem locations in response headers

### DIFF
--- a/src/fs_location.rs
+++ b/src/fs_location.rs
@@ -1,3 +1,4 @@
+#[derive(serde::Serialize)]
 pub struct FsLocation {
     pub server_root: Option<String>,
     pub server_exe_dir: Option<String>,

--- a/src/fs_location.rs
+++ b/src/fs_location.rs
@@ -1,0 +1,17 @@
+pub struct FsLocation {
+    pub server_root: Option<String>,
+    pub server_exe_dir: Option<String>,
+}
+
+impl FsLocation {
+    pub fn current() -> Self {
+        Self {
+            server_root: std::env::current_dir()
+                .ok()
+                .map(|p| p.to_string_lossy().into_owned()),
+            server_exe_dir: std::env::current_exe()
+                .ok()
+                .and_then(|p| p.parent().map(|d| d.to_string_lossy().into_owned())),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@ mod cron_jobs;
 #[cfg(not(target_arch = "wasm32"))]
 mod error;
 #[cfg(not(target_arch = "wasm32"))]
+mod fs_location;
+#[cfg(not(target_arch = "wasm32"))]
 mod middleware;
 #[cfg(not(target_arch = "wasm32"))]
 mod routes;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,6 +1,6 @@
 //! Axum middleware layers shared across routes.
 
-use axum::{extract::Request, middleware::Next, response::Response};
+use axum::{extract::Request, http::HeaderValue, middleware::Next, response::Response};
 use std::time::Instant;
 
 /// Log each request method, path, response status, and elapsed time.
@@ -16,5 +16,22 @@ pub async fn logger(req: Request, next: Next) -> Response {
         path,
         start.elapsed().as_millis()
     );
+    res
+}
+
+pub async fn fs_location(req: Request, next: Next) -> Response {
+    let mut res = next.run(req).await;
+    if let Ok(cwd) = std::env::current_dir() {
+        if let Ok(val) = HeaderValue::from_str(&cwd.to_string_lossy()) {
+            res.headers_mut().insert("x-server-root", val);
+        }
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            if let Ok(val) = HeaderValue::from_str(&dir.to_string_lossy()) {
+                res.headers_mut().insert("x-server-exe-dir", val);
+            }
+        }
+    }
     res
 }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -22,14 +22,17 @@ pub async fn logger(req: Request, next: Next) -> Response {
 pub async fn fs_location(req: Request, next: Next) -> Response {
     let mut res = next.run(req).await;
     let loc = crate::fs_location::FsLocation::current();
-    if let Some(root) = loc.server_root {
-        if let Ok(val) = HeaderValue::from_str(&root) {
-            res.headers_mut().insert("x-server-root", val);
-        }
-    }
-    if let Some(exe_dir) = loc.server_exe_dir {
-        if let Ok(val) = HeaderValue::from_str(&exe_dir) {
-            res.headers_mut().insert("x-server-exe-dir", val);
+    if let Ok(serde_json::Value::Object(map)) = serde_json::to_value(&loc) {
+        for (k, v) in map {
+            if let serde_json::Value::String(s) = v {
+                let name = format!("x-{}", k.replace('_', "-"));
+                if let (Ok(n), Ok(v)) = (
+                    axum::http::HeaderName::from_bytes(name.as_bytes()),
+                    HeaderValue::from_str(&s),
+                ) {
+                    res.headers_mut().insert(n, v);
+                }
+            }
         }
     }
     res

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -21,16 +21,15 @@ pub async fn logger(req: Request, next: Next) -> Response {
 
 pub async fn fs_location(req: Request, next: Next) -> Response {
     let mut res = next.run(req).await;
-    if let Ok(cwd) = std::env::current_dir() {
-        if let Ok(val) = HeaderValue::from_str(&cwd.to_string_lossy()) {
+    let loc = crate::fs_location::FsLocation::current();
+    if let Some(root) = loc.server_root {
+        if let Ok(val) = HeaderValue::from_str(&root) {
             res.headers_mut().insert("x-server-root", val);
         }
     }
-    if let Ok(exe) = std::env::current_exe() {
-        if let Some(dir) = exe.parent() {
-            if let Ok(val) = HeaderValue::from_str(&dir.to_string_lossy()) {
-                res.headers_mut().insert("x-server-exe-dir", val);
-            }
+    if let Some(exe_dir) = loc.server_exe_dir {
+        if let Ok(val) = HeaderValue::from_str(&exe_dir) {
+            res.headers_mut().insert("x-server-exe-dir", val);
         }
     }
     res

--- a/src/routes/http.rs
+++ b/src/routes/http.rs
@@ -83,6 +83,7 @@ pub async fn run(store: CronStore) -> anyhow::Result<()> {
         )
         .route("/system-cron-jobs", get(list_system_cron_jobs))
         .nest_service("/mcp", mcp_service)
+        .layer(middleware::from_fn(mw::fs_location))
         .layer(middleware::from_fn(mw::logger))
         .with_state(app_state);
 

--- a/src/routes/mcp.rs
+++ b/src/routes/mcp.rs
@@ -91,13 +91,21 @@ impl MoadimMcp {
         }
     }
 
-    /// Return server health status and uptime in seconds.
-    #[tool(description = "Get server health and uptime")]
+    /// Return server health status, uptime, and filesystem locations.
+    #[tool(description = "Get server health, uptime, and filesystem locations")]
     fn health(&self) -> Result<CallToolResult, rmcp::ErrorData> {
+        let server_root = std::env::current_dir()
+            .ok()
+            .map(|p| p.to_string_lossy().into_owned());
+        let server_exe_dir = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(|d| d.to_string_lossy().into_owned()));
         Ok(ok(serde_json::json!({
             "status": "ok",
             "uptime_secs": now_secs() - self.uptime_start,
             "running": true,
+            "server_root": server_root,
+            "server_exe_dir": server_exe_dir,
         })))
     }
 

--- a/src/routes/mcp.rs
+++ b/src/routes/mcp.rs
@@ -94,18 +94,13 @@ impl MoadimMcp {
     /// Return server health status, uptime, and filesystem locations.
     #[tool(description = "Get server health, uptime, and filesystem locations")]
     fn health(&self) -> Result<CallToolResult, rmcp::ErrorData> {
-        let server_root = std::env::current_dir()
-            .ok()
-            .map(|p| p.to_string_lossy().into_owned());
-        let server_exe_dir = std::env::current_exe()
-            .ok()
-            .and_then(|p| p.parent().map(|d| d.to_string_lossy().into_owned()));
+        let loc = crate::fs_location::FsLocation::current();
         Ok(ok(serde_json::json!({
             "status": "ok",
             "uptime_secs": now_secs() - self.uptime_start,
             "running": true,
-            "server_root": server_root,
-            "server_exe_dir": server_exe_dir,
+            "server_root": loc.server_root,
+            "server_exe_dir": loc.server_exe_dir,
         })))
     }
 

--- a/src/routes/mcp.rs
+++ b/src/routes/mcp.rs
@@ -95,13 +95,17 @@ impl MoadimMcp {
     #[tool(description = "Get server health, uptime, and filesystem locations")]
     fn health(&self) -> Result<CallToolResult, rmcp::ErrorData> {
         let loc = crate::fs_location::FsLocation::current();
-        Ok(ok(serde_json::json!({
+        let mut val = serde_json::json!({
             "status": "ok",
             "uptime_secs": now_secs() - self.uptime_start,
             "running": true,
-            "server_root": loc.server_root,
-            "server_exe_dir": loc.server_exe_dir,
-        })))
+        });
+        if let (Some(obj), Ok(serde_json::Value::Object(loc_map))) =
+            (val.as_object_mut(), serde_json::to_value(&loc))
+        {
+            obj.extend(loc_map);
+        }
+        Ok(ok(val))
     }
 
     /// Echo `message` back together with the current server timestamp.


### PR DESCRIPTION
## Summary

- Add `fs_location` axum middleware in `src/middleware.rs`
- Injects `x-server-root` (working directory) and `x-server-exe-dir` (binary's parent directory) into every HTTP response
- Middleware applied in `src/routes/http.rs` before the logger layer

## Test plan

- [ ] Start server, hit any endpoint (e.g. `curl -I http://localhost:5784/health`), verify `x-server-root` and `x-server-exe-dir` headers present
- [ ] Paths should reflect actual server cwd and binary directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)