### PR TITLE
fix: don't wipe routine crontab block when store is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+### Fixed
+
+- Routine crontab sync no longer wipes the populated `MOADIM-ROUTINES` block
+  when the routine store is empty. An empty store at sync time signals a load
+  failure or a racing second daemon rather than a genuine "no routines" state
+  (startup always reseeds the built-in defaults), and previously such a sync
+  silently dropped every scheduled routine's cron line — leaving routines that
+  never fired. The sync now detects this case and preserves the existing block.
+
 ## [0.11.0] - 2026-06-17
 
 ### Added

--- a/src/sync/routines.rs
+++ b/src/sync/routines.rs
@@ -106,11 +106,29 @@ fn build_block(store: &RoutineStore) -> String {
     }
 }
 
+/// Substring identifying a routine line inside the crontab block (`# moadim-routine:<id>`).
+const ROUTINE_LINE_MARKER: &str = "# moadim-routine:";
+
 /// Write all enabled managed routines from `store` into the OS routines crontab block.
 ///
 /// Idempotent: skips the `crontab -` call when the crontab would not change.
+///
+/// Footgun guard: refuses to overwrite a populated routines block when the store is *empty*. An
+/// empty store at sync time means the store never loaded (or a second daemon is racing this one),
+/// not a genuine "no routines" state — startup always reseeds the built-in defaults, so the steady
+/// state is never an empty store. Without this guard such a sync would write a bare block and
+/// silently drop every scheduled routine's cron line (the incident that motivated it). A store that
+/// loaded fine but holds only disabled/unmanaged routines is *not* empty, so legitimately clearing
+/// the last routine still works.
 pub fn sync_routines_to_crontab(store: &RoutineStore) -> Result<(), SyncError> {
     let current = read_crontab()?;
+    if store.lock().unwrap().is_empty() && current.contains(ROUTINE_LINE_MARKER) {
+        log::warn!(
+            "routine sync: store is empty but the crontab still has routine lines; refusing to \
+             wipe the routines block (suspected load failure or a concurrent daemon)"
+        );
+        return Ok(());
+    }
     let block = build_block(store);
     let new_crontab = replace_block_with(&current, &block, BLOCK_BEGIN, BLOCK_END);
     if new_crontab == current {

--- a/src/sync/routines_sync_tests.rs
+++ b/src/sync/routines_sync_tests.rs
@@ -164,6 +164,110 @@ fn build_block_skips_routine_with_missing_agent_config() {
     assert!(!block.contains("moadim-routine:"));
 }
 
+/// A temp-dir `crontab` shim wired in via `MOADIM_CRONTAB_BIN`: `-l` prints the store file, `-`
+/// overwrites it from stdin. Restores the prior env value and removes the temp dir on drop.
+struct CronShim {
+    base: std::path::PathBuf,
+    store_file: std::path::PathBuf,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl CronShim {
+    fn new(initial: &str) -> Self {
+        use std::os::unix::fs::PermissionsExt;
+
+        let base = std::env::temp_dir().join(format!("moadim-rcronshim-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&base).unwrap();
+        let store_file = base.join("store");
+        std::fs::write(&store_file, initial).unwrap();
+        let store_display = store_file.to_string_lossy().into_owned();
+        let script_path = base.join("crontab-shim.sh");
+        std::fs::write(
+            &script_path,
+            format!(
+                "#!/bin/sh\nSTORE=\"{store_display}\"\nif [ \"$1\" = \"-l\" ]; then cat \"$STORE\"; elif [ \"$1\" = \"-\" ]; then cat > \"$STORE\"; fi\n"
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let previous = std::env::var_os("MOADIM_CRONTAB_BIN");
+        // SAFETY: tests run single-threaded (RUST_TEST_THREADS=1); restored on drop.
+        unsafe {
+            std::env::set_var("MOADIM_CRONTAB_BIN", &script_path);
+        }
+        Self {
+            base,
+            store_file,
+            previous,
+        }
+    }
+
+    fn store_contents(&self) -> String {
+        std::fs::read_to_string(&self.store_file).unwrap_or_default()
+    }
+}
+
+impl Drop for CronShim {
+    fn drop(&mut self) {
+        // SAFETY: single-threaded test harness; restore the saved value.
+        unsafe {
+            match self.previous.take() {
+                Some(value) => std::env::set_var("MOADIM_CRONTAB_BIN", value),
+                None => std::env::remove_var("MOADIM_CRONTAB_BIN"),
+            }
+        }
+        let _ = std::fs::remove_dir_all(&self.base);
+    }
+}
+
+#[test]
+fn sync_refuses_to_wipe_routine_lines_when_store_is_empty() {
+    // Footgun guard: an empty store must NOT overwrite a populated routines block — that would
+    // silently drop every scheduled routine's cron line.
+    let populated = format!(
+        "{BLOCK_BEGIN}\n{BLOCK_HEADER}\n*/5 * * * * /bin/sh '/x/run.sh' # moadim-routine:keep-me\n{BLOCK_END}\n"
+    );
+    let shim = CronShim::new(&populated);
+    sync_routines_to_crontab(&new_store()).unwrap();
+    // The crontab is left untouched: the routine line survives.
+    assert_eq!(shim.store_contents(), populated);
+    assert!(shim.store_contents().contains("# moadim-routine:keep-me"));
+}
+
+#[test]
+fn sync_proceeds_when_store_empty_but_no_routine_lines() {
+    // Guard's second operand is false (no routine marker), so sync proceeds; the block is already
+    // empty so the result equals the input and the idempotent check returns without writing.
+    let empty_block = format!("{BLOCK_BEGIN}\n{BLOCK_HEADER}\n{BLOCK_END}\n");
+    let shim = CronShim::new(&empty_block);
+    sync_routines_to_crontab(&new_store()).unwrap();
+    assert!(!shim.store_contents().contains("moadim-routine:"));
+}
+
+#[test]
+fn sync_writes_block_for_a_loaded_store() {
+    // A non-empty store with a resolvable agent passes the guard and writes its routine line.
+    let agent_name = "test-sync-agent-write-block";
+    let title = "Write Block Sync Routine";
+    let slug = slugify(title);
+    std::fs::create_dir_all(crate::paths::agents_dir()).unwrap();
+    let cfg = crate::paths::agent_toml_path(agent_name);
+    std::fs::write(&cfg, "command = \"claude\"\nargs = []\n").unwrap();
+
+    let shim = CronShim::new("# BEGIN MOADIM-ROUTINES\n# END MOADIM-ROUTINES\n");
+    let store = new_store();
+    store
+        .lock()
+        .unwrap()
+        .insert("w".into(), make_routine("w", title, agent_name));
+    sync_routines_to_crontab(&store).unwrap();
+    assert!(shim.store_contents().contains("# moadim-routine:w"));
+
+    std::fs::remove_file(&cfg).unwrap();
+    let _ = std::fs::remove_dir_all(crate::paths::routine_dir(&slug));
+}
+
 #[test]
 fn build_block_includes_routine_with_agent_config() {
     let agent_name = "test-sync-agent-build-block";


### PR DESCRIPTION
## Problem

Scheduled routines stopped firing: the `MOADIM-ROUTINES` crontab block was found **empty** despite a fully populated routine store. Routines fire via OS cron (each line launches `run.sh` + a tmux agent session), so an empty block = nothing ever runs.

Root cause: `sync_routines_to_crontab` runs on every daemon startup (and on routine create/update/delete). When it runs against an **empty store** — a load failure, or a second daemon racing on the same port — `build_block` returns a bare block and the sync writes it, **silently dropping every routine's cron line**. Nothing repopulates it until the next create/update/delete, so the routines stay dead.

This was hit in practice when two daemon instances overlapped on port 5784.

## Fix

Guard the sync: when the store is empty **and** the crontab still contains routine lines (`# moadim-routine:`), log a warning and preserve the existing block instead of wiping it. An empty store is never the real steady state — startup always reseeds the built-in defaults. A store that loaded fine but holds only disabled/unmanaged routines is *not* empty, so legitimately clearing the last routine still works.

## Tests

- `sync_refuses_to_wipe_routine_lines_when_store_is_empty` — empty store + populated block → block preserved.
- `sync_proceeds_when_store_empty_but_no_routine_lines` — guard's second operand false → proceeds (idempotent no-op).
- `sync_writes_block_for_a_loaded_store` — loaded store passes the guard and writes its line.

New guard logic is fully covered. (`fmt` + `clippy --all-targets` clean.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)