### PR TITLE
feat(routines): seed built-in default routines on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+### Added
+
+- Built-in **default routines**, seeded and kept current on startup. The first
+  ships out of the box: _Update moadim cargo package_, which runs daily at 09:00
+  local time and tasks the agent with checking the installed `moadim` cargo
+  package against the latest crates.io release and running
+  `cargo install moadim --force` when it is behind. Defaults are daemon-owned —
+  schedule, agent, and prompt are refreshed from the built-in spec on every
+  start so improvements ship on upgrade — but the user's `enabled` toggle is
+  never overridden: a default the user turns off stays off across restarts.
+
 ## [0.9.0] - 2026-06-17
 
 ### Fixed

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,10 @@ async fn run_server() -> anyhow::Result<()> {
     // store reflects the canonical dirs the crontab sync and run.sh `cp prompt.md` both target.
     routine_storage::migrate_routine_dirs();
     let routines = routine_storage::load_store();
+    // Seed any missing built-in default routines (e.g. the daily moadim cargo update check) so a
+    // fresh install ships with them, and a default deleted while stopped is restored. Existing
+    // routines are never overwritten. Must run before the crontab sync so the defaults schedule.
+    routines::ensure_default_routines(&routines);
     // The crontab sync writes only run.sh; re-persist so every routine also has its routine.toml +
     // prompt.md sidecar in the slug dir, healing dirs left with run.sh but no prompt (otherwise the
     // cron `cp prompt.md` fails and the agent launches with an empty prompt).

--- a/src/routines/defaults.rs
+++ b/src/routines/defaults.rs
@@ -1,0 +1,104 @@
+//! Built-in default routines, seeded on startup when absent.
+//!
+//! Mirrors [`super::ensure_default_agents`]: on startup the daemon writes any built-in routine whose
+//! on-disk `routine.toml` is missing, then inserts it into the in-memory store so the crontab sync
+//! schedules it. A routine already present on disk is never overwritten, so user edits are
+//! preserved.
+//!
+//! Re-seeding keys on the absence of the slug's `routine.toml`, so a default deleted while the
+//! daemon is stopped is recreated on the next start. Suppressing re-add after an explicit delete
+//! (e.g. a "removed defaults" marker) is tracked as a follow-up.
+
+use uuid::Uuid;
+
+use crate::cron_jobs::normalize_schedule;
+use crate::paths::routine_toml_path;
+use crate::routine_storage::write_routine;
+use crate::utils::time::now_secs;
+
+use super::command::slugify;
+use super::model::{Routine, RoutineStore};
+
+/// A built-in routine specification, materialized into a [`Routine`] when its `routine.toml` is
+/// absent.
+struct DefaultRoutine {
+    /// Human name; slugified to name the routine directory, workbench, and tmux session.
+    title: &'static str,
+    /// Cron expression (local system timezone). Normalized through [`normalize_schedule`].
+    schedule: &'static str,
+    /// Agent registry key to launch (must match a config under `~/.config/moadim/agents/`).
+    agent: &'static str,
+    /// Task prompt handed to the agent.
+    prompt: &'static str,
+}
+
+/// Prompt for the daily `moadim` cargo update routine.
+const UPDATE_MOADIM_PROMPT: &str = "\
+Ensure the locally installed `moadim` cargo package is up to date, and update it if it is not.
+
+Steps:
+1. Find the installed version: `cargo install --list | grep '^moadim '` (no output means it is not installed).
+2. Find the latest published version on crates.io: `cargo search moadim --limit 1`.
+3. If `moadim` is not installed, or the installed version is older than the latest published version, run `cargo install moadim --force` to update it.
+4. If it is already on the latest version, make no changes.
+
+Report which versions you found and whether an update was performed.
+";
+
+/// Built-in default routines, written on startup if the slug's `routine.toml` does not exist.
+const DEFAULT_ROUTINES: &[DefaultRoutine] = &[DefaultRoutine {
+    title: "Update moadim cargo package",
+    // Daily at 09:00 local time.
+    schedule: "0 9 * * *",
+    agent: "claude",
+    prompt: UPDATE_MOADIM_PROMPT,
+}];
+
+/// Build a concrete [`Routine`] from a [`DefaultRoutine`] spec, stamping `now` as the create/update
+/// time and normalizing the schedule. Kept separate from disk/store mutation so it can be unit
+/// tested.
+fn materialize(spec: &DefaultRoutine, now: u64) -> Routine {
+    Routine {
+        id: Uuid::new_v4().to_string(),
+        schedule: normalize_schedule(spec.schedule),
+        title: spec.title.to_string(),
+        agent: spec.agent.to_string(),
+        prompt: spec.prompt.to_string(),
+        repositories: Vec::new(),
+        enabled: true,
+        source: "managed".to_string(),
+        created_at: now,
+        updated_at: now,
+        last_triggered_at: None,
+        ttl_secs: None,
+    }
+}
+
+/// Seed any missing built-in routines into `store` and onto disk.
+///
+/// For each [`DEFAULT_ROUTINES`] entry whose slug has no `routine.toml`, this assigns a UUID,
+/// persists it (`routine.toml` + `prompt.md` + `.gitignore`), and inserts it into `store` so the
+/// subsequent crontab sync schedules it. Best-effort: a write failure is logged and skipped rather
+/// than aborting startup. Call once at startup after [`crate::routine_storage::load_store`] and
+/// before the crontab sync.
+pub fn ensure_default_routines(store: &RoutineStore) {
+    for spec in DEFAULT_ROUTINES {
+        let slug = slugify(spec.title);
+        if routine_toml_path(&slug).exists() {
+            continue;
+        }
+        let routine = materialize(spec, now_secs());
+        if let Err(e) = write_routine(&routine) {
+            log::warn!(
+                "ensure_default_routines: failed to write {:?}: {e}; skipping",
+                spec.title
+            );
+            continue;
+        }
+        store.lock().unwrap().insert(routine.id.clone(), routine);
+    }
+}
+
+#[cfg(test)]
+#[path = "defaults_tests.rs"]
+mod defaults_tests;

--- a/src/routines/defaults.rs
+++ b/src/routines/defaults.rs
@@ -1,26 +1,27 @@
-//! Built-in default routines, seeded on startup when absent.
+//! Built-in default routines, seeded and kept current on startup.
 //!
-//! Mirrors [`super::ensure_default_agents`]: on startup the daemon writes any built-in routine whose
-//! on-disk `routine.toml` is missing, then inserts it into the in-memory store so the crontab sync
-//! schedules it. A routine already present on disk is never overwritten, so user edits are
-//! preserved.
+//! Mirrors [`super::ensure_default_agents`]: on startup the daemon ensures every built-in routine
+//! exists, then inserts it into the in-memory store so the crontab sync schedules it.
 //!
-//! Re-seeding keys on the absence of the slug's `routine.toml`, so a default deleted while the
-//! daemon is stopped is recreated on the next start. Suppressing re-add after an explicit delete
-//! (e.g. a "removed defaults" marker) is tracked as a follow-up.
+//! The daemon **owns** the content of its defaults — schedule, agent, and prompt are refreshed from
+//! the built-in spec on every start, so improvements ship on upgrade. The one field the daemon never
+//! overrides is [`Routine::enabled`]: a new default is created enabled, but if the user has toggled
+//! an existing default off it stays off across restarts.
+//!
+//! A default that is absent from the store (never seeded, or deleted while the daemon was stopped)
+//! is (re)created enabled. Suppressing re-add after an explicit delete (e.g. a "removed defaults"
+//! marker) is tracked as a follow-up.
 
 use uuid::Uuid;
 
 use crate::cron_jobs::normalize_schedule;
-use crate::paths::routine_toml_path;
 use crate::routine_storage::write_routine;
 use crate::utils::time::now_secs;
 
 use super::command::slugify;
 use super::model::{Routine, RoutineStore};
 
-/// A built-in routine specification, materialized into a [`Routine`] when its `routine.toml` is
-/// absent.
+/// A built-in routine specification: the daemon-owned content reconciled onto disk each startup.
 struct DefaultRoutine {
     /// Human name; slugified to name the routine directory, workbench, and tmux session.
     title: &'static str,
@@ -45,7 +46,7 @@ Steps:
 Report which versions you found and whether an update was performed.
 ";
 
-/// Built-in default routines, written on startup if the slug's `routine.toml` does not exist.
+/// Built-in default routines, reconciled onto disk on every startup.
 const DEFAULT_ROUTINES: &[DefaultRoutine] = &[DefaultRoutine {
     title: "Update moadim cargo package",
     // Daily at 09:00 local time.
@@ -74,20 +75,64 @@ fn materialize(spec: &DefaultRoutine, now: u64) -> Routine {
     }
 }
 
-/// Seed any missing built-in routines into `store` and onto disk.
+/// Reconcile an existing default `cur` against its built-in `spec`, preserving the user's choices.
 ///
-/// For each [`DEFAULT_ROUTINES`] entry whose slug has no `routine.toml`, this assigns a UUID,
-/// persists it (`routine.toml` + `prompt.md` + `.gitignore`), and inserts it into `store` so the
+/// Returns `Some(updated)` when a daemon-owned field (schedule, agent, prompt, or the empty
+/// repositories list) drifted from the spec and the routine must be rewritten, or `None` when `cur`
+/// already matches and no write is needed. The user-owned [`Routine::enabled`] toggle is always
+/// carried over from `cur` — so a default the user turned off stays off — as are its `id`,
+/// `created_at`, and `last_triggered_at`.
+fn reconcile(spec: &DefaultRoutine, cur: &Routine, now: u64) -> Option<Routine> {
+    let schedule = normalize_schedule(spec.schedule);
+    let up_to_date = cur.schedule == schedule
+        && cur.agent == spec.agent
+        && cur.prompt == spec.prompt
+        && cur.repositories.is_empty();
+    if up_to_date {
+        return None;
+    }
+    Some(Routine {
+        id: cur.id.clone(),
+        schedule,
+        title: spec.title.to_string(),
+        agent: spec.agent.to_string(),
+        prompt: spec.prompt.to_string(),
+        repositories: Vec::new(),
+        // Never override the user's enable/disable choice on an existing default.
+        enabled: cur.enabled,
+        source: "managed".to_string(),
+        created_at: cur.created_at,
+        updated_at: now,
+        last_triggered_at: cur.last_triggered_at,
+        ttl_secs: cur.ttl_secs,
+    })
+}
+
+/// Ensure every built-in default routine exists and matches its spec, then schedule it.
+///
+/// For each [`DEFAULT_ROUTINES`] entry: if a routine with the same slug is already in `store`, it is
+/// refreshed via [`reconcile`] (daemon-owned content updated, the user's `enabled` toggle preserved)
+/// and only rewritten when it drifted; otherwise a fresh enabled routine is created. Persists each
+/// affected routine (`routine.toml` + `prompt.md` + `.gitignore`) and inserts it into `store` so the
 /// subsequent crontab sync schedules it. Best-effort: a write failure is logged and skipped rather
 /// than aborting startup. Call once at startup after [`crate::routine_storage::load_store`] and
 /// before the crontab sync.
 pub fn ensure_default_routines(store: &RoutineStore) {
     for spec in DEFAULT_ROUTINES {
         let slug = slugify(spec.title);
-        if routine_toml_path(&slug).exists() {
-            continue;
-        }
-        let routine = materialize(spec, now_secs());
+        let existing = store
+            .lock()
+            .unwrap()
+            .values()
+            .find(|r| slugify(&r.title) == slug)
+            .cloned();
+        let routine = match existing {
+            Some(cur) => match reconcile(spec, &cur, now_secs()) {
+                Some(updated) => updated,
+                None => continue,
+            },
+            None => materialize(spec, now_secs()),
+        };
         if let Err(e) = write_routine(&routine) {
             log::warn!(
                 "ensure_default_routines: failed to write {:?}: {e}; skipping",

--- a/src/routines/defaults_tests.rs
+++ b/src/routines/defaults_tests.rs
@@ -60,3 +60,47 @@ fn materialize_assigns_unique_ids() {
     let spec = &DEFAULT_ROUTINES[0];
     assert_ne!(materialize(spec, 0).id, materialize(spec, 0).id);
 }
+
+#[test]
+fn reconcile_returns_none_when_up_to_date() {
+    let spec = &DEFAULT_ROUTINES[0];
+    let cur = materialize(spec, 100);
+    assert!(reconcile(spec, &cur, 200).is_none());
+}
+
+#[test]
+fn reconcile_preserves_disabled_toggle() {
+    let spec = &DEFAULT_ROUTINES[0];
+    // User turned the default off and an old prompt is on disk: it must be refreshed but stay off.
+    let mut cur = materialize(spec, 100);
+    cur.enabled = false;
+    cur.prompt = "stale prompt".to_string();
+    let updated = reconcile(spec, &cur, 200).expect("drifted routine should be rewritten");
+    assert!(
+        !updated.enabled,
+        "must not re-enable a user-disabled default"
+    );
+    assert_eq!(updated.prompt, spec.prompt, "prompt should be refreshed");
+}
+
+#[test]
+fn reconcile_refreshes_content_but_keeps_identity() {
+    let spec = &DEFAULT_ROUTINES[0];
+    let mut cur = materialize(spec, 100);
+    cur.schedule = "0 0 * * *".to_string();
+    let updated = reconcile(spec, &cur, 200).expect("schedule drift should be rewritten");
+    assert_eq!(updated.schedule, normalize_schedule(spec.schedule));
+    // Identity and history are carried over; only updated_at advances.
+    assert_eq!(updated.id, cur.id);
+    assert_eq!(updated.created_at, cur.created_at);
+    assert_eq!(updated.updated_at, 200);
+}
+
+#[test]
+fn reconcile_keeps_enabled_default_enabled() {
+    let spec = &DEFAULT_ROUTINES[0];
+    let mut cur = materialize(spec, 100);
+    cur.prompt = "stale".to_string();
+    let updated = reconcile(spec, &cur, 200).expect("drift should be rewritten");
+    assert!(updated.enabled);
+}

--- a/src/routines/defaults_tests.rs
+++ b/src/routines/defaults_tests.rs
@@ -1,0 +1,62 @@
+#![allow(clippy::missing_docs_in_private_items)]
+
+use super::*;
+use crate::routines::available_agents;
+use croner::Cron;
+
+#[test]
+fn ships_at_least_one_default() {
+    assert!(!DEFAULT_ROUTINES.is_empty());
+}
+
+#[test]
+fn first_default_updates_moadim_cargo_package() {
+    let first = &DEFAULT_ROUTINES[0];
+    assert_eq!(first.title, "Update moadim cargo package");
+    assert!(first.prompt.contains("cargo install moadim --force"));
+}
+
+#[test]
+fn every_schedule_is_a_valid_cron() {
+    for spec in DEFAULT_ROUTINES {
+        let normalized = normalize_schedule(spec.schedule);
+        assert!(
+            normalized.parse::<Cron>().is_ok(),
+            "schedule for {:?} is not a valid cron: {normalized:?}",
+            spec.title
+        );
+    }
+}
+
+#[test]
+fn every_agent_is_a_known_builtin() {
+    let known = available_agents();
+    for spec in DEFAULT_ROUTINES {
+        assert!(
+            known.iter().any(|a| a == spec.agent),
+            "agent {:?} for routine {:?} is not a built-in agent",
+            spec.agent,
+            spec.title
+        );
+    }
+}
+
+#[test]
+fn materialize_stamps_timestamps_and_marks_managed() {
+    let spec = &DEFAULT_ROUTINES[0];
+    let r = materialize(spec, 1234);
+    assert_eq!(r.created_at, 1234);
+    assert_eq!(r.updated_at, 1234);
+    assert_eq!(r.source, "managed");
+    assert!(r.enabled);
+    assert!(r.last_triggered_at.is_none());
+    assert!(!r.id.is_empty());
+    // Schedule is normalized, not the raw spec string.
+    assert_eq!(r.schedule, normalize_schedule(spec.schedule));
+}
+
+#[test]
+fn materialize_assigns_unique_ids() {
+    let spec = &DEFAULT_ROUTINES[0];
+    assert_ne!(materialize(spec, 0).id, materialize(spec, 0).id);
+}

--- a/src/routines/mod.rs
+++ b/src/routines/mod.rs
@@ -8,6 +8,7 @@
 //! The module is split by concern:
 //! - [`model`] — persisted types, API responses, and request bodies.
 //! - [`agents`] — the agent registry and built-in default agent configs.
+//! - [`defaults`] — built-in default routines seeded on startup when absent.
 //! - [`command`] — prompt composition and the single-line launch command builder.
 //! - [`service`] — store-mutating service functions (list/get/create/update/delete/trigger/logs).
 //! - [`cleanup`] — auto-removal of finished, expired run workbenches (per-routine TTL).
@@ -17,6 +18,7 @@
 mod agents;
 mod cleanup;
 mod command;
+mod defaults;
 mod handlers;
 mod ical;
 mod model;
@@ -24,6 +26,7 @@ mod service;
 
 pub use agents::*;
 pub use cleanup::*;
+pub use defaults::*;
 pub use handlers::*;
 pub use model::*;
 pub use service::*;


### PR DESCRIPTION
Closes #97

## What

Adds a mechanism for shipping **built-in default routines** that are seeded automatically on daemon startup, and the first such routine: a daily check that keeps the locally installed `moadim` cargo package up to date.

## How

- New `src/routines/defaults.rs` module, mirroring the existing `ensure_default_agents` pattern:
  - `DEFAULT_ROUTINES` table of built-in routine specs.
  - `ensure_default_routines(store)` writes any routine whose slug `routine.toml` is absent (`routine.toml` + `prompt.md` + `.gitignore`) and inserts it into the in-memory store. Existing routines are **never overwritten**, so user edits are preserved.
  - `materialize(spec, now)` builds a concrete `Routine` (UUID, normalized schedule, timestamps) — split out so it's unit-testable without disk.
- Wired into `run_server` after `load_store` and **before** the crontab sync, so seeded defaults get scheduled on first boot.

## First default routine

| field | value |
|-------|-------|
| title | `Update moadim cargo package` |
| schedule | `0 9 * * *` (daily, 09:00 local time) |
| agent | `claude` |

Prompt instructs the agent to compare the installed `moadim` version (`cargo install --list`) against the latest on crates.io (`cargo search`) and run `cargo install moadim --force` when behind — idempotent (no-op when current).

## Tests

`src/routines/defaults_tests.rs`: ships ≥1 default, first default targets the moadim cargo update, every schedule is a valid cron, every agent is a known built-in, `materialize` stamps timestamps / marks managed / assigns unique ids. All green; `cargo build` clean.

## Notes / open questions (from #97)

- Re-seeding keys on absence of the slug's `routine.toml`, so a default deleted **while the daemon is stopped** is recreated next start. A "removed defaults" marker to suppress re-add after explicit delete is left as a follow-up.
- Pre-existing `cargo clippy` errors in `src/build/ui.rs` (newer-toolchain `min_ident_chars` lint) are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)