### PR TITLE
style: apply cargo fmt to satisfy pre-push hook

### DIFF
--- a/src/routines/command.rs
+++ b/src/routines/command.rs
@@ -121,9 +121,7 @@ pub(crate) fn shell_quote(s: &str) -> String {
 /// command is `;`-joined (no newlines) so it fits one crontab line.
 pub(crate) fn build_routine_command(routine: &Routine, agent: &AgentCommand) -> String {
     let slug = slugify(&routine.title);
-    let prompt_path = routine_prompt_path(&slug)
-        .to_string_lossy()
-        .into_owned();
+    let prompt_path = routine_prompt_path(&slug).to_string_lossy().into_owned();
 
     let prompt_file_ref = "prompt.md";
     let workbench_ref = ".";

--- a/src/routines/model.rs
+++ b/src/routines/model.rs
@@ -6,8 +6,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use crate::paths::{agent_toml_path, routine_toml_path};
 use super::command::slugify;
+use crate::paths::{agent_toml_path, routine_toml_path};
 
 /// A git repository made available to a routine's agent as prompt context (not cloned by moadim).
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, utoipa::ToSchema)]

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -91,7 +91,11 @@ pub fn svc_update(
     // Check slug conflict before mutating.
     if let Some(ref new_title) = req.title {
         let new_slug = slugify(new_title);
-        if new_slug != old_slug && lock.values().any(|r| r.id != id && slugify(&r.title) == new_slug) {
+        if new_slug != old_slug
+            && lock
+                .values()
+                .any(|r| r.id != id && slugify(&r.title) == new_slug)
+        {
             return Err(AppError::Conflict(format!(
                 "a routine with the name \"{new_slug}\" already exists"
             )));

--- a/src/sync/routines_sync_tests.rs
+++ b/src/sync/routines_sync_tests.rs
@@ -69,7 +69,11 @@ fn build_block_skips_routine_with_missing_agent_config() {
     let store = new_store();
     store.lock().unwrap().insert(
         "m".into(),
-        make_routine("m", "Missing Agent Sync Routine", "definitely-missing-agent-zzz"),
+        make_routine(
+            "m",
+            "Missing Agent Sync Routine",
+            "definitely-missing-agent-zzz",
+        ),
     );
     let block = build_block(&store);
     // Missing agent config → routine skipped, block stays empty.


### PR DESCRIPTION
## Why

The repo's pre-push hook (`.githooks/pre-push`) gates on `cargo fmt --check` before clippy and coverage. On current stable (`rustc 1.94.1`), four checked-in source files had drifted from rustfmt formatting, so the hook fails at the **format** stage — blocking pushes and giving contributors a red gate that has nothing to do with their change.

## What

Ran `cargo fmt`. Whitespace/line-wrap only, no behavior change:

- `src/routines/command.rs` — collapse a chained call onto one line
- `src/routines/model.rs` — `use` ordering
- `src/routines/service.rs` — wrap a long `if` condition
- `src/sync/routines_sync_tests.rs` — wrap a long call

## Verify

```
cargo fmt --check   # now clean
cargo clippy        # clean
```

Generated `prebuilt.html` was intentionally left untouched so this PR stays format-only.