### PR TITLE
docs(readme): add Scripting table for stop/status/cleanup --json shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   contract alongside `status` and `cleanup`. The exit code is unchanged
   (`0` running, `3` not).
 
+### Documentation
+
+- Added a **Scripting** table to the README that documents the `--json` object
+  shapes for `status` (`{"running":bool,"pid":N|null,"address":…}`), `cleanup`
+  (`{"running":bool,"removed":N}`), and `stop` (`{"running":bool}`) alongside
+  their exit codes, so the machine-readable contract is discoverable without
+  reading `--help`. Also documents `moadim stop --json`, which was previously
+  only mentioned in `--help`.
+
 ### Fixed
 
 - Restored `cargo clippy` compliance across the crate. The `min_ident_chars`

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ moadim cleanup         # reap finished, expired routine workbenches now
 moadim cleanup --json  # same, as a machine-readable JSON object
 moadim restart         # stop a running server (if any) and start a fresh one
 moadim stop            # ask a running server to stop
+moadim stop --json     # same, as a machine-readable JSON object
 ```
 
 | Command            | Mode          | Behaviour |
@@ -198,7 +199,7 @@ moadim stop            # ask a running server to stop
 | `moadim`           | background    | Spawns a detached server, writes its PID to `~/.config/moadim/moadim.pid`, logs to `~/.config/moadim/daemon.log`, and exits. Refuses to start if one is already running. |
 | `moadim -i`        | interactive   | Runs in the foreground; logs to the terminal; Ctrl-C stops it. |
 | `moadim restart`   | background    | Stops the running server (if any) and spawns a fresh detached instance, so you get a clean process without a separate stop/start. Prints the PID rotation as `restarted: pid <old> -> <new>` (old reads `none` when nothing was running) so scripts/logs can confirm the process actually changed. |
-| `moadim stop`      | —             | Sends `POST /shutdown` to the running server for a graceful stop. Exits `0` when a running server was asked to shut down, `3` when none was reachable. |
+| `moadim stop`      | —             | Sends `POST /shutdown` to the running server for a graceful stop. Add `--json` for `{"running":bool}`. Exits `0` when a running server was asked to shut down, `3` when none was reachable. |
 | `moadim status`    | —             | Prints whether a server is reachable on `127.0.0.1:5784`. Add `--json` for `{"running":bool,"pid":N\|null,"address":"127.0.0.1:5784"}`. Exits `0` when running, `3` when not. |
 | `moadim cleanup`   | —             | Sends `POST /api/v1/routines/cleanup` to the running server and prints how many finished, expired routine workbenches were reaped (the on-demand version of the hourly sweep). Add `--json` for `{"running":bool,"removed":N}`. Exits `0` when running, `3` when not. |
 
@@ -206,6 +207,20 @@ moadim stop            # ask a running server to stop
 on `$?` without parsing stdout: they exit `0` when a server is running (and `cleanup` swept, `stop`
 asked it to shut down) and `3` when no server is reachable. Any other failure exits non-zero (`1`)
 with a message on stderr.
+
+### Scripting
+
+`status`, `cleanup`, and `stop` each accept `--json` for a single-line, machine-readable object
+on stdout. Paired with the exit codes above, a caller gets the full contract without parsing prose:
+
+| Command            | `--json` shape | Exit codes |
+|--------------------|----------------|------------|
+| `moadim status --json`  | `{"running":bool,"pid":N\|null,"address":"127.0.0.1:5784"}` — `pid` is `null` when no pid file is present | `0` running, `3` not |
+| `moadim cleanup --json` | `{"running":bool,"removed":N}` — `removed` is `0` when no server is running | `0` running, `3` not |
+| `moadim stop --json`    | `{"running":bool}` — `true` when a running server was asked to shut down, `false` when none was reachable | `0` running, `3` not |
+
+Any other failure exits `1` with a message on stderr. The object is always a single line, so
+`moadim status --json | jq -r .pid` and similar pipelines work without buffering.
 
 Because the default mode is detached, you stop the server **from the client**:
 press the **STOP** button in the UI header, run `moadim stop`, or send

--- a/TODO.md
+++ b/TODO.md
@@ -20,7 +20,6 @@ This is a list of todos for consumption, in a pr remove the todo you have implem
 - Show a humanized retention countdown ("expires in 2d" / "expired") per finished run in the routine LOGS view, derived from the run's finish time and the routine's effective TTL
 - Enrich `moadim status --json` with the server's liveness details from `GET /health` (e.g. `uptime_secs`) so a single call returns running-state + age, not just the local PID
 - Fold the `pid` of the shut-down server into `moadim stop --json` (`{"running":bool,"pid":N|null}`) by reading the pid file before the shutdown request, mirroring `status --json`'s `pid` field
-- Document the `stop`/`status`/`cleanup` `--json` object shapes in README (a small "Scripting" table: command, JSON keys, exit codes) so the machine-readable contract is discoverable without reading `--help`
 - Add a CLI integration test (spawn a real listener on an ephemeral port, point the probe at it) that exercises the `status`/`cleanup`/`stop` network paths end-to-end, lifting `cli.rs` off its ~27% coverage floor toward the repo's 100% line-coverage gate
 - Add a `moadim status --wait[=SECS]` flag that polls `GET /health` until the server is reachable (or the timeout elapses), exiting 0 on success and the existing exit-3 on timeout, so scripts can block on startup instead of sleeping
 - Add a `moadim restart --interactive` (or `-i`) flavor that restarts the daemon in the foreground attached to the terminal instead of detached, mirroring `moadim -i`
@@ -29,3 +28,5 @@ This is a list of todos for consumption, in a pr remove the todo you have implem
 - Return the freed disk bytes alongside `removed` in `CleanupResponse` and surface "removed N (freed 12.4 MB)" in the UI cleanup toast
 - Auto-refresh the routine LOGS view (or show a removed badge) after a CLEANUP NOW sweep so stale run output isn't shown for reaped workbenches
 - Add the option to filter routines by repositories in the ui
+- Add a copy-pasteable shell snippet to the README "Scripting" section showing a real branch on `moadim status --json` exit codes (e.g. `if ! moadim status --json >/dev/null; then moadim; fi`) so readers see the contract in use, not just its shape
+- Run the README's fenced `sh`/`json` blocks through a docs lint in CI (e.g. a `markdownlint`/`mdsh` check or a `--json | jq -e` smoke test) so the documented JSON shapes can't drift from the actual CLI output silently


### PR DESCRIPTION
## TODO item implemented

> Document the `stop`/`status`/`cleanup` `--json` object shapes in README (a small "Scripting" table: command, JSON keys, exit codes) so the machine-readable contract is discoverable without reading `--help`

## Approach

Adds a **Scripting** subsection under `## Running` with a table mapping each command to its `--json` object shape and exit codes:

| Command | `--json` shape | Exit codes |
|---|---|---|
| `moadim status --json`  | `{"running":bool,"pid":N\|null,"address":"127.0.0.1:5784"}` | `0` running, `3` not |
| `moadim cleanup --json` | `{"running":bool,"removed":N}` | `0` running, `3` not |
| `moadim stop --json`    | `{"running":bool}` | `0` running, `3` not |

Shapes taken verbatim from `status_json` / `cleanup_json` / `stop_json` in `src/cli.rs`. Also fixes a doc gap: `moadim stop --json` (added in #118) was only surfaced in `--help`, never in the README — its row in the behaviour table and the `## Running` code block now mention `--json` too.

Docs-only change — no `src/`/`ui/` touched, so the changelog/lint/coverage gates are exempt, but a `## [Unreleased]` **Documentation** entry is added for hygiene.

## New TODOs added (ship one, dream up two)

- A copy-pasteable shell snippet in the Scripting section showing a real branch on `moadim status --json` exit codes.
- A CI docs-lint that runs the README's `--json` examples through `jq -e` so documented shapes can't drift from actual CLI output.