### PR TITLE
feat: add docs link to startup print

### DIFF
--- a/src/utils/startup_print.rs
+++ b/src/utils/startup_print.rs
@@ -6,6 +6,7 @@ pub fn print(addr: &str) {
     println!("  REST  http://{addr}/");
     println!("  MCP   http://{addr}/mcp");
     println!("  UI    http://{addr}/ui");
+    println!("  Docs  http://{addr}/docs");
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Adds `Docs  http://{addr}/docs` line to startup print, surfacing the Swagger UI alongside REST/MCP/UI links

## Test plan
- [ ] Run `cargo run`, verify startup output includes the docs line
- [ ] Visit `http://localhost:5784/docs` and confirm Swagger UI loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)