### PR TITLE
fix: move openapi inline test to sibling _tests.rs to satisfy pre-push convention

### DIFF
--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -56,19 +56,5 @@ impl ApiDoc {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::ApiDoc;
-
-    /// Keep the committed `apis/openapi.json` in sync with the path decorators. On drift this
-    /// rewrites the file (so `cargo test` regenerates it) and then fails so the change is committed.
-    #[test]
-    fn committed_spec_is_current() {
-        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/apis/openapi.json");
-        let generated = ApiDoc::to_json();
-        let committed = std::fs::read_to_string(path).unwrap_or_default();
-        if committed != generated {
-            std::fs::write(path, &generated).unwrap();
-            panic!("apis/openapi.json was stale — regenerated; re-run tests and commit the change");
-        }
-    }
-}
+#[path = "openapi_tests.rs"]
+mod openapi_tests;

--- a/src/openapi_tests.rs
+++ b/src/openapi_tests.rs
@@ -1,0 +1,16 @@
+#![allow(clippy::missing_docs_in_private_items)]
+
+use super::ApiDoc;
+
+/// Keep the committed `apis/openapi.json` in sync with the path decorators. On drift this
+/// rewrites the file (so `cargo test` regenerates it) and then fails so the change is committed.
+#[test]
+fn committed_spec_is_current() {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/apis/openapi.json");
+    let generated = ApiDoc::to_json();
+    let committed = std::fs::read_to_string(path).unwrap_or_default();
+    if committed != generated {
+        std::fs::write(path, &generated).unwrap();
+        panic!("apis/openapi.json was stale — regenerated; re-run tests and commit the change");
+    }
+}


### PR DESCRIPTION
## Why

`.githooks/pre-push` step 1 enforces a **test-file convention**: tests must live in `*_tests.rs` sibling files, not inline `#[cfg(test)] mod foo { ... }` blocks. `src/openapi.rs` was the **only** file violating this — its inline `mod tests` block trips the check and fails the hook on every push, blocking contributors before fmt/clippy/coverage even run.

Reproduce on `main`:

```sh
$ sh .githooks/pre-push
Checking test-file convention (tests must be in *_tests.rs files)...
  FAIL: src/openapi.rs: inline test block found (use *_tests.rs instead)
Test-convention check FAILED.
```

## What

- Move the `committed_spec_is_current` test from the inline `mod tests` block in `src/openapi.rs` into a new `src/openapi_tests.rs` sibling.
- Declare it with `#[cfg(test)] #[path = "openapi_tests.rs"] mod openapi_tests;`, matching the pattern already used across the codebase (`error.rs`, `time.rs`, `command.rs`, …).

No behavior change — the test still runs and passes (`openapi::openapi_tests::committed_spec_is_current ... ok`). This is a focused compliance fix; it does not touch the separate fmt issue (PR #60).

## Verification

- Convention check now passes (no violators under `src/`).
- `rustfmt --check` clean on both touched files.
- `cargo test openapi_tests` → 1 passed.