### PR TITLE
feat(agents): add Hermes as a built-in agent

### DIFF
--- a/src/routines/agents/hermes/setup.rs
+++ b/src/routines/agents/hermes/setup.rs
@@ -1,0 +1,12 @@
+//! Built-in default agent config for Hermes.
+
+/// Registry key for this agent; also the config filename stem (`hermes.toml`).
+pub const NAME: &str = "hermes";
+
+/// Default `hermes.toml` contents, written on startup when the file is absent.
+///
+/// Runs `hermes exec` headless with the composed prompt file passed as an argument
+/// (`{prompt_file}`), mirroring the Codex default.
+pub const CONFIG: &str = r#"command = "hermes"
+args = ["exec", "{prompt_file}"]
+"#;

--- a/src/routines/agents/mod.rs
+++ b/src/routines/agents/mod.rs
@@ -12,6 +12,8 @@ use crate::paths::{agent_toml_path, agents_dir};
 mod claude_code;
 #[path = "codex/setup.rs"]
 mod codex;
+#[path = "hermes/setup.rs"]
+mod hermes;
 
 /// A resolved agent invocation read from `~/.config/moadim/agents/<name>.toml`.
 #[derive(Debug, Clone, Deserialize)]
@@ -39,6 +41,7 @@ pub fn load_agent_command(name: &str) -> Option<AgentCommand> {
 const DEFAULT_AGENT_CONFIGS: &[(&str, &str)] = &[
     (claude_code::NAME, claude_code::CONFIG),
     (codex::NAME, codex::CONFIG),
+    (hermes::NAME, hermes::CONFIG),
 ];
 
 /// Registry keys of the built-in agents, in declaration order.

--- a/src/routines/mod_tests.rs
+++ b/src/routines/mod_tests.rs
@@ -223,6 +223,12 @@ fn ensure_default_agents_writes_parsable_configs() {
     assert_eq!(codex.command, "codex");
     assert!(codex.args.contains(&"{prompt_file}".to_string()));
 
+    // hermes default parses and passes the prompt file as an argument
+    let hermes: AgentCommand =
+        toml::from_str(&std::fs::read_to_string(dir.join("hermes.toml")).unwrap()).unwrap();
+    assert_eq!(hermes.command, "hermes");
+    assert!(hermes.args.contains(&"{prompt_file}".to_string()));
+
     let _ = std::fs::remove_dir_all(&dir);
 }
 
@@ -270,7 +276,11 @@ fn available_agents_falls_back_to_builtins_when_missing() {
     // directory does not exist → built-in defaults
     assert_eq!(
         available_agents_in(&dir),
-        vec!["claude".to_string(), "codex".to_string()]
+        vec![
+            "claude".to_string(),
+            "codex".to_string(),
+            "hermes".to_string()
+        ]
     );
 }
 


### PR DESCRIPTION
## What

Adds **Hermes** as a built-in agent alongside `claude_code` and `codex`, so routines can be configured to launch Hermes.

- New `src/routines/agents/hermes/setup.rs` defining `NAME = "hermes"` and a default `hermes.toml` (`CONFIG`).
- Registered in `src/routines/agents/mod.rs`: `#[path = "hermes/setup.rs"] mod hermes;` and `(hermes::NAME, hermes::CONFIG)` added to `DEFAULT_AGENT_CONFIGS`.
- Tests: `ensure_default_agents_writes_parsable_configs` now asserts the seeded `hermes.toml` parses; `available_agents_falls_back_to_builtins_when_missing` includes `hermes`.

## Hermes invocation (resolves the issue's open question)

Mirrors Codex's headless pattern — runs `hermes exec` with the composed prompt file:

```toml
command = "hermes"
args = ["exec", "{prompt_file}"]
```

No pre-launch `setup` step is needed (same as Codex). If the real Hermes CLI uses different headless flags, only `hermes.toml` needs adjusting — existing user files are never overwritten on startup.

## Acceptance criteria

- [x] `hermes` appears in `available_agents()` and `hermes.toml` is seeded on startup.
- [x] A routine can be configured with the `hermes` agent (it is a registered built-in).
- [x] Tests cover the new agent registration, consistent with existing agent tests.

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets` — clean
- `cargo test` — 282 passed, 0 failed
- `typos` — clean

> Note: local `cargo llvm-cov --fail-under-lines 100` reports the repo's pre-existing sandbox coverage floor (network/OS-integration paths in `cli.rs`/`restart.rs`/`sync` can't run locally); this change adds no new uncovered lines.

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)