### PR TITLE
chore(lints): deny single-character identifiers via clippy::min_ident_chars

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,5 @@ missing_docs = "deny"
 [lints.clippy]
 all = "deny"
 missing_docs_in_private_items = "deny"
+# Reject single-character identifiers (threshold 1, the lint default).
+min_ident_chars = "deny"


### PR DESCRIPTION
## What

Enable the `clippy::min_ident_chars` restriction lint at `deny` level in the `moadim` package's `[lints.clippy]` block.

## Why

`min_ident_chars` is allow-by-default and is **not** pulled in by `clippy::all`, so single-character identifiers slipped through. With the lint's default threshold of `1`, any identifier that is a single character (after stripping leading underscores) now fails the build — keeping names descriptive.

## Notes

- Scoped to the `moadim` package (`[lints]` is package-scoped, not workspace-wide).
- `cargo clippy` is already clean against the existing code — no source changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)