### PR TITLE
fix(routines): heal legacy UUID dirs + re-persist prompt sidecars on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+### Fixed
+
+- Routines created before the UUID→slug storage-directory change launched their
+  agent with an empty prompt: their `routine.toml`/`prompt.md` stayed in the
+  legacy `{id}/` dir while the crontab sync wrote `run.sh` into a fresh `{slug}/`
+  dir, so the cron `cp prompt.md` read an empty dir. Startup now migrates legacy
+  UUID-named routine dirs to the slug layout and re-persists every routine's
+  `routine.toml` + `prompt.md` sidecar, healing dirs left with only `run.sh`. The
+  generated `run.sh` also now aborts (and logs to the workbench `agent.log`) when
+  the source prompt is missing instead of launching a task-less agent session.
+
 ### Added
 
 - `moadim restart` CLI subcommand that stops a running daemon (if any) and

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,10 +52,17 @@ async fn main() -> anyhow::Result<()> {
 async fn run_server() -> anyhow::Result<()> {
     routines::ensure_default_agents();
     let store = storage::load_store();
-    let routines = routine_storage::load_store();
     // Rename any prompt.txt sidecars to prompt.md before rewriting run.sh scripts; otherwise the
     // first cron trigger after upgrade would fail on the cp step.
     routine_storage::migrate_prompt_files();
+    // Move legacy UUID-named routine dirs to the current slug-based layout before loading, so the
+    // store reflects the canonical dirs the crontab sync and run.sh `cp prompt.md` both target.
+    routine_storage::migrate_routine_dirs();
+    let routines = routine_storage::load_store();
+    // The crontab sync writes only run.sh; re-persist so every routine also has its routine.toml +
+    // prompt.md sidecar in the slug dir, healing dirs left with run.sh but no prompt (otherwise the
+    // cron `cp prompt.md` fails and the agent launches with an empty prompt).
+    routine_storage::repersist_routines(&routines);
     // Re-sync routines to the crontab on startup; otherwise a block that went stale (e.g. emptied
     // by an earlier run before agent configs existed) would never be regenerated until the next
     // create/update/delete, leaving scheduled routines silently un-fired.

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -136,6 +136,66 @@ pub fn migrate_prompt_files() {
     }
 }
 
+/// Migrate legacy UUID-named routine directories to the current slug-based layout.
+///
+/// Early daemon versions stored each routine under `{routines_dir}/{id}/` (the UUID). The current
+/// layout uses `{routines_dir}/{slugify(title)}/`. After an upgrade the legacy dir still holds the
+/// real `routine.toml` + `prompt.md`, while the crontab sync creates a *fresh* slug dir containing
+/// only `run.sh` — so the cron `cp prompt.md` reads an empty dir and the agent launches task-less.
+///
+/// For every on-disk routine whose directory name does not already equal its slug, this re-persists
+/// it into the slug dir (preserving any `run.sh` already there) and removes the stale legacy dir.
+/// Idempotent: routines already in their slug dir are skipped. Call once at startup before
+/// `load_store` so the in-memory store reflects the canonical layout.
+pub fn migrate_routine_dirs() {
+    let dir = routines_dir();
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        let dir_name = entry.file_name().to_string_lossy().to_string();
+        let Some(routine) = load_routine_from_dir(&dir_name) else {
+            // A dir without a parsable routine.toml (e.g. a sync-created dir holding only run.sh)
+            // carries no routine to migrate; the routine it shadows is healed from its own dir.
+            continue;
+        };
+        let slug = slugify(&routine.title);
+        if slug == dir_name {
+            continue;
+        }
+        if let Err(e) = write_routine(&routine) {
+            log::warn!("migrate_routine_dirs: failed to write {slug:?}: {e}; leaving legacy dir");
+            continue;
+        }
+        if let Err(e) = remove_routine_dir(&dir_name) {
+            log::warn!("migrate_routine_dirs: failed to remove legacy dir {dir_name:?}: {e}");
+        }
+    }
+}
+
+/// Re-persist every loaded routine to disk, recreating `routine.toml`, `prompt.md`, and `.gitignore`
+/// in its canonical slug directory.
+///
+/// The crontab sync writes only `run.sh`; nothing else rewrites the prompt sidecar on startup. So a
+/// slug dir that ends up with `run.sh` but no `prompt.md` (e.g. after the UUID→slug migration, or if
+/// the sidecar was lost) would fail the cron `cp prompt.md`. Re-persisting from the in-memory store
+/// heals those dirs. Idempotent; safe to call on every startup after [`load_store`].
+pub fn repersist_routines(store: &RoutineStore) {
+    let routines: Vec<Routine> = store.lock().unwrap().values().cloned().collect();
+    for r in &routines {
+        if let Err(e) = write_routine(r) {
+            log::warn!(
+                "repersist_routines: failed to write routine {:?}: {e}",
+                r.id
+            );
+        }
+    }
+}
+
 /// Scan `~/.config/moadim/routines/` and load all valid routines into a new store.
 pub fn load_store() -> RoutineStore {
     load_store_from_dir(&routines_dir())

--- a/src/routine_storage_tests.rs
+++ b/src/routine_storage_tests.rs
@@ -87,3 +87,51 @@ fn load_store_from_dir_missing_dir_empty() {
 fn remove_routine_dir_noop_when_absent() {
     remove_routine_dir("rs-never-created-zzz").unwrap();
 }
+
+#[test]
+fn migrate_routine_dirs_moves_legacy_uuid_dir_to_slug() {
+    let id = "rs-legacy-uuid-1234";
+    let title = "Rs Legacy Migrate Routine";
+    let slug = slugify(title);
+    let legacy_dir = crate::paths::routine_dir(id);
+    std::fs::create_dir_all(&legacy_dir).unwrap();
+    // Legacy layout: routine.toml + prompt.md live under the UUID-named dir.
+    let toml = format!(
+        "id = \"{id}\"\nschedule = \"@daily\"\ntitle = \"{title}\"\nagent = \"claude\"\nprompt = \"task\"\nenabled = true\n"
+    );
+    std::fs::write(legacy_dir.join("routine.toml"), toml).unwrap();
+    std::fs::write(legacy_dir.join("prompt.md"), "legacy prompt").unwrap();
+
+    migrate_routine_dirs();
+
+    // Legacy dir removed; canonical slug dir now holds toml + prompt.
+    assert!(!legacy_dir.exists(), "legacy UUID dir should be removed");
+    assert!(crate::paths::routine_toml_path(&slug).exists());
+    assert!(crate::paths::routine_prompt_path(&slug).exists());
+    let loaded = load_routine_from_dir(&slug).unwrap();
+    assert_eq!(loaded.id, id, "UUID id preserved across the dir migration");
+
+    remove_routine_dir(&slug).unwrap();
+}
+
+#[test]
+fn repersist_routines_recreates_missing_prompt_sidecar() {
+    let id = "rs-repersist-id";
+    let title = "Rs Repersist Routine";
+    let slug = slugify(title);
+    write_routine(&make_routine(id, title)).unwrap();
+    // Simulate the sync-only state: prompt.md gone, only run.sh-style dir remains.
+    std::fs::remove_file(crate::paths::routine_prompt_path(&slug)).unwrap();
+    assert!(!crate::paths::routine_prompt_path(&slug).exists());
+
+    let mut map = HashMap::new();
+    map.insert(id.to_string(), make_routine(id, title));
+    let store = Arc::new(Mutex::new(map));
+    repersist_routines(&store);
+
+    assert!(
+        crate::paths::routine_prompt_path(&slug).exists(),
+        "repersist should recreate the prompt sidecar"
+    );
+    remove_routine_dir(&slug).unwrap();
+}


### PR DESCRIPTION
## Problem

Routines created before the UUID→slug storage-directory change launched their agent with an **empty prompt** (blank, task-less Claude session).

Their `routine.toml` + `prompt.md` stayed in the legacy `{routines_dir}/{id}/` dir, while the crontab sync wrote `run.sh` into a *fresh* `{routines_dir}/{slug}/` dir. The generated `run.sh` does `cp {slug}/prompt.md "$WB/prompt.md"`, so the `cp` read an empty dir and `claude … "$(cat prompt.md)"` got an empty argument.

`write_routine` (toml + prompt) is only called on create/update/trigger — never on startup — so the slug dir never gained its prompt sidecar after an upgrade. Affected every routine created before the slug migration.

## Fix

Startup now heals the layout (`run_server`):

- **`migrate_routine_dirs()`** — for every on-disk routine whose dir name ≠ its slug, re-persist into the slug dir and remove the stale legacy UUID dir. Runs before `load_store`.
- **`repersist_routines()`** — rewrite `routine.toml` + `prompt.md` for every loaded routine into its slug dir, healing dirs left with only `run.sh`. Both idempotent.

Complements the already-merged fail-fast guard (`86a9306`): the generated `run.sh` aborts + logs to the workbench `agent.log` when the source prompt is missing instead of launching a task-less session.

## Tests

- `migrate_routine_dirs_moves_legacy_uuid_dir_to_slug`
- `repersist_routines_recreates_missing_prompt_sidecar`

Full storage + routines suites pass. Verified live: rebuilt + redeployed the daemon; all legacy routines healed (prompt.md restored, UUID dirs migrated), daemon healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)