### PR TITLE
feat(cli): script-friendly exit codes for status/cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 - `moadim restart` CLI subcommand that stops a running daemon (if any) and
   starts a fresh detached background instance.
+- Script-friendly exit-code contract for `moadim status` and `moadim cleanup`:
+  they exit `0` when a server is running and `3` when none is, so callers can
+  branch on `$?` without parsing stdout.
 - Multiselect in the web UI cron-jobs table: select rows via click /
   `Shift`+click range / `Cmd`/`Ctrl`+click toggle, a select-all checkbox, and a
   bulk-action bar to enable, disable, or delete the selected jobs at once.

--- a/README.md
+++ b/README.md
@@ -199,8 +199,12 @@ moadim stop            # ask a running server to stop
 | `moadim -i`        | interactive   | Runs in the foreground; logs to the terminal; Ctrl-C stops it. |
 | `moadim restart`   | background    | Stops the running server (if any) and spawns a fresh detached instance, so you get a clean process without a separate stop/start. |
 | `moadim stop`      | —             | Sends `POST /shutdown` to the running server for a graceful stop. |
-| `moadim status`    | —             | Prints whether a server is reachable on `127.0.0.1:5784`. Add `--json` for `{"running":bool,"pid":N\|null,"address":"127.0.0.1:5784"}`. |
-| `moadim cleanup`   | —             | Sends `POST /api/v1/routines/cleanup` to the running server and prints how many finished, expired routine workbenches were reaped (the on-demand version of the hourly sweep). Add `--json` for `{"running":bool,"removed":N}`. |
+| `moadim status`    | —             | Prints whether a server is reachable on `127.0.0.1:5784`. Add `--json` for `{"running":bool,"pid":N\|null,"address":"127.0.0.1:5784"}`. Exits `0` when running, `3` when not. |
+| `moadim cleanup`   | —             | Sends `POST /api/v1/routines/cleanup` to the running server and prints how many finished, expired routine workbenches were reaped (the on-demand version of the hourly sweep). Add `--json` for `{"running":bool,"removed":N}`. Exits `0` when running, `3` when not. |
+
+`status` and `cleanup` follow a script-friendly exit-code contract so callers can branch on
+`$?` without parsing stdout: they exit `0` when a server is running (and `cleanup` swept) and
+`3` when no server is reachable. Any other failure exits non-zero (`1`) with a message on stderr.
 
 Because the default mode is detached, you stop the server **from the client**:
 press the **STOP** button in the UI header, run `moadim stop`, or send

--- a/TODO.md
+++ b/TODO.md
@@ -20,7 +20,8 @@ This is a list of todos for consumption, in a pr remove the todo you have implem
 - Add a TTL preset row (1h / 1d / 7d / 30d) under the WORKBENCH TTL input in the routine form, mirroring the cron schedule presets
 - Show a humanized retention countdown ("expires in 2d" / "expired") per finished run in the routine LOGS view, derived from the run's finish time and the routine's effective TTL
 - Enrich `moadim status --json` with the server's liveness details from `GET /health` (e.g. `uptime_secs`) so a single call returns running-state + age, not just the local PID
-- Give `moadim status`/`cleanup` a script-friendly exit-code contract (e.g. exit 3 when no server is running) so callers can branch on `$?` without parsing stdout, and document it in the README CLI table
+- Give `moadim stop` the same script-friendly exit-code contract as `status`/`cleanup` (exit 3 when no server was running to stop, 0 when a running server was asked to shut down) and document it in the README CLI table
+- Add a `moadim status --wait[=SECS]` flag that polls `GET /health` until the server is reachable (or the timeout elapses), exiting 0 on success and the existing exit-3 on timeout, so scripts can block on startup instead of sleeping
 - Add a `moadim restart --interactive` (or `-i`) flavor that restarts the daemon in the foreground attached to the terminal instead of detached, mirroring `moadim -i`
 - Have `moadim restart` print the old PID it stopped and the new PID it started (e.g. "restarted: pid 123 -> 456") so scripts/logs can see the process actually rotated
 - Return the freed disk bytes alongside `removed` in `CleanupResponse` and surface "removed N (freed 12.4 MB)" in the UI cleanup toast

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,6 +18,20 @@ const PROBE_TIMEOUT: Duration = Duration::from_millis(750);
 /// Environment marker set on the backgrounded child so it knows it was spawned by the launcher.
 const DAEMONIZED_ENV: &str = "MOADIM_DAEMONIZED";
 
+/// Process exit code emitted by `status`/`cleanup` when no server is running, so callers can branch
+/// on `$?` without parsing stdout. The success case (server reachable) exits `0`.
+pub const EXIT_NOT_RUNNING: i32 = 3;
+
+/// Map a server-liveness flag to the script-friendly process exit code: `0` when a server is
+/// reachable, [`EXIT_NOT_RUNNING`] when it is not.
+fn liveness_exit_code(running: bool) -> i32 {
+    if running {
+        0
+    } else {
+        EXIT_NOT_RUNNING
+    }
+}
+
 /// The action the user asked for on the command line.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Command {
@@ -93,6 +107,8 @@ pub fn print_help() {
          \x20   version, -V            show the version\n\
          \n\
          Pass --json to `status`/`cleanup` for a single-line machine-readable object.\n\
+         `status`/`cleanup` exit 0 when a server is running and 3 when none is, so scripts can\n\
+         branch on $? without parsing stdout.\n\
          \n\
          Once running, manage the server from the web client at http://{BIND_ADDR}\n\
          (the STOP button) or with `moadim stop`."
@@ -172,7 +188,10 @@ pub fn stop() -> anyhow::Result<()> {
 /// `/api/v1/routines/cleanup` route. Prints how many workbenches were removed, or a hint when no
 /// server is up. With `json`, emits a single machine-readable object instead so the result can be
 /// piped into scripts.
-pub fn cleanup(json: bool) -> anyhow::Result<()> {
+///
+/// Returns the process exit code to surface: `0` when the server handled the sweep, and
+/// [`EXIT_NOT_RUNNING`] when no server is running, so scripts can branch on `$?`.
+pub fn cleanup(json: bool) -> anyhow::Result<i32> {
     match http_request_with_body("POST", "/api/v1/routines/cleanup") {
         Ok((200, body)) => {
             let removed = parse_removed_count(&body).unwrap_or(0);
@@ -182,7 +201,7 @@ pub fn cleanup(json: bool) -> anyhow::Result<()> {
                 let plural = if removed == 1 { "" } else { "es" };
                 println!("cleanup removed {removed} workbench{plural}");
             }
-            Ok(())
+            Ok(liveness_exit_code(true))
         }
         Ok((status, _)) => {
             anyhow::bail!("unexpected response from server: HTTP {status}");
@@ -193,19 +212,22 @@ pub fn cleanup(json: bool) -> anyhow::Result<()> {
             } else {
                 println!("moadim is not running");
             }
-            Ok(())
+            Ok(liveness_exit_code(false))
         }
     }
 }
 
 /// Report whether a server is running, with its PID when known. With `json`, emits a single
 /// machine-readable object instead of the human-readable line.
-pub fn status(json: bool) -> anyhow::Result<()> {
+///
+/// Returns the process exit code to surface: `0` when a server is reachable, and
+/// [`EXIT_NOT_RUNNING`] when not, so scripts can branch on `$?` without parsing stdout.
+pub fn status(json: bool) -> anyhow::Result<i32> {
     let running = is_running();
     let pid = read_pid_file();
     if json {
         println!("{}", status_json(running, pid));
-        return Ok(());
+        return Ok(liveness_exit_code(running));
     }
     if running {
         let pid_suffix = pid.map(|p| format!(" (pid {p})")).unwrap_or_default();
@@ -213,7 +235,7 @@ pub fn status(json: bool) -> anyhow::Result<()> {
     } else {
         println!("moadim is not running");
     }
-    Ok(())
+    Ok(liveness_exit_code(running))
 }
 
 /// Render the `status` result as a one-line JSON object: `{"running":bool,"pid":N|null,"address":…}`.

--- a/src/cli_tests.rs
+++ b/src/cli_tests.rs
@@ -88,6 +88,14 @@ fn cleanup_json_reports_removed_and_running() {
 }
 
 #[test]
+fn liveness_exit_code_maps_running_to_codes() {
+    // A reachable server exits 0; a missing one exits the documented EXIT_NOT_RUNNING.
+    assert_eq!(liveness_exit_code(true), 0);
+    assert_eq!(liveness_exit_code(false), EXIT_NOT_RUNNING);
+    assert_eq!(EXIT_NOT_RUNNING, 3);
+}
+
+#[test]
 fn restart_command() {
     assert_eq!(parse(argv(&["restart"])), Command::Restart);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,8 +38,8 @@ async fn main() -> anyhow::Result<()> {
             cli::print_version();
             Ok(())
         }
-        cli::Command::Status { json } => cli::status(json),
-        cli::Command::Cleanup { json } => cli::cleanup(json),
+        cli::Command::Status { json } => std::process::exit(cli::status(json)?),
+        cli::Command::Cleanup { json } => std::process::exit(cli::cleanup(json)?),
         cli::Command::Stop => cli::stop(),
         cli::Command::Background => cli::run_background(),
         cli::Command::Restart => cli::restart(),


### PR DESCRIPTION
## TODO item implemented

> Give `moadim status`/`cleanup` a script-friendly exit-code contract (e.g. exit 3 when no server is running) so callers can branch on `$?` without parsing stdout, and document it in the README CLI table

## Approach

- Add `EXIT_NOT_RUNNING = 3` and a small pure `liveness_exit_code(running)` helper in `cli.rs`.
- `status` and `cleanup` now return `anyhow::Result<i32>` — the process exit code to surface: `0` when a server is reachable (and `cleanup` swept), `3` when none is. Any other failure still bubbles up as an `Err` so `main` exits `1` with a message on stderr.
- `main` maps the returned code via `std::process::exit(...)`.
- Output text/JSON is unchanged — only the exit status is new.
- Documented in the README CLI table (+ a contract paragraph) and in `--help`.
- Added a unit test for the mapping; `CHANGELOG.md` Unreleased updated.

Verified locally: `cargo fmt --check` clean, `cargo test` green (255 passed), and the built binary returns `0` while a server is running. The `3` path is covered by the unit test (`liveness_exit_code(false) == 3`).

Note: `cargo clippy` fails on `src/build/ui.rs` (`min_ident_chars`) on current stable — a pre-existing HEAD breakage unrelated to this change; no new lint in the touched files.

## New TODOs added

- Give `moadim stop` the same exit-code contract (exit 3 when nothing was running to stop).
- Add `moadim status --wait[=SECS]` that polls `GET /health` until reachable, exiting 0 on success and 3 on timeout.