### PR TITLE
fix(routines): atomic, locked write of ~/.claude.json in claude setup

### DIFF
--- a/src/routines/agents/claude_code/setup.rs
+++ b/src/routines/agents/claude_code/setup.rs
@@ -18,5 +18,9 @@ args = ["--permission-mode", "auto", "{prompt}"]
 #   - hasTrustDialogAccepted: skip the "Do you trust this folder?" dialog.
 #   - disabledMcpjsonServers: skip the "New MCP server found" approval for any project-scoped
 #     servers claude would discover from ancestor .mcp.json files (e.g. ~/.mcp.json).
-setup = '''python3 -c 'import json,os,sys; home=os.path.expanduser("~"); p=home+"/.claude.json"; d=json.load(open(p)) if os.path.exists(p) else {}; wb=sys.argv[1]; e=d.setdefault("projects",{}).setdefault(wb,{}); e.update({"hasTrustDialogAccepted":True,"hasCompletedProjectOnboarding":True}); e.setdefault("projectOnboardingSeenCount",1); g=lambda f: list(json.load(open(f)).get("mcpServers",{}).keys()) if os.path.exists(f) else []; e["disabledMcpjsonServers"]=sorted(set(e.get("disabledMcpjsonServers",[]))|set(g(home+"/.mcp.json"))|set(g(wb+"/.mcp.json"))); json.dump(d,open(p,"w"))' "$WB"'''
+# The read-modify-write is serialized by an flock on ~/.claude.json.lock and committed via a
+# temp file + os.replace (atomic rename). ~/.claude.json is shared with the live claude process,
+# so a plain open("w") truncate-then-write could interleave with a concurrent writer and leave a
+# spliced, unparseable file; the atomic replace guarantees readers always see one complete JSON.
+setup = '''python3 -c 'import json,os,sys,tempfile,fcntl; home=os.path.expanduser("~"); p=home+"/.claude.json"; lf=open(p+".lock","w"); fcntl.flock(lf,fcntl.LOCK_EX); d=json.load(open(p)) if os.path.exists(p) else {}; wb=sys.argv[1]; e=d.setdefault("projects",{}).setdefault(wb,{}); e.update({"hasTrustDialogAccepted":True,"hasCompletedProjectOnboarding":True}); e.setdefault("projectOnboardingSeenCount",1); g=lambda f: list(json.load(open(f)).get("mcpServers",{}).keys()) if os.path.exists(f) else []; e["disabledMcpjsonServers"]=sorted(set(e.get("disabledMcpjsonServers",[]))|set(g(home+"/.mcp.json"))|set(g(wb+"/.mcp.json"))); fd,tmp=tempfile.mkstemp(dir=home,prefix=".claude.json.",suffix=".tmp"); os.write(fd,json.dumps(d).encode()); os.close(fd); os.replace(tmp,p); fcntl.flock(lf,fcntl.LOCK_UN)' "$WB"'''
 "#;


### PR DESCRIPTION
## Summary
Fixes #46 — routine setup corrupted `~/.claude.json` via non-atomic concurrent write.

The claude routine `setup` step read-modify-wrote the shared `~/.claude.json` with `json.dump(d, open(p,"w"))` — non-atomic, unlocked. `~/.claude.json` is rewritten continuously by the live claude process, so a concurrent writer could interleave with the truncate-then-write and leave a spliced, unparseable file (`Extra data` parse error; observed orphaned tail `s-access"}`).

## Changes
- `flock` on `~/.claude.json.lock` → serialize moadim's read-modify-writes (no lost updates between concurrent setups).
- temp file + `os.replace` (atomic rename) → readers never see a spliced file.

## Testing
20-way concurrent stress test: all 20 writes land, JSON stays valid, no leftover temp files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)