### PR TITLE
ci: exempt Dependabot PRs from changelog enforcement

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,7 +5,8 @@ name: Changelog
 # TODO, tomorrow's changelog"). Docs-, CI-, and test-only PRs are exempt — the
 # gate only fires when product code under src/ or ui/ changes. Add the
 # `skip-changelog` label to a PR to bypass the check for deliberately
-# undocumented src/ui changes.
+# undocumented src/ui changes. Dependabot PRs are exempt — dependency bumps
+# don't need a hand-written changelog entry.
 
 on:
   pull_request:
@@ -14,6 +15,7 @@ on:
 jobs:
   changelog:
     name: unreleased-entry
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Skip the `changelog` workflow job for Dependabot PRs via `if: github.actor != 'dependabot[bot]'`. Dependency bumps can touch `src/` (Cargo updates) and trip the changelog gate, but they don't warrant a hand-written CHANGELOG entry.

**Note:** if this check is a required status in branch protection, a skipped job reports no status and the required check may sit pending. Either drop it from required checks, or switch to making the job report success early instead of skipping.

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)