### PR TITLE
docs: add one-line install to top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 >
 > _Set the loop. Forget the keyboard. moadim fires the prompt so you don't have to._
 
+**One-line install** — install Rust/Cargo, install moadim, then run it:
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && . "$HOME/.cargo/env" && cargo install moadim && moadim
+```
+
 Rust server that exposes cron job management over three interfaces simultaneously:
 
 - **UI** (`http://localhost:5784/`) — browser dashboard for managing jobs


### PR DESCRIPTION
Closes #120

## What

Adds a single copy-paste command at the top of the README (right under the tagline) that installs Rust/Cargo via rustup, installs moadim, and runs it:

```sh
curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && . "$HOME/.cargo/env" && cargo install moadim && moadim
```

## Why

New users can go from zero to a running server with one line, without reading the full Installation section first. The detailed Installation section is unchanged and still covers PATH setup, background vs. interactive mode, and stopping the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)