### PR TITLE
fix: restore cargo clippy compliance across the crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored `cargo clippy` compliance across the crate. The `min_ident_chars`
+  and `missing_docs` lints (both `deny` in `Cargo.toml`) were failing on
+  current stable, which also broke the pre-push hook. Renamed all single-letter
+  bindings to descriptive names and documented the remaining undocumented
+  fields — no behavioral change.
+
 ## [0.10.0] - 2026-06-17
 
 ### Added

--- a/src/build/ui.rs
+++ b/src/build/ui.rs
@@ -58,20 +58,20 @@ fn run_trunk(ui_dir: &Path) -> bool {
         .current_dir(ui_dir)
         .status()
     {
-        Ok(s) if s.success() => true,
+        Ok(status) if status.success() => true,
         Ok(_) => {
             println!("cargo:warning=trunk build exited with non-zero status");
             false
         }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
             println!(
                 "cargo:warning=trunk not found; Yew UI not compiled \
                  (install with: cargo install trunk)"
             );
             false
         }
-        Err(e) => {
-            println!("cargo:warning=failed to launch trunk: {e}");
+        Err(err) => {
+            println!("cargo:warning=failed to launch trunk: {err}");
             false
         }
     }
@@ -90,26 +90,26 @@ fn inline_into_html(dist: &Path, output: &Path) {
 
     let js = js_path
         .as_ref()
-        .map(|p| std::fs::read_to_string(p).expect("failed to read .js dist asset"))
+        .map(|path| std::fs::read_to_string(path).expect("failed to read .js dist asset"))
         .unwrap_or_default();
 
     let wasm_b64 = wasm_path
         .as_ref()
-        .map(|p| {
-            let bytes = std::fs::read(p).expect("failed to read .wasm dist asset");
+        .map(|path| {
+            let bytes = std::fs::read(path).expect("failed to read .wasm dist asset");
             base64_encode(&bytes)
         })
         .unwrap_or_default();
 
     let wasm_file = wasm_path
         .as_ref()
-        .and_then(|p| p.file_name())
+        .and_then(|path| path.file_name())
         .map(|n| n.to_string_lossy().to_string())
         .unwrap_or_default();
 
     let js_file = js_path
         .as_ref()
-        .and_then(|p| p.file_name())
+        .and_then(|path| path.file_name())
         .map(|n| n.to_string_lossy().to_string())
         .unwrap_or_default();
 
@@ -143,12 +143,12 @@ fn find_dist_assets(dist: &Path) -> (Option<PathBuf>, Option<PathBuf>) {
     let mut js_path = None;
     let mut wasm_path = None;
     for entry in std::fs::read_dir(dist).expect("dist dir missing").flatten() {
-        let p = entry.path();
-        let name = p.file_name().unwrap_or_default().to_string_lossy();
+        let path = entry.path();
+        let name = path.file_name().unwrap_or_default().to_string_lossy();
         if name.ends_with(".js") && name != "index.html" {
-            js_path = Some(p);
+            js_path = Some(path);
         } else if name.ends_with(".wasm") {
-            wasm_path = Some(p);
+            wasm_path = Some(path);
         }
     }
     (js_path, wasm_path)
@@ -160,8 +160,8 @@ fn assemble_html(html: &str, inline_script: &str, js_file: &str, wasm_file: &str
     let stripped: String = html
         .lines()
         .filter(|line| {
-            let l = line.trim();
-            !(l.contains(js_file) || l.contains(wasm_file))
+            let trimmed = line.trim();
+            !(trimmed.contains(js_file) || trimmed.contains(wasm_file))
         })
         .collect::<Vec<_>>()
         .join("\n");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,10 +44,16 @@ pub enum Command {
     /// Ask a running background server to stop.
     Stop,
     /// Report whether a server is currently running. `json` requests machine-readable output.
-    Status { json: bool },
+    Status {
+        /// Emit machine-readable JSON output instead of human-readable text.
+        json: bool,
+    },
     /// Ask a running server to reap finished, expired routine run workbenches now. `json` requests
     /// machine-readable output.
-    Cleanup { json: bool },
+    Cleanup {
+        /// Emit machine-readable JSON output instead of human-readable text.
+        json: bool,
+    },
     /// Print usage help.
     Help,
     /// Print the binary version.
@@ -127,7 +133,7 @@ pub fn print_version() {
 pub fn run_background() -> anyhow::Result<()> {
     if is_running() {
         let pid = read_pid_file()
-            .map(|p| format!(" (pid {p})"))
+            .map(|process_id| format!(" (pid {process_id})"))
             .unwrap_or_default();
         println!("moadim is already running{pid}; stopping it to start a fresh instance");
         crate::restart::stop_running_and_wait()?;
@@ -143,7 +149,9 @@ pub fn run_background() -> anyhow::Result<()> {
 pub fn restart() -> anyhow::Result<()> {
     let old_pid = if is_running() {
         let pid = read_pid_file();
-        let suffix = pid.map(|p| format!(" (pid {p})")).unwrap_or_default();
+        let suffix = pid
+            .map(|process_id| format!(" (pid {process_id})"))
+            .unwrap_or_default();
         println!("moadim is running{suffix}; stopping it");
         crate::restart::stop_running_and_wait()?;
         pid
@@ -249,7 +257,9 @@ pub fn status(json: bool) -> anyhow::Result<i32> {
         return Ok(liveness_exit_code(running));
     }
     if running {
-        let pid_suffix = pid.map(|p| format!(" (pid {p})")).unwrap_or_default();
+        let pid_suffix = pid
+            .map(|process_id| format!(" (pid {process_id})"))
+            .unwrap_or_default();
         println!("moadim is running{pid_suffix} at http://{BIND_ADDR}");
     } else {
         println!("moadim is not running");

--- a/src/cli_tests.rs
+++ b/src/cli_tests.rs
@@ -4,7 +4,7 @@ use super::*;
 
 /// Build a `Vec<String>` from string literals for [`parse`].
 fn argv(args: &[&str]) -> Vec<String> {
-    args.iter().map(|s| s.to_string()).collect()
+    args.iter().map(|arg| arg.to_string()).collect()
 }
 
 #[test]

--- a/src/cron_jobs.rs
+++ b/src/cron_jobs.rs
@@ -87,7 +87,11 @@ impl CronJobResponse {
         let source_type = CronJobSourceType::from_source(&job.source);
         let handler_registered = handlers.contains(&job.handler);
         let file_path = job_toml_path(&job.id).to_string_lossy().into_owned();
-        let schedule_description = job.schedule.parse::<Cron>().ok().map(|c| c.describe());
+        let schedule_description = job
+            .schedule
+            .parse::<Cron>()
+            .ok()
+            .map(|cron| cron.describe());
         Self {
             job,
             source_type,
@@ -153,14 +157,14 @@ pub fn new_registry() -> HandlerRegistry {
 /// Strips the seconds (field 0) and year (field 6) from any 7-field expression.
 /// `@keyword` schedules and already-5-field expressions are returned unchanged.
 pub(crate) fn normalize_schedule(expr: &str) -> String {
-    let s = expr.trim();
-    if s.starts_with('@') {
-        return s.to_string();
+    let trimmed = expr.trim();
+    if trimmed.starts_with('@') {
+        return trimmed.to_string();
     }
-    let fields: Vec<&str> = s.split_ascii_whitespace().collect();
+    let fields: Vec<&str> = trimmed.split_ascii_whitespace().collect();
     match fields.len() {
         7 => fields[1..6].join(" "),
-        _ => s.to_string(),
+        _ => trimmed.to_string(),
     }
 }
 
@@ -172,7 +176,7 @@ pub(crate) fn validate_cron(expr: &str) -> Result<(), AppError> {
     let normalized = normalize_schedule(expr.trim());
     normalized
         .parse::<Cron>()
-        .map_err(|e| AppError::BadRequest(format!("invalid cron expression: {}", e)))?;
+        .map_err(|err| AppError::BadRequest(format!("invalid cron expression: {}", err)))?;
     Ok(())
 }
 
@@ -262,8 +266,8 @@ pub fn svc_create(
     };
     write_job(&job).map_err(|_| AppError::Internal)?;
     store.lock().unwrap().insert(job.id.clone(), job.clone());
-    if let Err(e) = crate::sync::sync_to_crontab(store) {
-        log::warn!("crontab sync after create failed: {e}");
+    if let Err(err) = crate::sync::sync_to_crontab(store) {
+        log::warn!("crontab sync after create failed: {err}");
     }
     Ok(CronJobResponse::from_job(job, handlers))
 }
@@ -280,24 +284,24 @@ pub fn svc_update(
     }
     let mut lock = store.lock().unwrap();
     let job = lock.get_mut(id).ok_or(AppError::NotFound)?;
-    if let Some(s) = req.schedule {
-        job.schedule = normalize_schedule(&s);
+    if let Some(sched) = req.schedule {
+        job.schedule = normalize_schedule(&sched);
     }
-    if let Some(h) = req.handler {
-        job.handler = h;
+    if let Some(handler) = req.handler {
+        job.handler = handler;
     }
-    if let Some(m) = req.metadata {
-        job.metadata = m;
+    if let Some(metadata) = req.metadata {
+        job.metadata = metadata;
     }
-    if let Some(e) = req.enabled {
-        job.enabled = e;
+    if let Some(enabled) = req.enabled {
+        job.enabled = enabled;
     }
     job.updated_at = now_secs();
     let job = job.clone();
     drop(lock);
     write_job(&job).map_err(|_| AppError::Internal)?;
-    if let Err(e) = crate::sync::sync_to_crontab(store) {
-        log::warn!("crontab sync after update failed: {e}");
+    if let Err(err) = crate::sync::sync_to_crontab(store) {
+        log::warn!("crontab sync after update failed: {err}");
     }
     Ok(CronJobResponse::from_job(job, handlers))
 }
@@ -310,8 +314,8 @@ pub fn svc_delete(
 ) -> Result<CronJobResponse, AppError> {
     let job = store.lock().unwrap().remove(id).ok_or(AppError::NotFound)?;
     remove_job_dir(id).map_err(|_| AppError::Internal)?;
-    if let Err(e) = crate::sync::sync_to_crontab(store) {
-        log::warn!("crontab sync after delete failed: {e}");
+    if let Err(err) = crate::sync::sync_to_crontab(store) {
+        log::warn!("crontab sync after delete failed: {err}");
     }
     Ok(CronJobResponse::from_job(job, handlers))
 }
@@ -327,8 +331,8 @@ pub fn svc_trigger(store: &CronStore, id: &str) -> Result<CronJob, AppError> {
     write_job(&job).map_err(|_| AppError::Internal)?;
     let handler_path = crate::paths::handlers_dir().join(&job.handler);
     if handler_path.exists() {
-        if let Err(e) = std::process::Command::new(&handler_path).spawn() {
-            log::warn!("trigger: failed to spawn handler {:?}: {e}", handler_path);
+        if let Err(err) = std::process::Command::new(&handler_path).spawn() {
+            log::warn!("trigger: failed to spawn handler {:?}: {err}", handler_path);
         }
     } else {
         log::warn!("trigger: handler script not found at {:?}", handler_path);

--- a/src/filesystem/mod.rs
+++ b/src/filesystem/mod.rs
@@ -13,10 +13,10 @@ impl FsLocation {
         Self {
             server_root: std::env::current_dir()
                 .ok()
-                .map(|p| p.to_string_lossy().into_owned()),
+                .map(|path| path.to_string_lossy().into_owned()),
             server_exe_dir: std::env::current_exe()
                 .ok()
-                .and_then(|p| p.parent().map(|d| d.to_string_lossy().into_owned())),
+                .and_then(|path| path.parent().map(|dir| dir.to_string_lossy().into_owned())),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,8 +70,8 @@ async fn run_server() -> anyhow::Result<()> {
     // Re-sync routines to the crontab on startup; otherwise a block that went stale (e.g. emptied
     // by an earlier run before agent configs existed) would never be regenerated until the next
     // create/update/delete, leaving scheduled routines silently un-fired.
-    if let Err(e) = sync::routines::sync_routines_to_crontab(&routines) {
-        log::warn!("startup crontab sync failed: {e}");
+    if let Err(err) = sync::routines::sync_routines_to_crontab(&routines) {
+        log::warn!("startup crontab sync failed: {err}");
     }
     let listener = tokio::net::TcpListener::bind(cli::BIND_ADDR).await?;
     cli::write_pid_file()?;

--- a/src/middlewares/fs_location.rs
+++ b/src/middlewares/fs_location.rs
@@ -11,20 +11,20 @@ pub async fn fs_location(req: Request, next: Next) -> Response {
 /// Inject fields from a JSON object value as `x-*` response headers.
 fn inject_headers_from_value(mut res: Response, val: serde_json::Value) -> Response {
     let map = match val {
-        serde_json::Value::Object(m) => m,
+        serde_json::Value::Object(obj) => obj,
         _ => return res,
     };
-    for (k, v) in map {
-        let s = match v {
-            serde_json::Value::String(s) => s,
+    for (key, value) in map {
+        let str_value = match value {
+            serde_json::Value::String(string) => string,
             _ => continue,
         };
-        let name = format!("x-{}", k.replace('_', "-"));
-        if let (Ok(n), Ok(v)) = (
+        let name = format!("x-{}", key.replace('_', "-"));
+        if let (Ok(header_name), Ok(header_value)) = (
             axum::http::HeaderName::from_bytes(name.as_bytes()),
-            HeaderValue::from_str(&s),
+            HeaderValue::from_str(&str_value),
         ) {
-            res.headers_mut().insert(n, v);
+            res.headers_mut().insert(header_name, header_value);
         }
     }
     res

--- a/src/paths/mod_tests.rs
+++ b/src/paths/mod_tests.rs
@@ -4,39 +4,45 @@ use super::*;
 
 #[test]
 fn jobs_dir_contains_moadim_and_ends_with_jobs() {
-    let p = jobs_dir().to_string_lossy().into_owned();
-    assert!(p.contains("moadim"), "expected 'moadim' in {p}");
-    assert!(p.ends_with("jobs"), "expected path to end with 'jobs': {p}");
+    let path = jobs_dir().to_string_lossy().into_owned();
+    assert!(path.contains("moadim"), "expected 'moadim' in {path}");
+    assert!(
+        path.ends_with("jobs"),
+        "expected path to end with 'jobs': {path}"
+    );
 }
 
 #[test]
 fn job_dir_appends_id() {
-    let p = job_dir("my-id").to_string_lossy().into_owned();
+    let path = job_dir("my-id").to_string_lossy().into_owned();
     assert!(
-        p.ends_with("my-id"),
-        "expected path to end with 'my-id': {p}"
+        path.ends_with("my-id"),
+        "expected path to end with 'my-id': {path}"
     );
 }
 
 #[test]
 fn job_toml_path_filename() {
-    let p = job_toml_path("abc");
-    assert_eq!(p.file_name().unwrap().to_str().unwrap(), "job.toml");
-    assert!(p.to_string_lossy().contains("abc"));
+    let path = job_toml_path("abc");
+    assert_eq!(path.file_name().unwrap().to_str().unwrap(), "job.toml");
+    assert!(path.to_string_lossy().contains("abc"));
 }
 
 #[test]
 fn job_local_toml_path_filename() {
-    let p = job_local_toml_path("abc");
-    assert_eq!(p.file_name().unwrap().to_str().unwrap(), "job.local.toml");
-    assert!(p.to_string_lossy().contains("abc"));
+    let path = job_local_toml_path("abc");
+    assert_eq!(
+        path.file_name().unwrap().to_str().unwrap(),
+        "job.local.toml"
+    );
+    assert!(path.to_string_lossy().contains("abc"));
 }
 
 #[test]
 fn job_gitignore_path_filename() {
-    let p = job_gitignore_path("abc");
-    assert_eq!(p.file_name().unwrap().to_str().unwrap(), ".gitignore");
-    assert!(p.to_string_lossy().contains("abc"));
+    let path = job_gitignore_path("abc");
+    assert_eq!(path.file_name().unwrap().to_str().unwrap(), ".gitignore");
+    assert!(path.to_string_lossy().contains("abc"));
 }
 
 #[test]
@@ -55,11 +61,11 @@ fn jobs_dir_from_home_none_falls_back_to_dot() {
 
 #[test]
 fn handlers_dir_contains_moadim_and_ends_with_handlers() {
-    let p = handlers_dir().to_string_lossy().into_owned();
-    assert!(p.contains("moadim"), "expected 'moadim' in {p}");
+    let path = handlers_dir().to_string_lossy().into_owned();
+    assert!(path.contains("moadim"), "expected 'moadim' in {path}");
     assert!(
-        p.ends_with("handlers"),
-        "expected path to end with 'handlers': {p}"
+        path.ends_with("handlers"),
+        "expected path to end with 'handlers': {path}"
     );
 }
 
@@ -72,16 +78,19 @@ fn handlers_dir_from_home_none_falls_back_to_dot() {
 
 #[test]
 fn job_log_path_filename() {
-    let p = super::job_log_path("abc");
-    assert_eq!(p.file_name().unwrap().to_str().unwrap(), "job.local.log");
-    assert!(p.to_string_lossy().contains("abc"));
+    let path = super::job_log_path("abc");
+    assert_eq!(path.file_name().unwrap().to_str().unwrap(), "job.local.log");
+    assert!(path.to_string_lossy().contains("abc"));
 }
 
 #[test]
 fn routines_dir_ends_with_routines() {
-    let p = routines_dir().to_string_lossy().into_owned();
-    assert!(p.contains("moadim"), "expected 'moadim' in {p}");
-    assert!(p.ends_with("routines"), "expected end with 'routines': {p}");
+    let path = routines_dir().to_string_lossy().into_owned();
+    assert!(path.contains("moadim"), "expected 'moadim' in {path}");
+    assert!(
+        path.ends_with("routines"),
+        "expected end with 'routines': {path}"
+    );
 }
 
 #[test]
@@ -98,29 +107,32 @@ fn routine_dir_is_child_of_routines_dir() {
 
 #[test]
 fn routine_toml_path_filename() {
-    let p = routine_toml_path("abc");
-    assert_eq!(p.file_name().unwrap().to_str().unwrap(), "routine.toml");
-    assert!(p.to_string_lossy().contains("abc"));
+    let path = routine_toml_path("abc");
+    assert_eq!(path.file_name().unwrap().to_str().unwrap(), "routine.toml");
+    assert!(path.to_string_lossy().contains("abc"));
 }
 
 #[test]
 fn routine_prompt_path_filename() {
-    let p = routine_prompt_path("abc");
-    assert_eq!(p.file_name().unwrap().to_str().unwrap(), "prompt.md");
-    assert!(p.to_string_lossy().contains("abc"));
+    let path = routine_prompt_path("abc");
+    assert_eq!(path.file_name().unwrap().to_str().unwrap(), "prompt.md");
+    assert!(path.to_string_lossy().contains("abc"));
 }
 
 #[test]
 fn routine_gitignore_path_filename() {
-    let p = routine_gitignore_path("abc");
-    assert_eq!(p.file_name().unwrap().to_str().unwrap(), ".gitignore");
-    assert!(p.to_string_lossy().contains("abc"));
+    let path = routine_gitignore_path("abc");
+    assert_eq!(path.file_name().unwrap().to_str().unwrap(), ".gitignore");
+    assert!(path.to_string_lossy().contains("abc"));
 }
 
 #[test]
 fn agents_dir_ends_with_agents() {
-    let p = agents_dir().to_string_lossy().into_owned();
-    assert!(p.ends_with("agents"), "expected end with 'agents': {p}");
+    let path = agents_dir().to_string_lossy().into_owned();
+    assert!(
+        path.ends_with("agents"),
+        "expected end with 'agents': {path}"
+    );
 }
 
 #[test]
@@ -132,8 +144,8 @@ fn agents_dir_from_home_none_falls_back_to_dot() {
 
 #[test]
 fn agent_toml_path_appends_name_and_extension() {
-    let p = agent_toml_path("claude");
-    assert_eq!(p.file_name().unwrap().to_str().unwrap(), "claude.toml");
+    let path = agent_toml_path("claude");
+    assert_eq!(path.file_name().unwrap().to_str().unwrap(), "claude.toml");
 }
 
 #[test]
@@ -150,30 +162,33 @@ fn moadim_home_from_home_none_falls_back_to_dot() {
 
 #[test]
 fn workbenches_dir_under_moadim_home() {
-    let p = workbenches_dir();
-    assert!(p.ends_with("workbenches"));
-    assert_eq!(p.parent().unwrap(), moadim_home());
+    let path = workbenches_dir();
+    assert!(path.ends_with("workbenches"));
+    assert_eq!(path.parent().unwrap(), moadim_home());
 }
 
 #[test]
 fn config_gitignore_path_in_config_dir() {
-    let p = config_gitignore_path();
-    assert_eq!(p.file_name().unwrap().to_str().unwrap(), ".gitignore");
-    assert_eq!(p.parent().unwrap(), config_dir());
+    let path = config_gitignore_path();
+    assert_eq!(path.file_name().unwrap().to_str().unwrap(), ".gitignore");
+    assert_eq!(path.parent().unwrap(), config_dir());
 }
 
 #[test]
 fn user_prompt_path_filename() {
-    let p = user_prompt_path();
-    assert_eq!(p.file_name().unwrap().to_str().unwrap(), "user_prompt.md");
-    assert!(p.to_string_lossy().contains("moadim"));
+    let path = user_prompt_path();
+    assert_eq!(
+        path.file_name().unwrap().to_str().unwrap(),
+        "user_prompt.md"
+    );
+    assert!(path.to_string_lossy().contains("moadim"));
 }
 
 #[test]
 fn user_prompt_path_from_home_none_falls_back_to_dot() {
-    let p = super::user_prompt_path_from_home(None);
-    assert!(p.ends_with(".config/moadim/user_prompt.md"));
-    assert!(p.starts_with("."));
+    let path = super::user_prompt_path_from_home(None);
+    assert!(path.ends_with(".config/moadim/user_prompt.md"));
+    assert!(path.starts_with("."));
 }
 
 #[test]

--- a/src/routes/http.rs
+++ b/src/routes/http.rs
@@ -198,8 +198,8 @@ pub async fn run_with_listener_until(
 ) -> anyhow::Result<()> {
     let addr = listener.local_addr()?.to_string();
     let spec_path = concat!(env!("CARGO_MANIFEST_DIR"), "/apis/openapi.json");
-    if let Err(e) = std::fs::write(spec_path, crate::openapi::ApiDoc::to_json()) {
-        log::warn!("could not write openapi spec: {e}");
+    if let Err(err) = std::fs::write(spec_path, crate::openapi::ApiDoc::to_json()) {
+        log::warn!("could not write openapi spec: {err}");
     }
     let signal: ShutdownSignal = Arc::new(tokio::sync::Notify::new());
     // Periodically reap finished, expired run workbenches so triggered routines do not accumulate

--- a/src/routes/mcp.rs
+++ b/src/routes/mcp.rs
@@ -150,7 +150,7 @@ impl MoadimMcp {
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         Ok(match cron_jobs::svc_get(&self.store, &self.handlers, &id) {
             Ok(resp) => ok(resp),
-            Err(e) => err(e),
+            Err(error) => err(error),
         })
     }
 
@@ -165,7 +165,7 @@ impl MoadimMcp {
         Ok(
             match cron_jobs::svc_create(&self.store, &self.handlers, req) {
                 Ok(resp) => ok(resp),
-                Err(e) => err(e),
+                Err(error) => err(error),
             },
         )
     }
@@ -187,7 +187,7 @@ impl MoadimMcp {
         Ok(
             match cron_jobs::svc_update(&self.store, &self.handlers, &input.id, req) {
                 Ok(resp) => ok(resp),
-                Err(e) => err(e),
+                Err(error) => err(error),
             },
         )
     }
@@ -201,7 +201,7 @@ impl MoadimMcp {
         Ok(
             match cron_jobs::svc_delete(&self.store, &self.handlers, &id) {
                 Ok(resp) => ok(resp),
-                Err(e) => err(e),
+                Err(error) => err(error),
             },
         )
     }
@@ -216,7 +216,7 @@ impl MoadimMcp {
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         Ok(match cron_jobs::svc_trigger(&self.store, &id) {
             Ok(job) => ok(job),
-            Err(e) => err(e),
+            Err(error) => err(error),
         })
     }
 
@@ -234,7 +234,7 @@ impl MoadimMcp {
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         Ok(match routines::svc_get(&self.routines, &id) {
             Ok(resp) => ok(resp),
-            Err(e) => err(e),
+            Err(error) => err(error),
         })
     }
 
@@ -248,7 +248,7 @@ impl MoadimMcp {
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         Ok(match routines::svc_create(&self.routines, req) {
             Ok(resp) => ok(resp),
-            Err(e) => err(e),
+            Err(error) => err(error),
         })
     }
 
@@ -271,7 +271,7 @@ impl MoadimMcp {
         };
         Ok(match routines::svc_update(&self.routines, &input.id, req) {
             Ok(resp) => ok(resp),
-            Err(e) => err(e),
+            Err(error) => err(error),
         })
     }
 
@@ -283,7 +283,7 @@ impl MoadimMcp {
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         Ok(match routines::svc_delete(&self.routines, &id) {
             Ok(resp) => ok(resp),
-            Err(e) => err(e),
+            Err(error) => err(error),
         })
     }
 
@@ -297,7 +297,7 @@ impl MoadimMcp {
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         Ok(match routines::svc_trigger(&self.routines, &id) {
             Ok(routine) => ok(routine),
-            Err(e) => err(e),
+            Err(error) => err(error),
         })
     }
 

--- a/src/routes/mcp_tests.rs
+++ b/src/routes/mcp_tests.rs
@@ -33,7 +33,7 @@ fn health_content_contains_status() {
     let result = handler.health().unwrap();
     let text = &result.content[0];
     let json_str = match &text.raw {
-        rmcp::model::RawContent::Text(t) => t.text.clone(),
+        rmcp::model::RawContent::Text(txt) => txt.text.clone(),
         _ => panic!("expected text content"),
     };
     let val: serde_json::Value = serde_json::from_str(&json_str).unwrap();
@@ -52,7 +52,7 @@ fn echo_tool_returns_message() {
         .unwrap();
     assert!(!result.is_error.unwrap_or(false));
     let text = match &result.content[0].raw {
-        rmcp::model::RawContent::Text(t) => t.text.clone(),
+        rmcp::model::RawContent::Text(txt) => txt.text.clone(),
         _ => panic!("expected text content"),
     };
     let val: serde_json::Value = serde_json::from_str(&text).unwrap();
@@ -65,7 +65,7 @@ fn list_cron_jobs_empty() {
     let result = handler.list_cron_jobs().unwrap();
     assert!(!result.is_error.unwrap_or(false));
     let text = match &result.content[0].raw {
-        rmcp::model::RawContent::Text(t) => t.text.clone(),
+        rmcp::model::RawContent::Text(txt) => txt.text.clone(),
         _ => panic!("expected text content"),
     };
     let val: serde_json::Value = serde_json::from_str(&text).unwrap();
@@ -203,7 +203,7 @@ fn create_cron_job_tool_success() {
     let result = handler.create_cron_job(Parameters(req)).unwrap();
     assert!(!result.is_error.unwrap_or(false));
     let text = match &result.content[0].raw {
-        rmcp::model::RawContent::Text(t) => t.text.clone(),
+        rmcp::model::RawContent::Text(txt) => txt.text.clone(),
         _ => panic!("expected text content"),
     };
     let val: serde_json::Value = serde_json::from_str(&text).unwrap();
@@ -330,7 +330,7 @@ fn create_get_update_trigger_delete_routine_success() {
         .unwrap();
     assert!(!result.is_error.unwrap_or(false));
     let text = match &result.content[0].raw {
-        rmcp::model::RawContent::Text(t) => t.text.clone(),
+        rmcp::model::RawContent::Text(txt) => txt.text.clone(),
         _ => panic!("expected text content"),
     };
     let id = serde_json::from_str::<serde_json::Value>(&text).unwrap()["id"]
@@ -378,7 +378,7 @@ fn cleanup_workbenches_tool_returns_removed_count() {
     let result = handler.cleanup_workbenches().unwrap();
     assert!(!result.is_error.unwrap_or(false));
     let json_str = match &result.content[0].raw {
-        rmcp::model::RawContent::Text(t) => t.text.clone(),
+        rmcp::model::RawContent::Text(txt) => txt.text.clone(),
         _ => panic!("expected text content"),
     };
     let val: serde_json::Value = serde_json::from_str(&json_str).unwrap();

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -50,22 +50,22 @@ fn read_routine_toml(path: &std::path::PathBuf) -> Option<RoutineToml> {
 /// `dir_name` is the slug (title-derived folder name). The routine's UUID `id` is read from
 /// `routine.toml`; for legacy dirs created before this change `id` falls back to `dir_name`.
 fn load_routine_from_dir(dir_name: &str) -> Option<Routine> {
-    let t = read_routine_toml(&routine_toml_path(dir_name))?;
-    let title = t.title?;
-    let id = t.id.unwrap_or_else(|| dir_name.to_string());
+    let toml = read_routine_toml(&routine_toml_path(dir_name))?;
+    let title = toml.title?;
+    let id = toml.id.unwrap_or_else(|| dir_name.to_string());
     Some(Routine {
         id,
-        schedule: t.schedule?,
+        schedule: toml.schedule?,
         title,
-        agent: t.agent?,
-        prompt: t.prompt.unwrap_or_default(),
-        repositories: t.repositories,
-        enabled: t.enabled.unwrap_or(true),
+        agent: toml.agent?,
+        prompt: toml.prompt.unwrap_or_default(),
+        repositories: toml.repositories,
+        enabled: toml.enabled.unwrap_or(true),
         source: "managed".to_string(),
-        created_at: t.created_at.unwrap_or(0),
-        updated_at: t.updated_at.unwrap_or(0),
-        last_triggered_at: t.last_triggered_at,
-        ttl_secs: t.ttl_secs,
+        created_at: toml.created_at.unwrap_or(0),
+        updated_at: toml.updated_at.unwrap_or(0),
+        last_triggered_at: toml.last_triggered_at,
+        ttl_secs: toml.ttl_secs,
     })
 }
 
@@ -119,18 +119,18 @@ pub fn remove_routine_dir(slug: &str) -> std::io::Result<()> {
 pub fn migrate_prompt_files() {
     let dir = routines_dir();
     let entries = match std::fs::read_dir(&dir) {
-        Ok(e) => e,
+        Ok(entries) => entries,
         Err(_) => return,
     };
     for entry in entries.flatten() {
-        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+        if !entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
             continue;
         }
         let old = entry.path().join("prompt.txt");
         let new = entry.path().join("prompt.md");
         if old.exists() && !new.exists() {
-            if let Err(e) = std::fs::rename(&old, &new) {
-                log::warn!("migrate_prompt_files: failed to rename {:?}: {e}", old);
+            if let Err(err) = std::fs::rename(&old, &new) {
+                log::warn!("migrate_prompt_files: failed to rename {:?}: {err}", old);
             }
         }
     }
@@ -150,11 +150,11 @@ pub fn migrate_prompt_files() {
 pub fn migrate_routine_dirs() {
     let dir = routines_dir();
     let entries = match std::fs::read_dir(&dir) {
-        Ok(e) => e,
+        Ok(entries) => entries,
         Err(_) => return,
     };
     for entry in entries.flatten() {
-        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+        if !entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
             continue;
         }
         let dir_name = entry.file_name().to_string_lossy().to_string();
@@ -167,12 +167,12 @@ pub fn migrate_routine_dirs() {
         if slug == dir_name {
             continue;
         }
-        if let Err(e) = write_routine(&routine) {
-            log::warn!("migrate_routine_dirs: failed to write {slug:?}: {e}; leaving legacy dir");
+        if let Err(err) = write_routine(&routine) {
+            log::warn!("migrate_routine_dirs: failed to write {slug:?}: {err}; leaving legacy dir");
             continue;
         }
-        if let Err(e) = remove_routine_dir(&dir_name) {
-            log::warn!("migrate_routine_dirs: failed to remove legacy dir {dir_name:?}: {e}");
+        if let Err(err) = remove_routine_dir(&dir_name) {
+            log::warn!("migrate_routine_dirs: failed to remove legacy dir {dir_name:?}: {err}");
         }
     }
 }
@@ -186,11 +186,11 @@ pub fn migrate_routine_dirs() {
 /// heals those dirs. Idempotent; safe to call on every startup after [`load_store`].
 pub fn repersist_routines(store: &RoutineStore) {
     let routines: Vec<Routine> = store.lock().unwrap().values().cloned().collect();
-    for r in &routines {
-        if let Err(e) = write_routine(r) {
+    for routine in &routines {
+        if let Err(err) = write_routine(routine) {
             log::warn!(
-                "repersist_routines: failed to write routine {:?}: {e}",
-                r.id
+                "repersist_routines: failed to write routine {:?}: {err}",
+                routine.id
             );
         }
     }
@@ -206,7 +206,7 @@ pub(crate) fn load_store_from_dir(dir: &std::path::Path) -> RoutineStore {
     let mut routines = HashMap::new();
     if let Ok(entries) = std::fs::read_dir(dir) {
         for entry in entries.flatten() {
-            if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            if entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
                 let dir_name = entry.file_name().to_string_lossy().to_string();
                 if let Some(routine) = load_routine_from_dir(&dir_name) {
                     routines.insert(routine.id.clone(), routine);

--- a/src/routines/agents/mod.rs
+++ b/src/routines/agents/mod.rs
@@ -64,9 +64,9 @@ pub(crate) fn available_agents_in(dir: &Path) -> Vec<String> {
         return builtin_agent_names();
     };
     let mut names: Vec<String> = entries
-        .filter_map(|e| e.ok())
-        .filter_map(|e| {
-            let path = e.path();
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| {
+            let path = entry.path();
             (path.extension()? == "toml")
                 .then(|| path.file_stem()?.to_str().map(str::to_string))
                 .flatten()
@@ -89,8 +89,8 @@ pub fn ensure_default_agents() {
 
 /// Write missing built-in agent configs into `dir`. See [`ensure_default_agents`].
 pub(crate) fn ensure_default_agents_in(dir: &Path) {
-    if let Err(e) = std::fs::create_dir_all(dir) {
-        log::warn!("ensure_default_agents: failed to create {dir:?}: {e}");
+    if let Err(err) = std::fs::create_dir_all(dir) {
+        log::warn!("ensure_default_agents: failed to create {dir:?}: {err}");
         return;
     }
     for (name, contents) in DEFAULT_AGENT_CONFIGS {
@@ -98,8 +98,8 @@ pub(crate) fn ensure_default_agents_in(dir: &Path) {
         if path.exists() {
             continue;
         }
-        if let Err(e) = std::fs::write(&path, contents) {
-            log::warn!("ensure_default_agents: failed to write {path:?}: {e}");
+        if let Err(err) = std::fs::write(&path, contents) {
+            log::warn!("ensure_default_agents: failed to write {path:?}: {err}");
         }
     }
 }

--- a/src/routines/cleanup/mod.rs
+++ b/src/routines/cleanup/mod.rs
@@ -28,7 +28,7 @@ pub const CLEANUP_INTERVAL: Duration = Duration::from_secs(60 * 60);
 /// are skipped rather than reaped).
 fn parse_workbench_name(name: &str) -> Option<(&str, u64)> {
     let (slug, ts) = name.rsplit_once('-')?;
-    if slug.is_empty() || ts.is_empty() || !ts.bytes().all(|b| b.is_ascii_digit()) {
+    if slug.is_empty() || ts.is_empty() || !ts.bytes().all(|byte| byte.is_ascii_digit()) {
         return None;
     }
     Some((slug, ts.parse().ok()?))
@@ -53,7 +53,7 @@ fn tmux_session_alive(session: &str) -> bool {
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .status()
-        .map(|s| s.success())
+        .map(|status| status.success())
         .unwrap_or(false)
 }
 
@@ -73,7 +73,7 @@ fn reap_dir(
     };
     let mut removed = 0;
     for entry in entries.flatten() {
-        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+        if !entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
             continue;
         }
         let name = entry.file_name().to_string_lossy().into_owned();
@@ -91,7 +91,7 @@ fn reap_dir(
                 removed += 1;
                 log::info!("cleanup: removed expired workbench {name:?}");
             }
-            Err(e) => log::warn!("cleanup: failed to remove workbench {name:?}: {e}"),
+            Err(err) => log::warn!("cleanup: failed to remove workbench {name:?}: {err}"),
         }
     }
     removed

--- a/src/routines/cleanup/snapshot.rs
+++ b/src/routines/cleanup/snapshot.rs
@@ -13,7 +13,7 @@ use super::ttl::MAX_TTL_SECS;
 pub fn snapshot_ttls(store: &RoutineStore) -> HashMap<String, u64> {
     let lock = store.lock().unwrap();
     lock.values()
-        .map(|r| (slugify(&r.title), r.effective_ttl_secs()))
+        .map(|routine| (slugify(&routine.title), routine.effective_ttl_secs()))
         .collect()
 }
 

--- a/src/routines/cleanup/ttl.rs
+++ b/src/routines/cleanup/ttl.rs
@@ -23,7 +23,7 @@ impl Routine {
     /// An explicit `ttl_secs` can only shorten retention, never raise it above the cron-derived cap.
     pub fn effective_ttl_secs(&self) -> u64 {
         let ceiling = MAX_TTL_SECS.min(self.cron_interval_secs().unwrap_or(MAX_TTL_SECS));
-        self.ttl_secs.map_or(ceiling, |t| t.min(ceiling))
+        self.ttl_secs.map_or(ceiling, |secs| secs.min(ceiling))
     }
 
     /// Seconds between the next two scheduled runs, or `None` if the schedule can't be parsed or two

--- a/src/routines/command.rs
+++ b/src/routines/command.rs
@@ -12,9 +12,9 @@ use super::model::Routine;
 pub(crate) fn slugify(title: &str) -> String {
     let mut out = String::new();
     let mut prev_dash = false;
-    for c in title.chars() {
-        if c.is_ascii_alphanumeric() {
-            out.push(c.to_ascii_lowercase());
+    for ch in title.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
             prev_dash = false;
         } else if !prev_dash {
             out.push('-');
@@ -31,28 +31,29 @@ pub(crate) fn slugify(title: &str) -> String {
 
 /// Compose the `prompt.md` body: a repositories-as-context preamble followed by the prompt.
 pub(crate) fn compose_prompt(routine: &Routine) -> String {
-    let mut s = String::from("# Workbench\n");
-    s.push_str(
+    let mut body = String::from("# Workbench\n");
+    body.push_str(
         "You are working in an empty directory. These repositories are relevant — clone any you need:\n",
     );
     for repo in &routine.repositories {
         match &repo.branch {
-            Some(b) => s.push_str(&format!("- {} (branch {})\n", repo.repository, b)),
-            None => s.push_str(&format!("- {}\n", repo.repository)),
+            Some(branch) => body.push_str(&format!("- {} (branch {})\n", repo.repository, branch)),
+            None => body.push_str(&format!("- {}\n", repo.repository)),
         }
     }
-    s.push_str("\n---\n");
-    s.push_str(&routine.prompt);
-    s.push('\n');
-    s
+    body.push_str("\n---\n");
+    body.push_str(&routine.prompt);
+    body.push('\n');
+    body
 }
 
 /// Substitute `{workbench}`, `{prompt_file}`, and `{prompt}` placeholders in `s`.
 ///
 /// `{prompt}` expands to a shell command substitution that reads `prompt.md` from the agent's
 /// cwd (the workbench), so the full prompt is passed as a single argument to the agent process.
-pub(crate) fn substitute(s: &str, workbench: &str, prompt_file: &str) -> String {
-    s.replace("{workbench}", workbench)
+pub(crate) fn substitute(template: &str, workbench: &str, prompt_file: &str) -> String {
+    template
+        .replace("{workbench}", workbench)
         .replace("{prompt_file}", prompt_file)
         .replace("{prompt}", r#""$(cat prompt.md)""#)
 }
@@ -61,8 +62,8 @@ pub(crate) fn substitute(s: &str, workbench: &str, prompt_file: &str) -> String 
 fn bin_dir(bin: &str) -> Option<String> {
     let path = std::env::var("PATH").ok()?;
     path.split(':')
-        .filter(|d| !d.is_empty())
-        .find(|d| std::path::Path::new(d).join(bin).is_file())
+        .filter(|dir| !dir.is_empty())
+        .find(|dir| std::path::Path::new(dir).join(bin).is_file())
         .map(str::to_string)
 }
 
@@ -77,11 +78,11 @@ fn cron_path(agent_command: &str) -> String {
     let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
     let mut dirs: Vec<String> = Vec::new();
     for bin in ["tmux", agent_command] {
-        if let Some(d) = bin_dir(bin) {
-            dirs.push(d);
+        if let Some(dir) = bin_dir(bin) {
+            dirs.push(dir);
         }
     }
-    for d in [
+    for dir in [
         format!("{home}/.local/bin"),
         "/opt/homebrew/bin".to_string(),
         "/usr/local/bin".to_string(),
@@ -92,21 +93,21 @@ fn cron_path(agent_command: &str) -> String {
         "/usr/sbin".to_string(),
         "/sbin".to_string(),
     ] {
-        dirs.push(d);
+        dirs.push(dir);
     }
     let mut seen = std::collections::HashSet::new();
-    dirs.retain(|d| seen.insert(d.clone()));
+    dirs.retain(|dir| seen.insert(dir.clone()));
     dirs.join(":")
 }
 
 /// Wrap `s` in single quotes for safe inclusion in a POSIX shell command.
-pub(crate) fn shell_quote(s: &str) -> String {
+pub(crate) fn shell_quote(text: &str) -> String {
     let mut out = String::from("'");
-    for c in s.chars() {
-        if c == '\'' {
+    for ch in text.chars() {
+        if ch == '\'' {
             out.push_str("'\\''");
         } else {
-            out.push(c);
+            out.push(ch);
         }
     }
     out.push('\'');
@@ -161,8 +162,8 @@ pub(crate) fn build_routine_command(routine: &Routine, agent: &AgentCommand) -> 
     let workbench_ref = ".";
 
     let mut invocation = vec![agent.command.clone()];
-    for a in &agent.args {
-        invocation.push(substitute(a, workbench_ref, prompt_file_ref));
+    for arg in &agent.args {
+        invocation.push(substitute(arg, workbench_ref, prompt_file_ref));
     }
     let invocation = invocation.join(" ");
 

--- a/src/routines/defaults.rs
+++ b/src/routines/defaults.rs
@@ -124,7 +124,7 @@ pub fn ensure_default_routines(store: &RoutineStore) {
             .lock()
             .unwrap()
             .values()
-            .find(|r| slugify(&r.title) == slug)
+            .find(|routine| slugify(&routine.title) == slug)
             .cloned();
         let routine = match existing {
             Some(cur) => match reconcile(spec, &cur, now_secs()) {
@@ -133,9 +133,9 @@ pub fn ensure_default_routines(store: &RoutineStore) {
             },
             None => materialize(spec, now_secs()),
         };
-        if let Err(e) = write_routine(&routine) {
+        if let Err(err) = write_routine(&routine) {
             log::warn!(
-                "ensure_default_routines: failed to write {:?}: {e}; skipping",
+                "ensure_default_routines: failed to write {:?}: {err}; skipping",
                 spec.title
             );
             continue;

--- a/src/routines/defaults_tests.rs
+++ b/src/routines/defaults_tests.rs
@@ -33,7 +33,7 @@ fn every_agent_is_a_known_builtin() {
     let known = available_agents();
     for spec in DEFAULT_ROUTINES {
         assert!(
-            known.iter().any(|a| a == spec.agent),
+            known.iter().any(|agent| agent == spec.agent),
             "agent {:?} for routine {:?} is not a built-in agent",
             spec.agent,
             spec.title
@@ -44,15 +44,15 @@ fn every_agent_is_a_known_builtin() {
 #[test]
 fn materialize_stamps_timestamps_and_marks_managed() {
     let spec = &DEFAULT_ROUTINES[0];
-    let r = materialize(spec, 1234);
-    assert_eq!(r.created_at, 1234);
-    assert_eq!(r.updated_at, 1234);
-    assert_eq!(r.source, "managed");
-    assert!(r.enabled);
-    assert!(r.last_triggered_at.is_none());
-    assert!(!r.id.is_empty());
+    let routine = materialize(spec, 1234);
+    assert_eq!(routine.created_at, 1234);
+    assert_eq!(routine.updated_at, 1234);
+    assert_eq!(routine.source, "managed");
+    assert!(routine.enabled);
+    assert!(routine.last_triggered_at.is_none());
+    assert!(!routine.id.is_empty());
     // Schedule is normalized, not the raw spec string.
-    assert_eq!(r.schedule, normalize_schedule(spec.schedule));
+    assert_eq!(routine.schedule, normalize_schedule(spec.schedule));
 }
 
 #[test]

--- a/src/routines/ical.rs
+++ b/src/routines/ical.rs
@@ -14,15 +14,15 @@ const MAX_EVENTS_PER_ROUTINE: usize = 100;
 const PRODID: &str = "-//moadim//routines//EN";
 
 /// Escape a text value for an iCalendar property per RFC 5545 §3.3.11.
-fn escape_text(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
+fn escape_text(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for ch in text.chars() {
+        match ch {
             '\\' => out.push_str("\\\\"),
             ';' => out.push_str("\\;"),
             ',' => out.push_str("\\,"),
             '\n' => out.push_str("\\n"),
-            _ => out.push(c),
+            _ => out.push(ch),
         }
     }
     out

--- a/src/routines/ical_tests.rs
+++ b/src/routines/ical_tests.rs
@@ -74,9 +74,9 @@ fn high_frequency_schedule_is_capped() {
 
 #[test]
 fn text_fields_are_escaped() {
-    let mut r = routine_with("r1", "@daily", true);
-    r.title = "a,b;c\\d\ne".to_string();
-    let ics = build_ical(&[r], fixed_now());
+    let mut routine = routine_with("r1", "@daily", true);
+    routine.title = "a,b;c\\d\ne".to_string();
+    let ics = build_ical(&[routine], fixed_now());
     assert!(ics.contains("SUMMARY:a\\,b\\;c\\\\d\\ne\r\n"));
 }
 

--- a/src/routines/mod_tests.rs
+++ b/src/routines/mod_tests.rs
@@ -38,22 +38,22 @@ fn slugify_empty_falls_back() {
 
 #[test]
 fn compose_prompt_lists_repos_and_prompt() {
-    let r = make_routine("x");
-    let p = compose_prompt(&r);
-    assert!(p.contains("# Workbench"));
-    assert!(p.contains("https://github.com/octocat/Hello-World (branch master)"));
-    assert!(p.contains("do the thing"));
+    let routine = make_routine("x");
+    let prompt = compose_prompt(&routine);
+    assert!(prompt.contains("# Workbench"));
+    assert!(prompt.contains("https://github.com/octocat/Hello-World (branch master)"));
+    assert!(prompt.contains("do the thing"));
 }
 
 #[test]
 fn compose_prompt_repo_without_branch() {
-    let mut r = make_routine("x");
-    r.repositories = vec![Repository {
+    let mut routine = make_routine("x");
+    routine.repositories = vec![Repository {
         repository: "git@example.com:a/b".to_string(),
         branch: None,
     }];
-    let p = compose_prompt(&r);
-    assert!(p.contains("- git@example.com:a/b\n"));
+    let prompt = compose_prompt(&routine);
+    assert!(prompt.contains("- git@example.com:a/b\n"));
 }
 
 #[test]
@@ -76,7 +76,7 @@ fn shell_quote_wraps_and_escapes() {
 
 #[test]
 fn build_routine_command_contains_expected_pieces() {
-    let r = make_routine("rid");
+    let routine = make_routine("rid");
     let agent = AgentCommand {
         command: "claude".to_string(),
         args: vec![
@@ -85,7 +85,7 @@ fn build_routine_command_contains_expected_pieces() {
         ],
         setup: None,
     };
-    let cmd = build_routine_command(&r, &agent);
+    let cmd = build_routine_command(&routine, &agent);
     assert!(cmd.contains("tmux new-session -d -s \"$SESS\" -c \"$WB\""));
     // bakes a PATH export so cron's minimal PATH does not hide tmux/claude
     assert!(cmd.contains("export PATH="));
@@ -108,25 +108,25 @@ fn build_routine_command_contains_expected_pieces() {
 
 #[test]
 fn build_routine_command_substitutes_arg_placeholders() {
-    let r = make_routine("rid");
+    let routine = make_routine("rid");
     let agent = AgentCommand {
         command: "codex".to_string(),
         args: vec!["exec".to_string(), "{prompt_file}".to_string()],
         setup: None,
     };
-    let cmd = build_routine_command(&r, &agent);
+    let cmd = build_routine_command(&routine, &agent);
     assert!(cmd.contains("'codex exec prompt.md'"));
 }
 
 #[test]
 fn build_routine_command_writes_claude_md() {
-    let r = make_routine("rid");
+    let routine = make_routine("rid");
     let agent = AgentCommand {
         command: "claude".to_string(),
         args: vec!["{prompt}".to_string()],
         setup: None,
     };
-    let cmd = build_routine_command(&r, &agent);
+    let cmd = build_routine_command(&routine, &agent);
     // moadim-managed section written via printf %b
     assert!(cmd.contains("CLAUDE.md"), "CLAUDE.md write missing");
     assert!(
@@ -151,19 +151,19 @@ fn build_routine_command_writes_claude_md() {
 
 #[test]
 fn build_routine_command_aborts_when_prompt_missing() {
-    let r = make_routine("rid");
+    let routine = make_routine("rid");
     let agent = AgentCommand {
         command: "claude".to_string(),
         args: vec!["{prompt}".to_string()],
         setup: None,
     };
-    let cmd = build_routine_command(&r, &agent);
+    let cmd = build_routine_command(&routine, &agent);
     // The cp of the routine's source prompt must fail-fast: a missing source aborts the launch
     // instead of starting the agent with an empty "$(cat prompt.md)" argument (a task-less session).
     let cp_at = cmd.find("cp ").expect("cp in cmd");
     let abort_at = cmd[cp_at..]
         .find("exit 1")
-        .map(|o| cp_at + o)
+        .map(|off| cp_at + off)
         .expect("cp should be guarded by an abort");
     let launch_at = cmd.find("tmux new-session").expect("launch present");
     assert!(
@@ -176,13 +176,13 @@ fn build_routine_command_aborts_when_prompt_missing() {
 
 #[test]
 fn build_routine_command_inserts_setup_before_launch() {
-    let r = make_routine("rid");
+    let routine = make_routine("rid");
     let agent = AgentCommand {
         command: "claude".to_string(),
         args: vec!["{prompt}".to_string()],
         setup: Some("seed-trust \"$WB\"".to_string()),
     };
-    let cmd = build_routine_command(&r, &agent);
+    let cmd = build_routine_command(&routine, &agent);
     let setup_at = cmd.find("seed-trust").expect("setup present");
     let launch_at = cmd.find("tmux new-session").expect("launch present");
     // setup runs before the agent launches
@@ -273,9 +273,9 @@ fn routine_response_schedule_description() {
 
 #[test]
 fn routine_response_schedule_description_none_for_reboot() {
-    let mut r = make_routine("x");
-    r.schedule = "@reboot".to_string();
-    let resp = RoutineResponse::from_routine(r);
+    let mut routine = make_routine("x");
+    routine.schedule = "@reboot".to_string();
+    let resp = RoutineResponse::from_routine(routine);
     assert!(resp.schedule_description.is_none());
 }
 
@@ -430,9 +430,9 @@ fn svc_trigger_not_found() {
 fn svc_trigger_records_time_without_agent_config() {
     // Agent name that has no config file → records trigger, does not spawn.
     let store = new_store();
-    let mut r = make_routine("trig-id");
-    r.agent = "no-such-agent-xyz".into();
-    store.lock().unwrap().insert("trig-id".into(), r);
+    let mut routine = make_routine("trig-id");
+    routine.agent = "no-such-agent-xyz".into();
+    store.lock().unwrap().insert("trig-id".into(), routine);
     let triggered = svc_trigger(&store, "trig-id").unwrap();
     assert!(triggered.last_triggered_at.is_some());
     // folder is slug of "My Routine"
@@ -454,11 +454,14 @@ fn svc_trigger_with_agent_config_spawns() {
 
     let store = new_store();
     let title = "Trigger Cov Title ZZZ";
-    let mut r = make_routine("trig-cfg");
-    r.title = title.into();
-    r.agent = agent_name.into();
-    store.lock().unwrap().insert("trig-cfg".into(), r.clone());
-    crate::routine_storage::write_routine(&r).unwrap();
+    let mut routine = make_routine("trig-cfg");
+    routine.title = title.into();
+    routine.agent = agent_name.into();
+    store
+        .lock()
+        .unwrap()
+        .insert("trig-cfg".into(), routine.clone());
+    crate::routine_storage::write_routine(&routine).unwrap();
 
     let triggered = svc_trigger(&store, "trig-cfg").unwrap();
     assert!(triggered.last_triggered_at.is_some());
@@ -470,9 +473,9 @@ fn svc_trigger_with_agent_config_spawns() {
     crate::routine_storage::remove_routine_dir("trigger-cov-title-zzz").unwrap();
     let prefix = format!("{}-", slugify(title));
     if let Ok(entries) = std::fs::read_dir(crate::paths::workbenches_dir()) {
-        for e in entries.flatten() {
-            if e.file_name().to_string_lossy().starts_with(&prefix) {
-                let _ = std::fs::remove_dir_all(e.path());
+        for entry in entries.flatten() {
+            if entry.file_name().to_string_lossy().starts_with(&prefix) {
+                let _ = std::fs::remove_dir_all(entry.path());
             }
         }
     }
@@ -495,19 +498,19 @@ fn svc_logs_not_found() {
 #[test]
 fn svc_logs_empty_when_no_workbench() {
     let store = new_store();
-    let mut r = make_routine("logs-id");
-    r.title = "Unlikely Title For Logs 9988".into();
-    store.lock().unwrap().insert("logs-id".into(), r);
+    let mut routine = make_routine("logs-id");
+    routine.title = "Unlikely Title For Logs 9988".into();
+    store.lock().unwrap().insert("logs-id".into(), routine);
     assert_eq!(svc_logs(&store, "logs-id").unwrap(), "");
 }
 
 #[test]
 fn svc_logs_returns_newest_workbench_log() {
     let store = new_store();
-    let mut r = make_routine("logs-newest");
-    r.title = "Logs Cov Newest AAA".into();
-    let slug = slugify(&r.title);
-    store.lock().unwrap().insert("logs-newest".into(), r);
+    let mut routine = make_routine("logs-newest");
+    routine.title = "Logs Cov Newest AAA".into();
+    let slug = slugify(&routine.title);
+    store.lock().unwrap().insert("logs-newest".into(), routine);
 
     let wb = crate::paths::workbenches_dir();
     let old = wb.join(format!("{slug}-1000"));
@@ -526,10 +529,10 @@ fn svc_logs_returns_newest_workbench_log() {
 #[test]
 fn svc_logs_empty_when_newest_has_no_log_file() {
     let store = new_store();
-    let mut r = make_routine("logs-nofile");
-    r.title = "Logs Cov NoFile BBB".into();
-    let slug = slugify(&r.title);
-    store.lock().unwrap().insert("logs-nofile".into(), r);
+    let mut routine = make_routine("logs-nofile");
+    routine.title = "Logs Cov NoFile BBB".into();
+    let slug = slugify(&routine.title);
+    store.lock().unwrap().insert("logs-nofile".into(), routine);
 
     let dir = crate::paths::workbenches_dir().join(format!("{slug}-3000"));
     std::fs::create_dir_all(&dir).unwrap();

--- a/src/routines/model.rs
+++ b/src/routines/model.rs
@@ -90,8 +90,8 @@ impl RoutineResponse {
             .to_string_lossy()
             .into_owned();
         let timezone = local_timezone();
-        let schedule_description = routine.schedule.parse::<Cron>().ok().map(|c| {
-            let desc = c.describe();
+        let schedule_description = routine.schedule.parse::<Cron>().ok().map(|cron| {
+            let desc = cron.describe();
             match &timezone {
                 Some(tz) => format!("{desc} ({tz})"),
                 None => desc,

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -20,7 +20,7 @@ use super::model::{
 pub fn svc_list(store: &RoutineStore) -> Vec<RoutineResponse> {
     let lock = store.lock().unwrap();
     let mut routines: Vec<Routine> = lock.values().cloned().collect();
-    routines.sort_by_key(|r| r.created_at);
+    routines.sort_by_key(|routine| routine.created_at);
     drop(lock);
     routines
         .into_iter()
@@ -48,7 +48,7 @@ pub fn svc_create(
     let slug = slugify(&req.title);
     {
         let lock = store.lock().unwrap();
-        if lock.values().any(|r| slugify(&r.title) == slug) {
+        if lock.values().any(|routine| slugify(&routine.title) == slug) {
             return Err(AppError::Conflict(format!(
                 "a routine with the name \"{slug}\" already exists"
             )));
@@ -74,8 +74,8 @@ pub fn svc_create(
         .lock()
         .unwrap()
         .insert(routine.id.clone(), routine.clone());
-    if let Err(e) = crate::sync::routines::sync_routines_to_crontab(store) {
-        log::warn!("crontab sync after routine create failed: {e}");
+    if let Err(err) = crate::sync::routines::sync_routines_to_crontab(store) {
+        log::warn!("crontab sync after routine create failed: {err}");
     }
     Ok(RoutineResponse::from_routine(routine))
 }
@@ -97,7 +97,7 @@ pub fn svc_update(
         if new_slug != old_slug
             && lock
                 .values()
-                .any(|r| r.id != id && slugify(&r.title) == new_slug)
+                .any(|routine| routine.id != id && slugify(&routine.title) == new_slug)
         {
             return Err(AppError::Conflict(format!(
                 "a routine with the name \"{new_slug}\" already exists"
@@ -105,23 +105,23 @@ pub fn svc_update(
         }
     }
     let routine = lock.get_mut(id).unwrap();
-    if let Some(s) = req.schedule {
-        routine.schedule = normalize_schedule(&s);
+    if let Some(schedule) = req.schedule {
+        routine.schedule = normalize_schedule(&schedule);
     }
-    if let Some(t) = req.title {
-        routine.title = t;
+    if let Some(title) = req.title {
+        routine.title = title;
     }
-    if let Some(a) = req.agent {
-        routine.agent = a;
+    if let Some(agent) = req.agent {
+        routine.agent = agent;
     }
-    if let Some(p) = req.prompt {
-        routine.prompt = p;
+    if let Some(prompt) = req.prompt {
+        routine.prompt = prompt;
     }
-    if let Some(r) = req.repositories {
-        routine.repositories = r;
+    if let Some(repositories) = req.repositories {
+        routine.repositories = repositories;
     }
-    if let Some(e) = req.enabled {
-        routine.enabled = e;
+    if let Some(enabled) = req.enabled {
+        routine.enabled = enabled;
     }
     if let Some(ttl) = req.ttl_secs {
         routine.ttl_secs = Some(ttl);
@@ -134,8 +134,8 @@ pub fn svc_update(
     if new_slug != old_slug {
         remove_routine_dir(&old_slug).map_err(|_| AppError::Internal)?;
     }
-    if let Err(e) = crate::sync::routines::sync_routines_to_crontab(store) {
-        log::warn!("crontab sync after routine update failed: {e}");
+    if let Err(err) = crate::sync::routines::sync_routines_to_crontab(store) {
+        log::warn!("crontab sync after routine update failed: {err}");
     }
     Ok(RoutineResponse::from_routine(routine))
 }
@@ -144,8 +144,8 @@ pub fn svc_update(
 pub fn svc_delete(store: &RoutineStore, id: &str) -> Result<RoutineResponse, AppError> {
     let routine = store.lock().unwrap().remove(id).ok_or(AppError::NotFound)?;
     remove_routine_dir(&slugify(&routine.title)).map_err(|_| AppError::Internal)?;
-    if let Err(e) = crate::sync::routines::sync_routines_to_crontab(store) {
-        log::warn!("crontab sync after routine delete failed: {e}");
+    if let Err(err) = crate::sync::routines::sync_routines_to_crontab(store) {
+        log::warn!("crontab sync after routine delete failed: {err}");
     }
     Ok(RoutineResponse::from_routine(routine))
 }
@@ -161,8 +161,8 @@ pub fn svc_trigger(store: &RoutineStore, id: &str) -> Result<Routine, AppError> 
     match load_agent_command(&routine.agent) {
         Some(agent) => {
             let cmd = build_routine_command(&routine, &agent);
-            if let Err(e) = std::process::Command::new("sh").arg("-c").arg(&cmd).spawn() {
-                log::warn!("trigger: failed to spawn routine command: {e}");
+            if let Err(err) = std::process::Command::new("sh").arg("-c").arg(&cmd).spawn() {
+                log::warn!("trigger: failed to spawn routine command: {err}");
             }
         }
         None => log::warn!(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -44,9 +44,9 @@ fn json_to_toml_table(val: &serde_json::Value) -> toml::Table {
     match val {
         serde_json::Value::Object(map) => {
             let mut table = toml::Table::new();
-            for (k, v) in map {
-                if let Ok(tv) = serde_json::from_value::<toml::Value>(v.clone()) {
-                    table.insert(k.clone(), tv);
+            for (key, value) in map {
+                if let Ok(toml_value) = serde_json::from_value::<toml::Value>(value.clone()) {
+                    table.insert(key.clone(), toml_value);
                 }
             }
             table
@@ -62,36 +62,36 @@ fn load_job_from_dir(id: &str) -> Option<CronJob> {
     let (schedule, handler, enabled, created_at, updated_at, last_triggered_at, mut meta) = (
         local
             .as_ref()
-            .and_then(|l| l.schedule.clone())
+            .and_then(|local_job| local_job.schedule.clone())
             .or(base.schedule)?,
         local
             .as_ref()
-            .and_then(|l| l.handler.clone())
+            .and_then(|local_job| local_job.handler.clone())
             .or(base.handler)?,
         local
             .as_ref()
-            .and_then(|l| l.enabled)
+            .and_then(|local_job| local_job.enabled)
             .or(base.enabled)
             .unwrap_or(true),
         local
             .as_ref()
-            .and_then(|l| l.created_at)
+            .and_then(|local_job| local_job.created_at)
             .or(base.created_at)
             .unwrap_or(0),
         local
             .as_ref()
-            .and_then(|l| l.updated_at)
+            .and_then(|local_job| local_job.updated_at)
             .or(base.updated_at)
             .unwrap_or(0),
         local
             .as_ref()
-            .and_then(|l| l.last_triggered_at)
+            .and_then(|local_job| local_job.last_triggered_at)
             .or(base.last_triggered_at),
         base.metadata,
     );
-    if let Some(local_meta) = local.as_ref().map(|l| &l.metadata) {
-        for (k, v) in local_meta {
-            meta.insert(k.clone(), v.clone());
+    if let Some(local_meta) = local.as_ref().map(|local_job| &local_job.metadata) {
+        for (key, value) in local_meta {
+            meta.insert(key.clone(), value.clone());
         }
     }
     Some(CronJob {
@@ -150,7 +150,11 @@ pub(crate) fn load_store_from_dir(dir: &std::path::Path) -> CronStore {
     let mut jobs = HashMap::new();
     if let Ok(entries) = std::fs::read_dir(dir) {
         for entry in entries.flatten() {
-            if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            if entry
+                .file_type()
+                .map(|file_type| file_type.is_dir())
+                .unwrap_or(false)
+            {
                 let id = entry.file_name().to_string_lossy().to_string();
                 if let Some(job) = load_job_from_dir(&id) {
                     jobs.insert(id, job);

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -53,14 +53,14 @@ impl std::fmt::Display for SyncError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             SyncError::CrontabCommand(msg) => write!(f, "crontab: {msg}"),
-            SyncError::Io(e) => write!(f, "io: {e}"),
+            SyncError::Io(err) => write!(f, "io: {err}"),
         }
     }
 }
 
 impl From<std::io::Error> for SyncError {
-    fn from(e: std::io::Error) -> Self {
-        SyncError::Io(e)
+    fn from(err: std::io::Error) -> Self {
+        SyncError::Io(err)
     }
 }
 
@@ -72,15 +72,15 @@ impl From<std::io::Error> for SyncError {
 /// `@keyword` schedules are passed through unchanged.
 /// The seconds (field 0) and year (field 6) are dropped.
 pub(crate) fn to_os_schedule(schedule: &str) -> String {
-    let s = schedule.trim();
-    if s.starts_with('@') {
-        return s.to_string();
+    let trimmed = schedule.trim();
+    if trimmed.starts_with('@') {
+        return trimmed.to_string();
     }
-    let fields: Vec<&str> = s.split_ascii_whitespace().collect();
+    let fields: Vec<&str> = trimmed.split_ascii_whitespace().collect();
     match fields.len() {
         7 => fields[1..6].join(" "),
-        5 => s.to_string(),
-        _ => s.to_string(),
+        5 => trimmed.to_string(),
+        _ => trimmed.to_string(),
     }
 }
 
@@ -119,11 +119,15 @@ pub(crate) fn resolve_handler_path(handler: &str, dir: &Path) -> PathBuf {
 /// is used. Otherwise the bare filename stem is returned.
 #[allow(dead_code)]
 pub(crate) fn handler_from_command(command: &str, dir: &Path) -> String {
-    let p = Path::new(command.trim());
-    let stem = if let Ok(rel) = p.strip_prefix(dir) {
-        rel.file_stem().and_then(|s| s.to_str()).map(str::to_string)
+    let path = Path::new(command.trim());
+    let stem = if let Ok(rel) = path.strip_prefix(dir) {
+        rel.file_stem()
+            .and_then(|stem| stem.to_str())
+            .map(str::to_string)
     } else {
-        p.file_stem().and_then(|s| s.to_str()).map(str::to_string)
+        path.file_stem()
+            .and_then(|stem| stem.to_str())
+            .map(str::to_string)
     };
     stem.unwrap_or_else(|| command.trim().to_string())
 }
@@ -137,7 +141,7 @@ pub(crate) fn read_crontab() -> Result<String, SyncError> {
     let out = Command::new("crontab")
         .arg("-l")
         .output()
-        .map_err(|e| SyncError::CrontabCommand(format!("failed to run crontab -l: {e}")))?;
+        .map_err(|err| SyncError::CrontabCommand(format!("failed to run crontab -l: {err}")))?;
 
     if out.status.success() {
         return Ok(String::from_utf8_lossy(&out.stdout).into_owned());
@@ -156,7 +160,7 @@ pub(crate) fn write_crontab(content: &str) -> Result<(), SyncError> {
         .arg("-")
         .stdin(Stdio::piped())
         .spawn()
-        .map_err(|e| SyncError::CrontabCommand(format!("failed to spawn crontab: {e}")))?;
+        .map_err(|err| SyncError::CrontabCommand(format!("failed to spawn crontab: {err}")))?;
 
     // Taking stdin drops (closes) it after write_all, signalling EOF.
     child
@@ -167,7 +171,7 @@ pub(crate) fn write_crontab(content: &str) -> Result<(), SyncError> {
 
     let status = child
         .wait()
-        .map_err(|e| SyncError::CrontabCommand(format!("crontab wait failed: {e}")))?;
+        .map_err(|err| SyncError::CrontabCommand(format!("crontab wait failed: {err}")))?;
 
     if !status.success() {
         return Err(SyncError::CrontabCommand(format!(
@@ -279,7 +283,7 @@ pub(crate) fn parse_moadim_line(line: &str) -> Option<(String, String, String)> 
 
     if body.starts_with('@') {
         // @keyword command
-        let mut parts = body.splitn(2, |c: char| c.is_ascii_whitespace());
+        let mut parts = body.splitn(2, |ch: char| ch.is_ascii_whitespace());
         let schedule = parts.next()?.trim().to_string();
         let command = parts.next()?.trim().to_string();
         return Some((uuid, schedule, command));
@@ -409,8 +413,8 @@ pub fn sync_from_crontab(store: &CronStore) -> Result<bool, SyncError> {
 
     // Persist changes outside the lock.
     for job in &jobs_to_write {
-        if let Err(e) = write_job(job) {
-            log::warn!("cron_sync: failed to persist job {}: {e}", job.id);
+        if let Err(err) = write_job(job) {
+            log::warn!("cron_sync: failed to persist job {}: {err}", job.id);
         }
     }
 

--- a/src/sync/routines.rs
+++ b/src/sync/routines.rs
@@ -52,10 +52,10 @@ fn write_routine_script(routine: &Routine, agent: &AgentCommand) -> io::Result<s
 /// Returns `None` (after a warning) if the script cannot be written.
 pub(crate) fn format_routine_line(routine: &Routine, agent: &AgentCommand) -> Option<String> {
     let script = match write_routine_script(routine, agent) {
-        Ok(p) => p,
-        Err(e) => {
+        Ok(path) => path,
+        Err(err) => {
             log::warn!(
-                "routine sync: failed to write run.sh for routine {:?}: {e}; skipping",
+                "routine sync: failed to write run.sh for routine {:?}: {err}; skipping",
                 routine.id
             );
             return None;
@@ -77,21 +77,21 @@ fn build_block(store: &RoutineStore) -> String {
     let mut routines: Vec<Routine> = {
         let lock = store.lock().unwrap();
         lock.values()
-            .filter(|r| r.source == "managed" && r.enabled)
+            .filter(|routine| routine.source == "managed" && routine.enabled)
             .cloned()
             .collect()
     };
-    routines.sort_by_key(|r| r.created_at);
+    routines.sort_by_key(|routine| routine.created_at);
 
     let lines: Vec<String> = routines
         .iter()
-        .filter_map(|r| match load_agent_command(&r.agent) {
-            Some(agent) => format_routine_line(r, &agent),
+        .filter_map(|routine| match load_agent_command(&routine.agent) {
+            Some(agent) => format_routine_line(routine, &agent),
             None => {
                 log::warn!(
                     "routine sync: agent config not found for routine {:?} (agent {:?}); skipping",
-                    r.id,
-                    r.agent
+                    routine.id,
+                    routine.agent
                 );
                 None
             }

--- a/src/sync/routines_sync_tests.rs
+++ b/src/sync/routines_sync_tests.rs
@@ -24,13 +24,13 @@ fn make_routine(id: &str, title: &str, agent: &str) -> Routine {
 fn format_routine_line_invokes_script_with_schedule_and_tag() {
     let title = "Fid Sync Routine";
     let slug = slugify(title);
-    let r = make_routine("fid", title, "claude");
+    let routine = make_routine("fid", title, "claude");
     let agent = AgentCommand {
         command: "claude".to_string(),
         args: vec![],
         setup: None,
     };
-    let line = format_routine_line(&r, &agent).unwrap();
+    let line = format_routine_line(&routine, &agent).unwrap();
     assert!(line.starts_with("30 9 * * 1-5 "));
     // crontab line just runs the generated script — keeps it well under cron's length limit
     assert!(line.contains("/bin/sh "));


### PR DESCRIPTION
## Why

`Cargo.toml` denies these lints repo-wide:

```toml
[lints.rust]
missing_docs = "deny"
[lints.clippy]
all = "deny"
missing_docs_in_private_items = "deny"
min_ident_chars = "deny"
```

On current stable, `cargo clippy` fails with **159 `min_ident_chars` errors** plus **2 `missing documentation for a field` errors**. The first failures are in the build script (`src/build/ui.rs`), which aborts the lint pass before the rest of the crate is even checked. This breaks the lint gate in the `pre-push` hook (`.githooks/pre-push`) and means `cargo clippy` is red on a fresh clone.

## What

- Rename every single-letter binding — closure params (`|e|`, `|p|`, `|t|`…), `for`/`let` bindings, and match arms — to a short descriptive name (`err`, `path`, `entry`, `status`, …), updating all in-scope usages.
- Add `///` docs to the two undocumented `Command::{Status,Cleanup}` `json` fields in `src/cli.rs`.

Pure renames and doc comments — **no behavioral change**.

## Verification

- `cargo fmt --check` ✅
- `cargo clippy --all-targets` ✅ (zero errors)
- `cargo test` ✅ (270 passed)
- `typos` ✅

CHANGELOG updated under `[Unreleased]` to satisfy the changelog-enforcer gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)