### PR TITLE
fix: atomic routine store writes (write temp + rename)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Fixed
 
+- Routine store writes are now atomic. `write_routine` persists `routine.toml`
+  and `prompt.md` via a shared `atomic_write` helper (write a sibling temp file,
+  then rename it into place) instead of an in-place `std::fs::write` truncate.
+  A crash or full disk mid-write can no longer leave a torn `routine.toml` —
+  which parsed to nothing and silently dropped the routine from the store — and
+  the continuously-running reverse crontab sync never observes a partial file.
 - Routine logs (`GET /routines/{id}/logs`) could return another routine's log
   when one routine's slug is a dash-prefix of another's (e.g. `logs` vs
   `logs-extra`): the newest-workbench lookup matched a bare `{slug}-` prefix,

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -9,6 +9,7 @@ use crate::paths::{
     routine_dir, routine_gitignore_path, routine_prompt_path, routine_toml_path, routines_dir,
 };
 use crate::routines::{compose_prompt, slugify, Repository, Routine, RoutineStore};
+use crate::utils::atomic::atomic_write;
 
 /// TOML representation of a routine on disk.
 #[derive(Debug, Deserialize, Serialize)]
@@ -97,8 +98,14 @@ pub fn write_routine(routine: &Routine) -> std::io::Result<()> {
         ttl_secs: routine.ttl_secs,
     };
     let text = toml::to_string_pretty(&toml_routine).map_err(std::io::Error::other)?;
-    std::fs::write(routine_toml_path(&slug), text)?;
-    std::fs::write(routine_prompt_path(&slug), compose_prompt(routine))?;
+    // Atomic write (temp + rename) so the continuously-running reverse crontab sync, which re-reads
+    // these files every 30s, never observes a torn routine.toml — a torn file parses to `None` and
+    // would silently drop the routine from the store.
+    atomic_write(&routine_toml_path(&slug), text.as_bytes())?;
+    atomic_write(
+        &routine_prompt_path(&slug),
+        compose_prompt(routine).as_bytes(),
+    )?;
     Ok(())
 }
 

--- a/src/routine_storage_tests.rs
+++ b/src/routine_storage_tests.rs
@@ -67,6 +67,33 @@ fn load_routine_from_dir_missing_returns_none() {
 }
 
 #[test]
+fn torn_routine_toml_loads_as_none() {
+    // A truncated/garbage routine.toml (e.g. left by a crash mid-write) must not panic or load a
+    // half-baked routine; the loader returns None and the routine is simply absent.
+    let slug = "rs-torn-toml-routine";
+    let dir = crate::paths::routine_dir(slug);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(crate::paths::routine_toml_path(slug), "id = \"x\"\nschedu").unwrap();
+    assert!(load_routine_from_dir(slug).is_none());
+    remove_routine_dir(slug).unwrap();
+}
+
+#[test]
+fn write_routine_leaves_no_tmp_residue() {
+    let id = "rs-no-residue-id";
+    let title = "Rs No Residue Routine";
+    let slug = slugify(title);
+    write_routine(&make_routine(id, title)).unwrap();
+    let residue = std::fs::read_dir(crate::paths::routine_dir(&slug))
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_name().to_string_lossy().contains(".tmp"))
+        .count();
+    assert_eq!(residue, 0, "atomic_write must leave no .tmp files behind");
+    remove_routine_dir(&slug).unwrap();
+}
+
+#[test]
 fn load_store_includes_written_routine() {
     let id = "rs-loadstore-id";
     let title = "Rs Loadstore Routine";

--- a/src/utils/atomic.rs
+++ b/src/utils/atomic.rs
@@ -1,0 +1,53 @@
+//! Atomic file writes: write to a temp file in the same directory, then rename into place.
+//!
+//! `std::fs::write` truncates-then-writes in place, so a crash mid-write leaves a torn file holding
+//! neither the old nor the new complete contents. [`atomic_write`] avoids that by writing to a
+//! uniquely-named sibling temp file and renaming it over the target, so a concurrent reader always
+//! observes one complete version. This mirrors the durability guarantee the daemon already gives
+//! `~/.claude.json` (write temp + `os.replace`).
+
+use std::fs::{self, File};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use uuid::Uuid;
+
+/// Write `bytes` to `path` atomically: a reader sees either the previous contents or the complete
+/// new contents, never a partial/torn file.
+///
+/// Writes to a uniquely-named temporary file in the **same directory** as `path` (so the final
+/// rename stays on one filesystem), flushes it to disk, then renames it over `path`. The temp file
+/// is removed if any step fails, so a failed write leaves no `.tmp` residue.
+pub fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let tmp = tmp_path(path);
+    if let Err(err) = write_tmp(&tmp, bytes) {
+        let _ = fs::remove_file(&tmp);
+        return Err(err);
+    }
+    if let Err(err) = fs::rename(&tmp, path) {
+        let _ = fs::remove_file(&tmp);
+        return Err(err);
+    }
+    Ok(())
+}
+
+/// Path to a unique sibling temp file alongside `path` (same directory, so the rename that follows
+/// stays on one filesystem). The random UUID suffix avoids collisions between concurrent writers.
+fn tmp_path(path: &Path) -> PathBuf {
+    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("tmp");
+    let mut tmp = path.to_path_buf();
+    tmp.set_file_name(format!(".{name}.{}.tmp", Uuid::new_v4()));
+    tmp
+}
+
+/// Create `tmp`, write all of `bytes`, and flush to disk so the rename publishes complete contents.
+fn write_tmp(tmp: &Path, bytes: &[u8]) -> io::Result<()> {
+    let mut file = File::create(tmp)?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "atomic_tests.rs"]
+mod atomic_tests;

--- a/src/utils/atomic_tests.rs
+++ b/src/utils/atomic_tests.rs
@@ -1,0 +1,85 @@
+#![allow(clippy::missing_docs_in_private_items)]
+
+use super::*;
+
+/// Create and return a unique empty scratch directory under the system temp dir.
+fn scratch_dir() -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("moadim-atomic-{}", Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// Number of entries in `dir` whose name contains `.tmp`.
+fn tmp_residue(dir: &Path) -> usize {
+    std::fs::read_dir(dir)
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_name().to_string_lossy().contains(".tmp"))
+        .count()
+}
+
+#[test]
+fn writes_contents_and_leaves_no_tmp_residue() {
+    let dir = scratch_dir();
+    let target = dir.join("routine.toml");
+    atomic_write(&target, b"hello").unwrap();
+
+    assert_eq!(std::fs::read(&target).unwrap(), b"hello");
+    assert_eq!(
+        tmp_residue(&dir),
+        0,
+        "no .tmp file should remain on success"
+    );
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[test]
+fn overwrites_existing_file_atomically() {
+    let dir = scratch_dir();
+    let target = dir.join("prompt.md");
+    atomic_write(&target, b"first").unwrap();
+    atomic_write(&target, b"second").unwrap();
+
+    assert_eq!(std::fs::read(&target).unwrap(), b"second");
+    assert_eq!(tmp_residue(&dir), 0);
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[test]
+fn errors_when_temp_cannot_be_created() {
+    // Parent directory does not exist, so creating the sibling temp file fails.
+    let target = std::env::temp_dir()
+        .join(format!("moadim-atomic-missing-{}", Uuid::new_v4()))
+        .join("routine.toml");
+    let err = atomic_write(&target, b"data").unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    assert!(!target.exists());
+}
+
+#[test]
+fn errors_and_cleans_up_when_rename_fails() {
+    // A directory already occupies the target path, so renaming the temp file over it fails. The
+    // temp file must still be cleaned up, leaving no residue.
+    let dir = scratch_dir();
+    let target = dir.join("occupied");
+    std::fs::create_dir(&target).unwrap();
+
+    assert!(atomic_write(&target, b"data").is_err());
+    assert_eq!(
+        tmp_residue(&dir),
+        0,
+        "temp file should be removed on rename failure"
+    );
+    assert!(target.is_dir(), "the occupying directory is left untouched");
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[test]
+fn tmp_path_falls_back_when_no_file_name() {
+    // A path ending in `..` has no final component, exercising the `unwrap_or("tmp")` fallback.
+    let tmp = tmp_path(Path::new("/some/dir/.."));
+    assert!(tmp.to_string_lossy().contains(".tmp"));
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,5 @@
+/// Atomic file writes (write temp + rename) so readers never observe a torn file.
+pub mod atomic;
 /// JSON Schema helpers for schemars.
 pub mod schema;
 /// Startup print printed to stdout when the server begins listening.


### PR DESCRIPTION
## Problem

`write_routine` (`src/routine_storage.rs`) persisted `routine.toml` and `prompt.md` with in-place `std::fs::write`, which truncates-then-writes. A crash or full disk mid-write leaves a **torn** file. Because `read_routine_toml` swallows parse errors and returns `None`, a torn `routine.toml` makes the routine **silently disappear** from the store — and the reverse crontab sync re-reads these files every 30s, so a reader can observe a partial file.

## Change

- Add a shared `utils::atomic::atomic_write(path, &[u8])` helper: write a uniquely-named sibling temp file **in the same directory** (so the rename stays on one filesystem), flush it, then `fs::rename` it over the target. The temp file is removed on any failure, leaving no `.tmp` residue.
- Use it for both `routine.toml` and `prompt.md` in `write_routine`.

Mirrors the durability guarantee the daemon already gives `~/.claude.json` (#46) — consistency, not new philosophy. No change to on-disk format, file names, or the public REST/MCP API.

## Tests

- `atomic_write`: round-trip writes contents and leaves no `.tmp` residue; overwrites atomically; both error paths (temp-create failure, rename failure) return `Err` and clean up.
- `routine_storage`: a torn/garbage `routine.toml` loads as `None` (well-defined); `write_routine` leaves no `.tmp` residue.

## Verification

- `cargo fmt --check`, `cargo clippy` clean; `typos` clean; full test suite passes (282 tests). New `utils/atomic.rs` is 100% line-covered.

Closes #131

This PR was opened by the "implement-my-assigned-issues-without-a-pr" routine of moadim (@tupe12334).

🤖 Generated with [Claude Code](https://claude.com/claude-code)