### PR TITLE
chore(release): v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-06-17
+
 ### Added
 
 - Built-in **default routines**, seeded and kept current on startup. The first
@@ -170,7 +172,8 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 - Ship the prebuilt UI in the published crate.
 - Rename the binary to `moadim` and add install docs.
 
-[Unreleased]: https://github.com/moadim-io/daemon/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/moadim-io/daemon/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/moadim-io/daemon/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/moadim-io/daemon/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/moadim-io/daemon/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/moadim-io/daemon/compare/v0.6.1...v0.7.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ opt-level = "z"
 
 [package]
 name = "moadim"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Moadim.io MCP/REST server for managing cron jobs"
 license = "MIT"


### PR DESCRIPTION
Release **v0.10.0**.

- Bump `Cargo.toml` / `Cargo.lock` to `0.10.0`.
- Roll `CHANGELOG.md`: move the Unreleased entry into the `[0.10.0]` section and update compare links.

Headline: built-in default routines (daily `moadim` cargo update check), per #97 / #107.

Merge, then push tag `v0.10.0` to trigger the crates.io publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)