### PR TITLE
feat(routines): disclose moadim routine origin in external communication

### DIFF
--- a/src/routines/command.rs
+++ b/src/routines/command.rs
@@ -124,7 +124,13 @@ const MOADIM_SYSTEM_PROMPT: &str = "# Moadim Context\\n\
     > This section is managed by the moadim daemon. Do not edit it.\\n\
     \\n\
     You are running inside a moadim-managed agent session. \
-    Complete the task described in `prompt.md` and exit when done.";
+    Complete the task described in `prompt.md` and exit when done.\\n\
+    \\n\
+    When you take any outward-facing action — opening or commenting on GitHub issues and \
+    pull requests, sending Slack messages, sending emails, or any other external communication \
+    — disclose that you act on behalf of this moadim routine and name it (see **Routine** \
+    below). This keeps automated actions transparent and traceable. It does not apply to \
+    internal logs or in-repo working files.";
 
 /// Shell statements that write `CLAUDE.md` into `$WB` with two layers:
 ///
@@ -133,13 +139,18 @@ const MOADIM_SYSTEM_PROMPT: &str = "# Moadim Context\\n\
 ///
 /// Uses `printf '%b'` so `\n` sequences in the static header expand to real newlines without
 /// embedding literal newlines in the crontab line. `$WB` must be in scope when the statements run.
-pub(crate) fn system_prompt_stmts(user_prompt_path: &str) -> Vec<String> {
+///
+/// `routine_name` is stamped into the `**Routine**` field so the disclosure instruction in the
+/// static header has a concrete name to cite. It is passed as a `printf` `%s` argument (no escape
+/// expansion) so names containing `%` or `\` survive verbatim.
+pub(crate) fn system_prompt_stmts(routine_name: &str, user_prompt_path: &str) -> Vec<String> {
     let header = shell_quote(MOADIM_SYSTEM_PROMPT);
+    let name_q = shell_quote(routine_name);
     let uq = shell_quote(user_prompt_path);
     vec![
         format!(
-            r#"printf '%b\n\n**Run date**: %s\n**Timezone**: %s\n' {} "$(date)" "$(date +%Z)" > "$WB/CLAUDE.md""#,
-            header
+            r#"printf '%b\n\n**Routine**: %s\n**Run date**: %s\n**Timezone**: %s\n' {} {} "$(date)" "$(date +%Z)" > "$WB/CLAUDE.md""#,
+            header, name_q
         ),
         format!(
             r#"[ -f {uq} ] && {{ printf '\n---\n\n'; cat {uq}; printf '\n'; }} >> "$WB/CLAUDE.md" || true"#,
@@ -179,6 +190,7 @@ pub(crate) fn build_routine_command(routine: &Routine, agent: &AgentCommand) -> 
         r#"mkdir -p "$WB""#.to_string(),
     ];
     stmts.extend(system_prompt_stmts(
+        &routine.title,
         &crate::paths::user_prompt_path().to_string_lossy(),
     ));
     stmts.extend([

--- a/src/routines/mod_tests.rs
+++ b/src/routines/mod_tests.rs
@@ -150,6 +150,41 @@ fn build_routine_command_writes_claude_md() {
 }
 
 #[test]
+fn build_routine_command_discloses_routine_origin() {
+    let routine = make_routine("rid");
+    let agent = AgentCommand {
+        command: "claude".to_string(),
+        args: vec!["{prompt}".to_string()],
+        setup: None,
+    };
+    let cmd = build_routine_command(&routine, &agent);
+    // the static header instructs the agent to disclose its routine origin externally
+    assert!(
+        cmd.contains("disclose that you act on behalf of this moadim routine"),
+        "disclosure instruction missing"
+    );
+    // the routine name is stamped into a Routine field the instruction can cite
+    assert!(cmd.contains("**Routine**: %s"), "Routine field missing");
+    assert!(
+        cmd.contains("'My Routine'"),
+        "routine name not passed to printf"
+    );
+}
+
+#[test]
+fn system_prompt_stmts_quotes_routine_name() {
+    // a name with shell-special characters must be single-quoted, not interpreted
+    let stmts = system_prompt_stmts("Deploy & ship $NOW", "/tmp/user_prompt.md");
+    let printf = &stmts[0];
+    assert!(
+        printf.contains(r#"'Deploy & ship $NOW'"#),
+        "routine name not safely quoted: {printf}"
+    );
+    // passed as a %s argument, so escape sequences in the name are not expanded
+    assert!(printf.contains("**Routine**: %s"));
+}
+
+#[test]
 fn build_routine_command_aborts_when_prompt_missing() {
     let routine = make_routine("rid");
     let agent = AgentCommand {


### PR DESCRIPTION
## Summary

Implements #129: the moadim-managed agent now discloses that it acts on behalf of a moadim routine in every external communication, naming the routine.

## Changes

- **`MOADIM_SYSTEM_PROMPT`** (`src/routines/command.rs`): added an instruction that, for any outward-facing action — GitHub issues/PRs/comments, Slack messages, emails, etc. — the agent discloses it acts on behalf of this moadim routine and names it (citing the `**Routine**` field). Internal logs and in-repo working files are explicitly exempt.
- **`system_prompt_stmts`**: now takes `routine_name` and stamps a `**Routine**: <name>` field into the workbench `CLAUDE.md`, right above the existing `**Run date**` / `**Timezone**` fields, giving the instruction a concrete name to cite. The name is passed as a `printf` `%s` argument and shell-quoted, so names containing `%`, `\`, `$`, or other shell metacharacters survive verbatim (no escape expansion, no injection).
- **`build_routine_command`**: passes `routine.title` through.

## Open questions from the issue

- *Where the routine name is injected*: at launch time, into the daemon-managed preamble of the workbench `CLAUDE.md` (alongside run date/timezone).
- *Standard template vs. free-form*: a fixed `**Routine**` field plus a free-form disclosure instruction — phrasing can adapt per channel, but must name the routine.

## Tests

- `build_routine_command_discloses_routine_origin` — header carries the disclosure instruction and the routine name is stamped in.
- `system_prompt_stmts_quotes_routine_name` — names with shell metacharacters are safely single-quoted and not escape-expanded.

`cargo fmt`, `cargo clippy` clean; routines test suite passes. New lines are fully covered (verified via `cargo llvm-cov`).

Closes #129

---
*This pull request was opened by the "Implement my assigned issues without a PR" routine of moadim.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)