### PR TITLE
feat(logging): initialize a logging backend so log:: calls emit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Added
 
+- The daemon now **initializes a logging backend** (`env_logger`) on the
+  foreground server path, so the existing `log::` call sites actually emit —
+  the request logger (`{method} {path} -> {status} in {ms}ms`), startup
+  warnings (e.g. a failed crontab sync), and the rest. Records go to **stderr**
+  with a timestamp and level, keeping stdout clean for the machine-readable
+  `--json` CLI subcommands (`status`/`stop`/`cleanup`), which never initialize
+  the backend. The level is configurable via `RUST_LOG` (e.g. `RUST_LOG=debug`),
+  defaulting to `info` when unset.
 - The moadim-managed system prompt (`CLAUDE.md`) now carries a **routine-origin
   disclosure** section that instructs the agent to reveal, in every
   outward-facing communication (GitHub issues/PRs/comments, Slack, email, etc.),

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +260,12 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console_error_panic_hook"
@@ -443,6 +499,29 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "env_filter"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
 
 [[package]]
 name = "equivalent"
@@ -1283,10 +1362,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "js-sys"
@@ -1399,6 +1508,7 @@ dependencies = [
  "chrono",
  "croner",
  "dirs",
+ "env_logger",
  "iana-time-zone",
  "log",
  "rmcp",
@@ -1437,6 +1547,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "option-ext"
@@ -1514,6 +1630,21 @@ dependencies = [
  "futures",
  "rustversion",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -2371,6 +2502,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ axum = "0.8"
 chrono = "0.4"
 croner = "3"
 dirs = "6"
+env_logger = "0.11"
 iana-time-zone = "0.1"
 log = "0.4"
 serde = { version = "1", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,9 +47,24 @@ async fn main() -> anyhow::Result<()> {
     }
 }
 
+/// Initialize the `log` backend once, on the foreground server path, so the 27 `log::` call sites
+/// (request logger middleware, startup warnings, …) actually emit. Records go to **stderr** with a
+/// timestamp and level, leaving stdout clean for the machine-readable `--json` CLI subcommands
+/// (which never reach this path). The level is read from `RUST_LOG`, defaulting to `info` when unset.
+///
+/// `try_init` is idempotent: a second call (e.g. from a test that already installed a logger) is a
+/// no-op rather than a panic.
+fn init_logging() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .target(env_logger::Target::Stderr)
+        .try_init()
+        .ok();
+}
+
 /// Run the HTTP/MCP/UI server in the foreground until a termination signal or the `/shutdown` route
 /// stops it. Records this process's PID so `moadim stop`/`status` can find it, and clears it on exit.
 async fn run_server() -> anyhow::Result<()> {
+    init_logging();
     routines::ensure_default_agents();
     let store = storage::load_store();
     // Rename any prompt.txt sidecars to prompt.md before rewriting run.sh scripts; otherwise the


### PR DESCRIPTION
## Problem

The daemon uses the `log` facade in **27 call sites** but never installs a backend, so the `log` crate falls back to its no-op logger and **silently discards every record** — the request logger middleware, startup warnings (`startup crontab sync failed`), all of it. Operators get zero visibility into a running daemon.

## Change

Initialize `env_logger` once, early in the foreground startup path (`run_server` in `src/main.rs`), before the first `log::` call:

```rust
fn init_logging() {
    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
        .target(env_logger::Target::Stderr)
        .try_init()
        .ok();
}
```

- **Timestamps + levels**: `env_logger`'s default format prefixes each line with a timestamp and level.
- **Configurable level**: read from `RUST_LOG`, defaulting to `info` when unset.
- **Idempotent**: `try_init()` returns `Err` (ignored) instead of panicking if a logger is already installed.
- **`--json` stdout stays clean**: records go to **stderr**, and the `status`/`stop`/`cleanup` subcommands never reach `run_server`, so they never init the backend.

`env_logger = "0.11"` added to `Cargo.toml`; CHANGELOG updated.

## Acceptance criteria

- [x] Backend initialized once, early in `run_server`, before the first `log::` call.
- [x] Output includes timestamps and levels.
- [x] Level configurable via `RUST_LOG`, default `info`.
- [x] Idempotent (`try_init`), no panic on repeat.
- [x] `--json` subcommands not polluted on stdout (log to stderr; those paths don't init).

Distinct from #23 (per-run `job.log` capture) — this is the daemon's own process-level logging.

## Verification

- `cargo fmt --all --check`, `cargo clippy --all-targets` — clean
- `cargo test` — 282 passed, 0 failed
- `typos` — clean

> The init lives in `src/main.rs`, which the coverage gate already excludes (`--ignore-filename-regex 'src/main\.rs'`), so it adds no new uncovered lines.

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)