### PR TITLE
feat(cli): `moadim restart` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 - This changelog.
 - `GET /routines.ics` iCalendar feed of upcoming routine fire times for
   subscribing in external calendars.
+- `moadim restart` CLI subcommand that stops a running daemon (if any) and
+  starts a fresh detached background instance.
 
 ## [0.7.0] - 2026-06-16
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ moadim                 # start detached, print the PID, return to the shell
 moadim --interactive   # run in the foreground, attached to the terminal (Ctrl-C to stop)
 moadim status          # report whether a server is running
 moadim cleanup         # reap finished, expired routine workbenches now
+moadim restart         # stop a running server (if any) and start a fresh one
 moadim stop            # ask a running server to stop
 ```
 
@@ -194,6 +195,7 @@ moadim stop            # ask a running server to stop
 |--------------------|---------------|-----------|
 | `moadim`           | background    | Spawns a detached server, writes its PID to `~/.config/moadim/moadim.pid`, logs to `~/.config/moadim/daemon.log`, and exits. Refuses to start if one is already running. |
 | `moadim -i`        | interactive   | Runs in the foreground; logs to the terminal; Ctrl-C stops it. |
+| `moadim restart`   | background    | Stops the running server (if any) and spawns a fresh detached instance, so you get a clean process without a separate stop/start. |
 | `moadim stop`      | —             | Sends `POST /shutdown` to the running server for a graceful stop. |
 | `moadim status`    | —             | Prints whether a server is reachable on `127.0.0.1:5784`. |
 | `moadim cleanup`   | —             | Sends `POST /routines/cleanup` to the running server and prints how many finished, expired routine workbenches were reaped (the on-demand version of the hourly sweep). |

--- a/TODO.md
+++ b/TODO.md
@@ -20,7 +20,8 @@ This is a list of todos for consumption, in a pr remove the todo you have implem
 - Add a TTL preset row (1h / 1d / 7d / 30d) under the WORKBENCH TTL input in the routine form, mirroring the cron schedule presets
 - Show a humanized retention countdown ("expires in 2d" / "expired") per finished run in the routine LOGS view, derived from the run's finish time and the routine's effective TTL
 - Add a `--json` flag to `moadim status`/`cleanup` so the CLI output can be consumed by scripts
-- Add a `moadim restart` CLI subcommand that stops a running daemon (if any) and starts a fresh background instance
+- Add a `moadim restart --interactive` (or `-i`) flavor that restarts the daemon in the foreground attached to the terminal instead of detached, mirroring `moadim -i`
+- Have `moadim restart` print the old PID it stopped and the new PID it started (e.g. "restarted: pid 123 -> 456") so scripts/logs can see the process actually rotated
 - Return the freed disk bytes alongside `removed` in `CleanupResponse` and surface "removed N (freed 12.4 MB)" in the UI cleanup toast
 - Auto-refresh the routine LOGS view (or show a removed badge) after a CLEANUP NOW sweep so stale run output isn't shown for reaped workbenches
 - Add the option to filter routines by repositories in the ui

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,6 +25,8 @@ pub enum Command {
     Foreground,
     /// Spawn the server as a detached background process, then exit (the default, non-interactive).
     Background,
+    /// Stop a running background server (if any) and start a fresh detached instance.
+    Restart,
     /// Ask a running background server to stop.
     Stop,
     /// Report whether a server is currently running.
@@ -45,6 +47,7 @@ pub fn parse(args: impl IntoIterator<Item = String>) -> Command {
     let args: Vec<String> = args.into_iter().collect();
     match args.first().map(String::as_str) {
         None => Command::Background,
+        Some("restart") => Command::Restart,
         Some("stop") => Command::Stop,
         Some("status") => Command::Status,
         Some("cleanup") => Command::Cleanup,
@@ -71,6 +74,7 @@ pub fn print_help() {
          \x20   -b, --background       start the server detached in the background (explicit default)\n\
          \n\
          COMMANDS:\n\
+         \x20   restart                stop a running server (if any) and start a fresh background one\n\
          \x20   stop                   stop a running background server\n\
          \x20   status                 show whether a server is running\n\
          \x20   cleanup                reap finished, expired routine workbenches now\n\
@@ -99,8 +103,33 @@ pub fn run_background() -> anyhow::Result<()> {
         println!("moadim is already running{pid}; stopping it to start a fresh instance");
         crate::restart::stop_running_and_wait()?;
     }
+    start_detached_and_report("started")
+}
+
+/// Stop a running background server (if any) and start a fresh detached instance.
+///
+/// Unlike [`run_background`], which restarts only as a side effect of being asked to start while
+/// one is already up, this is the explicit "give me a clean process now" command: it stops the
+/// running server when present, otherwise just starts one.
+pub fn restart() -> anyhow::Result<()> {
+    if is_running() {
+        let pid = read_pid_file()
+            .map(|p| format!(" (pid {p})"))
+            .unwrap_or_default();
+        println!("moadim is running{pid}; stopping it");
+        crate::restart::stop_running_and_wait()?;
+    } else {
+        println!("moadim is not running; starting a fresh instance");
+    }
+    start_detached_and_report("restarted")
+}
+
+/// Spawn a detached server process and print where to reach and manage it.
+///
+/// `verb` describes how the process came to be ("started" / "restarted") for the first line.
+fn start_detached_and_report(verb: &str) -> anyhow::Result<()> {
     let pid = spawn_detached()?;
-    println!("moadim started in the background (pid {pid}) at http://{BIND_ADDR}");
+    println!("moadim {verb} in the background (pid {pid}) at http://{BIND_ADDR}");
     println!("  UI    http://{BIND_ADDR}");
     println!("  stop  moadim stop   (or use the STOP button in the UI)");
     println!("  logs  {}", paths_daemon_log());

--- a/src/cli_tests.rs
+++ b/src/cli_tests.rs
@@ -38,6 +38,11 @@ fn cleanup_command() {
 }
 
 #[test]
+fn restart_command() {
+    assert_eq!(parse(argv(&["restart"])), Command::Restart);
+}
+
+#[test]
 fn help_and_version_flags() {
     for flag in ["-h", "--help", "help"] {
         assert_eq!(parse(argv(&[flag])), Command::Help, "flag {flag}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ async fn main() -> anyhow::Result<()> {
         cli::Command::Cleanup => cli::cleanup(),
         cli::Command::Stop => cli::stop(),
         cli::Command::Background => cli::run_background(),
+        cli::Command::Restart => cli::restart(),
         cli::Command::Foreground => run_server().await,
     }
 }


### PR DESCRIPTION
## TODO item implemented

> Add a `moadim restart` CLI subcommand that stops a running daemon (if any) and starts a fresh background instance

## What & approach

New `moadim restart` command: stops the running background daemon when one is up, then spawns a fresh detached instance — a clean process rotation without a manual `stop` + start.

- `Command::Restart` added to the CLI enum; `parse` maps `restart` to it; `main` dispatches to `cli::restart()`.
- `restart()` reuses the existing plumbing: `restart::stop_running_and_wait()` (graceful `POST /shutdown`, falling back to a kill) and `spawn_detached()`. When nothing is running it just starts fresh and says so.
- Factored the shared "spawn + print UI/stop/logs lines" out of `run_background` into `start_detached_and_report(verb)`, so `started` / `restarted` reuse one code path (no duplication).
- `--help`, README command list + table, and CHANGELOG `[Unreleased]` updated.

## Difference from `moadim` (background)

`moadim` restarts only as a side effect of being asked to *start* while one is already up. `moadim restart` is the explicit "give me a clean process now" command, with messaging to match (and it works whether or not one is currently running).

## Checks

- `cargo test cli` — 14 passed, including the new `restart_command` parse test.
- `cargo fmt` / `cargo clippy` — changed files (`src/cli.rs`, `src/cli_tests.rs`, `src/main.rs`) are clean. Remaining `fmt --check` diffs (`src/routines/cleanup/cleanup_tests.rs`, `src/routines/command.rs`) and `clippy::min_ident_chars` errors (`src/build/ui.rs`) are pre-existing HEAD gate failures, untouched here (same ones called out in #86 / #18).

## New todos added (ship one, dream up two)

- Add a `moadim restart --interactive` (`-i`) flavor that restarts in the foreground attached to the terminal, mirroring `moadim -i`.
- Have `moadim restart` print the old PID it stopped and the new PID it started (e.g. "restarted: pid 123 -> 456") so scripts/logs can see the process actually rotated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)