### PR TITLE
feat(routines): disclose moadim routine origin in system prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Added
 
+- The moadim-managed system prompt (`CLAUDE.md`) now carries a **routine-origin
+  disclosure** section that instructs the agent to reveal, in every
+  outward-facing communication (GitHub issues/PRs/comments, Slack, email, etc.),
+  that the action originates from the running moadim routine — naming it. The
+  routine name is injected at launch time. Internal logs and in-repo working
+  files are exempt.
 - Routine listings can now be filtered and sorted by repository. `GET /routines`
   accepts `repository` (case-insensitive URL substring filter), `sort`
   (`created`|`updated`|`title`|`repository`), and `order` (`asc`|`desc`) query

--- a/src/routines/command.rs
+++ b/src/routines/command.rs
@@ -126,20 +126,42 @@ const MOADIM_SYSTEM_PROMPT: &str = "# Moadim Context\\n\
     You are running inside a moadim-managed agent session. \
     Complete the task described in `prompt.md` and exit when done.";
 
+/// Routine-origin disclosure appended to the moadim system prompt.
+///
+/// Instructs the agent to reveal, in every outward-facing communication, that it acts on behalf of
+/// the moadim routine — naming it. The routine name itself is *not* part of this constant: it is
+/// injected at run time as a separate `printf` `%s` argument (text expanded by `printf '%b'` is not
+/// re-scanned for conversions, so a `%s` placed inside this `%b` string would print literally).
+/// This constant therefore ends just before the name. `\n` are literal two-character sequences
+/// re-expanded into newlines by `printf '%b'`, matching `MOADIM_SYSTEM_PROMPT`.
+const MOADIM_DISCLOSURE: &str = "## Routine origin disclosure\\n\
+    \\n\
+    You act on behalf of the moadim routine named below. In every external, outward-facing \
+    communication you produce — GitHub issues, pull requests and comments; Slack messages; emails; \
+    any channel a human or third-party system receives — you MUST disclose that the action \
+    originates from this moadim routine, naming it (for example: 'This pull request was opened by \
+    the <routine name> routine of moadim.'). Phrasing may be adapted per channel but must \
+    include the routine name. This does NOT apply to internal logs or in-repo working files.\\n\
+    \\n\
+    Routine name: ";
+
 /// Shell statements that write `CLAUDE.md` into `$WB` with two layers:
 ///
-/// 1. **Moadim prompt** — daemon-managed preamble plus a run-time date stamp.
+/// 1. **Moadim prompt** — daemon-managed preamble, the routine-origin disclosure naming
+///    `routine_title`, plus a run-time date stamp.
 /// 2. **User prompt** — contents of `~/.config/moadim/user_prompt.md`, appended if the file exists.
 ///
 /// Uses `printf '%b'` so `\n` sequences in the static header expand to real newlines without
 /// embedding literal newlines in the crontab line. `$WB` must be in scope when the statements run.
-pub(crate) fn system_prompt_stmts(user_prompt_path: &str) -> Vec<String> {
+pub(crate) fn system_prompt_stmts(user_prompt_path: &str, routine_title: &str) -> Vec<String> {
     let header = shell_quote(MOADIM_SYSTEM_PROMPT);
+    let disclosure = shell_quote(MOADIM_DISCLOSURE);
+    let title = shell_quote(routine_title);
     let uq = shell_quote(user_prompt_path);
     vec![
         format!(
-            r#"printf '%b\n\n**Run date**: %s\n**Timezone**: %s\n' {} "$(date)" "$(date +%Z)" > "$WB/CLAUDE.md""#,
-            header
+            r#"printf '%b\n\n%b%s\n\n**Run date**: %s\n**Timezone**: %s\n' {} {} {} "$(date)" "$(date +%Z)" > "$WB/CLAUDE.md""#,
+            header, disclosure, title
         ),
         format!(
             r#"[ -f {uq} ] && {{ printf '\n---\n\n'; cat {uq}; printf '\n'; }} >> "$WB/CLAUDE.md" || true"#,
@@ -180,6 +202,7 @@ pub(crate) fn build_routine_command(routine: &Routine, agent: &AgentCommand) -> 
     ];
     stmts.extend(system_prompt_stmts(
         &crate::paths::user_prompt_path().to_string_lossy(),
+        &routine.title,
     ));
     stmts.extend([
         // Fail-fast if the routine's source prompt is missing. The statements are `;`-joined, so a

--- a/src/routines/mod_tests.rs
+++ b/src/routines/mod_tests.rs
@@ -135,6 +135,17 @@ fn build_routine_command_writes_claude_md() {
     );
     // dynamic date/timezone appended at run time
     assert!(cmd.contains("$(date)"), "run-time date expansion missing");
+    // routine-origin disclosure section, naming the routine, written into the moadim prompt
+    assert!(
+        cmd.contains("Routine origin disclosure"),
+        "routine-origin disclosure section missing"
+    );
+    assert!(cmd.contains("Routine name: "), "routine-name label missing");
+    // the routine title is injected as a printf %s argument after the disclosure body
+    assert!(
+        cmd.contains("'My Routine'"),
+        "routine title not injected into CLAUDE.md write"
+    );
     // user prompt appended if file exists
     assert!(
         cmd.contains("user_prompt.md"),


### PR DESCRIPTION
## Summary

Implements #129: the moadim agent must disclose that it acts on behalf of a moadim routine in every external communication.

Adds a **Routine origin disclosure** section to the moadim-managed `CLAUDE.md` system prompt. It instructs the agent that, in every outward-facing communication it produces — GitHub issues/PRs/comments, Slack messages, emails, any channel a human or third-party system receives — it MUST disclose the action originates from the running moadim routine, **naming it**. Internal logs and in-repo working files are explicitly exempt.

## How

- New `MOADIM_DISCLOSURE` constant holds the static disclosure guidance (same `\n`-as-literal / `printf '%b'` convention as `MOADIM_SYSTEM_PROMPT`).
- The **routine name is injected at launch time** as a `printf %s` argument, not baked into the constant. Text expanded by `printf '%b'` is not re-scanned for conversions, so a `%s` inside the `%b` disclosure body would print literally — the constant therefore ends just before the name and the title is appended as its own argument.
- `system_prompt_stmts` now takes the routine title; `build_routine_command` passes `routine.title`.
- The disclosure lands in `CLAUDE.md` between the moadim header and the run-date stamp, so it is present for every routine-launched session.

## Rendered output (excerpt)

```
## Routine origin disclosure

You act on behalf of the moadim routine named below. In every external,
outward-facing communication you produce ... you MUST disclose that the action
originates from this moadim routine, naming it ... 

Routine name: <routine title>
```

## Tests / checks

- Extended `build_routine_command_writes_claude_md` to assert the disclosure section, the `Routine name:` label, and the injected title.
- `cargo fmt --check`, `cargo clippy`, full test suite (274 passed) all green locally. The new lines in `command.rs` are covered (lcov reports no uncovered lines in the file); the repo-wide 100% gate can't be reached in this sandbox because `crontab`/`tmux` integration tests can't run here.

Closes #129

---

_This pull request was opened by the "Implement my assigned issues without a PR (daemon + landing)" routine of moadim._
