### PR TITLE
chore: auto-enable git hooks via SessionStart hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "git config core.hooksPath .githooks"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
## What

Add a Claude Code `SessionStart` hook in `.claude/settings.json` that runs `git config core.hooksPath .githooks` on every session start.

## Why

The bundled `.githooks` (pre-commit spell-check; pre-push test-convention / fmt / clippy / coverage) had to be enabled per-clone with a manual `git config core.hooksPath .githooks` — easy to forget, so the gates silently didn't run.

Running it from `SessionStart` makes the hooks always active in any Claude Code session, no per-clone setup. Idempotent — safe to re-run every session.

## Changes

- `.claude/settings.json`: add `SessionStart` hook → `git config core.hooksPath .githooks`

`.githooks/` and `CONTRIBUTING.md` are unchanged; the manual command still works for non-Claude-Code workflows.

## Note

The pre-push hook enforces `--fail-under-lines 100`, but the tree is currently ~81.7% — so once active, pre-push will block pushes until coverage rises or the threshold is relaxed. Unrelated to this change, but worth knowing as the gate starts actually firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)