### PR TITLE
chore(release): v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-06-17
+
 ### Fixed
 
 - Routine crontab sync no longer wipes the populated `MOADIM-ROUTINES` block

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ opt-level = "z"
 
 [package]
 name = "moadim"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 description = "Moadim.io MCP/REST server for managing cron jobs"
 license = "MIT"


### PR DESCRIPTION
Release **v0.11.1** — patch bump over v0.11.0.

## Changes
- Bump `version` to 0.11.1 (Cargo.toml + Cargo.lock)
- Promote CHANGELOG `[Unreleased]` → `[0.11.1] - 2026-06-17`

### Fixed (since v0.11.0)
- Routine crontab sync no longer wipes the populated `MOADIM-ROUTINES` block when the routine store is empty (#164).

Tag `v0.11.1` pushed after merge → triggers crates.io publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)