### PR TITLE
feat(cli): print PID rotation on restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 - `moadim restart` CLI subcommand that stops a running daemon (if any) and
   starts a fresh detached background instance.
+- `moadim restart` now prints the PID rotation as `restarted: pid <old> -> <new>`
+  (old reads `none` when nothing was running) so scripts/logs can confirm the
+  process was actually replaced.
 - Multiselect in the web UI cron-jobs table: select rows via click /
   `Shift`+click range / `Cmd`/`Ctrl`+click toggle, a select-all checkbox, and a
   bulk-action bar to enable, disable, or delete the selected jobs at once.

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ moadim stop            # ask a running server to stop
 |--------------------|---------------|-----------|
 | `moadim`           | background    | Spawns a detached server, writes its PID to `~/.config/moadim/moadim.pid`, logs to `~/.config/moadim/daemon.log`, and exits. Refuses to start if one is already running. |
 | `moadim -i`        | interactive   | Runs in the foreground; logs to the terminal; Ctrl-C stops it. |
-| `moadim restart`   | background    | Stops the running server (if any) and spawns a fresh detached instance, so you get a clean process without a separate stop/start. |
+| `moadim restart`   | background    | Stops the running server (if any) and spawns a fresh detached instance, so you get a clean process without a separate stop/start. Prints the PID rotation as `restarted: pid <old> -> <new>` (old reads `none` when nothing was running) so scripts/logs can confirm the process actually changed. |
 | `moadim stop`      | —             | Sends `POST /shutdown` to the running server for a graceful stop. |
 | `moadim status`    | —             | Prints whether a server is reachable on `127.0.0.1:5784`. Add `--json` for `{"running":bool,"pid":N\|null,"address":"127.0.0.1:5784"}`. |
 | `moadim cleanup`   | —             | Sends `POST /api/v1/routines/cleanup` to the running server and prints how many finished, expired routine workbenches were reaped (the on-demand version of the hourly sweep). Add `--json` for `{"running":bool,"removed":N}`. |

--- a/TODO.md
+++ b/TODO.md
@@ -22,7 +22,8 @@ This is a list of todos for consumption, in a pr remove the todo you have implem
 - Enrich `moadim status --json` with the server's liveness details from `GET /health` (e.g. `uptime_secs`) so a single call returns running-state + age, not just the local PID
 - Give `moadim status`/`cleanup` a script-friendly exit-code contract (e.g. exit 3 when no server is running) so callers can branch on `$?` without parsing stdout, and document it in the README CLI table
 - Add a `moadim restart --interactive` (or `-i`) flavor that restarts the daemon in the foreground attached to the terminal instead of detached, mirroring `moadim -i`
-- Have `moadim restart` print the old PID it stopped and the new PID it started (e.g. "restarted: pid 123 -> 456") so scripts/logs can see the process actually rotated
+- Have `moadim restart` emit its PID-rotation summary as a `--json` object (`{"old":N|null,"new":M}`) too, mirroring the `status`/`cleanup` `--json` contract
+- Give `moadim restart` a `--quiet`/`-q` flag that prints only the rotation line (`restarted: pid <old> -> <new>`) and suppresses the UI/stop/logs hint block, for script consumption
 - Return the freed disk bytes alongside `removed` in `CleanupResponse` and surface "removed N (freed 12.4 MB)" in the UI cleanup toast
 - Auto-refresh the routine LOGS view (or show a removed badge) after a CLEANUP NOW sweep so stale run output isn't shown for reaped workbenches
 - Add the option to filter routines by repositories in the ui

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -125,16 +125,30 @@ pub fn run_background() -> anyhow::Result<()> {
 /// one is already up, this is the explicit "give me a clean process now" command: it stops the
 /// running server when present, otherwise just starts one.
 pub fn restart() -> anyhow::Result<()> {
-    if is_running() {
-        let pid = read_pid_file()
-            .map(|p| format!(" (pid {p})"))
-            .unwrap_or_default();
-        println!("moadim is running{pid}; stopping it");
+    let old_pid = if is_running() {
+        let pid = read_pid_file();
+        let suffix = pid.map(|p| format!(" (pid {p})")).unwrap_or_default();
+        println!("moadim is running{suffix}; stopping it");
         crate::restart::stop_running_and_wait()?;
+        pid
     } else {
         println!("moadim is not running; starting a fresh instance");
-    }
-    start_detached_and_report("restarted")
+        None
+    };
+    let new_pid = spawn_detached()?;
+    // Headline the rotation so scripts/logs can see the process actually changed.
+    println!("{}", restart_rotation_line(old_pid, new_pid));
+    report_endpoints();
+    Ok(())
+}
+
+/// Format the one-line PID rotation summary `restart` prints, e.g. `restarted: pid 123 -> 456`.
+///
+/// `old` is the PID of the server that was stopped; when nothing was running (or its PID could not
+/// be read) the old side reads `none`, e.g. `restarted: pid none -> 456`.
+fn restart_rotation_line(old: Option<u32>, new: u32) -> String {
+    let old = old.map_or_else(|| "none".to_string(), |pid| pid.to_string());
+    format!("restarted: pid {old} -> {new}")
 }
 
 /// Spawn a detached server process and print where to reach and manage it.
@@ -143,10 +157,15 @@ pub fn restart() -> anyhow::Result<()> {
 fn start_detached_and_report(verb: &str) -> anyhow::Result<()> {
     let pid = spawn_detached()?;
     println!("moadim {verb} in the background (pid {pid}) at http://{BIND_ADDR}");
+    report_endpoints();
+    Ok(())
+}
+
+/// Print the reach/manage hints (UI, stop, logs) shared by every detached-launch report.
+fn report_endpoints() {
     println!("  UI    http://{BIND_ADDR}");
     println!("  stop  moadim stop   (or use the STOP button in the UI)");
     println!("  logs  {}", paths_daemon_log());
-    Ok(())
 }
 
 /// Ask a running server to stop via the `/shutdown` route.

--- a/src/cli_tests.rs
+++ b/src/cli_tests.rs
@@ -93,6 +93,22 @@ fn restart_command() {
 }
 
 #[test]
+fn restart_rotation_line_shows_old_and_new_pid() {
+    assert_eq!(
+        restart_rotation_line(Some(123), 456),
+        "restarted: pid 123 -> 456"
+    );
+}
+
+#[test]
+fn restart_rotation_line_reads_none_when_nothing_was_running() {
+    assert_eq!(
+        restart_rotation_line(None, 456),
+        "restarted: pid none -> 456"
+    );
+}
+
+#[test]
 fn help_and_version_flags() {
     for flag in ["-h", "--help", "help"] {
         assert_eq!(parse(argv(&[flag])), Command::Help, "flag {flag}");


### PR DESCRIPTION
## TODO item implemented

> Have `moadim restart` print the old PID it stopped and the new PID it started (e.g. "restarted: pid 123 -> 456") so scripts/logs can see the process actually rotated

## Approach

- `restart()` now captures the old PID (from the pid file) **before** stopping the running server, spawns the fresh instance, and prints a headline rotation line `restarted: pid <old> -> <new>`. When nothing was running (or the old PID couldn't be read), the old side reads `none`, e.g. `restarted: pid none -> 456`.
- Added a small pure helper `restart_rotation_line(old: Option<u32>, new: u32) -> String` that owns the formatting, so it's unit-testable without spawning processes.
- Factored the shared `UI`/`stop`/`logs` hint block out of `start_detached_and_report` into `report_endpoints()`, reused by both the `restart` path and the normal start path — `restart` no longer prints the now-redundant "moadim restarted in the background (pid Y)" line, since the rotation line is the headline.
- Documented the new output in the README CLI table and added a `CHANGELOG.md` Unreleased entry.

## Checks

- `cargo fmt --check` clean.
- `cargo test` green: **257 passed** (+2 new tests covering both rotation-line branches).
- `cargo clippy` fails only on pre-existing `src/build/ui.rs` `min_ident_chars` errors (HEAD breakage, same one noted in #92); no new lint in the touched files.

## New TODOs added

- Have `moadim restart` emit its PID-rotation summary as a `--json` object (`{"old":N|null,"new":M}`) too, mirroring the `status`/`cleanup` `--json` contract.
- Give `moadim restart` a `--quiet`/`-q` flag that prints only the rotation line and suppresses the UI/stop/logs hint block, for script consumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)