### PR TITLE
chore(release): v0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+## [0.11.2] - 2026-06-17
+
 ### Fixed
 
 - Scheduled routine agents now run under a **login shell** (`/bin/sh -l '<run.sh>'`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ opt-level = "z"
 
 [package]
 name = "moadim"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 description = "Moadim.io MCP/REST server for managing cron jobs"
 license = "MIT"


### PR DESCRIPTION
Release v0.11.2.

### Fixed
- Scheduled routine agents now run under a login shell (`sh -l` in crontab, `sh -lc` for manual triggers) so they source `~/.profile` and inherit env vars (`GH_TOKEN`, API keys, etc.). Previously routines ran with cron's minimal environment and tools like `gh`/`git` had no credentials (#165).

Bumps Cargo.toml/Cargo.lock to 0.11.2 and promotes the `[Unreleased]` CHANGELOG entry. Merge, then tag `v0.11.2` to trigger the crates.io publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)