### PR TITLE
feat: add .gitignore for generated .pid and .log files in config dir

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -138,8 +138,19 @@ pub fn write_pid_file() -> anyhow::Result<()> {
     if let Some(dir) = path.parent() {
         std::fs::create_dir_all(dir)?;
     }
+    ensure_config_gitignore();
     std::fs::write(&path, std::process::id().to_string())?;
     Ok(())
+}
+
+/// Write a `.gitignore` into the config dir so generated runtime files (`*.pid`, `*.log`)
+/// stay out of version control when users track `~/.config/moadim` in a dotfiles repo.
+/// Best-effort: failure to write it is not fatal to starting the daemon.
+fn ensure_config_gitignore() {
+    let gitignore = crate::paths::config_gitignore_path();
+    if !gitignore.exists() {
+        let _ = std::fs::write(&gitignore, "*.pid\n*.log\n");
+    }
 }
 
 /// Remove the pid file. Best-effort: a missing file is not an error.

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -137,6 +137,12 @@ pub fn daemon_log_file() -> PathBuf {
     config_dir().join("daemon.log")
 }
 
+/// Returns the path to `~/.config/moadim/.gitignore`, used to keep generated runtime
+/// files (`*.pid`, `*.log`) out of version control when the config dir is tracked.
+pub fn config_gitignore_path() -> PathBuf {
+    config_dir().join(".gitignore")
+}
+
 // ─── Workbenches ─────────────────────────────────────────────────────────────
 
 /// Returns the path to `~/.moadim/`.

--- a/src/paths/mod_tests.rs
+++ b/src/paths/mod_tests.rs
@@ -154,3 +154,10 @@ fn workbenches_dir_under_moadim_home() {
     assert!(p.ends_with("workbenches"));
     assert_eq!(p.parent().unwrap(), moadim_home());
 }
+
+#[test]
+fn config_gitignore_path_in_config_dir() {
+    let p = config_gitignore_path();
+    assert_eq!(p.file_name().unwrap().to_str().unwrap(), ".gitignore");
+    assert_eq!(p.parent().unwrap(), config_dir());
+}


### PR DESCRIPTION
## What

On daemon startup (`write_pid_file`), write a `.gitignore` into `~/.config/moadim/` containing:

```gitignore
*.pid
*.log
```

…unless one already exists. Adds `paths::config_gitignore_path()` plus a covering test.

## Why

The daemon writes `moadim.pid` and `daemon.log` into `~/.config/moadim`. Those ephemeral runtime artifacts made the directory impractical to version-control, so users couldn't cleanly track `~/.config/moadim` in a dotfiles repo. Ignoring them lets the rest of the config dir be tracked.

This mirrors the existing per-job / per-routine `.gitignore` writing already in `storage.rs` and `routine_storage.rs`.

## Checks

- `cargo test` → 215 passed
- `cargo clippy --all-targets` → clean

Closes #52