### PR TITLE
feat(cli): restart daemon on launch when already running

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -85,14 +85,15 @@ pub fn print_version() {
 
 /// Start the server as a detached background process and return immediately.
 ///
-/// Refuses to start a second instance if one is already responding on [`BIND_ADDR`].
+/// If a server is already responding on [`BIND_ADDR`], it is stopped and replaced with a fresh
+/// process so each launch yields a clean instance.
 pub fn run_background() -> anyhow::Result<()> {
     if is_running() {
         let pid = read_pid_file()
             .map(|p| format!(" (pid {p})"))
             .unwrap_or_default();
-        println!("moadim is already running{pid} at http://{BIND_ADDR}");
-        return Ok(());
+        println!("moadim is already running{pid}; stopping it to start a fresh instance");
+        crate::restart::stop_running_and_wait()?;
     }
     let pid = spawn_detached()?;
     println!("moadim started in the background (pid {pid}) at http://{BIND_ADDR}");
@@ -159,7 +160,7 @@ pub fn clear_pid_file() {
 }
 
 /// Read the PID recorded in the pid file, if present and parseable.
-fn read_pid_file() -> Option<u32> {
+pub(crate) fn read_pid_file() -> Option<u32> {
     std::fs::read_to_string(crate::paths::pid_file())
         .ok()?
         .trim()
@@ -173,12 +174,12 @@ fn paths_daemon_log() -> String {
 }
 
 /// Returns `true` if a server answers `GET /health` on [`BIND_ADDR`].
-fn is_running() -> bool {
+pub(crate) fn is_running() -> bool {
     matches!(http_request("GET", "/health"), Ok(200))
 }
 
 /// Send a minimal HTTP/1.1 request to the local server and return the response status code.
-fn http_request(method: &str, path: &str) -> std::io::Result<u16> {
+pub(crate) fn http_request(method: &str, path: &str) -> std::io::Result<u16> {
     let addr: SocketAddr = BIND_ADDR
         .parse()
         .expect("BIND_ADDR is a valid socket address");

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,8 @@ mod middlewares;
 mod openapi;
 /// Filesystem path builders for the jobs directory.
 mod paths;
+/// Replace an already-running daemon with a fresh process on launch.
+mod restart;
 /// HTTP and MCP route definitions.
 mod routes;
 /// TOML-backed routine persistence.

--- a/src/restart.rs
+++ b/src/restart.rs
@@ -1,0 +1,67 @@
+//! Replace an already-running daemon with a fresh process.
+//!
+//! When a launch finds a server already responding on [`crate::cli::BIND_ADDR`], we stop it and
+//! start a new instance instead of reusing it, so each launch yields a clean process.
+
+use std::time::Duration;
+
+use crate::cli::{is_running, read_pid_file, BIND_ADDR};
+
+/// How long to wait for an already-running server to exit before starting a fresh one.
+const RESTART_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// How often to re-probe the port while waiting for the old server to exit.
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Stop the running server and block until it stops answering, falling back to a kill signal.
+///
+/// Sends `POST /shutdown` for a graceful exit, then polls [`is_running`] until the port goes quiet
+/// or [`RESTART_TIMEOUT`] elapses. If it is still up by then, the recorded PID is killed directly.
+pub fn stop_running_and_wait() -> anyhow::Result<()> {
+    let _ = crate::cli::http_request("POST", "/shutdown");
+
+    if wait_until_stopped() {
+        return Ok(());
+    }
+
+    // Graceful shutdown did not take effect in time; force-kill the recorded PID.
+    if let Some(pid) = read_pid_file() {
+        kill_pid(pid);
+        if wait_until_stopped() {
+            return Ok(());
+        }
+    }
+
+    if is_running() {
+        anyhow::bail!("could not stop the running moadim instance at http://{BIND_ADDR}");
+    }
+    Ok(())
+}
+
+/// Poll the port until it stops answering or [`RESTART_TIMEOUT`] elapses. Returns `true` if stopped.
+fn wait_until_stopped() -> bool {
+    let deadline = std::time::Instant::now() + RESTART_TIMEOUT;
+    while std::time::Instant::now() < deadline {
+        if !is_running() {
+            return true;
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+    !is_running()
+}
+
+/// Force-kill a process by PID. Best-effort: a missing/already-dead process is ignored.
+#[cfg(unix)]
+fn kill_pid(pid: u32) {
+    let _ = std::process::Command::new("kill")
+        .args(["-9", &pid.to_string()])
+        .output();
+}
+
+/// Force-kill a process by PID. Best-effort: failures are ignored.
+#[cfg(not(unix))]
+fn kill_pid(pid: u32) {
+    let _ = std::process::Command::new("taskkill")
+        .args(["/F", "/PID", &pid.to_string()])
+        .output();
+}


### PR DESCRIPTION
## Summary
- `run_background` no longer refuses to start when a daemon is already running — it stops the old instance and spawns a fresh one, so each launch yields a clean process.
- New `restart` module holds the restart logic: graceful `POST /shutdown`, poll the port until quiet (5s), then SIGKILL the recorded PID as fallback, and bail if it still won't die.
- Exposed `is_running`, `read_pid_file`, `http_request` as `pub(crate)` for the new module.

## Test plan
- `cargo build` ✅
- `cargo clippy` ✅ (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)