### PR TITLE
ci: run the typos spell checker on PRs

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,21 @@
+name: Spell check
+
+# Gate every PR (and pushes to main) on the `typos` spell checker so prose and
+# source typos are caught even when contributors haven't installed the local
+# pre-commit hook. Uses the same typos.toml config as the hook, so CI and local
+# runs stay in lockstep.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  typos:
+    name: typos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Spell check with typos
+        uses: crate-ci/typos@master

--- a/TODO.md
+++ b/TODO.md
@@ -4,8 +4,9 @@
 
 This is a list of todos for consumption, in a pr remove the todo you have implemented and add any new ones you think of.
 
-- Run the `typos` spell check in CI (GitHub Actions) so PRs are gated even without local hooks installed
 - Add a `cargo xtask spellcheck` (or `make spell`) wrapper that installs and runs `typos` so contributors don't need to know the tool name
+- Add a `fmt + clippy` CI job (mirroring the pre-push hook: `cargo fmt --check`, `cargo clippy -- -D warnings`) so style/lint regressions are caught in PRs without local hooks
+- Pin the `crate-ci/typos` action to a tagged release (instead of `@master`) and add a weekly scheduled run so the spell-check gate is reproducible and stays current
 - Add a day-detail popover to the routines calendar: clicking a day lists each fire time (HH:MM) with its routine, and a "run now" shortcut per routine
 - Link the routines calendar UI to the new `GET /routines.ics` feed: add a "SUBSCRIBE" button that copies the feed URL, plus a per-routine `?routine=<id>` filter on the endpoint
 - Fold the host's local timezone into the `.ics` feed as a `VTIMEZONE` block with `DTSTART;TZID=` local times, so subscribers see fire times in the routine's own zone instead of only UTC


### PR DESCRIPTION
## TODO item implemented

> Run the `typos` spell check in CI (GitHub Actions) so PRs are gated even without local hooks installed

## Approach

The repo already runs `typos` in the `pre-commit` hook (config in `typos.toml`), but that only helps contributors who installed the local hooks. This adds a `.github/workflows/spellcheck.yml` workflow that runs the official `crate-ci/typos` action on every `pull_request` and on pushes to `main`.

- Reuses the existing `typos.toml` automatically (the action reads repo-root config), so CI and the local hook stay in lockstep — same excludes, same `extend-words`.
- No Rust touched, so the fmt/clippy/100%-coverage pre-push gates are unaffected.
- Verified locally: `typos` passes clean on the branch (including the new workflow file).

## New TODOs added (ship one, dream up two)

- Add a `fmt + clippy` CI job mirroring the pre-push hook so style/lint regressions are caught in PRs without local hooks.
- Pin the `crate-ci/typos` action to a tagged release (instead of `@master`) and add a weekly scheduled run so the gate is reproducible and stays current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)