### PR TITLE
fix(routines): return correct log when one routine's slug prefixes another's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   contract alongside `status` and `cleanup`. The exit code is unchanged
   (`0` running, `3` not).
 
+### Fixed
+
+- Routine logs (`GET /routines/{id}/logs`) could return another routine's log
+  when one routine's slug is a dash-prefix of another's (e.g. `logs` vs
+  `logs-extra`): the newest-workbench lookup matched a bare `{slug}-` prefix,
+  so `logs-extra-<ts>` was wrongly attributed to `logs`. It now matches the
+  slug exactly via the same `{slug}-{ts}` parser the cleanup sweep uses, and
+  picks the newest run by numeric timestamp instead of a lexicographic compare
+  over the directory name.
+
 ### Documentation
 
 - Added a **Scripting** table to the README that documents the `--json` object

--- a/src/routines/cleanup/mod.rs
+++ b/src/routines/cleanup/mod.rs
@@ -26,7 +26,7 @@ pub const CLEANUP_INTERVAL: Duration = Duration::from_secs(60 * 60);
 /// Names are `{slug}-{unix_secs}`; the timestamp is the trailing all-digit segment after the final
 /// `-`. Returns `None` when the name has no such suffix or an empty slug (so unrelated directories
 /// are skipped rather than reaped).
-fn parse_workbench_name(name: &str) -> Option<(&str, u64)> {
+pub(super) fn parse_workbench_name(name: &str) -> Option<(&str, u64)> {
     let (slug, ts) = name.rsplit_once('-')?;
     if slug.is_empty() || ts.is_empty() || !ts.bytes().all(|byte| byte.is_ascii_digit()) {
         return None;

--- a/src/routines/mod_tests.rs
+++ b/src/routines/mod_tests.rs
@@ -539,3 +539,28 @@ fn svc_logs_empty_when_newest_has_no_log_file() {
     assert_eq!(svc_logs(&store, "logs-nofile").unwrap(), "");
     std::fs::remove_dir_all(&dir).unwrap();
 }
+
+#[test]
+fn svc_logs_ignores_other_routine_with_shared_slug_prefix() {
+    let store = new_store();
+    let mut routine = make_routine("logs-prefix");
+    routine.title = "Logs Cov Prefix ZZQ".into();
+    let slug = slugify(&routine.title); // "logs-cov-prefix-zzq"
+    store.lock().unwrap().insert("logs-prefix".into(), routine);
+
+    let wb = crate::paths::workbenches_dir();
+    let mine = wb.join(format!("{slug}-1000"));
+    // Belongs to a *different* routine whose slug is `{slug}-extra`. Its name shares
+    // the bare `{slug}-` prefix and sorts lexicographically *after* `mine`, so the old
+    // prefix match would wrongly return its log.
+    let other = wb.join(format!("{slug}-extra-2000"));
+    std::fs::create_dir_all(&mine).unwrap();
+    std::fs::create_dir_all(&other).unwrap();
+    std::fs::write(mine.join("agent.log"), "mine").unwrap();
+    std::fs::write(other.join("agent.log"), "not-mine").unwrap();
+
+    assert_eq!(svc_logs(&store, "logs-prefix").unwrap(), "mine");
+
+    std::fs::remove_dir_all(&mine).unwrap();
+    std::fs::remove_dir_all(&other).unwrap();
+}

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -9,7 +9,7 @@ use crate::routine_storage::{remove_routine_dir, write_routine};
 use crate::utils::time::now_secs;
 
 use super::agents::load_agent_command;
-use super::cleanup::cleanup_expired_workbenches;
+use super::cleanup::{cleanup_expired_workbenches, parse_workbench_name};
 use super::command::{build_routine_command, slugify};
 use super::model::{
     CleanupResponse, CreateRoutineRequest, Routine, RoutineResponse, RoutineStore,
@@ -192,17 +192,26 @@ pub fn svc_logs(store: &RoutineStore, id: &str) -> Result<String, AppError> {
         .get(id)
         .cloned()
         .ok_or(AppError::NotFound)?;
-    let prefix = format!("{}-", slugify(&routine.title));
-    let mut newest: Option<String> = None;
+    let slug = slugify(&routine.title);
+    let mut newest: Option<(u64, String)> = None;
     if let Ok(entries) = std::fs::read_dir(workbenches_dir()) {
         for entry in entries.flatten() {
             let name = entry.file_name().to_string_lossy().into_owned();
-            if name.starts_with(&prefix) && newest.as_ref().is_none_or(|n| name > *n) {
-                newest = Some(name);
+            // Select only this routine's own workbenches by an *exact* slug match.
+            // A bare `{slug}-` prefix would also match another routine whose slug
+            // begins with this one (e.g. `logs` vs `logs-extra`), leaking that
+            // routine's log. Reusing the canonical `{slug}-{ts}` parser also makes
+            // "newest" a numeric timestamp comparison rather than a lexicographic
+            // one over the whole directory name.
+            if let Some((dir_slug, ts)) = parse_workbench_name(&name) {
+                if dir_slug == slug && newest.as_ref().is_none_or(|(newest_ts, _)| ts > *newest_ts)
+                {
+                    newest = Some((ts, name));
+                }
             }
         }
     }
-    let Some(dir) = newest else {
+    let Some((_, dir)) = newest else {
         return Ok(String::new());
     };
     let log_path = workbenches_dir().join(dir).join("agent.log");


### PR DESCRIPTION
## The bug

`svc_logs` (`GET /routines/{id}/logs`) finds a routine's newest run by scanning the workbenches directory and matching directory names against a bare `{slug}-` prefix:

```rust
let prefix = format!("{}-", slugify(&routine.title));
if name.starts_with(&prefix) && newest.as_ref().is_none_or(|n| name > *n) { ... }
```

Slug collisions are rejected at create/update time, but two routines whose slugs are a **dash-prefix of one another** are perfectly legal and coexist — e.g. `logs` and `logs-extra`. The bare-prefix match means `logs-extra`'s workbenches (`logs-extra-<ts>`) also match routine `logs`'s prefix `logs-`.

Worse, selection takes the **lexicographically greatest** name, and `logs-extra-2000` > `logs-1000`, so:

> `GET /routines/{logs_id}/logs` returns routine **`logs-extra`**'s log.

A cross-routine log leak / wrong content for the requested routine.

## The fix

Reuse the cleanup module's canonical `{slug}-{ts}` parser — `parse_workbench_name` (promoted from private `fn` to `pub(super)`) — and require an **exact slug match**, then pick the newest run by **numeric trigger timestamp** instead of a lexicographic compare over the directory name:

```rust
if let Some((dir_slug, ts)) = parse_workbench_name(&name) {
    if dir_slug == slug && newest.as_ref().is_none_or(|(newest_ts, _)| ts > *newest_ts) {
        newest = Some((ts, name));
    }
}
```

`parse_workbench_name` splits on the *final* `-` and requires an all-digit timestamp, so `logs-extra-2000` parses as slug `logs-extra` (≠ `logs`) and is correctly skipped. This is the same attribution logic the cleanup sweep already uses, so logs and cleanup now agree on which workbench belongs to which routine.

## Tests

Added `svc_logs_ignores_other_routine_with_shared_slug_prefix`: it drops a foreign-routine workbench sharing the `{slug}-` prefix (and sorting lexicographically *after* the real one) into the workbenches dir and asserts the routine's **own** log is returned. Fails on the old code, passes now.

- `cargo fmt --check` ✅
- `cargo clippy --all-targets` ✅ (incl. the repo's `min_ident_chars = deny`)
- `cargo test` ✅ — 272 passed
- Added a `### Fixed` CHANGELOG entry (changelog-enforcer gate).

Distinct from the open daemon PRs (CI fmt/clippy, MCP-schema docs, dependabot bumps) and not on any `TODO.md` bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)