### PR TITLE
chore: bump moadim version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["ui"]
 
 [package]
 name = "moadim"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Moadim.io MCP/REST server for managing cron jobs"
 license = "MIT"


### PR DESCRIPTION
Bump version 0.1.0 → 0.2.0 for release. Adds features since v0.1.0 (routines, logs page, OpenAPI) plus fixes. Tag v0.2.0 will be pushed after merge to trigger the crates.io publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)