### PR TITLE
feat(routines): auto-cleanup finished run workbenches with per-routine TTL

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,5 +6,6 @@ This is a list of todos for consumption, in a pr remove the todo you have implem
 
 - Add a way to see all the routines in the UI as a calendar view
 - Add spell check for pre commit
-- Add TTL for triggered routines, so they don't stay in the system forever
 - Add validation dialog before shutdown
+- Surface and edit a routine's workbench TTL (`ttl_secs`) in the UI
+- Add an endpoint/CLI to trigger workbench cleanup on demand (not only the hourly sweep)

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -760,6 +760,15 @@
           "title": {
             "type": "string",
             "description": "Human name for the routine."
+          },
+          "ttl_secs": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Workbench retention in seconds for finished runs; `None` uses [`DEFAULT_TTL_SECS`].",
+            "minimum": 0
           }
         }
       },
@@ -1012,6 +1021,15 @@
             "type": "string",
             "description": "Human name; slugified to name the workbench and tmux session."
           },
+          "ttl_secs": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "How long (seconds) a finished run's workbench is retained before auto-cleanup removes it.\n`None` falls back to [`DEFAULT_TTL_SECS`]. Sessions still running are never reaped.",
+            "minimum": 0
+          },
           "updated_at": {
             "type": "integer",
             "format": "int64",
@@ -1144,6 +1162,15 @@
               "null"
             ],
             "description": "New title, or `None` to keep the existing value."
+          },
+          "ttl_secs": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "New workbench TTL (seconds), or `None` to keep the existing value.",
+            "minimum": 0
           }
         }
       }

--- a/src/routes/http.rs
+++ b/src/routes/http.rs
@@ -193,6 +193,21 @@ pub async fn run_with_listener_until(
         log::warn!("could not write openapi spec: {e}");
     }
     let signal: ShutdownSignal = Arc::new(tokio::sync::Notify::new());
+    // Periodically reap finished, expired run workbenches so triggered routines do not accumulate
+    // forever (see `routines::cleanup`). The first tick fires immediately, sweeping leftovers from
+    // before this process started.
+    let cleanup_store = routines.clone();
+    let cleanup_task = tokio::spawn(async move {
+        let mut tick = tokio::time::interval(crate::routines::CLEANUP_INTERVAL);
+        loop {
+            tick.tick().await;
+            let store = cleanup_store.clone();
+            let _ = tokio::task::spawn_blocking(move || {
+                crate::routines::cleanup_expired_workbenches(&store)
+            })
+            .await;
+        }
+    });
     let app = build_app_with_shutdown(store, routines, signal.clone());
     crate::utils::startup_print::print(&addr);
     // Shut down when either the caller-supplied future resolves (e.g. a SIGINT/SIGTERM handler) or
@@ -206,6 +221,7 @@ pub async fn run_with_listener_until(
     axum::serve(listener, app)
         .with_graceful_shutdown(combined)
         .await?;
+    cleanup_task.abort();
     Ok(())
 }
 

--- a/src/routes/mcp.rs
+++ b/src/routes/mcp.rs
@@ -74,6 +74,8 @@ struct UpdateRoutineInput {
     repositories: Option<Vec<crate::routines::Repository>>,
     /// New enabled state, or `None` to keep the existing value.
     enabled: Option<bool>,
+    /// New workbench TTL (seconds) for finished runs, or `None` to keep the existing value.
+    ttl_secs: Option<u64>,
 }
 
 /// Wrap a serializable value in a successful `CallToolResult`.
@@ -265,6 +267,7 @@ impl MoadimMcp {
             prompt: input.prompt,
             repositories: input.repositories,
             enabled: input.enabled,
+            ttl_secs: input.ttl_secs,
         };
         Ok(match routines::svc_update(&self.routines, &input.id, req) {
             Ok(resp) => ok(resp),

--- a/src/routes/mcp_tests.rs
+++ b/src/routes/mcp_tests.rs
@@ -285,6 +285,7 @@ fn make_create_routine_req() -> crate::routines::CreateRoutineRequest {
         prompt: "p".into(),
         repositories: vec![],
         enabled: true,
+        ttl_secs: None,
     }
 }
 
@@ -353,6 +354,7 @@ fn create_get_update_trigger_delete_routine_success() {
             prompt: None,
             repositories: None,
             enabled: Some(false),
+            ttl_secs: None,
         }))
         .unwrap();
     assert!(!result.is_error.unwrap_or(false));
@@ -383,6 +385,7 @@ fn update_routine_tool_not_found_is_error() {
             prompt: None,
             repositories: None,
             enabled: None,
+            ttl_secs: None,
         }))
         .unwrap();
     assert!(result.is_error.unwrap_or(false));

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -34,6 +34,9 @@ struct RoutineToml {
     updated_at: Option<u64>,
     /// Unix timestamp of last manual trigger.
     last_triggered_at: Option<u64>,
+    /// Workbench retention in seconds for finished runs; absent means the daemon default.
+    #[serde(default)]
+    ttl_secs: Option<u64>,
 }
 
 /// Parse a routine TOML file at `path`, returning `None` on any error.
@@ -62,6 +65,7 @@ fn load_routine_from_dir(dir_name: &str) -> Option<Routine> {
         created_at: t.created_at.unwrap_or(0),
         updated_at: t.updated_at.unwrap_or(0),
         last_triggered_at: t.last_triggered_at,
+        ttl_secs: t.ttl_secs,
     })
 }
 
@@ -90,6 +94,7 @@ pub fn write_routine(routine: &Routine) -> std::io::Result<()> {
         created_at: Some(routine.created_at),
         updated_at: Some(routine.updated_at),
         last_triggered_at: routine.last_triggered_at,
+        ttl_secs: routine.ttl_secs,
     };
     let text = toml::to_string_pretty(&toml_routine).map_err(std::io::Error::other)?;
     std::fs::write(routine_toml_path(&slug), text)?;

--- a/src/routine_storage_tests.rs
+++ b/src/routine_storage_tests.rs
@@ -19,6 +19,7 @@ fn make_routine(id: &str, title: &str) -> Routine {
         created_at: 5,
         updated_at: 6,
         last_triggered_at: None,
+        ttl_secs: None,
     }
 }
 

--- a/src/routines/cleanup.rs
+++ b/src/routines/cleanup.rs
@@ -1,0 +1,121 @@
+//! Auto-cleanup of finished routine runs.
+//!
+//! Triggering a routine creates a workbench at `~/.moadim/workbenches/{slug}-{ts}` and launches the
+//! agent in a tmux session named `moadim-{slug}-{ts}`. When the agent exits the session ends, but
+//! the workbench (prompt, logs, cloned repos) lingers forever. This module reaps those leftovers: a
+//! workbench is removed once its run has *finished* (no live tmux session) **and** it is older than
+//! the owning routine's [`Routine::effective_ttl_secs`]. Still-running sessions are never touched,
+//! and orphaned workbenches (routine since deleted) fall back to [`DEFAULT_TTL_SECS`].
+
+use std::path::Path;
+use std::time::Duration;
+
+use crate::paths::workbenches_dir;
+use crate::utils::time::now_secs;
+
+use super::command::slugify;
+use super::model::{RoutineStore, DEFAULT_TTL_SECS};
+
+/// How often the background task scans for expired workbenches.
+pub const CLEANUP_INTERVAL: Duration = Duration::from_secs(60 * 60);
+
+/// Split a workbench directory name into its `(slug, trigger_timestamp)`.
+///
+/// Names are `{slug}-{unix_secs}`; the timestamp is the trailing all-digit segment after the final
+/// `-`. Returns `None` when the name has no such suffix or an empty slug (so unrelated directories
+/// are skipped rather than reaped).
+fn parse_workbench_name(name: &str) -> Option<(&str, u64)> {
+    let (slug, ts) = name.rsplit_once('-')?;
+    if slug.is_empty() || ts.is_empty() || !ts.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    Some((slug, ts.parse().ok()?))
+}
+
+/// Whether a workbench triggered at `ts` has outlived `ttl` as of `now` (saturating, so clock skew
+/// that puts `ts` in the future reads as age 0, never expired).
+fn is_expired(now: u64, ts: u64, ttl: u64) -> bool {
+    now.saturating_sub(ts) > ttl
+}
+
+/// Return `true` if a tmux session named `session` currently exists.
+///
+/// Uses an exact (`=`) target match so `moadim-foo-1` never matches `moadim-foo-10`. A missing
+/// `tmux` binary (exit status unavailable) is treated as "not alive": with no tmux there is no
+/// running session to protect, so an expired workbench is safe to reap.
+fn tmux_session_alive(session: &str) -> bool {
+    std::process::Command::new("tmux")
+        .arg("has-session")
+        .arg("-t")
+        .arg(format!("={session}"))
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Scan `dir`, removing each `{slug}-{ts}` workbench that is expired (`is_alive` returns `false` for
+/// its session and `ttl_for(slug)` has elapsed). Returns the number of directories removed.
+///
+/// `ttl_for` and `is_alive` are injected so the decision logic is unit-testable without a filesystem
+/// clock or a live tmux server.
+fn reap_dir(
+    dir: &Path,
+    now: u64,
+    ttl_for: &dyn Fn(&str) -> u64,
+    is_alive: &dyn Fn(&str) -> bool,
+) -> usize {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    let mut removed = 0;
+    for entry in entries.flatten() {
+        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let Some((slug, ts)) = parse_workbench_name(&name) else {
+            continue;
+        };
+        if !is_expired(now, ts, ttl_for(slug)) {
+            continue;
+        }
+        if is_alive(&format!("moadim-{name}")) {
+            continue;
+        }
+        match std::fs::remove_dir_all(entry.path()) {
+            Ok(()) => {
+                removed += 1;
+                log::info!("cleanup: removed expired workbench {name:?}");
+            }
+            Err(e) => log::warn!("cleanup: failed to remove workbench {name:?}: {e}"),
+        }
+    }
+    removed
+}
+
+/// Remove finished, expired workbenches under `~/.moadim/workbenches/`, using each routine's TTL.
+///
+/// Returns the number of workbenches removed. Safe to call repeatedly; it only ever touches
+/// directories whose run has ended.
+pub fn cleanup_expired_workbenches(store: &RoutineStore) -> usize {
+    // Snapshot slug -> ttl so the store lock is not held across filesystem and tmux calls.
+    let ttls: std::collections::HashMap<String, u64> = {
+        let lock = store.lock().unwrap();
+        lock.values()
+            .map(|r| (slugify(&r.title), r.effective_ttl_secs()))
+            .collect()
+    };
+    let ttl_for = |slug: &str| ttls.get(slug).copied().unwrap_or(DEFAULT_TTL_SECS);
+    reap_dir(
+        &workbenches_dir(),
+        now_secs(),
+        &ttl_for,
+        &tmux_session_alive,
+    )
+}
+
+#[cfg(test)]
+#[path = "cleanup_tests.rs"]
+mod cleanup_tests;

--- a/src/routines/cleanup_tests.rs
+++ b/src/routines/cleanup_tests.rs
@@ -1,0 +1,105 @@
+#![allow(clippy::missing_docs_in_private_items)]
+
+use super::*;
+
+#[test]
+fn parse_workbench_name_splits_slug_and_timestamp() {
+    assert_eq!(parse_workbench_name("foo-123"), Some(("foo", 123)));
+    // Slug may contain dashes; only the final all-digit segment is the timestamp.
+    assert_eq!(
+        parse_workbench_name("my-routine-1700000000"),
+        Some(("my-routine", 1_700_000_000))
+    );
+}
+
+#[test]
+fn parse_workbench_name_rejects_non_workbench_dirs() {
+    assert_eq!(parse_workbench_name("noseparator"), None);
+    assert_eq!(parse_workbench_name("foo-bar"), None); // suffix not numeric
+    assert_eq!(parse_workbench_name("foo-"), None); // empty timestamp
+    assert_eq!(parse_workbench_name("-123"), None); // empty slug
+}
+
+#[test]
+fn is_expired_compares_age_against_ttl() {
+    assert!(is_expired(1000, 0, 500)); // age 1000 > ttl 500
+    assert!(!is_expired(1000, 600, 500)); // age 400 <= ttl 500
+    assert!(!is_expired(1000, 1000, 0)); // age 0, never expired at ttl 0
+                                         // Trigger timestamp in the future (clock skew) saturates to age 0.
+    assert!(!is_expired(1000, 2000, 0));
+}
+
+fn touch_dir(parent: &std::path::Path, name: &str) {
+    std::fs::create_dir_all(parent.join(name)).unwrap();
+}
+
+#[test]
+fn reap_dir_removes_only_finished_and_expired() {
+    let base = std::env::temp_dir().join("moadim-cleanup-reap-test");
+    let _ = std::fs::remove_dir_all(&base);
+    std::fs::create_dir_all(&base).unwrap();
+
+    touch_dir(&base, "expired-100"); // old + dead  -> removed
+    touch_dir(&base, "fresh-900"); // recent       -> kept
+    touch_dir(&base, "running-100"); // old but live -> kept
+    touch_dir(&base, "notawb"); // no timestamp      -> kept
+    std::fs::write(base.join("stray-50"), b"x").unwrap(); // a file, not a dir -> ignored
+
+    let now = 1000;
+    let ttl_for = |_slug: &str| 500u64; // expiry threshold: age > 500
+    let alive = |session: &str| session == "moadim-running-100";
+
+    let removed = reap_dir(&base, now, &ttl_for, &alive);
+
+    assert_eq!(removed, 1);
+    assert!(!base.join("expired-100").exists());
+    assert!(base.join("fresh-900").exists());
+    assert!(base.join("running-100").exists());
+    assert!(base.join("notawb").exists());
+
+    std::fs::remove_dir_all(&base).unwrap();
+}
+
+#[test]
+fn reap_dir_uses_per_slug_ttl() {
+    let base = std::env::temp_dir().join("moadim-cleanup-perslug-test");
+    let _ = std::fs::remove_dir_all(&base);
+    std::fs::create_dir_all(&base).unwrap();
+
+    // Same age (500s) for both, but "short" has a tighter TTL so only it expires.
+    touch_dir(&base, "short-500");
+    touch_dir(&base, "long-500");
+
+    let now = 1000;
+    let ttl_for = |slug: &str| if slug == "short" { 100 } else { 100_000 };
+    let dead = |_session: &str| false;
+
+    let removed = reap_dir(&base, now, &ttl_for, &dead);
+
+    assert_eq!(removed, 1);
+    assert!(!base.join("short-500").exists());
+    assert!(base.join("long-500").exists());
+
+    std::fs::remove_dir_all(&base).unwrap();
+}
+
+#[test]
+fn effective_ttl_falls_back_to_default() {
+    let mut r = super::super::model::Routine {
+        id: "x".into(),
+        schedule: "@daily".into(),
+        title: "t".into(),
+        agent: "claude".into(),
+        prompt: "p".into(),
+        repositories: vec![],
+        enabled: true,
+        source: "managed".into(),
+        created_at: 0,
+        updated_at: 0,
+        last_triggered_at: None,
+        ttl_secs: None,
+    };
+    assert_eq!(r.effective_ttl_secs(), DEFAULT_TTL_SECS);
+    r.ttl_secs = Some(42);
+    assert_eq!(r.effective_ttl_secs(), 42);
+}

--- a/src/routines/mod.rs
+++ b/src/routines/mod.rs
@@ -10,15 +10,18 @@
 //! - [`agents`] — the agent registry and built-in default agent configs.
 //! - [`command`] — prompt composition and the single-line launch command builder.
 //! - [`service`] — store-mutating service functions (list/get/create/update/delete/trigger/logs).
+//! - [`cleanup`] — auto-removal of finished, expired run workbenches (per-routine TTL).
 //! - [`handlers`] — the Axum HTTP handlers.
 
 mod agents;
+mod cleanup;
 mod command;
 mod handlers;
 mod model;
 mod service;
 
 pub use agents::*;
+pub use cleanup::*;
 pub use handlers::*;
 pub use model::*;
 pub use service::*;

--- a/src/routines/mod_tests.rs
+++ b/src/routines/mod_tests.rs
@@ -18,6 +18,7 @@ fn make_routine(id: &str) -> Routine {
         created_at: 0,
         updated_at: 0,
         last_triggered_at: None,
+        ttl_secs: None,
     }
 }
 
@@ -255,6 +256,7 @@ fn svc_create_invalid_cron_rejected() {
         prompt: "p".into(),
         repositories: vec![],
         enabled: true,
+        ttl_secs: None,
     };
     assert!(svc_create(&store, req).is_err());
 }
@@ -271,6 +273,7 @@ fn svc_create_update_delete_lifecycle() {
             prompt: "p".into(),
             repositories: vec![],
             enabled: true,
+            ttl_secs: None,
         },
     )
     .unwrap();
@@ -292,6 +295,7 @@ fn svc_create_update_delete_lifecycle() {
                 branch: None,
             }]),
             enabled: Some(false),
+            ttl_secs: None,
         },
     )
     .unwrap();
@@ -314,6 +318,7 @@ fn svc_update_not_found() {
         prompt: None,
         repositories: None,
         enabled: None,
+        ttl_secs: None,
     };
     assert!(svc_update(&new_store(), "missing", req).is_err());
 }
@@ -332,6 +337,7 @@ fn svc_update_invalid_cron_rejected() {
         prompt: None,
         repositories: None,
         enabled: None,
+        ttl_secs: None,
     };
     assert!(svc_update(&store, "id", req).is_err());
 }

--- a/src/routines/model.rs
+++ b/src/routines/model.rs
@@ -6,8 +6,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use crate::paths::{agent_toml_path, routine_toml_path};
 use super::command::slugify;
+use crate::paths::{agent_toml_path, routine_toml_path};
 
 /// A git repository made available to a routine's agent as prompt context (not cloned by moadim).
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, utoipa::ToSchema)]
@@ -46,6 +46,20 @@ pub struct Routine {
     pub updated_at: u64,
     /// Unix timestamp (seconds) when the routine was last manually triggered, if ever.
     pub last_triggered_at: Option<u64>,
+    /// How long (seconds) a finished run's workbench is retained before auto-cleanup removes it.
+    /// `None` falls back to [`DEFAULT_TTL_SECS`]. Sessions still running are never reaped.
+    #[serde(default)]
+    pub ttl_secs: Option<u64>,
+}
+
+/// Default retention for a finished run's workbench when a routine sets no explicit `ttl_secs`.
+pub const DEFAULT_TTL_SECS: u64 = 7 * 24 * 60 * 60;
+
+impl Routine {
+    /// Retention for this routine's finished workbenches: its `ttl_secs` or [`DEFAULT_TTL_SECS`].
+    pub fn effective_ttl_secs(&self) -> u64 {
+        self.ttl_secs.unwrap_or(DEFAULT_TTL_SECS)
+    }
 }
 
 /// A [`Routine`] enriched with derived, non-persisted fields for API responses.
@@ -111,6 +125,9 @@ pub struct CreateRoutineRequest {
     /// Whether to create the routine enabled (defaults to `true`).
     #[serde(default = "bool_true")]
     pub enabled: bool,
+    /// Workbench retention in seconds for finished runs; `None` uses [`DEFAULT_TTL_SECS`].
+    #[serde(default)]
+    pub ttl_secs: Option<u64>,
 }
 
 /// Request body for partially updating an existing routine.
@@ -129,4 +146,6 @@ pub struct UpdateRoutineRequest {
     pub repositories: Option<Vec<Repository>>,
     /// New enabled state, or `None` to keep the existing value.
     pub enabled: Option<bool>,
+    /// New workbench TTL (seconds), or `None` to keep the existing value.
+    pub ttl_secs: Option<u64>,
 }

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -65,6 +65,7 @@ pub fn svc_create(
         created_at: now,
         updated_at: now,
         last_triggered_at: None,
+        ttl_secs: req.ttl_secs,
     };
     write_routine(&routine).map_err(|_| AppError::Internal)?;
     store
@@ -119,6 +120,9 @@ pub fn svc_update(
     }
     if let Some(e) = req.enabled {
         routine.enabled = e;
+    }
+    if let Some(ttl) = req.ttl_secs {
+        routine.ttl_secs = Some(ttl);
     }
     routine.updated_at = now_secs();
     let routine = routine.clone();

--- a/src/sync/routines_sync_tests.rs
+++ b/src/sync/routines_sync_tests.rs
@@ -16,6 +16,7 @@ fn make_routine(id: &str, title: &str, agent: &str) -> Routine {
         created_at: 0,
         updated_at: 0,
         last_triggered_at: None,
+        ttl_secs: None,
     }
 }
 


### PR DESCRIPTION
## Why

Triggering a routine creates a workbench at `~/.moadim/workbenches/{slug}-{ts}` and launches the agent in a tmux session `moadim-{slug}-{ts}`. When the agent exits the session ends, but the workbench (prompt, logs, cloned repos) lingered **forever** — disk grows unbounded. Closes the TODO "Add TTL for triggered routines, so they don't stay in the system forever".

## What

- **`Routine.ttl_secs: Option<u64>`** — per-routine retention for finished runs. `None` → `DEFAULT_TTL_SECS` (7 days). Persisted in `routine.toml`; settable on create/update via REST and MCP.
- **`routines::cleanup`** — hourly background sweep:
  - parses `{slug}-{ts}` (slug may contain dashes; timestamp = trailing all-digit segment),
  - resolves TTL per slug (orphaned workbenches from deleted routines fall back to the default),
  - removes a workbench only when it is **expired AND its tmux session is gone** — running sessions are never reaped (exact `tmux has-session -t =...` match),
  - first tick fires at startup, sweeping pre-existing leftovers.
- Cleanup task spawned in the HTTP runner, aborted on graceful shutdown.
- Regenerated `apis/openapi.json`; removed the implemented TODO, added two follow-ups (UI field, on-demand trigger).

## Safety

- Only ever touches directories whose run has **finished**; no mid-run deletion.
- Missing `tmux` → treated as "not alive" (no session to protect), so expired benches still reap.
- Future-dated timestamps (clock skew) saturate to age 0 → never expired.

## Tests

New unit tests for name parsing, expiry decision, per-slug TTL, finished-vs-running reaping, and TTL fallback. Full suite green (`cargo test`), clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)