### PR TITLE
feat(ui): serve web client from / instead of /ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Rust server that exposes cron job management over three interfaces simultaneously:
 
-- **UI** (`http://localhost:5784/ui`) — browser dashboard for managing jobs
+- **UI** (`http://localhost:5784/`) — browser dashboard for managing jobs
 - **REST** (`http://localhost:5784/`) — standard HTTP API for browsers, CLI tools, and services
 - **MCP** (`http://localhost:5784/mcp`) — [Model Context Protocol](https://modelcontextprotocol.io) for AI agents (Claude, etc.)
 

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -21,11 +21,11 @@
         "tags": [
           "crate::routes::http"
         ],
-        "summary": "`GET /` — liveness check.",
+        "summary": "`GET /` — serve the web client (single-page UI).",
         "operationId": "index",
         "responses": {
           "200": {
-            "description": "Server is running",
+            "description": "Web client HTML",
             "content": {
               "text/plain": {
                 "schema": {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,8 @@
 //! Command-line interface: run-mode selection and background-process lifecycle.
 //!
 //! The `moadim` binary runs an HTTP/MCP/UI server. By default it starts that server **detached in
-//! the background** and returns control to the shell — you then manage it from the client (the
-//! `/ui` "STOP" button) or with `moadim stop`. Pass `--interactive` to run it in the foreground
+//! the background** and returns control to the shell — you then manage it from the client (the web
+//! UI "STOP" button at the root URL) or with `moadim stop`. Pass `--interactive` to run it in the foreground
 //! attached to the terminal instead (Ctrl-C to stop).
 
 use std::io::{Read as _, Write as _};
@@ -77,7 +77,7 @@ pub fn print_help() {
          \x20   help, -h, --help       show this help\n\
          \x20   version, -V            show the version\n\
          \n\
-         Once running, manage the server from the web client at http://{BIND_ADDR}/ui\n\
+         Once running, manage the server from the web client at http://{BIND_ADDR}\n\
          (the STOP button) or with `moadim stop`."
     );
 }
@@ -101,7 +101,7 @@ pub fn run_background() -> anyhow::Result<()> {
     }
     let pid = spawn_detached()?;
     println!("moadim started in the background (pid {pid}) at http://{BIND_ADDR}");
-    println!("  UI    http://{BIND_ADDR}/ui");
+    println!("  UI    http://{BIND_ADDR}");
     println!("  stop  moadim stop   (or use the STOP button in the UI)");
     println!("  logs  {}", paths_daemon_log());
     Ok(())

--- a/src/routes/http.rs
+++ b/src/routes/http.rs
@@ -42,11 +42,11 @@ pub struct EchoResponse {
     pub timestamp: u64,
 }
 
-/// `GET /` — liveness check.
+/// `GET /` — serve the web client (single-page UI).
 #[utoipa::path(get, path = "/",
-    responses((status = 200, description = "Server is running", body = str)))]
-pub async fn index() -> &'static str {
-    "Moadim server is running"
+    responses((status = 200, description = "Web client HTML", body = str)))]
+pub async fn index() -> axum::response::Html<&'static str> {
+    axum::response::Html(include_str!(concat!(env!("OUT_DIR"), "/index.html")))
 }
 
 /// `GET /health` — health check with uptime.
@@ -139,13 +139,12 @@ pub(crate) fn build_app_with_shutdown(
     );
 
     Router::new()
+        .route("/", get(index))
+        // Back-compat: the UI used to live at `/ui`; redirect old links to the root.
         .route(
             "/ui",
-            get(|| async {
-                axum::response::Html(include_str!(concat!(env!("OUT_DIR"), "/index.html")))
-            }),
+            get(|| async { axum::response::Redirect::permanent("/") }),
         )
-        .route("/", get(index))
         .route("/health", get(health))
         .route("/shutdown", post(shutdown))
         .route("/echo", post(echo))

--- a/src/routes/http_tests.rs
+++ b/src/routes/http_tests.rs
@@ -65,13 +65,26 @@ async fn build_app_serves_health() {
 }
 
 #[tokio::test]
-async fn build_app_serves_ui() {
+async fn build_app_serves_ui_at_root() {
+    let app = build_app(new_store(), crate::routines::new_store());
+    let resp = app
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let ctype = resp.headers().get(CONTENT_TYPE).unwrap();
+    assert!(ctype.to_str().unwrap().starts_with("text/html"));
+}
+
+#[tokio::test]
+async fn build_app_redirects_ui_to_root() {
     let app = build_app(new_store(), crate::routines::new_store());
     let resp = app
         .oneshot(Request::builder().uri("/ui").body(Body::empty()).unwrap())
         .await
         .unwrap();
-    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.status(), StatusCode::PERMANENT_REDIRECT);
+    assert_eq!(resp.headers().get("location").unwrap(), "/");
 }
 
 // ── cron-jobs CRUD lifecycle (covers all HTTP handlers + FromRef) ─────────────

--- a/src/utils/startup_print.rs
+++ b/src/utils/startup_print.rs
@@ -3,9 +3,8 @@
 /// Print server addresses to stdout.
 pub fn print(addr: &str) {
     println!("Server on http://{addr}");
-    println!("  REST  http://{addr}/");
+    println!("  UI    http://{addr}/");
     println!("  MCP   http://{addr}/mcp");
-    println!("  UI    http://{addr}/ui");
     println!("  Docs  http://{addr}/docs");
 }
 


### PR DESCRIPTION
## What
Serve the single-page web UI from the root URL `/` instead of `/ui`.

## Changes
- `GET /` now returns the UI HTML (was a plain-text liveness string).
- `GET /ui` → **308 permanent redirect** to `/` (back-compat for old links/bookmarks).
- Updated CLI help text, background-start output, and startup banner to point at the root URL.
- Updated README.
- Tests: `/` serves `text/html`; `/ui` redirects to `/`.

Liveness checks should use `GET /health` (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)