### PR TITLE
chore(release): v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-17
+
 ### Fixed
 
 - Routines created before the UUID→slug storage-directory change launched their
@@ -151,7 +153,8 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 - Ship the prebuilt UI in the published crate.
 - Rename the binary to `moadim` and add install docs.
 
-[Unreleased]: https://github.com/moadim-io/daemon/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/moadim-io/daemon/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/moadim-io/daemon/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/moadim-io/daemon/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/moadim-io/daemon/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/moadim-io/daemon/compare/v0.6.0...v0.6.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ opt-level = "z"
 
 [package]
 name = "moadim"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Moadim.io MCP/REST server for managing cron jobs"
 license = "MIT"


### PR DESCRIPTION
Release v0.9.0.

Bumps `Cargo.toml` + `Cargo.lock` to `0.9.0` and rolls the CHANGELOG `[Unreleased]` section into `[0.9.0]`.

### Fixed
- Heal legacy UUID-named routine dirs + re-persist prompt sidecars on startup (#94); generated `run.sh` aborts on a missing prompt instead of launching a task-less session.

### Added
- `moadim restart` CLI subcommand.
- Multiselect + bulk actions in the web UI cron-jobs table.

Merging this, then tagging `v0.9.0`, triggers the crates.io publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)