### PR TITLE
ci: add fmt + clippy gate mirroring the pre-push hook

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,55 @@
+name: Lint
+
+# Mirror the local pre-push hook's format and lint gates (`cargo fmt --check`
+# and `cargo clippy`) in CI, so style and lint regressions are caught on every
+# PR even when a contributor hasn't installed the git hooks. HEAD has
+# historically drifted out of clippy/fmt compliance between hook runs; this gate
+# keeps `main` green against the same standard the hook enforces locally.
+#
+# fmt and clippy run as separate jobs so a formatting failure and a lint failure
+# are reported independently. The build relies on the committed `prebuilt.html`
+# (build.rs falls back to it when trunk is absent), so no trunk or wasm target
+# is needed just to type-check and lint the server crate.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust (with rustfmt)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust (with clippy)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache cargo registry (registry only, not target)
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Run clippy
+        run: cargo clippy --all-targets -- -D warnings

--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,6 @@
 This is a list of todos for consumption, in a pr remove the todo you have implemented and add any new ones you think of.
 
 - Add a `cargo xtask spellcheck` (or `make spell`) wrapper that installs and runs `typos` so contributors don't need to know the tool name
-- Add a `fmt + clippy` CI job (mirroring the pre-push hook: `cargo fmt --check`, `cargo clippy -- -D warnings`) so style/lint regressions are caught in PRs without local hooks
 - Add a CI step (or weekly scheduled job) that checks whether a newer `crate-ci/typos` release exists than the pinned tag and opens/updates a tracking issue, so the pin gets bumped on a cadence instead of drifting silently
 - Pin the remaining third-party GitHub Actions (e.g. `actions/checkout@v5`) to full commit SHAs, mirroring the typos pin, so every CI dependency is reproducible
 - Add a day-detail popover to the routines calendar: clicking a day lists each fire time (HH:MM) with its routine, and a "run now" shortcut per routine


### PR DESCRIPTION
## What

Adds a `Lint` GitHub Actions workflow (`.github/workflows/lint.yml`) with two jobs:

- **rustfmt** — `cargo fmt --check`
- **clippy** — `cargo clippy --all-targets -- -D warnings`

Both run on every pull request and on pushes to `main`. Also removes the matching entry from `TODO.md`, per the repo's "remove the todo you implemented" convention.

## Why

These exact checks already live in `.githooks/pre-push`, but the hook only protects contributors who have installed it. HEAD has **historically drifted out of fmt/clippy compliance between hook runs** — see the recent `fix: restore cargo clippy compliance across the crate` (#115) — and CI had no gate to catch it: only the changelog and spellcheck workflows were enforced. This closes that gap so style/lint regressions surface on the PR instead of after merge.

## Notes

- The clippy job needs **no trunk install or wasm target**: `build.rs` falls back to the committed `prebuilt.html` when trunk is absent, so the server crate type-checks and lints with just the stable toolchain + the `clippy`/`rustfmt` components.
- `fmt` and `clippy` are separate jobs so a formatting failure and a lint failure are reported independently.
- Follows the conventions of the existing `publish.yml` (action versions, registry-only cargo cache).

## Testing

Ran locally against this branch's base (current `main`):

- `cargo fmt --check` — clean.
- `cargo clippy --all-targets` — clean (exit 0).
- `typos .github/workflows/lint.yml TODO.md` — clean.

CI-only change (no `src/` or `ui/`), so the changelog gate does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)