### PR TITLE
fix(build): remove unused MOADIM_BUILD_UI var so clippy/pre-push hook passes

### DIFF
--- a/src/build/ui.rs
+++ b/src/build/ui.rs
@@ -13,7 +13,6 @@ pub fn build(manifest_dir: &str) {
     // is part of the `moadim` package and is included in the tarball.
     let prebuilt = Path::new(manifest_dir).join("prebuilt.html");
     let ui_dir = Path::new(manifest_dir).join("ui");
-    let should_build = std::env::var("MOADIM_BUILD_UI").is_ok_and(|v| v == "1" || v == "true");
 
     if ui_dir.exists() {
         emit_rerun_triggers(&ui_dir);


### PR DESCRIPTION
## What

Removes the dead `should_build` binding in `src/build/ui.rs` that read the `MOADIM_BUILD_UI` env var but was never used.

```diff
     let ui_dir = Path::new(manifest_dir).join("ui");
-    let should_build = std::env::var("MOADIM_BUILD_UI").is_ok_and(|v| v == "1" || v == "true");

     if ui_dir.exists() {
```

## Why

The build script computed `should_build` but never referenced it — the trunk build is gated solely on `ui_dir.exists()`. An unused variable is a hard error under this crate's lint config (`[lints.rust]`/`[lints.clippy] all = "deny"` plus the pre-push hook's `cargo clippy`), so the build script failed to compile on current stable:

```
error: unused variable: `should_build`
  --> src/build/ui.rs:16:9
```

This caused `cargo clippy --all-targets -- -D warnings` to fail and blocked the `.githooks/pre-push` clippy step.

## Why removal (not wiring the var in)

Wiring `should_build` into the `if` condition would change behavior: the publish workflow's "Build UI" step runs a plain `cargo check` (no `MOADIM_BUILD_UI` set) and relies on `build.rs` running trunk to generate `prebuilt.html`. Gating on the unset env var would skip that build and fail the workflow's "Verify prebuilt UI was generated" step. The env-var gate was never actually applied (the variable was unused), so removing it is fully behavior-preserving while making clippy pass.

## Checks (local, current stable)

- `cargo fmt --check` → exit 0
- `cargo clippy --all-targets -- -D warnings` → exit 0 (previously failed to compile)
- `cargo test` → 214 passed; 0 failed
- `cargo build` → succeeds; `prebuilt.html` still regenerated as before
- pre-push hook (fmt + clippy + test-convention + 100% line coverage) → passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)