### PR TITLE
docs: add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,125 @@
+# Changelog
+
+> _Today's TODO, tomorrow's changelog. Ship one, dream up two._
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Versions map to the `v*` git tags that drive the crates.io publish workflow.
+
+## [Unreleased]
+
+### Added
+
+- This changelog.
+
+## [0.7.0] - 2026-06-16
+
+### Added
+
+- Auto-cleanup of finished routine run workbenches with a per-routine TTL.
+
+### Changed
+
+- Surface the routine schedule timezone in MCP tools and responses.
+
+### Fixed
+
+- Apply the UI size-optimization release profile at the workspace root so the
+  server binary keeps its default release profile.
+- Move the OpenAPI inline test into a sibling `_tests.rs` file to satisfy the
+  test-file convention.
+
+## [0.6.1] - 2026-06-15
+
+### Changed
+
+- Document that cron schedules use the host local timezone, not UTC, across the
+  README, Architecture guide, and TODO list.
+
+## [0.6.0] - 2026-06-15
+
+### Added
+
+- Validation dialog before shutdown (groundwork in TODOs).
+- Per-routine TTL for triggered routines to prevent indefinite retention.
+- Write a `.gitignore` for generated runtime files in the config directory.
+
+### Changed
+
+- Use the slugified routine title as the run folder name instead of the UUID.
+- Rename the prompt sidecar from `prompt.txt` to `prompt.md`.
+
+### Fixed
+
+- Remove the unused `MOADIM_BUILD_UI` variable from the build script.
+
+## [0.5.0] - 2026-06-15
+
+### Fixed
+
+- Atomic, locked write of `~/.claude.json` during Claude agent setup.
+- Correct a typo in the TODOs description.
+
+## [0.4.0] - 2026-06-15
+
+### Added
+
+- `GET /agents` endpoint and an agent dropdown in the routines UI.
+
+### Fixed
+
+- Make the cron-job edit/delete modals clickable in the UI.
+
+## [0.3.0] - 2026-06-15
+
+### Added
+
+- Run the server in background or interactive mode, killable from the client.
+
+## [0.2.0] - 2026-06-15
+
+### Added
+
+- Routines: agent-driven scheduled jobs, with a dedicated routines tab in the UI.
+- Logs page in the UI and `GET /cron-jobs/{id}/logs`.
+- Swagger UI served at `/docs`.
+- `schedule_description` field on `CronJobResponse` via croner.
+- `CronJobSourceType` enum distinguishing managed vs OS jobs.
+- 100% line coverage, enforced via the pre-push hook.
+
+### Fixed
+
+- Run routines via a generated `run.sh` so crontab lines stay under cron's
+  length limit.
+- Make scheduled routines actually fire from cron.
+- Execute the handler script when the trigger endpoint is called.
+
+## [0.1.0] - 2026-06-11
+
+### Added
+
+- Persist cron jobs to `~/.config/moadim/jobs/`.
+- Manual trigger for cron jobs via HTTP, MCP, and the UI.
+- Type-safe Yew UI with the WASM bundle inlined at build time.
+- Expose filesystem locations in response headers.
+- Unify REST/MCP behind a shared service layer; include the job file path in
+  responses.
+- Extract storage and path-builder logic into dedicated modules.
+
+### Fixed
+
+- Ship the prebuilt UI in the published crate.
+- Rename the binary to `moadim` and add install docs.
+
+[Unreleased]: https://github.com/moadim-io/daemon/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/moadim-io/daemon/compare/v0.6.1...v0.7.0
+[0.6.1]: https://github.com/moadim-io/daemon/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/moadim-io/daemon/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/moadim-io/daemon/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/moadim-io/daemon/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/moadim-io/daemon/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/moadim-io/daemon/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/moadim-io/daemon/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,9 @@ cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'
 
 1. Branch from `main` — name it `feat/...`, `fix/...`, `chore/...`, or `docs/...`.
 2. Keep commits focused; one logical change per commit.
-3. Open a PR against `main`; fill in what changed and why.
+3. Note user-facing changes under `## [Unreleased]` in
+   [`CHANGELOG.md`](CHANGELOG.md) (Keep a Changelog format).
+4. Open a PR against `main`; fill in what changed and why.
 
 ## Code conventions
 

--- a/README.md
+++ b/README.md
@@ -231,3 +231,8 @@ url:       http://localhost:5784/mcp
 ## API
 
 Full interface definitions are auto-generated at build time — see the [`apis/`](apis/) folder.
+
+## Changelog
+
+Release history lives in [`CHANGELOG.md`](CHANGELOG.md), following the
+[Keep a Changelog](https://keepachangelog.com/) format.

--- a/TODO.md
+++ b/TODO.md
@@ -9,4 +9,5 @@ This is a list of todos for consumption, in a pr remove the todo you have implem
 - Add validation dialog before shutdown
 - Surface and edit a routine's workbench TTL (`ttl_secs`) in the UI
 - Add an endpoint/CLI to trigger workbench cleanup on demand (not only the hourly sweep)
-- Add change log
+- Auto-stamp the release version/date into CHANGELOG.md from the `chore(release)` step so the `## [Unreleased]` section rolls over on tag
+- Add a CI check that fails a PR when it changes `src/` or `ui/` but leaves `## [Unreleased]` in CHANGELOG.md empty


### PR DESCRIPTION
## TODO item

Implements **"Add change log"** from `TODO.md`.

## Approach

- Add `CHANGELOG.md` in [Keep a Changelog](https://keepachangelog.com/) / SemVer format, reconstructed from the `v0.1.0`..`v0.7.0` git tags (versions map to the `v*` tags that drive the crates.io publish workflow). Includes an `## [Unreleased]` section and compare-links per version.
- Link the changelog from `README.md` (new **Changelog** section).
- Add a contributing-workflow step to record user-facing changes under `## [Unreleased]`.

Docs-only — no Rust touched, so `cargo fmt` / `clippy` / coverage gates are unaffected.

## TODO bookkeeping

- Removed: `Add change log`
- Added:
  - Auto-stamp the release version/date into `CHANGELOG.md` from the `chore(release)` step so `## [Unreleased]` rolls over on tag.
  - CI check that fails a PR which changes `src/`/`ui/` but leaves `## [Unreleased]` empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)