### PR TITLE
chore: add typos spell-check pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+set -e
+
+# ── Spell check ─────────────────────────────────────────────────────────────
+# Catch typos in source and prose before they land. Configured by typos.toml
+# at the repo root (generated/vendored files are excluded there).
+# Requires: cargo install typos-cli  (or `brew install typos-cli`)
+if ! command -v typos >/dev/null 2>&1; then
+  echo ""
+  echo "typos is not installed. Run:"
+  echo "  cargo install typos-cli"
+  echo "(or 'brew install typos-cli'), then commit again."
+  exit 1
+fi
+
+echo "Spell-checking with typos..."
+typos
+echo "Spell check passed."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@
 | [Rust stable](https://rustup.rs/) | Build the daemon |
 | [Trunk](https://trunkrs.dev/) | Build the Yew UI (`cargo install trunk`) |
 | `wasm32-unknown-unknown` target | UI target (`rustup target add wasm32-unknown-unknown`) |
+| [`typos`](https://github.com/crate-ci/typos) | Spell check, run by the pre-commit hook (`cargo install typos-cli`) |
 
 The `wasm32` target and Trunk are only needed when working on the browser UI
 (`ui/`). The daemon itself is a native binary and builds without them.
@@ -32,6 +33,18 @@ Enable the bundled git hooks once per clone:
 ```sh
 git config core.hooksPath .githooks
 ```
+
+The **pre-commit** hook spell-checks the tree with
+[`typos`](https://github.com/crate-ci/typos); the **pre-push** hook runs the
+format/lint/coverage gates below. Spell-check the tree on demand with:
+
+```sh
+typos
+```
+
+Generated and vendored files (`prebuilt.html`, lockfiles, `apis/openapi.json`,
+`schemas/`) are excluded in `typos.toml`. To accept a real word that `typos`
+flags, add it to `[default.extend-words]` there.
 
 ## Architecture at a glance
 

--- a/TODO.md
+++ b/TODO.md
@@ -5,8 +5,9 @@
 This is a list of todos for consumption, in a pr remove the todo you have implemented and add any new ones you think of.
 
 - Add a way to see all the routines in the UI as a calendar view
-- Add spell check for pre commit
 - Add validation dialog before shutdown
+- Run the `typos` spell check in CI (GitHub Actions) so PRs are gated even without local hooks installed
+- Add a `cargo xtask spellcheck` (or `make spell`) wrapper that installs and runs `typos` so contributors don't need to know the tool name
 - Surface and edit a routine's workbench TTL (`ttl_secs`) in the UI
 - Add an endpoint/CLI to trigger workbench cleanup on demand (not only the hourly sweep)
 - Add change log

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,17 @@
+# Configuration for the `typos` spell checker run by the pre-commit hook.
+# See https://github.com/crate-ci/typos for the full schema.
+
+[files]
+# Generated, vendored, or lock artifacts — not hand-written prose/code, so
+# they produce only false positives.
+extend-exclude = [
+  "prebuilt.html",
+  "Cargo.lock",
+  "pnpm-lock.yaml",
+  "apis/openapi.json",
+  "schemas/",
+]
+
+[default.extend-words]
+# Intentional spelling used in the codebase; keep it as-is.
+unparseable = "unparseable"


### PR DESCRIPTION
## TODO item

Implements **"Add spell check for pre commit"** from `TODO.md`.

## Approach

- **Hook:** new `.githooks/pre-commit` runs [`typos`](https://github.com/crate-ci/typos) over the tree. If `typos` isn't installed it prints an install hint and exits non-zero — same graceful pattern the existing `pre-push` hook uses for `cargo-llvm-cov`. Hooks are activated per-clone via `git config core.hooksPath .githooks` (already documented in `CONTRIBUTING.md`).
- **Config:** new `typos.toml` excludes generated/vendored files that only yield false positives — `prebuilt.html` (minified embedded UI), `Cargo.lock`, `pnpm-lock.yaml`, `apis/openapi.json`, `schemas/` — and allows the intentional word `unparseable` used in the codebase. With this config `typos` exits clean on `main`.
- **Docs:** `CONTRIBUTING.md` gains `typos` as a prerequisite and a note on the pre-commit hook + how to allow flagged words.

## Checks

- `typos` exits `0` on the full tree with the new config.
- Pre-commit hook tested locally — passes.
- **No Rust touched** (only `.githooks/`, `typos.toml`, `CONTRIBUTING.md`, `TODO.md`), so the daemon's `cargo fmt` / `clippy` / 100%-coverage gates are byte-identical to `main`.

## TODO bookkeeping

- Removed: `Add spell check for pre commit`
- Added:
  - Run the `typos` spell check in CI (GitHub Actions) so PRs are gated even without local hooks installed.
  - Add a `cargo xtask spellcheck` (or `make spell`) wrapper that installs and runs `typos` so contributors don't need to know the tool name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)