### PR TITLE
feat(cli): --json output for `moadim status` and `moadim cleanup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 - This changelog.
 - `GET /routines.ics` iCalendar feed of upcoming routine fire times for
   subscribing in external calendars.
+- `--json` flag for `moadim status` and `moadim cleanup` so their output can be
+  consumed by scripts.
+
+### Fixed
+
+- Restore the build under `#![deny(warnings)]` and regenerate the committed
+  OpenAPI spec, both left stale by the cleanup-module/TTL refactor.
 
 ## [0.7.0] - 2026-06-16
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,9 @@ Moadim runs as a local daemon. By default it starts **in the background**:
 moadim                 # start detached, print the PID, return to the shell
 moadim --interactive   # run in the foreground, attached to the terminal (Ctrl-C to stop)
 moadim status          # report whether a server is running
+moadim status --json   # same, as a machine-readable JSON object
 moadim cleanup         # reap finished, expired routine workbenches now
+moadim cleanup --json  # same, as a machine-readable JSON object
 moadim stop            # ask a running server to stop
 ```
 
@@ -195,8 +197,8 @@ moadim stop            # ask a running server to stop
 | `moadim`           | background    | Spawns a detached server, writes its PID to `~/.config/moadim/moadim.pid`, logs to `~/.config/moadim/daemon.log`, and exits. Refuses to start if one is already running. |
 | `moadim -i`        | interactive   | Runs in the foreground; logs to the terminal; Ctrl-C stops it. |
 | `moadim stop`      | —             | Sends `POST /shutdown` to the running server for a graceful stop. |
-| `moadim status`    | —             | Prints whether a server is reachable on `127.0.0.1:5784`. |
-| `moadim cleanup`   | —             | Sends `POST /routines/cleanup` to the running server and prints how many finished, expired routine workbenches were reaped (the on-demand version of the hourly sweep). |
+| `moadim status`    | —             | Prints whether a server is reachable on `127.0.0.1:5784`. Add `--json` for `{"running":bool,"pid":N\|null,"address":"127.0.0.1:5784"}`. |
+| `moadim cleanup`   | —             | Sends `POST /routines/cleanup` to the running server and prints how many finished, expired routine workbenches were reaped (the on-demand version of the hourly sweep). Add `--json` for `{"running":bool,"removed":N}`. |
 
 Because the default mode is detached, you stop the server **from the client**:
 press the **STOP** button in the UI header, run `moadim stop`, or send

--- a/TODO.md
+++ b/TODO.md
@@ -19,7 +19,8 @@ This is a list of todos for consumption, in a pr remove the todo you have implem
 - Have better daemon logging, with timestamps and log levels
 - Add a TTL preset row (1h / 1d / 7d / 30d) under the WORKBENCH TTL input in the routine form, mirroring the cron schedule presets
 - Show a humanized retention countdown ("expires in 2d" / "expired") per finished run in the routine LOGS view, derived from the run's finish time and the routine's effective TTL
-- Add a `--json` flag to `moadim status`/`cleanup` so the CLI output can be consumed by scripts
+- Enrich `moadim status --json` with the server's liveness details from `GET /health` (e.g. `uptime_secs`) so a single call returns running-state + age, not just the local PID
+- Give `moadim status`/`cleanup` a script-friendly exit-code contract (e.g. exit 3 when no server is running) so callers can branch on `$?` without parsing stdout, and document it in the README CLI table
 - Add a `moadim restart` CLI subcommand that stops a running daemon (if any) and starts a fresh background instance
 - Return the freed disk bytes alongside `removed` in `CleanupResponse` and surface "removed N (freed 12.4 MB)" in the UI cleanup toast
 - Auto-refresh the routine LOGS view (or show a removed badge) after a CLEANUP NOW sweep so stale run output isn't shown for reaped workbenches

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,10 +27,11 @@ pub enum Command {
     Background,
     /// Ask a running background server to stop.
     Stop,
-    /// Report whether a server is currently running.
-    Status,
-    /// Ask a running server to reap finished, expired routine run workbenches now.
-    Cleanup,
+    /// Report whether a server is currently running. `json` requests machine-readable output.
+    Status { json: bool },
+    /// Ask a running server to reap finished, expired routine run workbenches now. `json` requests
+    /// machine-readable output.
+    Cleanup { json: bool },
     /// Print usage help.
     Help,
     /// Print the binary version.
@@ -46,14 +47,24 @@ pub fn parse(args: impl IntoIterator<Item = String>) -> Command {
     match args.first().map(String::as_str) {
         None => Command::Background,
         Some("stop") => Command::Stop,
-        Some("status") => Command::Status,
-        Some("cleanup") => Command::Cleanup,
+        Some("status") => Command::Status {
+            json: wants_json(&args[1..]),
+        },
+        Some("cleanup") => Command::Cleanup {
+            json: wants_json(&args[1..]),
+        },
         Some("-h" | "--help" | "help") => Command::Help,
         Some("-V" | "--version" | "version") => Command::Version,
         Some("-i" | "--interactive" | "-f" | "--foreground") => Command::Foreground,
         Some("-b" | "--background" | "-d" | "--detach" | "--daemon") => Command::Background,
         Some(_) => Command::Help,
     }
+}
+
+/// Whether a `--json` flag appears among a command's trailing arguments, requesting
+/// machine-readable output for `status`/`cleanup`.
+fn wants_json(rest: &[String]) -> bool {
+    rest.iter().any(|arg| arg == "--json")
 }
 
 /// Print usage help to stdout.
@@ -72,10 +83,12 @@ pub fn print_help() {
          \n\
          COMMANDS:\n\
          \x20   stop                   stop a running background server\n\
-         \x20   status                 show whether a server is running\n\
-         \x20   cleanup                reap finished, expired routine workbenches now\n\
+         \x20   status [--json]        show whether a server is running\n\
+         \x20   cleanup [--json]       reap finished, expired routine workbenches now\n\
          \x20   help, -h, --help       show this help\n\
          \x20   version, -V            show the version\n\
+         \n\
+         Pass --json to `status`/`cleanup` for a single-line machine-readable object.\n\
          \n\
          Once running, manage the server from the web client at http://{BIND_ADDR}\n\
          (the STOP button) or with `moadim stop`."
@@ -127,36 +140,72 @@ pub fn stop() -> anyhow::Result<()> {
 /// Ask a running server to reap finished, expired routine run workbenches now, and print the count.
 ///
 /// Runs the same sweep as the hourly background task instead of waiting for the next tick, via the
-/// `/routines/cleanup` route. Prints how many workbenches were removed, or a hint when no server is up.
-pub fn cleanup() -> anyhow::Result<()> {
+/// `/routines/cleanup` route. Prints how many workbenches were removed, or a hint when no server is
+/// up. With `json`, emits a single machine-readable object instead so the result can be piped into
+/// scripts.
+pub fn cleanup(json: bool) -> anyhow::Result<()> {
     match http_request_with_body("POST", "/routines/cleanup") {
         Ok((200, body)) => {
             let removed = parse_removed_count(&body).unwrap_or(0);
-            let plural = if removed == 1 { "" } else { "es" };
-            println!("cleanup removed {removed} workbench{plural}");
+            if json {
+                println!("{}", cleanup_json(removed, true));
+            } else {
+                let plural = if removed == 1 { "" } else { "es" };
+                println!("cleanup removed {removed} workbench{plural}");
+            }
             Ok(())
         }
         Ok((status, _)) => {
             anyhow::bail!("unexpected response from server: HTTP {status}");
         }
         Err(_) => {
-            println!("moadim is not running");
+            if json {
+                println!("{}", cleanup_json(0, false));
+            } else {
+                println!("moadim is not running");
+            }
             Ok(())
         }
     }
 }
 
-/// Report whether a server is running, with its PID when known.
-pub fn status() -> anyhow::Result<()> {
-    if is_running() {
-        let pid = read_pid_file()
-            .map(|p| format!(" (pid {p})"))
-            .unwrap_or_default();
-        println!("moadim is running{pid} at http://{BIND_ADDR}");
+/// Report whether a server is running, with its PID when known. With `json`, emits a single
+/// machine-readable object instead of the human-readable line.
+pub fn status(json: bool) -> anyhow::Result<()> {
+    let running = is_running();
+    let pid = read_pid_file();
+    if json {
+        println!("{}", status_json(running, pid));
+        return Ok(());
+    }
+    if running {
+        let pid_suffix = pid.map(|p| format!(" (pid {p})")).unwrap_or_default();
+        println!("moadim is running{pid_suffix} at http://{BIND_ADDR}");
     } else {
         println!("moadim is not running");
     }
     Ok(())
+}
+
+/// Render the `status` result as a one-line JSON object: `{"running":bool,"pid":N|null,"address":…}`.
+/// `pid` is `null` when no pid file is present (or the server is down).
+fn status_json(running: bool, pid: Option<u32>) -> String {
+    serde_json::json!({
+        "running": running,
+        "pid": pid,
+        "address": BIND_ADDR,
+    })
+    .to_string()
+}
+
+/// Render the `cleanup` result as a one-line JSON object: `{"running":bool,"removed":N}`. `removed`
+/// is `0` when the server is not running (`running:false`).
+fn cleanup_json(removed: usize, running: bool) -> String {
+    serde_json::json!({
+        "running": running,
+        "removed": removed,
+    })
+    .to_string()
 }
 
 /// Write the current process PID into the pid file so `stop`/`status` and signals can find it.

--- a/src/cli_tests.rs
+++ b/src/cli_tests.rs
@@ -29,12 +29,62 @@ fn background_flags_select_background() {
 #[test]
 fn stop_and_status_commands() {
     assert_eq!(parse(argv(&["stop"])), Command::Stop);
-    assert_eq!(parse(argv(&["status"])), Command::Status);
+    assert_eq!(parse(argv(&["status"])), Command::Status { json: false });
 }
 
 #[test]
 fn cleanup_command() {
-    assert_eq!(parse(argv(&["cleanup"])), Command::Cleanup);
+    assert_eq!(parse(argv(&["cleanup"])), Command::Cleanup { json: false });
+}
+
+#[test]
+fn json_flag_sets_machine_readable_output() {
+    assert_eq!(
+        parse(argv(&["status", "--json"])),
+        Command::Status { json: true }
+    );
+    assert_eq!(
+        parse(argv(&["cleanup", "--json"])),
+        Command::Cleanup { json: true }
+    );
+}
+
+#[test]
+fn json_flag_only_applies_to_its_command() {
+    // A bare `--json` (no subcommand) is an unknown arg, not a status/cleanup request.
+    assert_eq!(parse(argv(&["--json"])), Command::Help);
+    // An unrelated trailing flag does not switch on JSON output.
+    assert_eq!(
+        parse(argv(&["status", "--verbose"])),
+        Command::Status { json: false }
+    );
+}
+
+#[test]
+fn status_json_reports_running_pid_and_address() {
+    let value: serde_json::Value = serde_json::from_str(&status_json(true, Some(42))).unwrap();
+    assert_eq!(value["running"], serde_json::json!(true));
+    assert_eq!(value["pid"], serde_json::json!(42));
+    assert_eq!(value["address"], serde_json::json!(BIND_ADDR));
+}
+
+#[test]
+fn status_json_null_pid_when_unknown_or_down() {
+    let value: serde_json::Value = serde_json::from_str(&status_json(false, None)).unwrap();
+    assert_eq!(value["running"], serde_json::json!(false));
+    assert!(value["pid"].is_null());
+    assert_eq!(value["address"], serde_json::json!(BIND_ADDR));
+}
+
+#[test]
+fn cleanup_json_reports_removed_and_running() {
+    let value: serde_json::Value = serde_json::from_str(&cleanup_json(3, true)).unwrap();
+    assert_eq!(value["running"], serde_json::json!(true));
+    assert_eq!(value["removed"], serde_json::json!(3));
+
+    let down: serde_json::Value = serde_json::from_str(&cleanup_json(0, false)).unwrap();
+    assert_eq!(down["running"], serde_json::json!(false));
+    assert_eq!(down["removed"], serde_json::json!(0));
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,8 +38,8 @@ async fn main() -> anyhow::Result<()> {
             cli::print_version();
             Ok(())
         }
-        cli::Command::Status => cli::status(),
-        cli::Command::Cleanup => cli::cleanup(),
+        cli::Command::Status { json } => cli::status(json),
+        cli::Command::Cleanup { json } => cli::cleanup(json),
         cli::Command::Stop => cli::stop(),
         cli::Command::Background => cli::run_background(),
         cli::Command::Foreground => run_server().await,


### PR DESCRIPTION
## TODO item implemented

> Add a `--json` flag to `moadim status`/`cleanup` so the CLI output can be consumed by scripts

## What & approach

`moadim status` and `moadim cleanup` now accept a `--json` flag that emits a single machine-readable line instead of the human-readable text:

- `moadim status --json` → `{"running":bool,"pid":N|null,"address":"127.0.0.1:5784"}`
- `moadim cleanup --json` → `{"running":bool,"removed":N}`

Details:
- A shared `wants_json(&args[1..])` scanner drives both subcommands; the flag only switches on output for the command it trails (a bare `--json` is still an unknown arg → help).
- `Command::Status`/`Command::Cleanup` carry a `json: bool`; `main` threads it through.
- JSON is built with `serde_json::json!` (no hand-rolled strings) by pure helpers `status_json`/`cleanup_json`, unit-tested by parsing the output back and asserting fields. `pid` is `null` when no pid file is present or the server is down; `cleanup` reports `removed:0, running:false` when no server answers.
- README CLI table + `--help` + CHANGELOG updated.

## Build/test unblock (required for this branch to compile & test)

`main` (HEAD) currently fails its own pre-push gate; two of those failures stop this change from even building/testing, so they're fixed here (minimally) and called out:

- The cleanup-module/TTL refactor (#81) left `pub use ttl::DEFAULT_TTL_SECS;` with no non-doc consumer → fatal under `#![deny(warnings)]`. Annotated `#[allow(unused_imports)]` with a comment explaining it backs the `crate::routines::DEFAULT_TTL_SECS` doc/test path.
- The same refactor changed the `ttl_secs` doc comments but left `apis/openapi.json` stale, failing `openapi_tests::committed_spec_is_current`. Regenerated.

Other pre-existing HEAD gate failures are **left untouched** as out of scope: `cargo fmt --check` diff in `src/routines/command.rs`, and `clippy::min_ident_chars` errors in `src/build/*` (noted previously in #18). Repo-wide 100% line coverage is also unmet on HEAD (~83%); the actual PR CI is the `typos` spell-check, which passes.

## Checks

- `cargo test` — 249 passed (5 new CLI tests).
- `cargo fmt --check` / `cargo clippy` — changed files (`src/cli.rs`, `src/cli_tests.rs`, `src/main.rs`) are clean; remaining diagnostics are the pre-existing HEAD issues above.
- `typos` — clean.

## New todos added (ship one, dream up two)

- Enrich `moadim status --json` with liveness from `GET /health` (e.g. `uptime_secs`) so one call returns running-state + age, not just the local PID.
- Give `status`/`cleanup` a script-friendly exit-code contract (e.g. exit 3 when no server is running) so callers can branch on `$?` without parsing stdout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)