### PR TITLE
chore: add *.profraw to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .playwright-mcp
 node_modules/
 dist/
+*.profraw


### PR DESCRIPTION
## Summary
Add `*.profraw` to `.gitignore` so LLVM coverage instrumentation dumps are not committed.

Also fixes the missing trailing newline on the `dist/` line.

## Why
Coverage runs (rustc `-Cinstrument-coverage` / `cargo-llvm-cov`) emit `*.profraw` files into the working tree — build artifacts that pollute `git status` and risk accidental commit.

Closes #159
