### PR TITLE
feat: type-safe Yew UI client with inlined WASM build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "anymap2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,7 +40,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -59,7 +65,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "hyper",
@@ -90,7 +96,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "mime",
@@ -108,10 +114,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "boolinator"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "bumpalo"
@@ -162,6 +183,16 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -220,7 +251,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -231,7 +262,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -282,6 +313,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -354,7 +391,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -393,8 +430,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -409,6 +448,376 @@ dependencies = [
  "rand_core",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "gloo"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28999cda5ef6916ffd33fb4a7b87e1de633c47c0dc6d97905fee1cdaa142b94d"
+dependencies = [
+ "gloo-console 0.2.3",
+ "gloo-dialogs 0.1.1",
+ "gloo-events 0.1.2",
+ "gloo-file 0.2.3",
+ "gloo-history 0.1.5",
+ "gloo-net 0.3.1",
+ "gloo-render 0.1.1",
+ "gloo-storage 0.2.2",
+ "gloo-timers 0.2.6",
+ "gloo-utils 0.1.7",
+ "gloo-worker 0.2.1",
+]
+
+[[package]]
+name = "gloo"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd35526c28cc55c1db77aed6296de58677dbab863b118483a27845631d870249"
+dependencies = [
+ "gloo-console 0.3.0",
+ "gloo-dialogs 0.2.0",
+ "gloo-events 0.2.0",
+ "gloo-file 0.3.0",
+ "gloo-history 0.2.2",
+ "gloo-net 0.4.0",
+ "gloo-render 0.2.0",
+ "gloo-storage 0.3.0",
+ "gloo-timers 0.3.0",
+ "gloo-utils 0.2.0",
+ "gloo-worker 0.4.0",
+]
+
+[[package]]
+name = "gloo-console"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b7ce3c05debe147233596904981848862b068862e9ec3e34be446077190d3f"
+dependencies = [
+ "gloo-utils 0.1.7",
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-console"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a17868f56b4a24f677b17c8cb69958385102fa879418052d60b50bc1727e261"
+dependencies = [
+ "gloo-utils 0.2.0",
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-dialogs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67062364ac72d27f08445a46cab428188e2e224ec9e37efdba48ae8c289002e6"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-dialogs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4748e10122b01435750ff530095b1217cf6546173459448b83913ebe7815df"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-events"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b107f8abed8105e4182de63845afcc7b69c098b7852a813ea7462a320992fc"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-events"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c26fb45f7c385ba980f5fa87ac677e363949e065a083722697ef1b2cc91e41"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-file"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d5564e570a38b43d78bdc063374a0c3098c4f0d64005b12f9bbe87e869b6d7"
+dependencies = [
+ "gloo-events 0.1.2",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-file"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97563d71863fb2824b2e974e754a81d19c4a7ec47b09ced8a0e6656b6d54bd1f"
+dependencies = [
+ "gloo-events 0.2.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-history"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85725d90bf0ed47063b3930ef28e863658a7905989e9929a8708aab74a1d5e7f"
+dependencies = [
+ "gloo-events 0.1.2",
+ "gloo-utils 0.1.7",
+ "serde",
+ "serde-wasm-bindgen 0.5.0",
+ "serde_urlencoded",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-history"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "903f432be5ba34427eac5e16048ef65604a82061fe93789f2212afc73d8617d6"
+dependencies = [
+ "getrandom 0.2.17",
+ "gloo-events 0.2.0",
+ "gloo-utils 0.2.0",
+ "serde",
+ "serde-wasm-bindgen 0.6.5",
+ "serde_urlencoded",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-net"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a66b4e3c7d9ed8d315fd6b97c8b1f74a7c6ecbbc2320e65ae7ed38b7068cc620"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-sink",
+ "gloo-utils 0.1.7",
+ "http 0.2.12",
+ "js-sys",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-net"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ac9e8288ae2c632fa9f8657ac70bfe38a1530f345282d7ba66a1f70b72b7dc4"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-sink",
+ "gloo-utils 0.2.0",
+ "http 0.2.12",
+ "js-sys",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-net"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06f627b1a58ca3d42b45d6104bf1e1a03799df472df00988b6ba21accc10580"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-sink",
+ "gloo-utils 0.2.0",
+ "http 1.4.2",
+ "js-sys",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-render"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd9306aef67cfd4449823aadcd14e3958e0800aa2183955a309112a84ec7764"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-render"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56008b6744713a8e8d98ac3dcb7d06543d5662358c9c805b4ce2167ad4649833"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-storage"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6ab60bf5dbfd6f0ed1f7843da31b41010515c745735c970e821945ca91e480"
+dependencies = [
+ "gloo-utils 0.1.7",
+ "js-sys",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-storage"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc8031e8c92758af912f9bc08fbbadd3c6f3cfcbf6b64cdf3d6a81f0139277a"
+dependencies = [
+ "gloo-utils 0.2.0",
+ "js-sys",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037fcb07216cb3a30f7292bd0176b050b7b9a052ba830ef7d5d65f6dc64ba58e"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-worker"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13471584da78061a28306d1359dd0178d8d6fc1c7c80e5e35d27260346e0516a"
+dependencies = [
+ "anymap2",
+ "bincode",
+ "gloo-console 0.2.3",
+ "gloo-utils 0.1.7",
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-worker"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76495d3dd87de51da268fa3a593da118ab43eb7f8809e17eb38d3319b424e400"
+dependencies = [
+ "bincode",
+ "futures",
+ "gloo-utils 0.2.0",
+ "gloo-worker-macros",
+ "js-sys",
+ "pinned",
+ "serde",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-worker-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956caa58d4857bc9941749d55e4bd3000032d8212762586fa5705632967140e7"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -433,6 +842,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,7 +875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -460,7 +886,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
+ "http 1.4.2",
  "http-body",
  "pin-project-lite",
 ]
@@ -487,7 +913,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http",
+ "http 1.4.2",
  "http-body",
  "httparse",
  "httpdate",
@@ -504,7 +930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.2",
  "http-body",
  "hyper",
  "pin-project-lite",
@@ -547,6 +973,26 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "implicit-clone"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a9aa791c7b5a71b636b7a68207fdebf171ddfc593d9c8506ec4cbc527b6a84"
+dependencies = [
+ "implicit-clone-derive",
+ "indexmap",
+]
+
+[[package]]
+name = "implicit-clone-derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699c1b6d335e63d0ba5c1e1c7f647371ce989c3bcbe1f7ed2b85fa56e3bd1a21"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "indexmap"
@@ -668,6 +1114,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,10 +1171,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pinned"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a829027bd95e54cfe13e3e258a1ae7b645960553fb82b75ff852c29688ee595b"
+dependencies = [
+ "futures",
+ "rustversion",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "prettyplease"
@@ -727,7 +1214,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -737,6 +1258,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prokio"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b55e106e5791fa5a13abd13c85d6127312e8e09098059ca2bc9b03ca4cf488"
+dependencies = [
+ "futures",
+ "gloo 0.8.1",
+ "num_cpus",
+ "once_cell",
+ "pin-project",
+ "pinned",
+ "tokio",
+ "tokio-stream",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -808,7 +1346,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -851,7 +1389,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "http",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "pastey",
@@ -881,7 +1419,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -919,7 +1457,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -945,6 +1483,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,7 +1521,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -972,7 +1532,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1101,6 +1661,16 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -1142,7 +1712,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1153,7 +1723,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1181,7 +1751,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1217,7 +1787,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -1231,6 +1801,17 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
@@ -1240,7 +1821,7 @@ dependencies = [
  "serde_spanned",
  "toml_datetime",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -1297,7 +1878,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1307,6 +1888,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "ui"
+version = "0.1.0"
+dependencies = [
+ "console_log",
+ "gloo-net 0.6.0",
+ "gloo-timers 0.3.0",
+ "js-sys",
+ "log",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "yew",
 ]
 
 [[package]]
@@ -1342,7 +1940,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1355,6 +1953,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -1394,6 +1998,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,7 +2026,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1490,7 +2104,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1501,7 +2115,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1605,6 +2219,15 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
@@ -1648,7 +2271,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1664,7 +2287,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1704,6 +2327,46 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "yew"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f1a03f255c70c7aa3e9c62e15292f142ede0564123543c1cc0c7a4f31660cac"
+dependencies = [
+ "console_error_panic_hook",
+ "futures",
+ "gloo 0.10.0",
+ "implicit-clone",
+ "indexmap",
+ "js-sys",
+ "prokio",
+ "rustversion",
+ "serde",
+ "slab",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "yew-macro",
+]
+
+[[package]]
+name = "yew-macro"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02fd8ca5166d69e59f796500a2ce432ff751edecbbb308ca59fd3fe4d0343de2"
+dependencies = [
+ "boolinator",
+ "once_cell",
+ "prettyplease",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = ["ui"]
+
 [package]
 name = "server"
 version = "0.1.0"

--- a/build.rs
+++ b/build.rs
@@ -7,8 +7,10 @@ fn main() {
     println!("cargo:rerun-if-changed=src/routes/http.rs");
     println!("cargo:rerun-if-changed=src/cron_jobs.rs");
     println!("cargo:rerun-if-changed=src/system_cron.rs");
+    println!("cargo:rerun-if-changed=src/ui/index.html");
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=schemas/job.schema.json");
+    println!("cargo:rerun-if-env-changed=MOADIM_BUILD_UI");
 
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     build::run(&manifest_dir);

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -4,9 +4,11 @@
 mod job_schema;
 /// Job JSON Schema generator.
 mod openapi;
+mod ui;
 
 /// Run all code-generation steps, writing output into `manifest_dir`.
 pub fn run(manifest_dir: &str) {
     openapi::generate(manifest_dir);
     job_schema::generate(manifest_dir);
+    ui::build(manifest_dir);
 }

--- a/src/build/ui.rs
+++ b/src/build/ui.rs
@@ -1,0 +1,223 @@
+use std::path::{Path, PathBuf};
+
+/// Build the Yew UI and write a self-contained `index.html` to `$OUT_DIR`.
+///
+/// Set `MOADIM_BUILD_UI=1` to enable (skipped by default so normal `cargo
+/// build` stays fast). The server embeds the output via:
+///
+/// ```rust
+/// include_str!(concat!(env!("OUT_DIR"), "/index.html"))
+/// ```
+///
+/// If trunk is absent or the build is skipped, we fall back to copying
+/// `src/ui/index.html` (the legacy plain-HTML version).
+pub fn build(manifest_dir: &str) {
+    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");
+    let output = Path::new(&out_dir).join("index.html");
+
+    let ui_dir = Path::new(manifest_dir).join("ui");
+    let should_build =
+        std::env::var("MOADIM_BUILD_UI").map_or(false, |v| v == "1" || v == "true");
+
+    if should_build && ui_dir.exists() {
+        emit_rerun_triggers(&ui_dir);
+        if run_trunk(&ui_dir) {
+            let dist = ui_dir.join("dist");
+            if dist.exists() {
+                inline_into_html(&dist, &output);
+                return;
+            }
+        }
+        println!("cargo:warning=trunk build failed or produced no dist; using legacy HTML");
+    }
+
+    // Fallback: copy the legacy plain-HTML file
+    let fallback = Path::new(manifest_dir).join("src/ui/index.html");
+    if fallback.exists() {
+        std::fs::copy(&fallback, &output).expect("failed to copy fallback index.html");
+    } else {
+        std::fs::write(&output, PLACEHOLDER_HTML).expect("failed to write placeholder HTML");
+    }
+}
+
+fn emit_rerun_triggers(ui_dir: &Path) {
+    println!(
+        "cargo:rerun-if-changed={}",
+        ui_dir.join("src").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        ui_dir.join("index.html").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        ui_dir.join("Trunk.toml").display()
+    );
+}
+
+/// Run `trunk build --release` in `ui_dir`. Returns true on success.
+fn run_trunk(ui_dir: &Path) -> bool {
+    match std::process::Command::new("trunk")
+        .args(["build", "--release"])
+        .current_dir(ui_dir)
+        .status()
+    {
+        Ok(s) if s.success() => true,
+        Ok(_) => {
+            println!("cargo:warning=trunk build exited with non-zero status");
+            false
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            println!(
+                "cargo:warning=trunk not found; Yew UI not compiled \
+                 (install with: cargo install trunk)"
+            );
+            false
+        }
+        Err(e) => {
+            println!("cargo:warning=failed to launch trunk: {e}");
+            false
+        }
+    }
+}
+
+/// Read trunk's `dist/` output and produce a single self-contained HTML file.
+///
+/// Strategy: monkey-patch `fetch` before the wasm-bindgen init call so that
+/// any request for a `.wasm` URL returns our base64-encoded bytes instead.
+/// This avoids touching wasm-bindgen internals while keeping a single file.
+fn inline_into_html(dist: &Path, output: &Path) {
+    let html_src = std::fs::read_to_string(dist.join("index.html"))
+        .expect("dist/index.html missing after trunk build");
+
+    let (js_path, wasm_path) = find_dist_assets(dist);
+
+    let js = js_path
+        .as_ref()
+        .map(|p| std::fs::read_to_string(p).expect("failed to read .js dist asset"))
+        .unwrap_or_default();
+
+    let wasm_b64 = wasm_path
+        .as_ref()
+        .map(|p| {
+            let bytes = std::fs::read(p).expect("failed to read .wasm dist asset");
+            base64_encode(&bytes)
+        })
+        .unwrap_or_default();
+
+    let wasm_file = wasm_path
+        .as_ref()
+        .and_then(|p| p.file_name())
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    let js_file = js_path
+        .as_ref()
+        .and_then(|p| p.file_name())
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    // Build the inline <script type="module"> block:
+    //   1. Decode WASM from base64 into a Uint8Array.
+    //   2. Patch globalThis.fetch so any *.wasm request returns our bytes.
+    //   3. Inline the wasm-bindgen JS module (exports are ignored; init() is called).
+    //   4. Call await init().
+    let inline_script = format!(
+        r#"<script type="module">
+const __wasm=Uint8Array.from(atob('{wasm_b64}'),c=>c.charCodeAt(0));
+const __fetch=globalThis.fetch;
+globalThis.fetch=(u,...a)=>String(u).endsWith('.wasm')
+  ?Promise.resolve(new Response(__wasm,{{headers:{{'Content-Type':'application/wasm'}}}}))
+  :__fetch(u,...a);
+{js}
+await init();
+</script>"#
+    );
+
+    let final_html = assemble_html(&html_src, &inline_script, &js_file, &wasm_file);
+
+    if let Some(parent) = output.parent() {
+        std::fs::create_dir_all(parent).expect("failed to create output dir");
+    }
+    std::fs::write(output, final_html).expect("failed to write inlined index.html");
+}
+
+fn find_dist_assets(dist: &Path) -> (Option<PathBuf>, Option<PathBuf>) {
+    let mut js_path = None;
+    let mut wasm_path = None;
+    for entry in std::fs::read_dir(dist)
+        .expect("dist dir missing")
+        .flatten()
+    {
+        let p = entry.path();
+        let name = p.file_name().unwrap_or_default().to_string_lossy();
+        if name.ends_with(".js") && name != "index.html" {
+            js_path = Some(p);
+        } else if name.ends_with(".wasm") {
+            wasm_path = Some(p);
+        }
+    }
+    (js_path, wasm_path)
+}
+
+/// Strip external asset references and inject the inline script.
+fn assemble_html(html: &str, inline_script: &str, js_file: &str, wasm_file: &str) -> String {
+    // Drop <link> preload/modulepreload lines referencing the generated assets
+    let stripped: String = html
+        .lines()
+        .filter(|line| {
+            let l = line.trim();
+            !(l.contains(js_file) || l.contains(wasm_file))
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // Replace the trunk-generated <script type="module">…</script> with our inline version.
+    // Trunk emits exactly one such block; if the pattern changes between trunk versions
+    // this falls back to appending before </body>.
+    let marker = r#"<script type="module">"#;
+    if let Some(start) = stripped.find(marker) {
+        if let Some(rel_end) = stripped[start..].find("</script>") {
+            let end = start + rel_end + "</script>".len();
+            let mut out = stripped.clone();
+            out.replace_range(start..end, inline_script);
+            return out;
+        }
+    }
+
+    // Fallback: append before </body>
+    stripped.replace("</body>", &format!("{inline_script}\n</body>"))
+}
+
+fn base64_encode(bytes: &[u8]) -> String {
+    const TABLE: &[u8] =
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity((bytes.len() + 2) / 3 * 4);
+    for chunk in bytes.chunks(3) {
+        let n = match chunk.len() {
+            3 => (chunk[0] as usize) << 16 | (chunk[1] as usize) << 8 | chunk[2] as usize,
+            2 => (chunk[0] as usize) << 16 | (chunk[1] as usize) << 8,
+            1 => (chunk[0] as usize) << 16,
+            _ => unreachable!(),
+        };
+        out.push(TABLE[(n >> 18) & 63] as char);
+        out.push(TABLE[(n >> 12) & 63] as char);
+        out.push(if chunk.len() > 1 {
+            TABLE[(n >> 6) & 63] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            TABLE[n & 63] as char
+        } else {
+            '='
+        });
+    }
+    out
+}
+
+const PLACEHOLDER_HTML: &str = r#"<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>MOADIM</title></head>
+<body><p>UI not built. Run: MOADIM_BUILD_UI=1 cargo build</p></body>
+</html>"#;

--- a/src/routes/http.rs
+++ b/src/routes/http.rs
@@ -60,7 +60,12 @@ pub async fn run(store: CronStore) -> anyhow::Result<()> {
     );
 
     let app = Router::new()
-        .route("/ui", get(|| async { axum::response::Html(include_str!("../ui/index.html")) }))
+        .route(
+            "/ui",
+            get(|| async {
+                axum::response::Html(include_str!(concat!(env!("OUT_DIR"), "/index.html")))
+            }),
+        )
         .route("/", get(|| async { "Moadim server is running" }))
         .route(
             "/health",

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "ui"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "ui"
+path = "src/main.rs"
+
+[dependencies]
+yew = { version = "0.21", features = ["csr"] }
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+gloo-net = { version = "0.6", features = ["http"] }
+gloo-timers = { version = "0.3", features = ["futures"] }
+js-sys = "0.3"
+web-sys = { version = "0.3", features = ["HtmlInputElement"] }
+log = "0.4"
+console_log = "1"
+
+[profile.release]
+opt-level = "z"
+
+[lints.clippy]
+all = "deny"

--- a/ui/Trunk.toml
+++ b/ui/Trunk.toml
@@ -1,0 +1,3 @@
+[build]
+dist = "dist"
+public_url = "./"

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MOADIM — Cron Control</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
+  <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet" />
+  <!-- trunk replaces this with the compiled WASM loader -->
+  <link data-trunk rel="rust" data-wasm-opt="z" />
+  <style>
+    :root {
+      --bg:           #050905;
+      --bg-2:         #0b130a;
+      --bg-3:         #111d10;
+      --border:       #19291a;
+      --border-hi:    #2a4229;
+      --text-ghost:   #2a4d28;
+      --text-dim:     #3e6e3a;
+      --text-mid:     #5f9e58;
+      --text:         #9fd494;
+      --text-hi:      #c5eabc;
+      --accent:       #4ade80;
+      --accent-dim:   #0d2919;
+      --red:          #f87171;
+      --red-dim:      #270f0f;
+      --amber:        #fbbf24;
+      --amber-dim:    #271b06;
+      --mono:         'Share Tech Mono', 'Courier New', monospace;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { height: 100%; background: var(--bg); color: var(--text); font-family: var(--mono); font-size: 13px; line-height: 1.6; }
+
+    body::before {
+      content: ''; position: fixed; inset: 0;
+      background: repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(0,0,0,0.04) 2px, rgba(0,0,0,0.04) 4px);
+      pointer-events: none; z-index: 9999;
+    }
+    body::after {
+      content: ''; position: fixed; inset: 0; opacity: 0.025;
+      background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+      background-size: 128px 128px; pointer-events: none; z-index: 9998;
+    }
+
+    header { border-bottom: 1px solid var(--border); padding: 0 28px; height: 54px; display: flex; align-items: center; justify-content: space-between; background: var(--bg-2); position: sticky; top: 0; z-index: 100; }
+    .logo { display: flex; align-items: baseline; gap: 10px; font-size: 17px; letter-spacing: 0.3em; color: var(--accent); }
+    .logo-sub { font-size: 10px; letter-spacing: 0.2em; color: var(--text-dim); }
+    .header-right { display: flex; align-items: center; gap: 16px; }
+
+    .health { display: flex; align-items: center; gap: 8px; padding: 5px 12px; border: 1px solid var(--border); background: var(--bg-3); font-size: 11px; }
+    .health-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--text-ghost); flex-shrink: 0; }
+    .health-dot.ok    { background: var(--accent); animation: glow 2.4s ease-in-out infinite; }
+    .health-dot.error { background: var(--red); }
+    @keyframes glow { 0%,100% { box-shadow: 0 0 0 0 rgba(74,222,128,0.5); } 50% { box-shadow: 0 0 0 5px rgba(74,222,128,0); } }
+    .health-status { color: var(--text-mid); letter-spacing: 0.06em; }
+    .health-uptime  { color: var(--text-ghost); }
+
+    .btn { font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em; padding: 6px 14px; border: 1px solid; cursor: pointer; background: transparent; transition: background 0.12s, color 0.12s; }
+    .btn:disabled { opacity: 0.4; cursor: not-allowed; }
+    .btn-primary { border-color: var(--accent); color: var(--accent); }
+    .btn-primary:not(:disabled):hover { background: var(--accent); color: var(--bg); }
+    .btn-danger  { border-color: var(--red); color: var(--red); }
+    .btn-danger:not(:disabled):hover  { background: var(--red); color: var(--bg); }
+    .btn-ghost   { border-color: var(--border-hi); color: var(--text-mid); }
+    .btn-ghost:not(:disabled):hover   { border-color: var(--text-dim); color: var(--text); }
+    .btn-sm { padding: 4px 10px; }
+    .btn-refresh { background: none; border: 1px solid var(--border); color: var(--text-dim); font-family: var(--mono); font-size: 14px; padding: 4px 10px; cursor: pointer; transition: color 0.12s, border-color 0.12s; line-height: 1; }
+    .btn-refresh:hover { color: var(--accent); border-color: var(--border-hi); }
+
+    main { max-width: 1100px; margin: 0 auto; padding: 32px 28px; }
+
+    .stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin-bottom: 36px; }
+    .stat-card { border: 1px solid var(--border); border-left-width: 3px; background: var(--bg-2); padding: 14px 18px; display: flex; flex-direction: column; gap: 4px; }
+    .stat-card.all      { border-left-color: var(--border-hi); }
+    .stat-card.enabled  { border-left-color: var(--accent); }
+    .stat-card.disabled { border-left-color: var(--amber); }
+    .stat-label { font-size: 9px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--text-dim); }
+    .stat-val { font-size: 30px; color: var(--text-hi); line-height: 1.1; }
+    .stat-val.c-accent { color: var(--accent); }
+    .stat-val.c-amber  { color: var(--amber); }
+
+    .section-hd { display: flex; align-items: center; justify-content: space-between; margin-bottom: 14px; }
+    .section-label { font-size: 9px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--text-dim); }
+
+    .table-wrap { border: 1px solid var(--border); overflow: hidden; }
+    table { width: 100%; border-collapse: collapse; }
+    thead th { font-size: 9px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--text-ghost); text-align: left; padding: 9px 14px; border-bottom: 1px solid var(--border); background: var(--bg-3); font-weight: 400; }
+    tbody tr { border-bottom: 1px solid var(--border); transition: background 0.08s; }
+    tbody tr:last-child { border-bottom: none; }
+    tbody tr:hover { background: var(--bg-2); }
+    tbody td { padding: 11px 14px; vertical-align: middle; }
+    .cell-id { font-size: 10px; color: var(--text-ghost); font-family: var(--mono); letter-spacing: 0.03em; }
+    .cell-schedule { color: var(--text-hi); font-size: 12px; }
+    .cell-schedule-human { font-size: 10px; color: var(--text-mid); margin-top: 1px; }
+    .cell-handler { color: var(--accent); font-size: 12px; }
+    .cell-meta { font-size: 10px; color: var(--text-dim); max-width: 130px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .cell-time { font-size: 10px; color: var(--text-ghost); }
+
+    .toggle { position: relative; width: 34px; height: 18px; cursor: pointer; display: block; }
+    .toggle input { opacity: 0; width: 0; height: 0; position: absolute; }
+    .toggle-track { position: absolute; inset: 0; border: 1px solid var(--border-hi); background: var(--bg-3); transition: border-color 0.15s, background 0.15s; }
+    .toggle-track::after { content: ''; position: absolute; top: 2px; left: 2px; width: 12px; height: 12px; background: var(--text-dim); transition: transform 0.15s, background 0.15s; }
+    .toggle input:checked + .toggle-track { border-color: var(--accent); background: var(--accent-dim); }
+    .toggle input:checked + .toggle-track::after { transform: translateX(16px); background: var(--accent); }
+
+    .row-actions { display: flex; gap: 4px; align-items: center; }
+    .act-btn { font-family: var(--mono); font-size: 10px; letter-spacing: 0.04em; padding: 2px 8px; border: 1px solid transparent; cursor: pointer; background: transparent; transition: color 0.1s, border-color 0.1s; }
+    .act-btn.edit { color: var(--text-mid); border-color: var(--border); }
+    .act-btn.edit:hover { color: var(--text-hi); border-color: var(--border-hi); }
+    .act-btn.del  { color: var(--text-ghost); }
+    .act-btn.del:hover  { color: var(--red); border-color: var(--red-dim); }
+
+    .empty { padding: 72px 40px; text-align: center; color: var(--text-ghost); }
+    .empty-icon { font-size: 36px; margin-bottom: 14px; opacity: 0.4; }
+    .empty-msg  { font-size: 13px; letter-spacing: 0.22em; text-transform: uppercase; }
+    .empty-sub  { font-size: 10px; color: var(--text-ghost); margin-top: 6px; opacity: 0.7; }
+
+    .overlay { position: fixed; inset: 0; background: rgba(4,8,4,0.87); z-index: 200; display: flex; align-items: center; justify-content: center; }
+    .modal { background: var(--bg-2); border: 1px solid var(--border-hi); width: 540px; max-width: 92vw; max-height: 88vh; overflow-y: auto; }
+    .modal-hd { padding: 14px 18px; border-bottom: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; }
+    .modal-title { font-size: 11px; color: var(--text-hi); letter-spacing: 0.14em; text-transform: uppercase; }
+    .modal-x { background: none; border: none; color: var(--text-dim); cursor: pointer; font-family: var(--mono); font-size: 15px; line-height: 1; padding: 2px 4px; }
+    .modal-x:hover { color: var(--text); }
+    .modal-body { padding: 18px; }
+    .modal-ft { padding: 14px 18px; border-top: 1px solid var(--border); display: flex; gap: 8px; justify-content: flex-end; }
+
+    .form-group { margin-bottom: 18px; }
+    .form-label { display: block; font-size: 9px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--text-dim); margin-bottom: 5px; }
+    .form-required { color: var(--red); }
+    .form-input { width: 100%; background: var(--bg-3); border: 1px solid var(--border); color: var(--text); font-family: var(--mono); font-size: 13px; padding: 7px 11px; outline: none; transition: border-color 0.12s; }
+    .form-input:focus { border-color: var(--accent); }
+    .form-input.invalid { border-color: var(--red); }
+    .form-input::placeholder { color: var(--text-ghost); }
+    textarea.form-input { resize: vertical; min-height: 90px; }
+
+    .cron-presets { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 5px; }
+    .preset-btn { font-family: var(--mono); font-size: 9px; padding: 2px 7px; border: 1px solid var(--border); color: var(--text-dim); cursor: pointer; background: transparent; transition: all 0.1s; letter-spacing: 0.04em; }
+    .preset-btn:hover { border-color: var(--accent); color: var(--accent); }
+    .cron-preview { margin-top: 6px; padding: 6px 10px; font-size: 11px; border-left: 2px solid var(--border-hi); color: var(--text-dim); background: var(--bg-3); min-height: 26px; transition: border-color 0.12s, color 0.12s; }
+    .cron-preview.ok  { border-left-color: var(--accent); color: var(--accent); }
+    .cron-preview.bad { border-left-color: var(--red); color: var(--red); }
+    .field-err { font-size: 10px; color: var(--red); margin-top: 3px; }
+    .toggle-row { display: flex; align-items: center; justify-content: space-between; padding: 7px 11px; background: var(--bg-3); border: 1px solid var(--border); }
+    .toggle-row-label { font-size: 9px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-dim); }
+
+    .confirm-dialog { background: var(--bg-2); border: 1px solid var(--red); padding: 22px; width: 350px; max-width: 92vw; }
+    .confirm-title { font-size: 12px; color: var(--red); letter-spacing: 0.06em; margin-bottom: 8px; }
+    .confirm-msg   { font-size: 11px; color: var(--text-mid); line-height: 1.5; margin-bottom: 18px; }
+    .confirm-acts  { display: flex; gap: 8px; justify-content: flex-end; }
+
+    .toast-wrap { position: fixed; bottom: 22px; right: 22px; z-index: 500; display: flex; flex-direction: column; gap: 6px; align-items: flex-end; }
+    .toast { font-family: var(--mono); font-size: 11px; padding: 9px 14px; border: 1px solid; max-width: 300px; animation: toast-in 0.18s ease-out; letter-spacing: 0.03em; }
+    .toast.ok  { border-color: var(--accent); color: var(--accent); background: var(--accent-dim); }
+    .toast.err { border-color: var(--red);    color: var(--red);    background: var(--red-dim); }
+    @keyframes toast-in { from { opacity:0; transform: translateX(12px); } to { opacity:1; transform:none; } }
+
+    .spinner { display: inline-block; width: 11px; height: 11px; border: 1px solid var(--text-ghost); border-top-color: var(--accent); border-radius: 50%; animation: spin 0.55s linear infinite; }
+    @keyframes spin { to { transform: rotate(360deg); } }
+
+    ::-webkit-scrollbar       { width: 5px; }
+    ::-webkit-scrollbar-track { background: var(--bg); }
+    ::-webkit-scrollbar-thumb { background: var(--border-hi); }
+    ::-webkit-scrollbar-thumb:hover { background: var(--text-dim); }
+  </style>
+</head>
+<body></body>
+</html>

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1,0 +1,1059 @@
+use gloo_net::http::Request;
+use gloo_timers::future::TimeoutFuture;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as Json;
+use wasm_bindgen_futures::spawn_local;
+use web_sys::HtmlInputElement;
+use yew::prelude::*;
+
+// ─── Types (mirror server API exactly) ────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CronJob {
+    pub id: String,
+    pub schedule: String,
+    pub handler: String,
+    pub metadata: Json,
+    pub enabled: bool,
+    pub created_at: u64,
+    pub updated_at: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Default)]
+pub struct Health {
+    pub status: String,
+    pub uptime_secs: Option<u64>,
+    pub running: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CreateRequest {
+    pub schedule: String,
+    pub handler: String,
+    pub metadata: Json,
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct UpdateRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schedule: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub handler: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Json>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+}
+
+// ─── App state ────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ToastKind {
+    Ok,
+    Err,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Toast {
+    pub id: u32,
+    pub msg: AttrValue,
+    pub kind: ToastKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Modal {
+    None,
+    Create,
+    Edit(String),
+    ConfirmDelete { id: String, handler: String },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AppState {
+    pub jobs: Vec<CronJob>,
+    pub health: Health,
+    pub health_ok: bool,
+    pub loading: bool,
+    pub modal: Modal,
+    pub toasts: Vec<Toast>,
+    pub next_toast: u32,
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        Self {
+            jobs: vec![],
+            health: Health::default(),
+            health_ok: false,
+            loading: true,
+            modal: Modal::None,
+            toasts: vec![],
+            next_toast: 0,
+        }
+    }
+}
+
+pub enum AppAction {
+    JobsLoaded(Vec<CronJob>),
+    HealthLoaded { health: Health, ok: bool },
+    OpenCreate,
+    OpenEdit(String),
+    OpenConfirmDelete { id: String, handler: String },
+    CloseModal,
+    UpsertJob(CronJob),
+    RemoveJob(String),
+    AddToast { msg: String, kind: ToastKind },
+    DismissToast(u32),
+}
+
+impl Reducible for AppState {
+    type Action = AppAction;
+
+    fn reduce(self: std::rc::Rc<Self>, action: Self::Action) -> std::rc::Rc<Self> {
+        let mut s = (*self).clone();
+        match action {
+            AppAction::JobsLoaded(jobs) => {
+                s.jobs = jobs;
+                s.loading = false;
+            }
+            AppAction::HealthLoaded { health, ok } => {
+                s.health = health;
+                s.health_ok = ok;
+            }
+            AppAction::OpenCreate => s.modal = Modal::Create,
+            AppAction::OpenEdit(id) => s.modal = Modal::Edit(id),
+            AppAction::OpenConfirmDelete { id, handler } => {
+                s.modal = Modal::ConfirmDelete { id, handler };
+            }
+            AppAction::CloseModal => s.modal = Modal::None,
+            AppAction::UpsertJob(job) => {
+                if let Some(i) = s.jobs.iter().position(|j| j.id == job.id) {
+                    s.jobs[i] = job;
+                } else {
+                    s.jobs.push(job);
+                }
+            }
+            AppAction::RemoveJob(id) => s.jobs.retain(|j| j.id != id),
+            AppAction::AddToast { msg, kind } => {
+                let id = s.next_toast;
+                s.next_toast += 1;
+                s.toasts.push(Toast {
+                    id,
+                    msg: AttrValue::from(msg),
+                    kind,
+                });
+            }
+            AppAction::DismissToast(id) => s.toasts.retain(|t| t.id != id),
+        }
+        s.into()
+    }
+}
+
+// ─── API layer ────────────────────────────────────────────────────────────────
+
+async fn api_list_jobs() -> Result<Vec<CronJob>, String> {
+    Request::get("/cron-jobs")
+        .send()
+        .await
+        .map_err(|e| e.to_string())?
+        .json::<Vec<CronJob>>()
+        .await
+        .map_err(|e| e.to_string())
+}
+
+async fn api_health() -> Result<Health, String> {
+    Request::get("/health")
+        .send()
+        .await
+        .map_err(|e| e.to_string())?
+        .json::<Health>()
+        .await
+        .map_err(|e| e.to_string())
+}
+
+async fn api_create(req: &CreateRequest) -> Result<CronJob, String> {
+    let resp = Request::post("/cron-jobs")
+        .json(req)
+        .map_err(|e| e.to_string())?
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    if !resp.ok() {
+        return Err(format!("HTTP {}", resp.status()));
+    }
+    resp.json::<CronJob>().await.map_err(|e| e.to_string())
+}
+
+async fn api_update(id: &str, req: &UpdateRequest) -> Result<CronJob, String> {
+    let resp = Request::put(&format!("/cron-jobs/{id}"))
+        .json(req)
+        .map_err(|e| e.to_string())?
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    if !resp.ok() {
+        return Err(format!("HTTP {}", resp.status()));
+    }
+    resp.json::<CronJob>().await.map_err(|e| e.to_string())
+}
+
+async fn api_delete(id: &str) -> Result<(), String> {
+    let resp = Request::delete(&format!("/cron-jobs/{id}"))
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    if resp.status() == 204 || resp.ok() {
+        Ok(())
+    } else {
+        Err(format!("HTTP {}", resp.status()))
+    }
+}
+
+// ─── Root component ───────────────────────────────────────────────────────────
+
+#[function_component(App)]
+pub fn app() -> Html {
+    let state = use_reducer(AppState::default);
+
+    // Load jobs + poll health on mount
+    {
+        let state = state.clone();
+        use_effect_with((), move |_| {
+            let state = state.clone();
+            spawn_local(async move {
+                match api_list_jobs().await {
+                    Ok(jobs) => state.dispatch(AppAction::JobsLoaded(jobs)),
+                    Err(e) => state.dispatch(AppAction::AddToast {
+                        msg: format!("Failed to load jobs: {e}"),
+                        kind: ToastKind::Err,
+                    }),
+                }
+                poll_health(state).await;
+            });
+        });
+    }
+
+    // Health poll loop every 30 s
+    {
+        let state = state.clone();
+        use_effect_with((), move |_| {
+            let state = state.clone();
+            spawn_local(async move {
+                loop {
+                    TimeoutFuture::new(30_000).await;
+                    poll_health(state.clone()).await;
+                }
+            });
+        });
+    }
+
+    let on_refresh = {
+        let state = state.clone();
+        Callback::from(move |_: MouseEvent| {
+            let state = state.clone();
+            spawn_local(async move {
+                match api_list_jobs().await {
+                    Ok(jobs) => state.dispatch(AppAction::JobsLoaded(jobs)),
+                    Err(e) => state.dispatch(AppAction::AddToast {
+                        msg: format!("Refresh failed: {e}"),
+                        kind: ToastKind::Err,
+                    }),
+                }
+                poll_health(state).await;
+            });
+        })
+    };
+
+    let on_new = {
+        let state = state.clone();
+        Callback::from(move |_: MouseEvent| state.dispatch(AppAction::OpenCreate))
+    };
+
+    let on_edit = {
+        let state = state.clone();
+        Callback::from(move |id: String| state.dispatch(AppAction::OpenEdit(id)))
+    };
+
+    let on_ask_delete = {
+        let state = state.clone();
+        Callback::from(move |(id, handler): (String, String)| {
+            state.dispatch(AppAction::OpenConfirmDelete { id, handler });
+        })
+    };
+
+    let on_toggle = {
+        let state = state.clone();
+        Callback::from(move |(id, enabled): (String, bool)| {
+            let state = state.clone();
+            spawn_local(async move {
+                let req = UpdateRequest {
+                    enabled: Some(enabled),
+                    ..Default::default()
+                };
+                match api_update(&id, &req).await {
+                    Ok(job) => {
+                        state.dispatch(AppAction::UpsertJob(job));
+                        state.dispatch(AppAction::AddToast {
+                            msg: if enabled {
+                                "Job enabled".into()
+                            } else {
+                                "Job disabled".into()
+                            },
+                            kind: ToastKind::Ok,
+                        });
+                    }
+                    Err(e) => state.dispatch(AppAction::AddToast {
+                        msg: format!("Toggle failed: {e}"),
+                        kind: ToastKind::Err,
+                    }),
+                }
+            })
+        })
+    };
+
+    let on_close = {
+        let state = state.clone();
+        Callback::from(move |_: ()| state.dispatch(AppAction::CloseModal))
+    };
+
+    // Snapshot modal at render time so on_save sees the right mode
+    let current_modal = state.modal.clone();
+    let on_save = {
+        let state = state.clone();
+        Callback::from(move |req: CreateRequest| {
+            let state = state.clone();
+            let modal = current_modal.clone();
+            spawn_local(async move {
+                match &modal {
+                    Modal::Edit(id) => {
+                        let upd = UpdateRequest {
+                            schedule: Some(req.schedule),
+                            handler: Some(req.handler),
+                            metadata: Some(req.metadata),
+                            enabled: Some(req.enabled),
+                        };
+                        match api_update(id, &upd).await {
+                            Ok(job) => {
+                                state.dispatch(AppAction::UpsertJob(job));
+                                state.dispatch(AppAction::CloseModal);
+                                state.dispatch(AppAction::AddToast {
+                                    msg: "Job updated".into(),
+                                    kind: ToastKind::Ok,
+                                });
+                            }
+                            Err(e) => state.dispatch(AppAction::AddToast {
+                                msg: format!("Update failed: {e}"),
+                                kind: ToastKind::Err,
+                            }),
+                        }
+                    }
+                    _ => match api_create(&req).await {
+                        Ok(job) => {
+                            state.dispatch(AppAction::UpsertJob(job));
+                            state.dispatch(AppAction::CloseModal);
+                            state.dispatch(AppAction::AddToast {
+                                msg: "Job created".into(),
+                                kind: ToastKind::Ok,
+                            });
+                        }
+                        Err(e) => state.dispatch(AppAction::AddToast {
+                            msg: format!("Create failed: {e}"),
+                            kind: ToastKind::Err,
+                        }),
+                    },
+                }
+            })
+        })
+    };
+
+    let on_confirm_delete = {
+        let state = state.clone();
+        Callback::from(move |id: String| {
+            let state = state.clone();
+            spawn_local(async move {
+                match api_delete(&id).await {
+                    Ok(()) => {
+                        state.dispatch(AppAction::RemoveJob(id));
+                        state.dispatch(AppAction::CloseModal);
+                        state.dispatch(AppAction::AddToast {
+                            msg: "Job deleted".into(),
+                            kind: ToastKind::Ok,
+                        });
+                    }
+                    Err(e) => state.dispatch(AppAction::AddToast {
+                        msg: format!("Delete failed: {e}"),
+                        kind: ToastKind::Err,
+                    }),
+                }
+            })
+        })
+    };
+
+    let on_dismiss_toast = {
+        let state = state.clone();
+        Callback::from(move |id: u32| state.dispatch(AppAction::DismissToast(id)))
+    };
+
+    let jobs = state.jobs.clone();
+    let health = state.health.clone();
+    let health_ok = state.health_ok;
+    let loading = state.loading;
+    let modal = state.modal.clone();
+    let toasts = state.toasts.clone();
+
+    let edit_job = match &modal {
+        Modal::Edit(id) => jobs.iter().find(|j| j.id == *id).cloned(),
+        _ => None,
+    };
+
+    html! {
+        <>
+            <Header health={health} ok={health_ok} on_refresh={on_refresh} />
+            <main>
+                <StatsBar jobs={jobs.clone()} />
+                <div class="section-hd">
+                    <div class="section-label">{"SCHEDULED JOBS"}</div>
+                    <button class="btn btn-primary btn-sm" onclick={on_new}>{"+ NEW JOB"}</button>
+                </div>
+                <JobTable
+                    jobs={jobs}
+                    loading={loading}
+                    on_edit={on_edit}
+                    on_delete={on_ask_delete}
+                    on_toggle={on_toggle}
+                />
+            </main>
+            {
+                match &modal {
+                    Modal::Create | Modal::Edit(_) => html! {
+                        <JobModal
+                            editing={edit_job}
+                            on_close={on_close.clone()}
+                            on_save={on_save}
+                        />
+                    },
+                    Modal::ConfirmDelete { id, handler } => html! {
+                        <ConfirmDialog
+                            job_id={id.clone()}
+                            handler={handler.clone()}
+                            on_cancel={on_close}
+                            on_confirm={on_confirm_delete}
+                        />
+                    },
+                    Modal::None => html! {},
+                }
+            }
+            <ToastStack toasts={toasts} on_dismiss={on_dismiss_toast} />
+        </>
+    }
+}
+
+async fn poll_health(state: UseReducerHandle<AppState>) {
+    match api_health().await {
+        Ok(health) => {
+            let ok = health.running;
+            state.dispatch(AppAction::HealthLoaded { health, ok });
+        }
+        Err(_) => state.dispatch(AppAction::HealthLoaded {
+            health: Health {
+                status: "offline".into(),
+                running: false,
+                uptime_secs: None,
+            },
+            ok: false,
+        }),
+    }
+}
+
+// ─── Header ───────────────────────────────────────────────────────────────────
+
+#[derive(Properties, PartialEq)]
+pub struct HeaderProps {
+    pub health: Health,
+    pub ok: bool,
+    pub on_refresh: Callback<MouseEvent>,
+}
+
+#[function_component(Header)]
+pub fn header(props: &HeaderProps) -> Html {
+    let dot_class = if props.ok {
+        "health-dot ok"
+    } else {
+        "health-dot error"
+    };
+    let status = props.health.status.to_uppercase();
+    let uptime = props
+        .health
+        .uptime_secs
+        .map(|s| format!("/ UP {}", fmt_uptime(s)))
+        .unwrap_or_default();
+
+    html! {
+        <header>
+            <div class="logo">
+                {"MOADIM"}
+                <span class="logo-sub">{"/ CRON CONTROL"}</span>
+            </div>
+            <div class="header-right">
+                <div class="health">
+                    <div class={dot_class}></div>
+                    <span class="health-status">{status}</span>
+                    <span class="health-uptime">{uptime}</span>
+                </div>
+                <button class="btn-refresh" title="Refresh" onclick={props.on_refresh.clone()}>{"↻"}</button>
+            </div>
+        </header>
+    }
+}
+
+// ─── Stats bar ────────────────────────────────────────────────────────────────
+
+#[derive(Properties, PartialEq)]
+pub struct StatsProps {
+    pub jobs: Vec<CronJob>,
+}
+
+#[function_component(StatsBar)]
+pub fn stats_bar(props: &StatsProps) -> Html {
+    let total = props.jobs.len();
+    let enabled = props.jobs.iter().filter(|j| j.enabled).count();
+    let disabled = total - enabled;
+
+    html! {
+        <div class="stats">
+            <div class="stat-card all">
+                <div class="stat-label">{"TOTAL JOBS"}</div>
+                <div class="stat-val">{total}</div>
+            </div>
+            <div class="stat-card enabled">
+                <div class="stat-label">{"ENABLED"}</div>
+                <div class="stat-val c-accent">{enabled}</div>
+            </div>
+            <div class="stat-card disabled">
+                <div class="stat-label">{"DISABLED"}</div>
+                <div class="stat-val c-amber">{disabled}</div>
+            </div>
+        </div>
+    }
+}
+
+// ─── Job table ────────────────────────────────────────────────────────────────
+
+#[derive(Properties, PartialEq)]
+pub struct JobTableProps {
+    pub jobs: Vec<CronJob>,
+    pub loading: bool,
+    pub on_edit: Callback<String>,
+    pub on_delete: Callback<(String, String)>,
+    pub on_toggle: Callback<(String, bool)>,
+}
+
+#[function_component(JobTable)]
+pub fn job_table(props: &JobTableProps) -> Html {
+    if props.loading {
+        return html! {
+            <div class="table-wrap">
+                <div class="empty"><div class="spinner"></div></div>
+            </div>
+        };
+    }
+    if props.jobs.is_empty() {
+        return html! {
+            <div class="table-wrap">
+                <div class="empty">
+                    <div class="empty-icon">{"⧗"}</div>
+                    <div class="empty-msg">{"NO JOBS SCHEDULED"}</div>
+                    <div class="empty-sub">{"press + NEW JOB to create one"}</div>
+                </div>
+            </div>
+        };
+    }
+
+    html! {
+        <div class="table-wrap">
+            <table>
+                <thead>
+                    <tr>
+                        <th>{"ID"}</th>
+                        <th>{"SCHEDULE"}</th>
+                        <th>{"HANDLER"}</th>
+                        <th>{"METADATA"}</th>
+                        <th>{"ENABLED"}</th>
+                        <th>{"UPDATED"}</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    { for props.jobs.iter().map(|job| html! {
+                        <JobRow
+                            key={job.id.clone()}
+                            job={job.clone()}
+                            on_edit={props.on_edit.clone()}
+                            on_delete={props.on_delete.clone()}
+                            on_toggle={props.on_toggle.clone()}
+                        />
+                    }) }
+                </tbody>
+            </table>
+        </div>
+    }
+}
+
+// ─── Job row ──────────────────────────────────────────────────────────────────
+
+#[derive(Properties, PartialEq)]
+pub struct JobRowProps {
+    pub job: CronJob,
+    pub on_edit: Callback<String>,
+    pub on_delete: Callback<(String, String)>,
+    pub on_toggle: Callback<(String, bool)>,
+}
+
+#[function_component(JobRow)]
+pub fn job_row(props: &JobRowProps) -> Html {
+    let job = &props.job;
+    let id_short = format!("{}…", &job.id[..8.min(job.id.len())]);
+    let (cron_ok, cron_text) = describe_cron(&job.schedule);
+    let meta = meta_preview(&job.metadata);
+    let updated = reltime(job.updated_at);
+
+    let on_edit = {
+        let cb = props.on_edit.clone();
+        let id = job.id.clone();
+        Callback::from(move |_: MouseEvent| cb.emit(id.clone()))
+    };
+    let on_delete = {
+        let cb = props.on_delete.clone();
+        let id = job.id.clone();
+        let handler = job.handler.clone();
+        Callback::from(move |_: MouseEvent| cb.emit((id.clone(), handler.clone())))
+    };
+    let on_toggle = {
+        let cb = props.on_toggle.clone();
+        let id = job.id.clone();
+        let enabled = job.enabled;
+        Callback::from(move |_: Event| cb.emit((id.clone(), !enabled)))
+    };
+
+    let _ = cron_ok; // used only for styling if desired later
+    html! {
+        <tr>
+            <td><span class="cell-id" title={job.id.clone()}>{id_short}</span></td>
+            <td>
+                <div class="cell-schedule">{&job.schedule}</div>
+                <div class="cell-schedule-human">{cron_text}</div>
+            </td>
+            <td><span class="cell-handler">{&job.handler}</span></td>
+            <td><span class="cell-meta">{meta}</span></td>
+            <td>
+                <label class="toggle">
+                    <input type="checkbox" checked={job.enabled} onchange={on_toggle} />
+                    <div class="toggle-track"></div>
+                </label>
+            </td>
+            <td><span class="cell-time">{updated}</span></td>
+            <td>
+                <div class="row-actions">
+                    <button class="act-btn edit" onclick={on_edit}>{"EDIT"}</button>
+                    <button class="act-btn del" onclick={on_delete}>{"✕"}</button>
+                </div>
+            </td>
+        </tr>
+    }
+}
+
+// ─── Job modal ────────────────────────────────────────────────────────────────
+
+#[derive(Properties, PartialEq)]
+pub struct JobModalProps {
+    pub editing: Option<CronJob>,
+    pub on_close: Callback<()>,
+    pub on_save: Callback<CreateRequest>,
+}
+
+#[function_component(JobModal)]
+pub fn job_modal(props: &JobModalProps) -> Html {
+    let schedule = use_state(|| {
+        props
+            .editing
+            .as_ref()
+            .map(|j| j.schedule.clone())
+            .unwrap_or_default()
+    });
+    let handler = use_state(|| {
+        props
+            .editing
+            .as_ref()
+            .map(|j| j.handler.clone())
+            .unwrap_or_default()
+    });
+    let meta_raw = use_state(|| {
+        props
+            .editing
+            .as_ref()
+            .and_then(|j| {
+                if j.metadata.is_null() {
+                    None
+                } else {
+                    serde_json::to_string_pretty(&j.metadata).ok()
+                }
+            })
+            .unwrap_or_default()
+    });
+    let enabled = use_state(|| {
+        props
+            .editing
+            .as_ref()
+            .map(|j| j.enabled)
+            .unwrap_or(true)
+    });
+    let meta_err = use_state(String::new);
+    let saving = use_state(|| false);
+
+    let (cron_ok, cron_text) = describe_cron(&schedule);
+
+    let is_edit = props.editing.is_some();
+    let title = if is_edit { "EDIT JOB" } else { "NEW JOB" };
+    let save_label = if is_edit { "SAVE CHANGES" } else { "CREATE JOB" };
+
+    let on_schedule = {
+        let schedule = schedule.clone();
+        Callback::from(move |e: InputEvent| {
+            let input: HtmlInputElement = e.target_unchecked_into();
+            schedule.set(input.value());
+        })
+    };
+    let on_handler = {
+        let handler = handler.clone();
+        Callback::from(move |e: InputEvent| {
+            let input: HtmlInputElement = e.target_unchecked_into();
+            handler.set(input.value());
+        })
+    };
+    let on_meta = {
+        let meta_raw = meta_raw.clone();
+        let meta_err = meta_err.clone();
+        Callback::from(move |e: InputEvent| {
+            let input: HtmlInputElement = e.target_unchecked_into();
+            let val = input.value();
+            if val.trim().is_empty() {
+                meta_err.set(String::new());
+            } else if let Err(err) = serde_json::from_str::<Json>(&val) {
+                meta_err.set(format!("↳ {err}"));
+            } else {
+                meta_err.set(String::new());
+            }
+            meta_raw.set(val);
+        })
+    };
+    let on_enabled = {
+        let enabled = enabled.clone();
+        Callback::from(move |e: Event| {
+            let input: HtmlInputElement = e.target_unchecked_into();
+            enabled.set(input.checked());
+        })
+    };
+
+    let set_preset = |val: &'static str| {
+        let schedule = schedule.clone();
+        Callback::from(move |_: MouseEvent| schedule.set(val.to_string()))
+    };
+
+    let on_close_click = {
+        let cb = props.on_close.clone();
+        Callback::from(move |_: MouseEvent| cb.emit(()))
+    };
+    let on_save_click = {
+        let schedule = schedule.clone();
+        let handler = handler.clone();
+        let meta_raw = meta_raw.clone();
+        let meta_err = meta_err.clone();
+        let enabled = enabled.clone();
+        let saving = saving.clone();
+        let cb = props.on_save.clone();
+        Callback::from(move |_: MouseEvent| {
+            if !meta_err.is_empty() {
+                return;
+            }
+            let metadata = if meta_raw.trim().is_empty() {
+                Json::Null
+            } else {
+                serde_json::from_str(&*meta_raw).unwrap_or(Json::Null)
+            };
+            saving.set(true);
+            cb.emit(CreateRequest {
+                schedule: (*schedule).clone(),
+                handler: (*handler).clone(),
+                metadata,
+                enabled: *enabled,
+            });
+        })
+    };
+
+    let preview_class = if schedule.is_empty() {
+        "cron-preview"
+    } else if cron_ok {
+        "cron-preview ok"
+    } else {
+        "cron-preview bad"
+    };
+
+    let meta_class = if !meta_err.is_empty() {
+        "form-input invalid"
+    } else {
+        "form-input"
+    };
+
+    html! {
+        <div class="overlay">
+            <div class="modal">
+                <div class="modal-hd">
+                    <div class="modal-title">{title}</div>
+                    <button class="modal-x" onclick={on_close_click.clone()}>{"✕"}</button>
+                </div>
+                <div class="modal-body">
+                    <div class="form-group">
+                        <label class="form-label">
+                            {"SCHEDULE "}
+                            <span class="form-required">{"*"}</span>
+                        </label>
+                        <input
+                            class="form-input"
+                            type="text"
+                            placeholder="sec min hour dom month dow year"
+                            value={(*schedule).clone()}
+                            oninput={on_schedule}
+                            autocomplete="off"
+                            spellcheck="false"
+                        />
+                        <div class="cron-presets">
+                            { for [
+                                ("@daily", "@daily"), ("@hourly", "@hourly"),
+                                ("@weekly", "@weekly"), ("@monthly", "@monthly"),
+                                ("0 0 9 * * 1-5 *", "weekdays 9am"),
+                                ("0 */15 * * * * *", "every 15min"),
+                                ("0 0 * * * * *", "every hour"),
+                                ("0 0 0 1 * * *", "monthly"),
+                            ].iter().map(|(val, label)| html! {
+                                <button class="preset-btn" onclick={set_preset(val)}>{*label}</button>
+                            }) }
+                        </div>
+                        <div class={preview_class}>{cron_text}</div>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">
+                            {"HANDLER "}
+                            <span class="form-required">{"*"}</span>
+                        </label>
+                        <input
+                            class="form-input"
+                            type="text"
+                            placeholder="send-report"
+                            value={(*handler).clone()}
+                            oninput={on_handler}
+                            autocomplete="off"
+                            spellcheck="false"
+                        />
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">
+                            {"METADATA "}
+                            <span style="color:var(--text-ghost)">{"(JSON)"}</span>
+                        </label>
+                        <textarea
+                            class={meta_class}
+                            placeholder={r#"{"recipient": "team@example.com"}"#}
+                            value={(*meta_raw).clone()}
+                            oninput={on_meta}
+                        />
+                        if !meta_err.is_empty() {
+                            <div class="field-err">{(*meta_err).clone()}</div>
+                        }
+                    </div>
+                    <div class="form-group" style="margin-bottom:0">
+                        <div class="toggle-row">
+                            <span class="toggle-row-label">{"ENABLED"}</span>
+                            <label class="toggle">
+                                <input type="checkbox" checked={*enabled} onchange={on_enabled} />
+                                <div class="toggle-track"></div>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-ft">
+                    <button class="btn btn-ghost btn-sm" onclick={on_close_click}>{"CANCEL"}</button>
+                    <button
+                        class="btn btn-primary btn-sm"
+                        onclick={on_save_click}
+                        disabled={*saving}
+                    >
+                        { if *saving { "…" } else { save_label } }
+                    </button>
+                </div>
+            </div>
+        </div>
+    }
+}
+
+// ─── Confirm dialog ───────────────────────────────────────────────────────────
+
+#[derive(Properties, PartialEq)]
+pub struct ConfirmProps {
+    pub job_id: String,
+    pub handler: String,
+    pub on_cancel: Callback<()>,
+    pub on_confirm: Callback<String>,
+}
+
+#[function_component(ConfirmDialog)]
+pub fn confirm_dialog(props: &ConfirmProps) -> Html {
+    let on_cancel = {
+        let cb = props.on_cancel.clone();
+        Callback::from(move |_: MouseEvent| cb.emit(()))
+    };
+    let on_confirm = {
+        let cb = props.on_confirm.clone();
+        let id = props.job_id.clone();
+        Callback::from(move |_: MouseEvent| cb.emit(id.clone()))
+    };
+
+    html! {
+        <div class="overlay">
+            <div class="confirm-dialog">
+                <div class="confirm-title">{"⚠ DELETE JOB"}</div>
+                <div class="confirm-msg">
+                    { format!("Delete the job running \"{}\"? This cannot be undone.", props.handler) }
+                </div>
+                <div class="confirm-acts">
+                    <button class="btn btn-ghost btn-sm" onclick={on_cancel}>{"CANCEL"}</button>
+                    <button class="btn btn-danger btn-sm" onclick={on_confirm}>{"DELETE"}</button>
+                </div>
+            </div>
+        </div>
+    }
+}
+
+// ─── Toast stack ──────────────────────────────────────────────────────────────
+
+#[derive(Properties, PartialEq)]
+pub struct ToastStackProps {
+    pub toasts: Vec<Toast>,
+    pub on_dismiss: Callback<u32>,
+}
+
+#[function_component(ToastStack)]
+pub fn toast_stack(props: &ToastStackProps) -> Html {
+    html! {
+        <div class="toast-wrap">
+            { for props.toasts.iter().map(|t| {
+                let cls = match t.kind { ToastKind::Ok => "toast ok", ToastKind::Err => "toast err" };
+                html! {
+                    <div class={cls} key={t.id}>{t.msg.clone()}</div>
+                }
+            }) }
+        </div>
+    }
+}
+
+// ─── Utilities ────────────────────────────────────────────────────────────────
+
+/// Returns (is_valid, human description) for a cron expression.
+fn describe_cron(expr: &str) -> (bool, String) {
+    let s = expr.trim();
+    if s.is_empty() {
+        return (false, "— enter a cron expression —".into());
+    }
+    let specials = [
+        ("@yearly", "Yearly — January 1st at midnight"),
+        ("@annually", "Yearly — January 1st at midnight"),
+        ("@monthly", "Monthly — 1st at midnight"),
+        ("@weekly", "Weekly — every Sunday at midnight"),
+        ("@daily", "Daily — at midnight"),
+        ("@midnight", "Daily — at midnight"),
+        ("@hourly", "Every hour — at minute 0"),
+    ];
+    for (key, desc) in specials {
+        if s.eq_ignore_ascii_case(key) {
+            return (true, desc.into());
+        }
+    }
+    let parts: Vec<&str> = s.split_whitespace().collect();
+    if parts.len() < 5 || parts.len() > 7 {
+        return (
+            false,
+            format!("Invalid: expected 5–7 fields, got {}", parts.len()),
+        );
+    }
+    // Basic positional description (sec min hour dom month dow [year])
+    let (min, hour) = match parts.len() {
+        5 => (parts[0], parts[1]),
+        _ => (parts[1], parts[2]),
+    };
+    let time_desc = if hour == "*" && min == "*" {
+        "every minute".into()
+    } else if hour == "*" {
+        if let Some(n) = min.strip_prefix("*/") {
+            format!("every {n} minutes")
+        } else {
+            format!("minute {min} of every hour")
+        }
+    } else if let Some(n) = hour.strip_prefix("*/") {
+        format!("every {n} hours")
+    } else if let (Ok(h), Ok(m)) = (hour.parse::<u32>(), min.parse::<u32>()) {
+        let ap = if h >= 12 { "PM" } else { "AM" };
+        let dh = if h == 0 { 12 } else if h > 12 { h - 12 } else { h };
+        format!("{dh}:{m:02} {ap}")
+    } else {
+        format!("{hour}:{min}")
+    };
+    (true, time_desc)
+}
+
+fn meta_preview(v: &Json) -> String {
+    match v {
+        Json::Null => "—".into(),
+        Json::Object(o) if o.is_empty() => "{}".into(),
+        Json::Object(o) => {
+            let k = o.len();
+            if k == 1 {
+                format!("{{{}}}", o.keys().next().unwrap())
+            } else {
+                format!("{{{k} keys}}")
+            }
+        }
+        other => other.to_string().chars().take(24).collect(),
+    }
+}
+
+fn reltime(ts: u64) -> String {
+    if ts == 0 {
+        return "—".into();
+    }
+    let now = (js_sys::Date::now() / 1000.0) as u64;
+    let diff = now.saturating_sub(ts);
+    if diff < 60 {
+        "just now".into()
+    } else if diff < 3_600 {
+        format!("{}m ago", diff / 60)
+    } else if diff < 86_400 {
+        format!("{}h ago", diff / 3_600)
+    } else {
+        format!("{}d ago", diff / 86_400)
+    }
+}
+
+fn fmt_uptime(secs: u64) -> String {
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3_600 {
+        format!("{}m", secs / 60)
+    } else {
+        format!("{}h {}m", secs / 3_600, (secs % 3_600) / 60)
+    }
+}
+
+fn main() {
+    console_log::init_with_level(log::Level::Info).unwrap_or_default();
+    yew::Renderer::<App>::new().render();
+}


### PR DESCRIPTION
## Summary

- Add `ui/` workspace crate — Yew 0.21 app that is a full type-safe rewrite of `src/ui/index.html`
- All API types (`CronJob`, `Health`, `CreateRequest`, `UpdateRequest`) are Rust structs derived with `serde` — no stringly-typed JS
- `src/build/ui.rs` runs `trunk build --release` when `MOADIM_BUILD_UI=1` and produces **a single self-contained `index.html`**: WASM binary is base64-encoded and loaded via a `globalThis.fetch` monkey-patch instead of a separate HTTP request
- Falls back to the legacy `src/ui/index.html` when trunk is absent so normal `cargo build` is unaffected
- Server serves `include_str!(concat!(env!("OUT_DIR"), "/index.html"))` — binary always embeds a valid UI

## Build UI

```bash
# first-time: install trunk + wasm target
cargo install trunk
rustup target add wasm32-unknown-unknown

# build (slow on first run — compiles Yew + all WASM deps)
MOADIM_BUILD_UI=1 cargo build
```

## Test plan

- [ ] `cargo build` (no env var) — compiles clean, serves legacy HTML at `/ui`
- [ ] `MOADIM_BUILD_UI=1 cargo build` — runs trunk, produces single inlined HTML
- [ ] Open `/ui` in browser — Yew app loads, health indicator connects, jobs table renders
- [ ] Create / edit / delete / toggle jobs via the Yew UI
- [ ] Verify no external `.wasm` or `.js` network requests (single-file check)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)