### PR TITLE
fix(build): apply ui size-opt release profile at workspace root

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,12 @@
 [workspace]
 members = ["ui"]
 
+# Profiles must live at the workspace root; a `[profile.*]` in a member crate
+# (ui/Cargo.toml) is silently ignored by Cargo. Scope the size optimization to
+# the `ui` (wasm) crate so the server binary keeps its default release profile.
+[profile.release.package.ui]
+opt-level = "z"
+
 [package]
 name = "moadim"
 version = "0.6.1"

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -21,8 +21,5 @@ web-sys = { version = "0.3", features = ["HtmlInputElement", "HtmlSelectElement"
 log = "0.4"
 console_log = "1"
 
-[profile.release]
-opt-level = "z"
-
 [lints.clippy]
 all = "deny"


### PR DESCRIPTION
## Why

`ui/Cargo.toml` declares:

```toml
[profile.release]
opt-level = "z"
```

But `ui` is a **workspace member**, and Cargo only honors `[profile.*]` tables at the **workspace root**. So this table is silently ignored, and Cargo prints on every invocation:

```
warning: profiles for the non root package will be ignored, specify profiles at the workspace root
```

Two consequences:

1. The intended size optimization (`opt-level = "z"`) for the wasm UI bundle was **never actually applied** — the UI ships larger than intended.
2. The warning is noise on every `cargo build` / `clippy` / coverage run, including the pre-push hook.

## What

Move the profile to the workspace root as a **package-scoped override** so it applies only to the `ui` crate (the server binary keeps its default release profile):

```toml
[profile.release.package.ui]
opt-level = "z"
```

## Verification

- `cargo metadata` / `cargo build` — no more "profiles for the non root package will be ignored" warning.
- `cargo build --release -p ui` builds clean with the profile now in effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)