### PR TITLE
feat(routines): add iCal (.ics) export endpoint for routine schedules

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -228,6 +228,10 @@ placeholder expands to `"$(cat prompt.txt)"`), so there is no keystroke-injectio
 agent decides whether to clone the listed repositories. `POST /routines/{id}/trigger` runs the
 identical command via `sh -c`.
 
+`GET /routines.ics` returns an iCalendar (RFC 5545) feed of every enabled routine's upcoming fire
+times (next 30 days, capped per routine), evaluated in the host local timezone and emitted as UTC
+instants so external calendars can subscribe without an embedded `VTIMEZONE`. See `src/routines/ical.rs`.
+
 The agent command is resolved from a configurable registry at `~/.config/moadim/agents/<name>.toml`
 (`command`, `args`; placeholders `{prompt_file}` → `prompt.txt`, `{workbench}` → `.`,
 `{prompt}` → `"$(cat prompt.txt)"`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 ### Added
 
 - This changelog.
+- `GET /routines.ics` iCalendar feed of upcoming routine fire times for
+  subscribing in external calendars.
 
 ## [0.7.0] - 2026-06-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1395,6 +1395,7 @@ version = "0.7.0"
 dependencies = [
  "anyhow",
  "axum",
+ "chrono",
  "croner",
  "dirs",
  "iana-time-zone",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ homepage = "https://github.com/moadim-io/daemon"
 [dependencies]
 anyhow = "1"
 axum = "0.8"
+chrono = "0.4"
 croner = "3"
 dirs = "5"
 iana-time-zone = "0.1"

--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,8 @@ This is a list of todos for consumption, in a pr remove the todo you have implem
 - Surface and edit a routine's workbench TTL (`ttl_secs`) in the UI
 - Add an endpoint/CLI to trigger workbench cleanup on demand (not only the hourly sweep)
 - Add a day-detail popover to the routines calendar: clicking a day lists each fire time (HH:MM) with its routine, and a "run now" shortcut per routine
-- Add an iCal (`.ics`) export endpoint for routine schedules so upcoming fire times can be subscribed to in external calendars
+- Link the routines calendar UI to the new `GET /routines.ics` feed: add a "SUBSCRIBE" button that copies the feed URL, plus a per-routine `?routine=<id>` filter on the endpoint
+- Fold the host's local timezone into the `.ics` feed as a `VTIMEZONE` block with `DTSTART;TZID=` local times, so subscribers see fire times in the routine's own zone instead of only UTC
 - Auto-stamp the release version/date into CHANGELOG.md from the `chore(release)` step so the `## [Unreleased]` section rolls over on tag
 - Add a CI check that fails a PR when it changes `src/` or `ui/` but leaves `## [Unreleased]` in CHANGELOG.md empty
 - Have a commands folder for all the cli commands, we want to work with colocation of files

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -451,6 +451,21 @@
         }
       }
     },
+    "/routines.ics": {
+      "get": {
+        "tags": [
+          "crate::routines"
+        ],
+        "summary": "`GET /routines.ics` — iCalendar feed of every enabled routine's upcoming fire times.",
+        "description": "Returns a `text/calendar` body suitable for subscribing to in an external calendar\n(Google Calendar, Apple Calendar, …) so upcoming runs show up alongside other events.",
+        "operationId": "ical_feed",
+        "responses": {
+          "200": {
+            "description": "iCalendar (text/calendar) feed of upcoming routine fire times"
+          }
+        }
+      }
+    },
     "/routines/{id}": {
       "get": {
         "tags": [

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -26,6 +26,7 @@
         crate::routines::delete,
         crate::routines::trigger,
         crate::routines::get_logs,
+        crate::routines::ical_feed,
     ),
     components(schemas(
         crate::cron_jobs::CronJob,

--- a/src/routes/http.rs
+++ b/src/routes/http.rs
@@ -160,6 +160,7 @@ pub(crate) fn build_app_with_shutdown(
         .route("/cron-jobs/{id}/trigger", post(cron_jobs::trigger))
         .route("/cron-jobs/{id}/logs", get(cron_jobs::get_logs))
         .route("/agents", get(routines::list_agents))
+        .route("/routines.ics", get(routines::ical_feed))
         .route("/routines", get(routines::list).post(routines::create))
         .route(
             "/routines/{id}",

--- a/src/routes/http_tests.rs
+++ b/src/routes/http_tests.rs
@@ -702,3 +702,46 @@ async fn mcp_endpoint_triggers_factory() {
         .unwrap();
     assert!(resp.status().as_u16() < 500);
 }
+
+#[tokio::test]
+async fn router_serves_routines_ical_feed() {
+    let routines = crate::routines::new_store();
+    routines.lock().unwrap().insert(
+        "r1".to_string(),
+        crate::routines::Routine {
+            id: "r1".to_string(),
+            schedule: "@daily".to_string(),
+            title: "My Routine".to_string(),
+            agent: "claude".to_string(),
+            prompt: "do the thing".to_string(),
+            repositories: vec![],
+            enabled: true,
+            source: "managed".to_string(),
+            created_at: 0,
+            updated_at: 0,
+            last_triggered_at: None,
+            ttl_secs: None,
+        },
+    );
+    let resp = build_app(new_store(), routines)
+        .oneshot(
+            Request::builder()
+                .uri("/routines.ics")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers().get(CONTENT_TYPE).unwrap(),
+        "text/calendar; charset=utf-8"
+    );
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body = String::from_utf8(bytes.to_vec()).unwrap();
+    assert!(body.starts_with("BEGIN:VCALENDAR"));
+    assert!(body.contains("BEGIN:VEVENT"));
+    assert!(body.contains("SUMMARY:My Routine"));
+}

--- a/src/routines/handlers.rs
+++ b/src/routines/handlers.rs
@@ -2,12 +2,14 @@
 
 use axum::{
     extract::{Path, State},
-    http::StatusCode,
+    http::{header, StatusCode},
+    response::IntoResponse,
     Json,
 };
 
 use crate::error::AppError;
 
+use super::ical::svc_ical;
 use super::model::{
     CreateRoutineRequest, Routine, RoutineResponse, RoutineStore, UpdateRoutineRequest,
 };
@@ -97,6 +99,19 @@ pub async fn trigger(
     Path(id): Path<String>,
 ) -> Result<Json<Routine>, AppError> {
     Ok(Json(svc_trigger(&store, &id)?))
+}
+
+/// `GET /routines.ics` — iCalendar feed of every enabled routine's upcoming fire times.
+///
+/// Returns a `text/calendar` body suitable for subscribing to in an external calendar
+/// (Google Calendar, Apple Calendar, …) so upcoming runs show up alongside other events.
+#[utoipa::path(get, path = "/routines.ics",
+    responses((status = 200, description = "iCalendar (text/calendar) feed of upcoming routine fire times")))]
+pub async fn ical_feed(State(store): State<RoutineStore>) -> impl IntoResponse {
+    (
+        [(header::CONTENT_TYPE, "text/calendar; charset=utf-8")],
+        svc_ical(&store),
+    )
 }
 
 /// `GET /routines/{id}/logs` — return the newest workbench `agent.log` as plain text.

--- a/src/routines/ical.rs
+++ b/src/routines/ical.rs
@@ -1,0 +1,92 @@
+//! iCalendar (RFC 5545) export of routine schedules so upcoming fire times can be
+//! subscribed to in external calendars.
+
+use chrono::{DateTime, Duration, Local, Utc};
+use croner::Cron;
+
+use super::model::{Routine, RoutineStore};
+
+/// How far ahead (in days) the feed projects each routine's fire times.
+const HORIZON_DAYS: i64 = 30;
+/// Maximum events emitted per routine, bounding feed size for high-frequency schedules.
+const MAX_EVENTS_PER_ROUTINE: usize = 100;
+/// Product identifier advertised in the `PRODID` property.
+const PRODID: &str = "-//moadim//routines//EN";
+
+/// Escape a text value for an iCalendar property per RFC 5545 §3.3.11.
+fn escape_text(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            ';' => out.push_str("\\;"),
+            ',' => out.push_str("\\,"),
+            '\n' => out.push_str("\\n"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Format a UTC instant as an iCalendar UTC date-time (`YYYYMMDDTHHMMSSZ`).
+fn format_utc(dt: DateTime<Utc>) -> String {
+    dt.format("%Y%m%dT%H%M%SZ").to_string()
+}
+
+/// Render upcoming fire times of every enabled routine as an iCalendar (`.ics`) feed.
+///
+/// Each enabled routine with a parseable schedule contributes one `VEVENT` per fire time in
+/// `(now, now + HORIZON_DAYS]`, capped at [`MAX_EVENTS_PER_ROUTINE`]. Fire times are evaluated in
+/// the host's local timezone (matching crontab semantics) and emitted as UTC instants so the feed
+/// needs no embedded `VTIMEZONE`. Disabled routines and unparseable schedules (e.g. `@reboot`)
+/// contribute nothing.
+pub fn build_ical(routines: &[Routine], now: DateTime<Local>) -> String {
+    let dtstamp = format_utc(now.with_timezone(&Utc));
+    let horizon = now + Duration::days(HORIZON_DAYS);
+    let mut lines = vec![
+        "BEGIN:VCALENDAR".to_string(),
+        "VERSION:2.0".to_string(),
+        format!("PRODID:{PRODID}"),
+        "CALSCALE:GREGORIAN".to_string(),
+        "X-WR-CALNAME:Moadim Routines".to_string(),
+    ];
+    for routine in routines {
+        if !routine.enabled {
+            continue;
+        }
+        let Ok(cron) = routine.schedule.parse::<Cron>() else {
+            continue;
+        };
+        let summary = escape_text(&routine.title);
+        let description = escape_text(&format!("{} (agent: {})", routine.prompt, routine.agent));
+        for fire in cron
+            .iter_after(now)
+            .take_while(|dt| *dt <= horizon)
+            .take(MAX_EVENTS_PER_ROUTINE)
+        {
+            let stamp = format_utc(fire.with_timezone(&Utc));
+            lines.push("BEGIN:VEVENT".to_string());
+            lines.push(format!("UID:{}-{}@moadim", routine.id, stamp));
+            lines.push(format!("DTSTAMP:{dtstamp}"));
+            lines.push(format!("DTSTART:{stamp}"));
+            lines.push(format!("SUMMARY:{summary}"));
+            lines.push(format!("DESCRIPTION:{description}"));
+            lines.push("END:VEVENT".to_string());
+        }
+    }
+    lines.push("END:VCALENDAR".to_string());
+    // RFC 5545 mandates CRLF line endings, including a trailing CRLF after the final line.
+    let mut out = lines.join("\r\n");
+    out.push_str("\r\n");
+    out
+}
+
+/// Build the iCalendar feed for every routine currently in `store`.
+pub fn svc_ical(store: &RoutineStore) -> String {
+    let routines: Vec<Routine> = store.lock().unwrap().values().cloned().collect();
+    build_ical(&routines, Local::now())
+}
+
+#[cfg(test)]
+#[path = "ical_tests.rs"]
+mod ical_tests;

--- a/src/routines/ical_tests.rs
+++ b/src/routines/ical_tests.rs
@@ -1,0 +1,93 @@
+#![allow(clippy::missing_docs_in_private_items)]
+
+use super::*;
+use crate::routines::model::{new_store, Routine};
+use chrono::{Local, TimeZone};
+
+fn routine_with(id: &str, schedule: &str, enabled: bool) -> Routine {
+    Routine {
+        id: id.to_string(),
+        schedule: schedule.to_string(),
+        title: "My Routine".to_string(),
+        agent: "claude".to_string(),
+        prompt: "do the thing".to_string(),
+        repositories: vec![],
+        enabled,
+        source: "managed".to_string(),
+        created_at: 0,
+        updated_at: 0,
+        last_triggered_at: None,
+        ttl_secs: None,
+    }
+}
+
+fn fixed_now() -> chrono::DateTime<Local> {
+    Local.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap()
+}
+
+fn count(haystack: &str, needle: &str) -> usize {
+    haystack.matches(needle).count()
+}
+
+#[test]
+fn empty_feed_has_only_calendar_wrapper() {
+    let ics = build_ical(&[], fixed_now());
+    assert!(ics.starts_with("BEGIN:VCALENDAR\r\n"));
+    assert!(ics.contains("VERSION:2.0\r\n"));
+    assert!(ics.contains("PRODID:-//moadim//routines//EN\r\n"));
+    assert!(ics.contains("X-WR-CALNAME:Moadim Routines\r\n"));
+    assert!(ics.ends_with("END:VCALENDAR\r\n"));
+    assert_eq!(count(&ics, "BEGIN:VEVENT"), 0);
+}
+
+#[test]
+fn enabled_daily_routine_yields_events_within_horizon() {
+    let ics = build_ical(&[routine_with("r1", "@daily", true)], fixed_now());
+    let events = count(&ics, "BEGIN:VEVENT");
+    // ~30 daily fires fall inside the 30-day horizon; allow slack for DST edges.
+    assert!(events >= 28, "expected ~30 daily events, got {events}");
+    assert!(ics.contains("SUMMARY:My Routine\r\n"));
+    assert!(ics.contains("DESCRIPTION:do the thing (agent: claude)\r\n"));
+    assert!(ics.contains("UID:r1-"));
+    assert!(ics.contains("@moadim\r\n"));
+    assert!(ics.contains("DTSTART:"));
+    assert!(ics.contains("DTSTAMP:"));
+}
+
+#[test]
+fn disabled_routine_contributes_nothing() {
+    let ics = build_ical(&[routine_with("r1", "@daily", false)], fixed_now());
+    assert_eq!(count(&ics, "BEGIN:VEVENT"), 0);
+}
+
+#[test]
+fn unparseable_schedule_is_skipped() {
+    let ics = build_ical(&[routine_with("r1", "@reboot", true)], fixed_now());
+    assert_eq!(count(&ics, "BEGIN:VEVENT"), 0);
+}
+
+#[test]
+fn high_frequency_schedule_is_capped() {
+    let ics = build_ical(&[routine_with("r1", "* * * * *", true)], fixed_now());
+    assert_eq!(count(&ics, "BEGIN:VEVENT"), 100);
+}
+
+#[test]
+fn text_fields_are_escaped() {
+    let mut r = routine_with("r1", "@daily", true);
+    r.title = "a,b;c\\d\ne".to_string();
+    let ics = build_ical(&[r], fixed_now());
+    assert!(ics.contains("SUMMARY:a\\,b\\;c\\\\d\\ne\r\n"));
+}
+
+#[test]
+fn svc_ical_reads_store() {
+    let store = new_store();
+    store
+        .lock()
+        .unwrap()
+        .insert("r1".to_string(), routine_with("r1", "@daily", true));
+    let ics = svc_ical(&store);
+    assert!(ics.starts_with("BEGIN:VCALENDAR"));
+    assert!(ics.contains("BEGIN:VEVENT"));
+}

--- a/src/routines/mod.rs
+++ b/src/routines/mod.rs
@@ -11,12 +11,14 @@
 //! - [`command`] — prompt composition and the single-line launch command builder.
 //! - [`service`] — store-mutating service functions (list/get/create/update/delete/trigger/logs).
 //! - [`cleanup`] — auto-removal of finished, expired run workbenches (per-routine TTL).
+//! - [`ical`] — iCalendar (`.ics`) export of upcoming routine fire times.
 //! - [`handlers`] — the Axum HTTP handlers.
 
 mod agents;
 mod cleanup;
 mod command;
 mod handlers;
+mod ical;
 mod model;
 mod service;
 


### PR DESCRIPTION
## TODO item

Implements **"Add an iCal (`.ics`) export endpoint for routine schedules so upcoming fire times can be subscribed to in external calendars"** from `TODO.md`.

## Approach

New `GET /routines.ics` returns an [RFC 5545](https://datatracker.ietf.org/doc/html/rfc5545) iCalendar feed that any calendar client (Google/Apple/Outlook) can subscribe to.

- **`src/routines/ical.rs`**
  - `build_ical(routines, now)` — pure, fully unit-testable. For each **enabled** routine with a parseable schedule it emits one `VEVENT` per fire time in `(now, now + 30 days]`, capped at 100 events per routine. Fire times are computed with `croner` in the **host local timezone** (matching crontab semantics) and emitted as **UTC instants** (`...Z`), so the feed needs **no embedded `VTIMEZONE`**. Disabled routines and unparseable schedules (e.g. `@reboot`) contribute nothing. Text fields are escaped per RFC 5545 §3.3.11; output uses CRLF line endings.
  - `svc_ical(store)` — snapshots the store and renders with `Local::now()`.
- **`handlers::ical_feed`** serves the body as `text/calendar; charset=utf-8`.
- **Route:** `/routines.ics` — a sibling of `/routines`, so it never collides with the `/routines/{id}` capture.
- Registered in the OpenAPI spec; `Architecture.md` and `CHANGELOG.md` updated. Adds `chrono` as a direct dependency (already in the tree via `croner`).

## Checks

- `cargo fmt --check` — clean.
- `cargo clippy --all-targets` — clean.
- `cargo test` — **232 passed**.
- `cargo llvm-cov` — the new `src/routines/ical.rs` and `src/routines/handlers.rs` are at **100%** line & function coverage. (The repo-wide total is below 100% only in pre-existing, untouched files — the known HEAD-on-stable gap; this change adds only fully-covered lines.)

No UI/`prebuilt.html` churn — the diff is server-side + docs only.

## TODO bookkeeping

- **Removed:** `Add an iCal (.ics) export endpoint for routine schedules …`
- **Added:**
  - Link the routines calendar UI to the new `GET /routines.ics` feed: a "SUBSCRIBE" button that copies the feed URL, plus a per-routine `?routine=<id>` filter on the endpoint.
  - Fold the host's local timezone into the `.ics` feed as a `VTIMEZONE` block with `DTSTART;TZID=` local times, so subscribers see fire times in the routine's own zone instead of only UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)