### PR TITLE
test(error): cover AppError::Conflict display and 409 response

### DIFF
--- a/src/error_tests.rs
+++ b/src/error_tests.rs
@@ -24,6 +24,14 @@ fn display_not_found() {
 }
 
 #[test]
+fn display_conflict() {
+    assert_eq!(
+        AppError::Conflict("duplicate".into()).to_string(),
+        "conflict: duplicate"
+    );
+}
+
+#[test]
 fn into_response_internal_is_500() {
     assert_eq!(
         AppError::Internal.into_response().status(),
@@ -44,5 +52,13 @@ fn into_response_not_found_is_404() {
     assert_eq!(
         AppError::NotFound.into_response().status(),
         StatusCode::NOT_FOUND
+    );
+}
+
+#[test]
+fn into_response_conflict_is_409() {
+    assert_eq!(
+        AppError::Conflict("x".into()).into_response().status(),
+        StatusCode::CONFLICT
     );
 }


### PR DESCRIPTION
## Why

`AppError::Conflict` was the only error variant lacking unit tests for both its `Display` impl and its `IntoResponse` status mapping. Every other variant (`Internal`, `BadRequest`, `NotFound`) is covered by a `display_*` **and** an `into_response_*` test in `src/error_tests.rs`; `Conflict` had neither.

The variant is constructed in `src/routines/service.rs` (duplicate-slug guards), so its `error.rs` match arms were exercised only indirectly — a real gap under the repo's 100% line-coverage pre-push requirement, and an asymmetry in the otherwise-complete error contract test matrix.

## What

- `display_conflict` — asserts `Display` renders `conflict: <msg>`.
- `into_response_conflict_is_409` — asserts the HTTP status maps to `409 CONFLICT`.

Both mirror the existing test style. No production code changed.

## Verification

`cargo test error_tests` → `8 passed; 0 failed` (was 6). New code is `cargo fmt`-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)