### PR TITLE
style: apply cargo fmt to unblock the pre-push hook

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -182,18 +182,16 @@ fn http_request(method: &str, path: &str) -> std::io::Result<u16> {
     // A failed read after a clean shutdown can still yield the status line we already received.
     let _ = stream.read_to_string(&mut resp);
     parse_status_code(&resp).ok_or_else(|| {
-        std::io::Error::new(std::io::ErrorKind::InvalidData, "no HTTP status line in response")
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "no HTTP status line in response",
+        )
     })
 }
 
 /// Extract the numeric status code from an HTTP response's status line (e.g. `HTTP/1.1 200 OK`).
 fn parse_status_code(resp: &str) -> Option<u16> {
-    resp.lines()
-        .next()?
-        .split_whitespace()
-        .nth(1)?
-        .parse()
-        .ok()
+    resp.lines().next()?.split_whitespace().nth(1)?.parse().ok()
 }
 
 /// Spawn a detached copy of this binary running the server in the foreground, returning its PID.

--- a/src/cli_tests.rs
+++ b/src/cli_tests.rs
@@ -50,7 +50,10 @@ fn unknown_arg_falls_back_to_help() {
 #[test]
 fn parses_http_status_code() {
     assert_eq!(parse_status_code("HTTP/1.1 200 OK\r\n\r\n"), Some(200));
-    assert_eq!(parse_status_code("HTTP/1.1 503 Service Unavailable"), Some(503));
+    assert_eq!(
+        parse_status_code("HTTP/1.1 503 Service Unavailable"),
+        Some(503)
+    );
 }
 
 #[test]

--- a/src/routes/http.rs
+++ b/src/routes/http.rs
@@ -5,7 +5,6 @@ use crate::cron_jobs::{self, new_registry, AppState, CronStore, ShutdownSignal};
 use crate::middlewares;
 use crate::routines::{self, RoutineStore};
 use crate::utils::time::now_secs;
-use std::sync::Arc;
 use axum::{
     extract::State,
     middleware,
@@ -13,6 +12,7 @@ use axum::{
     Json, Router,
 };
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use utoipa_swagger_ui::SwaggerUi;
 
 /// Response body for `GET /health`.

--- a/src/routes/http_tests.rs
+++ b/src/routes/http_tests.rs
@@ -27,7 +27,12 @@ async fn build_app_serves_root() {
 async fn build_app_serves_agents() {
     let app = build_app(new_store(), crate::routines::new_store());
     let resp = app
-        .oneshot(Request::builder().uri("/agents").body(Body::empty()).unwrap())
+        .oneshot(
+            Request::builder()
+                .uri("/agents")
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);

--- a/src/routines/agents/mod.rs
+++ b/src/routines/agents/mod.rs
@@ -43,7 +43,10 @@ const DEFAULT_AGENT_CONFIGS: &[(&str, &str)] = &[
 
 /// Registry keys of the built-in agents, in declaration order.
 fn builtin_agent_names() -> Vec<String> {
-    DEFAULT_AGENT_CONFIGS.iter().map(|(n, _)| n.to_string()).collect()
+    DEFAULT_AGENT_CONFIGS
+        .iter()
+        .map(|(n, _)| n.to_string())
+        .collect()
 }
 
 /// Names of all agents the daemon can launch: the `<name>.toml` stems under

--- a/src/routines/handlers.rs
+++ b/src/routines/handlers.rs
@@ -11,7 +11,9 @@ use crate::error::AppError;
 use super::model::{
     CreateRoutineRequest, Routine, RoutineResponse, RoutineStore, UpdateRoutineRequest,
 };
-use super::service::{svc_create, svc_delete, svc_get, svc_list, svc_logs, svc_trigger, svc_update};
+use super::service::{
+    svc_create, svc_delete, svc_get, svc_list, svc_logs, svc_trigger, svc_update,
+};
 
 /// `POST /routines` — create a new routine.
 #[utoipa::path(post, path = "/routines",

--- a/src/routines/mod_tests.rs
+++ b/src/routines/mod_tests.rs
@@ -89,7 +89,11 @@ fn build_routine_command_contains_expected_pieces() {
     // bakes a PATH export so cron's minimal PATH does not hide tmux/claude
     assert!(cmd.contains("export PATH="));
     // stay well under cron's per-line length limit (~1000 chars) — a full inherited PATH blew past it
-    assert!(cmd.len() < 1000, "crontab line too long: {} chars", cmd.len());
+    assert!(
+        cmd.len() < 1000,
+        "crontab line too long: {} chars",
+        cmd.len()
+    );
     // prompt passed as a process argument via command substitution, no send-keys
     assert!(cmd.contains(r#""$(cat prompt.txt)""#));
     assert!(!cmd.contains("send-keys"));
@@ -145,7 +149,8 @@ fn ensure_default_agents_writes_parsable_configs() {
     assert!(setup.contains("disabledMcpjsonServers"));
 
     // codex default parses and passes the prompt file as an argument
-    let codex: AgentCommand = toml::from_str(&std::fs::read_to_string(dir.join("codex.toml")).unwrap()).unwrap();
+    let codex: AgentCommand =
+        toml::from_str(&std::fs::read_to_string(dir.join("codex.toml")).unwrap()).unwrap();
     assert_eq!(codex.command, "codex");
     assert!(codex.args.contains(&"{prompt_file}".to_string()));
 
@@ -181,7 +186,10 @@ fn available_agents_lists_sorted_toml_stems() {
     // non-toml files are ignored
     std::fs::write(dir.join("notes.txt"), "ignore me").unwrap();
 
-    assert_eq!(available_agents_in(&dir), vec!["alpha".to_string(), "zeta".to_string()]);
+    assert_eq!(
+        available_agents_in(&dir),
+        vec!["alpha".to_string(), "zeta".to_string()]
+    );
 
     let _ = std::fs::remove_dir_all(&dir);
 }
@@ -191,7 +199,10 @@ fn available_agents_falls_back_to_builtins_when_missing() {
     let dir = std::env::temp_dir().join("moadim-agents-missing-test");
     let _ = std::fs::remove_dir_all(&dir);
     // directory does not exist → built-in defaults
-    assert_eq!(available_agents_in(&dir), vec!["claude".to_string(), "codex".to_string()]);
+    assert_eq!(
+        available_agents_in(&dir),
+        vec!["claude".to_string(), "codex".to_string()]
+    );
 }
 
 #[test]

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -361,7 +361,11 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
                 match api_update(&id, &req).await {
                     Ok(r) => {
                         state.dispatch(RAction::Upsert(r));
-                        ok(if enabled { "Routine enabled" } else { "Routine disabled" });
+                        ok(if enabled {
+                            "Routine enabled"
+                        } else {
+                            "Routine disabled"
+                        });
                     }
                     Err(e) => toast.emit((format!("Toggle failed: {e}"), ToastKind::Err)),
                 }
@@ -499,7 +503,11 @@ pub fn routine_stats(props: &StatsProps) -> Html {
     let total = props.routines.len();
     let enabled = props.routines.iter().filter(|r| r.enabled).count();
     let disabled = total - enabled;
-    let unreg = props.routines.iter().filter(|r| !r.agent_registered).count();
+    let unreg = props
+        .routines
+        .iter()
+        .filter(|r| !r.agent_registered)
+        .count();
 
     html! {
         <div class="stats">
@@ -726,8 +734,18 @@ pub fn routine_form(props: &FormProps) -> Html {
     let editing = props.editing.clone();
     let is_edit = editing.is_some();
 
-    let title = use_state(|| editing.as_ref().map(|r| r.title.clone()).unwrap_or_default());
-    let schedule = use_state(|| editing.as_ref().map(|r| r.schedule.clone()).unwrap_or_default());
+    let title = use_state(|| {
+        editing
+            .as_ref()
+            .map(|r| r.title.clone())
+            .unwrap_or_default()
+    });
+    let schedule = use_state(|| {
+        editing
+            .as_ref()
+            .map(|r| r.schedule.clone())
+            .unwrap_or_default()
+    });
     let agent = use_state(|| {
         editing
             .as_ref()
@@ -736,7 +754,12 @@ pub fn routine_form(props: &FormProps) -> Html {
     });
     // Agent options fetched from `GET /agents`; seed with the built-in list so the select is never
     // empty before the request resolves or if it fails.
-    let agents = use_state(|| AVAILABLE_AGENTS.iter().map(|s| s.to_string()).collect::<Vec<_>>());
+    let agents = use_state(|| {
+        AVAILABLE_AGENTS
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>()
+    });
     {
         let agents = agents.clone();
         use_effect_with((), move |_| {
@@ -750,7 +773,12 @@ pub fn routine_form(props: &FormProps) -> Html {
             || ()
         });
     }
-    let prompt = use_state(|| editing.as_ref().map(|r| r.prompt.clone()).unwrap_or_default());
+    let prompt = use_state(|| {
+        editing
+            .as_ref()
+            .map(|r| r.prompt.clone())
+            .unwrap_or_default()
+    });
     let repos_raw = use_state(|| {
         editing
             .as_ref()


### PR DESCRIPTION
## Why

`.githooks/pre-push` runs, in order: test-file convention → `cargo fmt --check` → `cargo clippy` → 100% coverage. On `main`, **step 2 (`cargo fmt --check`) fails**, so the hook aborts before clippy/coverage ever run — every contributor's push is blocked by stale formatting.

This PR runs `cargo fmt` to bring the tree back into compliance.

## What

Pure whitespace/line-wrap reflow from `cargo fmt` — **no logic changes**. Touches `src/cli.rs`, `src/cli_tests.rs`, `src/routes/http*.rs`, `src/routines/{agents,handlers,mod_tests}`, and `ui/src/routines.rs`.

## Verification

```
cargo fmt --check          # clean
cargo test                 # 214 passed; 0 failed
cargo clippy --all-targets # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)