### PR TITLE
feat(cli): give `moadim stop` a script-friendly exit-code contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,13 +198,14 @@ moadim stop            # ask a running server to stop
 | `moadim`           | background    | Spawns a detached server, writes its PID to `~/.config/moadim/moadim.pid`, logs to `~/.config/moadim/daemon.log`, and exits. Refuses to start if one is already running. |
 | `moadim -i`        | interactive   | Runs in the foreground; logs to the terminal; Ctrl-C stops it. |
 | `moadim restart`   | background    | Stops the running server (if any) and spawns a fresh detached instance, so you get a clean process without a separate stop/start. Prints the PID rotation as `restarted: pid <old> -> <new>` (old reads `none` when nothing was running) so scripts/logs can confirm the process actually changed. |
-| `moadim stop`      | —             | Sends `POST /shutdown` to the running server for a graceful stop. |
+| `moadim stop`      | —             | Sends `POST /shutdown` to the running server for a graceful stop. Exits `0` when a running server was asked to shut down, `3` when none was reachable. |
 | `moadim status`    | —             | Prints whether a server is reachable on `127.0.0.1:5784`. Add `--json` for `{"running":bool,"pid":N\|null,"address":"127.0.0.1:5784"}`. Exits `0` when running, `3` when not. |
 | `moadim cleanup`   | —             | Sends `POST /api/v1/routines/cleanup` to the running server and prints how many finished, expired routine workbenches were reaped (the on-demand version of the hourly sweep). Add `--json` for `{"running":bool,"removed":N}`. Exits `0` when running, `3` when not. |
 
-`status` and `cleanup` follow a script-friendly exit-code contract so callers can branch on
-`$?` without parsing stdout: they exit `0` when a server is running (and `cleanup` swept) and
-`3` when no server is reachable. Any other failure exits non-zero (`1`) with a message on stderr.
+`status`, `cleanup`, and `stop` follow a script-friendly exit-code contract so callers can branch
+on `$?` without parsing stdout: they exit `0` when a server is running (and `cleanup` swept, `stop`
+asked it to shut down) and `3` when no server is reachable. Any other failure exits non-zero (`1`)
+with a message on stderr.
 
 Because the default mode is detached, you stop the server **from the client**:
 press the **STOP** button in the UI header, run `moadim stop`, or send

--- a/TODO.md
+++ b/TODO.md
@@ -20,7 +20,8 @@ This is a list of todos for consumption, in a pr remove the todo you have implem
 - Add a TTL preset row (1h / 1d / 7d / 30d) under the WORKBENCH TTL input in the routine form, mirroring the cron schedule presets
 - Show a humanized retention countdown ("expires in 2d" / "expired") per finished run in the routine LOGS view, derived from the run's finish time and the routine's effective TTL
 - Enrich `moadim status --json` with the server's liveness details from `GET /health` (e.g. `uptime_secs`) so a single call returns running-state + age, not just the local PID
-- Give `moadim stop` the same script-friendly exit-code contract as `status`/`cleanup` (exit 3 when no server was running to stop, 0 when a running server was asked to shut down) and document it in the README CLI table
+- Add a `moadim stop --json` flag emitting `{"running":bool}` (true when a server was asked to shut down, false when none was reachable), mirroring the `status`/`cleanup` `--json` objects
+- Add a CLI integration test (spawn a real listener on an ephemeral port, point the probe at it) that exercises the `status`/`cleanup`/`stop` network paths end-to-end, lifting `cli.rs` off its ~27% coverage floor toward the repo's 100% line-coverage gate
 - Add a `moadim status --wait[=SECS]` flag that polls `GET /health` until the server is reachable (or the timeout elapses), exiting 0 on success and the existing exit-3 on timeout, so scripts can block on startup instead of sleeping
 - Add a `moadim restart --interactive` (or `-i`) flavor that restarts the daemon in the foreground attached to the terminal instead of detached, mirroring `moadim -i`
 - Have `moadim restart` emit its PID-rotation summary as a `--json` object (`{"old":N|null,"new":M}`) too, mirroring the `status`/`cleanup` `--json` contract

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -107,8 +107,8 @@ pub fn print_help() {
          \x20   version, -V            show the version\n\
          \n\
          Pass --json to `status`/`cleanup` for a single-line machine-readable object.\n\
-         `status`/`cleanup` exit 0 when a server is running and 3 when none is, so scripts can\n\
-         branch on $? without parsing stdout.\n\
+         `status`/`cleanup`/`stop` exit 0 when a server is running and 3 when none is, so scripts\n\
+         can branch on $? without parsing stdout.\n\
          \n\
          Once running, manage the server from the web client at http://{BIND_ADDR}\n\
          (the STOP button) or with `moadim stop`."
@@ -185,18 +185,22 @@ fn report_endpoints() {
 }
 
 /// Ask a running server to stop via the `/shutdown` route.
-pub fn stop() -> anyhow::Result<()> {
+///
+/// Returns the process exit code to surface, mirroring the `status`/`cleanup` contract: `0` when a
+/// running server was asked to shut down, and [`EXIT_NOT_RUNNING`] when none was reachable, so
+/// scripts can branch on `$?` without parsing stdout.
+pub fn stop() -> anyhow::Result<i32> {
     match http_request("POST", "/api/v1/shutdown") {
         Ok(200) => {
             println!("moadim is shutting down");
-            Ok(())
+            Ok(liveness_exit_code(true))
         }
         Ok(status) => {
             anyhow::bail!("unexpected response from server: HTTP {status}");
         }
         Err(_) => {
             println!("moadim is not running");
-            Ok(())
+            Ok(liveness_exit_code(false))
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ async fn main() -> anyhow::Result<()> {
         }
         cli::Command::Status { json } => std::process::exit(cli::status(json)?),
         cli::Command::Cleanup { json } => std::process::exit(cli::cleanup(json)?),
-        cli::Command::Stop => cli::stop(),
+        cli::Command::Stop => std::process::exit(cli::stop()?),
         cli::Command::Background => cli::run_background(),
         cli::Command::Restart => cli::restart(),
         cli::Command::Foreground => run_server().await,


### PR DESCRIPTION
## TODO item implemented

> Give `moadim stop` the same script-friendly exit-code contract as `status`/`cleanup` (exit 3 when no server was running to stop, 0 when a running server was asked to shut down) and document it in the README CLI table

## Approach

`status` and `cleanup` already surface a liveness exit code via `liveness_exit_code(running)` — `0` when a server is reachable, `3` (`EXIT_NOT_RUNNING`) when not — and `main` runs them through `std::process::exit`. `stop` was the odd one out: it always returned `Ok(())`, so scripts couldn't tell "asked a live server to shut down" from "nothing was running" without scraping stdout.

This makes `stop()` return `anyhow::Result<i32>` and emit the same code:
- `0` when the server answered `POST /api/v1/shutdown` (it was running and was asked to stop)
- `3` when no server was reachable
- non-zero (`1`) on any other failure, unchanged (e.g. unexpected HTTP status → `bail!`)

`main` now dispatches `Stop` through `std::process::exit(cli::stop()?)`, exactly like `status`/`cleanup`. The help text and the README CLI table are updated to document the `stop` contract alongside the existing two.

No behavior change to the printed lines; only the process exit code is new.

## Checks

- `cargo fmt --check` — clean
- `cargo test` — 270 passed (single-threaded; the storage/routine tests share the real `~/.config/moadim` dir and flake under parallel execution, unrelated to this change)
- `cargo clippy` — the only failures are the pre-existing `min_ident_chars` errors in `src/build/ui.rs` (HEAD already fails clippy on current stable); none from this change
- Coverage: `cli.rs`'s network paths (`stop`/`status`/`cleanup`) are uncovered at HEAD already (repo total is ~80%, below its 100% gate on current stable); this change adds no new uncovered logic beyond the existing pattern

## New TODOs added (ship one, dream up two)

- Add a `moadim stop --json` flag emitting `{"running":bool}`, mirroring the `status`/`cleanup` `--json` objects
- Add a CLI integration test that spawns a real listener on an ephemeral port and exercises the `status`/`cleanup`/`stop` network paths end-to-end, lifting `cli.rs` off its ~27% coverage floor toward the repo's 100% line-coverage gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)