### PR TITLE
feat(routines): cap workbench TTL at min(1h, cron interval)

### DIFF
--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -817,7 +817,7 @@
               "null"
             ],
             "format": "int64",
-            "description": "Workbench retention in seconds for finished runs; `None` uses [`DEFAULT_TTL_SECS`].",
+            "description": "Workbench retention in seconds for finished runs; caps the cron-derived\nretention lower. `None` uses `min(MAX_TTL_SECS, cron interval)`.",
             "minimum": 0
           }
         }
@@ -1077,7 +1077,7 @@
               "null"
             ],
             "format": "int64",
-            "description": "How long (seconds) a finished run's workbench is retained before auto-cleanup removes it.\n`None` falls back to [`DEFAULT_TTL_SECS`]. Sessions still running are never reaped.",
+            "description": "How long (seconds) a finished run's workbench is retained before auto-cleanup removes it.\nCaps the cron-derived retention (`min(MAX_TTL_SECS, cron interval)`) lower; it can only\nshorten, never extend it. `None` uses the cron-derived value. Sessions still running are\nnever reaped. The cap and [`Routine::effective_ttl_secs`] live in the cleanup module.",
             "minimum": 0
           },
           "updated_at": {

--- a/src/routines/cleanup/cleanup_tests.rs
+++ b/src/routines/cleanup/cleanup_tests.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::missing_docs_in_private_items)]
 
 use super::*;
+use super::ttl::MAX_TTL_SECS;
 
 #[test]
 fn parse_workbench_name_splits_slug_and_timestamp() {
@@ -83,11 +84,10 @@ fn reap_dir_uses_per_slug_ttl() {
     std::fs::remove_dir_all(&base).unwrap();
 }
 
-#[test]
-fn effective_ttl_falls_back_to_default() {
-    let mut r = super::super::model::Routine {
+fn routine_with(schedule: &str, ttl_secs: Option<u64>) -> super::super::model::Routine {
+    super::super::model::Routine {
         id: "x".into(),
-        schedule: "@daily".into(),
+        schedule: schedule.into(),
         title: "t".into(),
         agent: "claude".into(),
         prompt: "p".into(),
@@ -97,9 +97,48 @@ fn effective_ttl_falls_back_to_default() {
         created_at: 0,
         updated_at: 0,
         last_triggered_at: None,
-        ttl_secs: None,
-    };
-    assert_eq!(r.effective_ttl_secs(), DEFAULT_TTL_SECS);
-    r.ttl_secs = Some(42);
-    assert_eq!(r.effective_ttl_secs(), 42);
+        ttl_secs,
+    }
+}
+
+#[test]
+fn effective_ttl_caps_at_max_for_long_intervals() {
+    // Daily interval (24h) is well above the 1h cap, so retention is the cap.
+    assert_eq!(
+        routine_with("@daily", None).effective_ttl_secs(),
+        MAX_TTL_SECS
+    );
+}
+
+#[test]
+fn effective_ttl_follows_sub_hour_cron_interval() {
+    // Every 10 minutes -> retention is the 600s interval, below the cap.
+    assert_eq!(
+        routine_with("*/10 * * * *", None).effective_ttl_secs(),
+        10 * 60
+    );
+}
+
+#[test]
+fn effective_ttl_explicit_only_lowers() {
+    // An explicit ttl_secs below the cap wins.
+    assert_eq!(routine_with("@daily", Some(42)).effective_ttl_secs(), 42);
+    // An explicit ttl_secs above the cap is clamped down to it.
+    assert_eq!(
+        routine_with("@daily", Some(u64::MAX)).effective_ttl_secs(),
+        MAX_TTL_SECS
+    );
+    // It cannot raise retention above the smaller cron interval either.
+    assert_eq!(
+        routine_with("*/10 * * * *", Some(u64::MAX)).effective_ttl_secs(),
+        10 * 60
+    );
+}
+
+#[test]
+fn effective_ttl_falls_back_to_cap_for_unparseable_schedule() {
+    assert_eq!(
+        routine_with("@reboot", None).effective_ttl_secs(),
+        MAX_TTL_SECS
+    );
 }

--- a/src/routines/cleanup/mod.rs
+++ b/src/routines/cleanup/mod.rs
@@ -5,7 +5,7 @@
 //! the workbench (prompt, logs, cloned repos) lingers forever. This module reaps those leftovers: a
 //! workbench is removed once its run has *finished* (no live tmux session) **and** it is older than
 //! the owning routine's [`Routine::effective_ttl_secs`]. Still-running sessions are never touched,
-//! and orphaned workbenches (routine since deleted) fall back to [`DEFAULT_TTL_SECS`].
+//! and orphaned workbenches (routine since deleted) fall back to `MAX_TTL_SECS`.
 
 use std::path::Path;
 use std::time::Duration;
@@ -17,7 +17,6 @@ use super::model::RoutineStore;
 
 mod snapshot;
 mod ttl;
-pub use ttl::DEFAULT_TTL_SECS;
 
 /// How often the background task scans for expired workbenches.
 pub const CLEANUP_INTERVAL: Duration = Duration::from_secs(60 * 60);

--- a/src/routines/cleanup/snapshot.rs
+++ b/src/routines/cleanup/snapshot.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use super::super::command::slugify;
 use super::super::model::RoutineStore;
-use super::ttl::DEFAULT_TTL_SECS;
+use super::ttl::MAX_TTL_SECS;
 
 /// Snapshot each routine's `slug -> effective TTL` from the store.
 ///
@@ -18,7 +18,7 @@ pub fn snapshot_ttls(store: &RoutineStore) -> HashMap<String, u64> {
 }
 
 /// Resolve a workbench slug's TTL against a [`snapshot_ttls`] map, falling back to
-/// [`DEFAULT_TTL_SECS`] for orphaned workbenches whose routine was since deleted.
+/// [`MAX_TTL_SECS`] for orphaned workbenches whose routine was since deleted.
 pub fn ttl_for(snapshot: &HashMap<String, u64>, slug: &str) -> u64 {
-    snapshot.get(slug).copied().unwrap_or(DEFAULT_TTL_SECS)
+    snapshot.get(slug).copied().unwrap_or(MAX_TTL_SECS)
 }

--- a/src/routines/cleanup/ttl.rs
+++ b/src/routines/cleanup/ttl.rs
@@ -1,16 +1,40 @@
 //! Retention (TTL) config for finished-run workbenches.
 //!
 //! A finished workbench is reaped once it is older than its routine's TTL (see the cleanup module).
-//! A routine without an explicit `ttl_secs` falls back to [`DEFAULT_TTL_SECS`].
+//! Retention is kept short: a finished run is worth keeping only until the next run is due, and
+//! never longer than [`MAX_TTL_SECS`]. So the effective TTL is `min(MAX_TTL_SECS, cron interval)`,
+//! optionally lowered further by an explicit `ttl_secs`.
+
+use chrono::Local;
+use croner::Cron;
 
 use super::super::model::Routine;
 
-/// Default retention for a finished run's workbench when a routine sets no explicit `ttl_secs`.
-pub const DEFAULT_TTL_SECS: u64 = 7 * 24 * 60 * 60;
+/// Upper bound on how long a finished run's workbench is retained: one hour.
+///
+/// Also the fallback when a routine's schedule can't be parsed (e.g. `@reboot`) or its interval
+/// can't be computed, and the retention for orphaned workbenches whose routine was since deleted.
+pub const MAX_TTL_SECS: u64 = 60 * 60;
 
 impl Routine {
-    /// Retention for this routine's finished workbenches: its `ttl_secs` or [`DEFAULT_TTL_SECS`].
+    /// Retention for this routine's finished workbenches.
+    ///
+    /// `min(MAX_TTL_SECS, cron interval)`, then further lowered by an explicit `ttl_secs` if set.
+    /// An explicit `ttl_secs` can only shorten retention, never raise it above the cron-derived cap.
     pub fn effective_ttl_secs(&self) -> u64 {
-        self.ttl_secs.unwrap_or(DEFAULT_TTL_SECS)
+        let ceiling = MAX_TTL_SECS.min(self.cron_interval_secs().unwrap_or(MAX_TTL_SECS));
+        self.ttl_secs.map_or(ceiling, |t| t.min(ceiling))
+    }
+
+    /// Seconds between the next two scheduled runs, or `None` if the schedule can't be parsed or two
+    /// future fire times can't be computed. For irregular schedules this is the interval starting
+    /// now; since it only matters when below [`MAX_TTL_SECS`], sub-hour schedules (the only ones it
+    /// changes) have a constant interval regardless of `now`.
+    fn cron_interval_secs(&self) -> Option<u64> {
+        let cron = self.schedule.parse::<Cron>().ok()?;
+        let mut fires = cron.iter_after(Local::now());
+        let first = fires.next()?;
+        let second = fires.next()?;
+        u64::try_from((second - first).num_seconds()).ok()
     }
 }

--- a/src/routines/model.rs
+++ b/src/routines/model.rs
@@ -47,8 +47,9 @@ pub struct Routine {
     /// Unix timestamp (seconds) when the routine was last manually triggered, if ever.
     pub last_triggered_at: Option<u64>,
     /// How long (seconds) a finished run's workbench is retained before auto-cleanup removes it.
-    /// `None` falls back to [`crate::routines::DEFAULT_TTL_SECS`]. Sessions still running are never
-    /// reaped. The default and [`Routine::effective_ttl_secs`] live in the cleanup module.
+    /// Caps the cron-derived retention (`min(MAX_TTL_SECS, cron interval)`) lower; it can only
+    /// shorten, never extend it. `None` uses the cron-derived value. Sessions still running are
+    /// never reaped. The cap and [`Routine::effective_ttl_secs`] live in the cleanup module.
     #[serde(default)]
     pub ttl_secs: Option<u64>,
 }
@@ -145,8 +146,8 @@ pub struct CreateRoutineRequest {
     /// Whether to create the routine enabled (defaults to `true`).
     #[serde(default = "bool_true")]
     pub enabled: bool,
-    /// Workbench retention in seconds for finished runs; `None` uses
-    /// [`crate::routines::DEFAULT_TTL_SECS`].
+    /// Workbench retention in seconds for finished runs; caps the cron-derived
+    /// retention lower. `None` uses `min(MAX_TTL_SECS, cron interval)`.
     #[serde(default)]
     pub ttl_secs: Option<u64>,
 }


### PR DESCRIPTION
## What

Finished-run workbenches were retained for a flat **7-day** default before auto-cleanup reaped them. A finished run is only worth keeping until the next run is due — so derive retention from the schedule instead.

Effective TTL is now:

```
min(MAX_TTL_SECS = 1h, interval between the next two cron fires)
```

e.g. `*/10 * * * *` → 10 minutes; `@daily` → capped at 1h; `@reboot`/unparseable → 1h fallback.

## Details

- `MAX_TTL_SECS` (1h) replaces the old 7-day `DEFAULT_TTL_SECS` as the retention ceiling and the fallback for unparseable schedules + orphaned workbenches.
- `Routine::cron_interval_secs()` parses the schedule via `croner` and measures the gap between the next two fire times. Sub-hour schedules (the only ones below the cap) have a constant interval, so the `now`-relative measurement is stable.
- An explicit `ttl_secs` can now only **lower** retention further — it is clamped to the cron-derived cap, never above it.
- Orphaned workbenches (routine since deleted) now fall back to 1h instead of 7 days.

## Tests

- `effective_ttl_caps_at_max_for_long_intervals` — `@daily` → 1h cap
- `effective_ttl_follows_sub_hour_cron_interval` — `*/10 * * * *` → 600s
- `effective_ttl_explicit_only_lowers` — explicit ttl below cap wins; above cap clamps down
- `effective_ttl_falls_back_to_cap_for_unparseable_schedule` — `@reboot` → 1h

`cargo test` (247 passing) + `cargo clippy --all-targets` clean. `apis/openapi.json` regenerated for the updated `ttl_secs` field docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)