### PR TITLE
docs: add moadim MCP at user scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,10 @@ The server exposes an MCP endpoint at `http://localhost:5784/mcp`. Connect any M
 
 ### Claude Code
 
+Add moadim at **user scope** so it's available across all your projects. moadim is a global daemon (one local server, one crontab) — there's no per-project state, so project scope would only force you to re-add it in every repo.
+
 ```sh
-claude mcp add --transport http moadim http://localhost:5784/mcp
+claude mcp add --scope user --transport http moadim http://localhost:5784/mcp
 ```
 
 ### Any MCP client


### PR DESCRIPTION
## What

Update README MCP usage to register moadim at **user scope** instead of the default (project) scope.

```sh
claude mcp add --scope user --transport http moadim http://localhost:5784/mcp
```

## Why

moadim is a global daemon — one local server, one crontab, no per-project state. Project scope would only force re-adding it in every repo. User scope makes it available across all projects once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)