### PR TITLE
ci: pin crate-ci/typos to a release tag and add a weekly run

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -4,11 +4,20 @@ name: Spell check
 # source typos are caught even when contributors haven't installed the local
 # pre-commit hook. Uses the same typos.toml config as the hook, so CI and local
 # runs stay in lockstep.
+#
+# The action is pinned to a tagged release (not `@master`) so the gate is
+# reproducible — a new typos dictionary entry can't turn a green PR red without
+# a visible version bump here. The weekly scheduled run keeps the gate exercised
+# against `main` so dependency drift surfaces on its own cadence, not inside an
+# unrelated PR.
 
 on:
   pull_request:
   push:
     branches: [main]
+  schedule:
+    # Mondays at 06:00 UTC — keep the spell-check gate current against main.
+    - cron: "0 6 * * 1"
 
 jobs:
   typos:
@@ -18,4 +27,4 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Spell check with typos
-        uses: crate-ci/typos@master
+        uses: crate-ci/typos@v1.47.2

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,8 @@ This is a list of todos for consumption, in a pr remove the todo you have implem
 
 - Add a `cargo xtask spellcheck` (or `make spell`) wrapper that installs and runs `typos` so contributors don't need to know the tool name
 - Add a `fmt + clippy` CI job (mirroring the pre-push hook: `cargo fmt --check`, `cargo clippy -- -D warnings`) so style/lint regressions are caught in PRs without local hooks
-- Pin the `crate-ci/typos` action to a tagged release (instead of `@master`) and add a weekly scheduled run so the spell-check gate is reproducible and stays current
+- Add a CI step (or weekly scheduled job) that checks whether a newer `crate-ci/typos` release exists than the pinned tag and opens/updates a tracking issue, so the pin gets bumped on a cadence instead of drifting silently
+- Pin the remaining third-party GitHub Actions (e.g. `actions/checkout@v5`) to full commit SHAs, mirroring the typos pin, so every CI dependency is reproducible
 - Add a day-detail popover to the routines calendar: clicking a day lists each fire time (HH:MM) with its routine, and a "run now" shortcut per routine
 - Link the routines calendar UI to the new `GET /routines.ics` feed: add a "SUBSCRIBE" button that copies the feed URL, plus a per-routine `?routine=<id>` filter on the endpoint
 - Fold the host's local timezone into the `.ics` feed as a `VTIMEZONE` block with `DTSTART;TZID=` local times, so subscribers see fire times in the routine's own zone instead of only UTC


### PR DESCRIPTION
## TODO item implemented

> Pin the `crate-ci/typos` action to a tagged release (instead of `@master`) and add a weekly scheduled run so the spell-check gate is reproducible and stays current

## Approach

`.github/workflows/spellcheck.yml` used `crate-ci/typos@master`, so an upstream change (e.g. a new dictionary entry) could flip a green PR red with no visible change in this repo.

- **Pin** the action to the current latest release tag `v1.47.2` for reproducibility.
- **Add a weekly schedule** (`cron: "0 6 * * 1"`, Mondays 06:00 UTC) so the gate stays exercised against `main` on its own cadence rather than only inside unrelated PRs.
- Expanded the workflow comment to explain why it is pinned and scheduled.

No Rust touched — the cargo build/clippy/fmt/coverage gates are unaffected. `typos` runs clean locally (exit 0).

## New TODOs added (ship one, dream up two)

- Add a CI step (or weekly scheduled job) that checks whether a newer `crate-ci/typos` release exists than the pinned tag and opens/updates a tracking issue, so the pin gets bumped on a cadence instead of drifting silently.
- Pin the remaining third-party GitHub Actions (e.g. `actions/checkout@v5`) to full commit SHAs, mirroring the typos pin, so every CI dependency is reproducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)