### PR TITLE
feat: rename prompt sidecar from prompt.txt to prompt.md

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,9 @@ async fn run_server() -> anyhow::Result<()> {
     routines::ensure_default_agents();
     let store = storage::load_store();
     let routines = routine_storage::load_store();
+    // Rename any prompt.txt sidecars to prompt.md before rewriting run.sh scripts; otherwise the
+    // first cron trigger after upgrade would fail on the cp step.
+    routine_storage::migrate_prompt_files();
     // Re-sync routines to the crontab on startup; otherwise a block that went stale (e.g. emptied
     // by an earlier run before agent configs existed) would never be regenerated until the next
     // create/update/delete, leaving scheduled routines silently un-fired.

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -78,9 +78,9 @@ pub fn routine_toml_path(id: &str) -> PathBuf {
     routine_dir(id).join("routine.toml")
 }
 
-/// Returns the path to `{routines_dir}/{id}/prompt.txt`.
+/// Returns the path to `{routines_dir}/{id}/prompt.md`.
 pub fn routine_prompt_path(id: &str) -> PathBuf {
-    routine_dir(id).join("prompt.txt")
+    routine_dir(id).join("prompt.md")
 }
 
 /// Returns the path to `{routines_dir}/{id}/.gitignore`.

--- a/src/paths/mod_tests.rs
+++ b/src/paths/mod_tests.rs
@@ -106,7 +106,7 @@ fn routine_toml_path_filename() {
 #[test]
 fn routine_prompt_path_filename() {
     let p = routine_prompt_path("abc");
-    assert_eq!(p.file_name().unwrap().to_str().unwrap(), "prompt.txt");
+    assert_eq!(p.file_name().unwrap().to_str().unwrap(), "prompt.md");
     assert!(p.to_string_lossy().contains("abc"));
 }
 

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -1,4 +1,4 @@
-//! TOML-backed persistence for routines, plus the composed `prompt.txt` sidecar file.
+//! TOML-backed persistence for routines, plus the composed `prompt.md` sidecar file.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -58,7 +58,7 @@ fn load_routine_from_dir(id: &str) -> Option<Routine> {
     })
 }
 
-/// Write `routine` to disk: `routine.toml`, the composed `prompt.txt`, and `.gitignore` if absent.
+/// Write `routine` to disk: `routine.toml`, the composed `prompt.md`, and `.gitignore` if absent.
 pub fn write_routine(routine: &Routine) -> std::io::Result<()> {
     let dir = routine_dir(&routine.id);
     std::fs::create_dir_all(&dir)?;
@@ -92,6 +92,31 @@ pub fn remove_routine_dir(id: &str) -> std::io::Result<()> {
         std::fs::remove_dir_all(dir)?;
     }
     Ok(())
+}
+
+/// Rename any `prompt.txt` sidecar to `prompt.md` in every routine directory.
+///
+/// Call once at startup before syncing the crontab. Routines written by older daemon versions have
+/// `prompt.txt` on disk; the new `run.sh` references `prompt.md`, so the first cron trigger would
+/// fail the `cp` step if this migration has not run.
+pub fn migrate_prompt_files() {
+    let dir = routines_dir();
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        let old = entry.path().join("prompt.txt");
+        let new = entry.path().join("prompt.md");
+        if old.exists() && !new.exists() {
+            if let Err(e) = std::fs::rename(&old, &new) {
+                log::warn!("migrate_prompt_files: failed to rename {:?}: {e}", old);
+            }
+        }
+    }
 }
 
 /// Scan `~/.config/moadim/routines/` and load all valid routines into a new store.

--- a/src/routines/command.rs
+++ b/src/routines/command.rs
@@ -29,7 +29,7 @@ pub(crate) fn slugify(title: &str) -> String {
     }
 }
 
-/// Compose the `prompt.txt` body: a repositories-as-context preamble followed by the prompt.
+/// Compose the `prompt.md` body: a repositories-as-context preamble followed by the prompt.
 pub(crate) fn compose_prompt(routine: &Routine) -> String {
     let mut s = String::from("# Workbench\n");
     s.push_str(
@@ -49,12 +49,12 @@ pub(crate) fn compose_prompt(routine: &Routine) -> String {
 
 /// Substitute `{workbench}`, `{prompt_file}`, and `{prompt}` placeholders in `s`.
 ///
-/// `{prompt}` expands to a shell command substitution that reads `prompt.txt` from the agent's
+/// `{prompt}` expands to a shell command substitution that reads `prompt.md` from the agent's
 /// cwd (the workbench), so the full prompt is passed as a single argument to the agent process.
 pub(crate) fn substitute(s: &str, workbench: &str, prompt_file: &str) -> String {
     s.replace("{workbench}", workbench)
         .replace("{prompt_file}", prompt_file)
-        .replace("{prompt}", r#""$(cat prompt.txt)""#)
+        .replace("{prompt}", r#""$(cat prompt.md)""#)
 }
 
 /// Return the first directory on the daemon's `PATH` that contains an executable named `bin`.
@@ -115,7 +115,7 @@ pub(crate) fn shell_quote(s: &str) -> String {
 
 /// Build the single-line shell command that creates a workbench and launches the agent in tmux.
 ///
-/// The agent's cwd is the workbench (via `tmux -c`), so `{prompt_file}` resolves to `prompt.txt`,
+/// The agent's cwd is the workbench (via `tmux -c`), so `{prompt_file}` resolves to `prompt.md`,
 /// `{workbench}` to `.`, and `{prompt}` to the prompt's contents passed as one argument. The prompt
 /// reaches the agent as a process argument (not keystrokes), so there is no readiness race. The
 /// command is `;`-joined (no newlines) so it fits one crontab line.
@@ -125,7 +125,7 @@ pub(crate) fn build_routine_command(routine: &Routine, agent: &AgentCommand) -> 
         .to_string_lossy()
         .into_owned();
 
-    let prompt_file_ref = "prompt.txt";
+    let prompt_file_ref = "prompt.md";
     let workbench_ref = ".";
 
     let mut invocation = vec![agent.command.clone()];
@@ -144,7 +144,7 @@ pub(crate) fn build_routine_command(routine: &Routine, agent: &AgentCommand) -> 
         r#"WB="$HOME/.moadim/workbenches/$SLUG-$TS""#.to_string(),
         r#"SESS="moadim-$SLUG-$TS""#.to_string(),
         r#"mkdir -p "$WB""#.to_string(),
-        format!(r#"cp {} "$WB/prompt.txt""#, shell_quote(&prompt_path)),
+        format!(r#"cp {} "$WB/prompt.md""#, shell_quote(&prompt_path)),
     ];
     if let Some(setup) = &agent.setup {
         // Inserted verbatim so the agent author controls quoting; `$WB`/`$SESS` are in scope.

--- a/src/routines/mod_tests.rs
+++ b/src/routines/mod_tests.rs
@@ -58,12 +58,12 @@ fn compose_prompt_repo_without_branch() {
 #[test]
 fn substitute_replaces_placeholders() {
     assert_eq!(
-        substitute("read {prompt_file} in {workbench}", ".", "prompt.txt"),
-        "read prompt.txt in ."
+        substitute("read {prompt_file} in {workbench}", ".", "prompt.md"),
+        "read prompt.md in ."
     );
     assert_eq!(
-        substitute("claude {prompt}", ".", "prompt.txt"),
-        r#"claude "$(cat prompt.txt)""#
+        substitute("claude {prompt}", ".", "prompt.md"),
+        r#"claude "$(cat prompt.md)""#
     );
 }
 
@@ -95,7 +95,7 @@ fn build_routine_command_contains_expected_pieces() {
         cmd.len()
     );
     // prompt passed as a process argument via command substitution, no send-keys
-    assert!(cmd.contains(r#""$(cat prompt.txt)""#));
+    assert!(cmd.contains(r#""$(cat prompt.md)""#));
     assert!(!cmd.contains("send-keys"));
     assert!(!cmd.contains("capture-pane"));
     assert!(cmd.contains("tmux pipe-pane"));
@@ -113,7 +113,7 @@ fn build_routine_command_substitutes_arg_placeholders() {
         setup: None,
     };
     let cmd = build_routine_command(&r, &agent);
-    assert!(cmd.contains("'codex exec prompt.txt'"));
+    assert!(cmd.contains("'codex exec prompt.md'"));
 }
 
 #[test]

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -37,7 +37,7 @@ pub fn svc_get(store: &RoutineStore, id: &str) -> Result<RoutineResponse, AppErr
     Ok(RoutineResponse::from_routine(routine))
 }
 
-/// Validate `req`, assign a UUID, persist (routine.toml + prompt.txt), and sync the crontab.
+/// Validate `req`, assign a UUID, persist (routine.toml + prompt.md), and sync the crontab.
 pub fn svc_create(
     store: &RoutineStore,
     req: CreateRoutineRequest,


### PR DESCRIPTION
Closes #56

## Summary

- `routine_prompt_path()` returns `prompt.md` instead of `prompt.txt`
- `{prompt}` placeholder expands to `"$(cat prompt.md)"` in agent launch commands
- `{prompt_file}` resolves to `prompt.md`
- Workbench `cp` target updated to `$WB/prompt.md`
- `migrate_prompt_files()` added: scans all routine dirs at daemon startup and renames any existing `prompt.txt` → `prompt.md` before the crontab sync rewrites `run.sh`

## Migration

Existing installations have `prompt.txt` on disk. Without migration the first cron-triggered run after upgrade would fail at the `cp` step (new `run.sh` references `prompt.md`, file doesn't exist yet).

`migrate_prompt_files()` is called in `run_server()` before `sync_routines_to_crontab()` — one-shot, skips dirs where `prompt.md` already exists.

## Test plan

- [ ] All 215 existing tests pass (`cargo test`)
- [ ] `routine_prompt_path_filename` asserts `prompt.md`
- [ ] `substitute_replaces_placeholders` asserts `prompt.md` in both `{prompt}` and `{prompt_file}` expansions
- [ ] `build_routine_command_contains_expected_pieces` asserts `"$(cat prompt.md)"` in command
- [ ] `build_routine_command_substitutes_arg_placeholders` asserts `codex exec prompt.md`
- [ ] Manual: install on a machine with existing `prompt.txt` files, restart daemon, verify rename and successful cron fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)