### PR TITLE
fix(ui): ship prebuilt UI in published crate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,16 +31,21 @@ jobs:
 
       - name: Build UI
         run: cargo check
-        # Runs build.rs fresh (no target cache) → trunk inlines Yew UI → writes ui/prebuilt.html
+        # Runs build.rs fresh (no target cache) → trunk inlines Yew UI → writes prebuilt.html
+        # at the package root (not ui/): ui/ is a separate workspace member and
+        # cargo publish strips it from the moadim tarball.
 
       - name: Verify prebuilt UI was generated
-        run: test -s ui/prebuilt.html || (echo "ui/prebuilt.html missing or empty" && exit 1)
+        run: test -s prebuilt.html || (echo "prebuilt.html missing or empty" && exit 1)
+
+      - name: Verify prebuilt UI ships in the published tarball
+        run: cargo package --list --allow-dirty | grep -qx prebuilt.html || (echo "prebuilt.html not in package tarball" && exit 1)
 
       - name: Commit prebuilt UI so cargo publish includes it
         run: |
           git config user.email "actions@github.com"
           git config user.name "GitHub Actions"
-          git add ui/prebuilt.html
+          git add prebuilt.html
           git commit -m "ci: bundle prebuilt UI"
 
       - name: Verify tag matches Cargo.toml version

--- a/build.rs
+++ b/build.rs
@@ -7,10 +7,9 @@ fn main() {
     println!("cargo:rerun-if-changed=src/routes/http.rs");
     println!("cargo:rerun-if-changed=src/cron_jobs.rs");
     println!("cargo:rerun-if-changed=src/system_cron.rs");
-    println!("cargo:rerun-if-changed=src/ui/index.html");
+    println!("cargo:rerun-if-changed=ui/index.html");
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=schemas/job.schema.json");
-    println!("cargo:rerun-if-env-changed=MOADIM_BUILD_UI");
 
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     build::run(&manifest_dir);

--- a/src/build/ui.rs
+++ b/src/build/ui.rs
@@ -7,7 +7,11 @@ use std::path::{Path, PathBuf};
 pub fn build(manifest_dir: &str) {
     let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");
     let output = Path::new(&out_dir).join("index.html");
-    let prebuilt = Path::new(manifest_dir).join("ui/prebuilt.html");
+    // Prebuilt lives at the package root — NOT under `ui/`. `ui/` is a separate
+    // workspace member, so `cargo publish` strips everything beneath it; a
+    // prebuilt stored there never ships in the published crate. The root path
+    // is part of the `moadim` package and is included in the tarball.
+    let prebuilt = Path::new(manifest_dir).join("prebuilt.html");
     let ui_dir = Path::new(manifest_dir).join("ui");
 
     if ui_dir.exists() {
@@ -16,7 +20,8 @@ pub fn build(manifest_dir: &str) {
             let dist = ui_dir.join("dist");
             if dist.exists() {
                 inline_into_html(&dist, &output);
-                // Write alongside sources so cargo publish --allow-dirty picks it up.
+                // Write to the package root so CI can commit it and
+                // `cargo publish` ships it for the `cargo install` path.
                 std::fs::copy(&output, &prebuilt).ok();
                 return;
             }
@@ -205,5 +210,5 @@ fn base64_encode(bytes: &[u8]) -> String {
 const PLACEHOLDER_HTML: &str = r#"<!DOCTYPE html>
 <html lang="en">
 <head><meta charset="UTF-8"><title>MOADIM</title></head>
-<body><p>UI not built. Run: MOADIM_BUILD_UI=1 cargo build</p></body>
+<body><p>UI not built. Install trunk (`cargo install trunk`) and rebuild from source, or reinstall a release that bundles the prebuilt UI.</p></body>
 </html>"#;


### PR DESCRIPTION
Fixes #13.

## Problem

`cargo install moadim` (0.0.4) ships no UI — the running server serves the `PLACEHOLDER_HTML` fallback:

> UI not built. Run: MOADIM_BUILD_UI=1 cargo build

## Root cause

The prebuilt UI was written to **`ui/prebuilt.html`**, but `ui/` is a **separate workspace member** (`members = ["ui"]`). `cargo publish` strips every file under a nested package dir from the `moadim` tarball — verified with `cargo package --list` (no `ui/` entries). So CI generated + committed `ui/prebuilt.html`, but it never reached the published crate. At install time `build.rs` found neither `ui/` sources nor the prebuilt → placeholder.

Secondary: the placeholder told users to run `MOADIM_BUILD_UI=1 cargo build`, but that env var is **never read** — `build.rs` only declared a `rerun-if-env-changed` for it.

## Fix

- **`src/build/ui.rs`** — store/read the prebuilt at the **package root** (`prebuilt.html`) instead of `ui/prebuilt.html`, so `cargo publish` includes it.
- **`.github/workflows/publish.yml`** — generate / verify / commit `prebuilt.html` at root, plus a new guard that fails the publish if `cargo package --list` does not contain `prebuilt.html`.
- **`src/build/ui.rs`** — correct the placeholder message (trunk / bundled release) since `MOADIM_BUILD_UI` does nothing.
- **`build.rs`** — drop the dead `MOADIM_BUILD_UI` rerun trigger; fix the stale `src/ui/index.html` rerun path (sources are at `ui/index.html`).

## Verification

- `cargo check` compiles.
- `cargo package --list` includes a root `prebuilt.html` (confirmed by creating one and listing) — it did **not** include `ui/prebuilt.html`.

The new CI guard means a future regression of this exact kind fails the publish instead of silently shipping a UI-less crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
