### PR TITLE
chore: add repository link to Cargo.toml metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ version = "0.5.0"
 edition = "2021"
 description = "Moadim.io MCP/REST server for managing cron jobs"
 license = "MIT"
+repository = "https://github.com/moadim-io/daemon"
+homepage = "https://github.com/moadim-io/daemon"
 
 [dependencies]
 anyhow = "1"


### PR DESCRIPTION
## What

Add `repository` and `homepage` fields to the `[package]` section of `Cargo.toml`, both pointing at `https://github.com/moadim-io/daemon`.

## Why

The `moadim` crate on crates.io has no `repository` or `homepage` metadata, so the crate page offers no link back to the source, issues, or changelog. This adds that path.

## Notes

- Metadata-only change; `cargo build` passes locally.

Closes #50