### PR TITLE
fix: execute managed cron jobs on schedule and on trigger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,8 +180,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -1100,6 +1102,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "chrono",
  "console_log",
  "cron",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ web-sys = { version = "0.3", features = ["console"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 anyhow = "1"
 axum = "0.8"
+chrono = "0.4"
 cron = "0.12"
 dirs = "5"
 toml = "0.8"

--- a/src/cron_jobs.rs
+++ b/src/cron_jobs.rs
@@ -310,7 +310,9 @@ pub async fn trigger(
     State(store): State<CronStore>,
     Path(id): Path<String>,
 ) -> Result<Json<CronJob>, AppError> {
-    Ok(Json(svc_trigger(&store, &id)?))
+    let job = svc_trigger(&store, &id)?;
+    tokio::spawn(crate::runner::run_job(job.clone()));
+    Ok(Json(job))
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,8 @@ mod paths;
 #[cfg(not(target_arch = "wasm32"))]
 mod routes;
 #[cfg(not(target_arch = "wasm32"))]
+mod runner;
+#[cfg(not(target_arch = "wasm32"))]
 mod storage;
 #[cfg(not(target_arch = "wasm32"))]
 mod system_cron;

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -30,3 +30,17 @@ pub fn job_local_toml_path(id: &str) -> PathBuf {
 pub fn job_gitignore_path(id: &str) -> PathBuf {
     job_dir(id).join(".gitignore")
 }
+
+/// Returns the path to `{jobs_dir}/{id}/job.log`.
+pub fn job_log_path(id: &str) -> PathBuf {
+    job_dir(id).join("job.log")
+}
+
+/// Returns the path to `~/.config/moadim/handlers/`.
+pub fn handlers_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".config")
+        .join("moadim")
+        .join("handlers")
+}

--- a/src/routes/http.rs
+++ b/src/routes/http.rs
@@ -79,6 +79,8 @@ pub async fn run(store: CronStore) -> anyhow::Result<()> {
         .layer(middleware::from_fn(middlewares::logger::logger))
         .with_state(app_state);
 
+    crate::runner::spawn_scheduler(store.clone());
+
     let addr = "127.0.0.1:5784";
     let listener = tokio::net::TcpListener::bind(addr).await?;
     crate::banner::print(addr);

--- a/src/routes/mcp.rs
+++ b/src/routes/mcp.rs
@@ -178,14 +178,17 @@ impl MoadimMcp {
         )
     }
 
-    /// Manually trigger a cron job immediately, recording the trigger time.
-    #[tool(description = "Manually trigger a cron job outside its schedule, recording last_triggered_at")]
+    /// Manually trigger a cron job immediately, running its handler and recording the trigger time.
+    #[tool(description = "Manually trigger a cron job outside its schedule: runs its handler now and records last_triggered_at")]
     fn trigger_cron_job(
         &self,
         Parameters(IdInput { id }): Parameters<IdInput>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         Ok(match cron_jobs::svc_trigger(&self.store, &id) {
-            Ok(job) => ok(job),
+            Ok(job) => {
+                tokio::spawn(crate::runner::run_job(job.clone()));
+                ok(job)
+            }
             Err(e) => err(e),
         })
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,0 +1,274 @@
+//! Execution engine for managed cron jobs.
+//!
+//! The HTTP/MCP layers only persist job declarations; this module is what
+//! actually runs them. [`spawn_scheduler`] launches a background task that
+//! evaluates every enabled managed job's cron expression against the local
+//! clock and invokes [`run_job`] when a schedule fires. [`run_job`] resolves
+//! the job's handler to an executable under `~/.config/moadim/handlers/`,
+//! passes job metadata as `MOADIM_*` environment variables, runs it, and
+//! appends a start/finish record to the job's `job.log`.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::time::{Duration, Instant};
+
+use chrono::{Local, SecondsFormat};
+use cron::Schedule;
+
+use crate::cron_jobs::{CronJob, CronStore};
+use crate::paths::{handlers_dir, job_log_path};
+
+/// How often the scheduler wakes to check for due jobs.
+const TICK: Duration = Duration::from_secs(1);
+
+/// Source value identifying jobs this server owns and is responsible for running.
+const MANAGED_SOURCE: &str = "managed";
+
+/// Spawn the background scheduler task.
+///
+/// On every [`TICK`] it loads the current set of enabled, managed jobs from
+/// `store` and runs any whose cron schedule has a fire time in the interval
+/// since the previous tick. Each run is dispatched on its own task so a
+/// long-running handler never blocks the scheduler or other jobs.
+pub fn spawn_scheduler(store: CronStore) {
+    tokio::spawn(async move {
+        // Anchor the first window at "now" so jobs created before startup do
+        // not all fire immediately on boot.
+        let mut last = Local::now();
+        loop {
+            tokio::time::sleep(TICK).await;
+            let now = Local::now();
+
+            let due: Vec<CronJob> = {
+                let lock = store.lock().unwrap();
+                lock.values()
+                    .filter(|j| j.enabled && j.source == MANAGED_SOURCE)
+                    .filter(|j| match Schedule::from_str(&j.schedule) {
+                        // Fire if the next scheduled time strictly after `last`
+                        // falls at or before `now` (i.e. inside this window).
+                        Ok(sched) => sched.after(&last).next().is_some_and(|t| t <= now),
+                        Err(_) => false,
+                    })
+                    .cloned()
+                    .collect()
+            };
+
+            for job in due {
+                tokio::spawn(run_job(job));
+            }
+
+            last = now;
+        }
+    });
+}
+
+/// Run a single job's handler to completion, logging start and finish.
+///
+/// Resolves the handler name to an executable under [`handlers_dir`], injects
+/// `MOADIM_*` environment variables derived from the job's id, handler,
+/// schedule, and metadata, then executes it. A start line and a finish line
+/// (with status and elapsed seconds) are appended to the job's `job.log`.
+/// Missing handlers and spawn failures are recorded in the log rather than
+/// propagated, since this runs detached from any request.
+pub async fn run_job(job: CronJob) {
+    append_log(&job.id, &format!("[{}] run started", job.handler));
+
+    let handler_path = match resolve_handler(&job.handler) {
+        Some(p) => p,
+        None => {
+            append_log(
+                &job.id,
+                &format!(
+                    "[{}] run failed: handler not found in {}",
+                    job.handler,
+                    handlers_dir().display()
+                ),
+            );
+            return;
+        }
+    };
+
+    let mut cmd = tokio::process::Command::new(&handler_path);
+    cmd.env("MOADIM_JOB_ID", &job.id)
+        .env("MOADIM_HANDLER", &job.handler)
+        .env("MOADIM_SCHEDULE", &job.schedule);
+    for (key, value) in metadata_env(&job.metadata) {
+        cmd.env(key, value);
+    }
+
+    let started = Instant::now();
+    let result = cmd.output().await;
+    let elapsed = started.elapsed().as_secs_f64();
+
+    match result {
+        Ok(output) if output.status.success() => {
+            append_log(
+                &job.id,
+                &format!("[{}] run finished OK ({:.1}s)", job.handler, elapsed),
+            );
+        }
+        Ok(output) => {
+            append_log(
+                &job.id,
+                &format!(
+                    "[{}] run finished with status {} ({:.1}s)",
+                    job.handler, output.status, elapsed
+                ),
+            );
+        }
+        Err(e) => {
+            append_log(
+                &job.id,
+                &format!("[{}] run failed to spawn: {} ({:.1}s)", job.handler, e, elapsed),
+            );
+        }
+    }
+}
+
+/// Resolve a handler identifier to an executable path under [`handlers_dir`].
+///
+/// Matches an exact filename first (e.g. `handler = "send-report"` →
+/// `handlers/send-report`), then any file whose stem matches the identifier
+/// (e.g. `handlers/send-report.sh`). Returns `None` if nothing matches.
+fn resolve_handler(handler: &str) -> Option<PathBuf> {
+    let dir = handlers_dir();
+
+    let exact = dir.join(handler);
+    if exact.is_file() {
+        return Some(exact);
+    }
+
+    let entries = std::fs::read_dir(&dir).ok()?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_file() && path.file_stem().and_then(|s| s.to_str()) == Some(handler) {
+            return Some(path);
+        }
+    }
+    None
+}
+
+/// Build `MOADIM_*` environment variables from a job's JSON metadata.
+///
+/// Each scalar value in a metadata object becomes `MOADIM_{UPPERCASED_KEY}`.
+/// Non-scalar values (arrays, nested objects) and non-object metadata are
+/// skipped. Keys are sorted for deterministic ordering.
+fn metadata_env(metadata: &serde_json::Value) -> BTreeMap<String, String> {
+    let mut env = BTreeMap::new();
+    if let serde_json::Value::Object(map) = metadata {
+        for (key, value) in map {
+            let rendered = match value {
+                serde_json::Value::String(s) => s.clone(),
+                serde_json::Value::Number(n) => n.to_string(),
+                serde_json::Value::Bool(b) => b.to_string(),
+                _ => continue,
+            };
+            env.insert(format!("MOADIM_{}", key.to_uppercase()), rendered);
+        }
+    }
+    env
+}
+
+/// Append a timestamped line to job `id`'s `job.log`, creating it if needed.
+///
+/// Errors are intentionally ignored: logging must never interrupt job
+/// execution, and the job directory may legitimately not exist yet.
+fn append_log(id: &str, message: &str) {
+    use std::io::Write;
+
+    let stamp = Local::now().to_rfc3339_opts(SecondsFormat::Secs, false);
+    let line = format!("{stamp} {message}\n");
+
+    let path = job_log_path(id);
+    if let Ok(mut file) = std::fs::OpenOptions::new().create(true).append(true).open(&path) {
+        let _ = file.write_all(line.as_bytes());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_env_renders_scalars_and_skips_complex() {
+        let meta = serde_json::json!({
+            "recipient": "team@example.com",
+            "retries": 3,
+            "active": true,
+            "tags": ["a", "b"],
+            "nested": {"k": "v"}
+        });
+        let env = metadata_env(&meta);
+        assert_eq!(env.get("MOADIM_RECIPIENT").map(String::as_str), Some("team@example.com"));
+        assert_eq!(env.get("MOADIM_RETRIES").map(String::as_str), Some("3"));
+        assert_eq!(env.get("MOADIM_ACTIVE").map(String::as_str), Some("true"));
+        assert!(!env.contains_key("MOADIM_TAGS"));
+        assert!(!env.contains_key("MOADIM_NESTED"));
+    }
+
+    #[test]
+    fn metadata_env_empty_for_non_object() {
+        assert!(metadata_env(&serde_json::Value::Null).is_empty());
+    }
+
+    #[test]
+    fn resolve_handler_missing_is_none() {
+        assert!(resolve_handler("definitely-not-a-real-handler-xyz").is_none());
+    }
+
+    /// End-to-end: `run_job` resolves the handler, passes `MOADIM_*` env, runs
+    /// the process, and appends a success line to `job.log`. Drives a temp HOME
+    /// so it touches no real config. Unix-only (uses a shell handler).
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn run_job_executes_handler_with_env_and_logs() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let base = std::env::temp_dir().join(format!("moadim-runtest-{}", std::process::id()));
+        let handlers = base.join(".config/moadim/handlers");
+        std::fs::create_dir_all(&handlers).unwrap();
+        // Pre-create the job dir so job.log has somewhere to land.
+        std::fs::create_dir_all(base.join(".config/moadim/jobs/job-1")).unwrap();
+
+        let marker = base.join("marker.out");
+        let handler = handlers.join("marker");
+        std::fs::write(
+            &handler,
+            format!(
+                "#!/bin/sh\necho \"who=$MOADIM_WHO id=$MOADIM_JOB_ID\" > {}\n",
+                marker.display()
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&handler, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        // SAFETY: single-threaded async test; no other task reads HOME concurrently.
+        unsafe {
+            std::env::set_var("HOME", &base);
+        }
+
+        let job = CronJob {
+            id: "job-1".to_string(),
+            schedule: "0 * * * * *".to_string(),
+            handler: "marker".to_string(),
+            metadata: serde_json::json!({ "who": "scheduler" }),
+            enabled: true,
+            source: MANAGED_SOURCE.to_string(),
+            created_at: 0,
+            updated_at: 0,
+            last_triggered_at: None,
+        };
+        run_job(job).await;
+
+        let out = std::fs::read_to_string(&marker).expect("handler should have written marker");
+        assert!(out.contains("who=scheduler"), "MOADIM_WHO not passed: {out}");
+        assert!(out.contains("id=job-1"), "MOADIM_JOB_ID not passed: {out}");
+
+        let log = std::fs::read_to_string(base.join(".config/moadim/jobs/job-1/job.log")).unwrap();
+        assert!(log.contains("run started"), "missing start line: {log}");
+        assert!(log.contains("run finished OK"), "missing finish line: {log}");
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+}


### PR DESCRIPTION
Fixes #17.

## Problem

Managed cron jobs (`~/.config/moadim/jobs/`) were persisted and served over REST/MCP/UI, but **nothing ever ran them**. There was no scheduler loop, no handler execution, no `MOADIM_*` env injection, and no `job.log` writes. `POST /cron-jobs/{id}/trigger` only stamped `last_triggered_at`. The only jobs that actually fired were pre-existing OS-crontab lines, read back via `/system-cron-jobs`. The README documents all of the missing behavior as if it existed.

## Change

New `src/runner.rs`:

- **`spawn_scheduler(store)`** — background task that wakes every second and runs any **enabled, managed** job whose cron schedule has a fire time in the elapsed window. Evaluated against the **local** clock to match OS-cron semantics and user intent. Each run is dispatched on its own task, so a long-running handler never blocks the scheduler or other jobs.
- **`run_job(job)`** — resolves the handler name to an executable under `~/.config/moadim/handlers/` (exact filename first, then by file stem so `send-report` → `send-report.sh`), injects `MOADIM_JOB_ID` / `MOADIM_HANDLER` / `MOADIM_SCHEDULE` plus `MOADIM_*` vars from scalar metadata, executes it, and appends `run started` / `run finished OK (1.2s)` (or failure detail) to `jobs/{id}/job.log`.

Wiring:
- `http::run` now calls `spawn_scheduler` before serving.
- REST and MCP trigger paths execute the handler (via `run_job`) in addition to recording `last_triggered_at`. Trigger tool/description updated accordingly.

Deps/paths:
- Adds `paths::handlers_dir` and `paths::job_log_path`.
- Adds `chrono` for local-time schedule evaluation and RFC3339 log stamps.

## Tests

- Unit: `MOADIM_*` env rendering (scalars in, arrays/objects skipped), handler resolution miss.
- End-to-end (`#[tokio::test]`, temp HOME): `run_job` resolves a shell handler, the process observes `MOADIM_WHO` / `MOADIM_JOB_ID`, and `job.log` records both the start line and `run finished OK`.

`cargo build`, `cargo test` (20 passed) green. New code is `cargo clippy`-clean; the 6 pre-existing clippy errors in `src/build/` are unrelated to this change (present on `main`).

## Notes / follow-ups

- Schedule is evaluated in local time. If UTC or a per-job timezone is preferred, that can be a follow-up (e.g. a `timezone` metadata key).
- Scheduler state (last-tick) is in memory: a fire missed while the server is down is not backfilled — matching typical cron behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)