### PR TITLE
fix: split routine runtime state out of git-tracked routine.toml (#127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+### Changed
+
+- Routine runtime state (last-run timestamps and related mutable fields) is now
+  stored in a separate, git-ignored sidecar file instead of the git-tracked
+  `routine.toml`, so scheduled runs no longer produce noisy diffs or merge
+  conflicts in version-controlled routine definitions (#127).
+
 ### Fixed
 
 - `now_secs()` no longer panics when the system clock reads before the Unix

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -101,6 +101,15 @@ pub fn routine_gitignore_path(id: &str) -> PathBuf {
     routine_dir(id).join(".gitignore")
 }
 
+/// Returns the path to `{routines_dir}/{id}/state.local.toml`, the gitignored sidecar holding
+/// daemon-written runtime state (e.g. `last_triggered_at`) kept out of the tracked `routine.toml`.
+///
+/// The `.local.` infix matches the `*.local.*` pattern seeded into each routine's `.gitignore`, so
+/// trigger churn never produces version-control diffs.
+pub fn routine_state_path(id: &str) -> PathBuf {
+    routine_dir(id).join("state.local.toml")
+}
+
 /// Returns the path to `{routines_dir}/{id}/run.sh`, the generated launch script invoked by cron.
 pub fn routine_script_path(id: &str) -> PathBuf {
     routine_dir(id).join("run.sh")

--- a/src/paths/mod_tests.rs
+++ b/src/paths/mod_tests.rs
@@ -127,6 +127,16 @@ fn routine_gitignore_path_filename() {
 }
 
 #[test]
+fn routine_state_path_filename() {
+    let path = routine_state_path("abc");
+    assert_eq!(
+        path.file_name().unwrap().to_str().unwrap(),
+        "state.local.toml"
+    );
+    assert_eq!(path.parent().unwrap(), routine_dir("abc"));
+}
+
+#[test]
 fn agents_dir_ends_with_agents() {
     let path = agents_dir().to_string_lossy().into_owned();
     assert!(

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -6,7 +6,8 @@ use std::sync::{Arc, Mutex};
 use serde::{Deserialize, Serialize};
 
 use crate::paths::{
-    routine_dir, routine_gitignore_path, routine_prompt_path, routine_toml_path, routines_dir,
+    routine_dir, routine_gitignore_path, routine_prompt_path, routine_state_path,
+    routine_toml_path, routines_dir,
 };
 use crate::routines::{compose_prompt, slugify, Repository, Routine, RoutineStore};
 use crate::utils::atomic::atomic_write;
@@ -34,10 +35,26 @@ struct RoutineToml {
     /// Unix last-updated timestamp.
     updated_at: Option<u64>,
     /// Unix timestamp of last manual trigger.
+    ///
+    /// **Read-only / legacy.** Runtime trigger state now lives in the gitignored `state.local.toml`
+    /// sidecar ([`RuntimeState`]) so it no longer churns the version-controlled `routine.toml`.
+    /// This field is still parsed so routines written by older daemons keep their timestamp (the
+    /// value migrates into the sidecar on the next [`write_routine`]), but it is never written back
+    /// — `skip_serializing` keeps it out of every freshly written `routine.toml`.
+    #[serde(default, skip_serializing)]
     last_triggered_at: Option<u64>,
     /// Workbench retention in seconds for finished runs; absent means the daemon default.
     #[serde(default)]
     ttl_secs: Option<u64>,
+}
+
+/// Daemon-written runtime state for a routine, persisted to the gitignored `state.local.toml`
+/// sidecar so it never appears in the version-controlled `routine.toml`.
+#[derive(Debug, Deserialize, Serialize)]
+struct RuntimeState {
+    /// Unix timestamp of the last manual trigger, or `None` if it has never been triggered.
+    #[serde(default)]
+    last_triggered_at: Option<u64>,
 }
 
 /// Parse a routine TOML file at `path`, returning `None` on any error.
@@ -46,14 +63,27 @@ fn read_routine_toml(path: &std::path::PathBuf) -> Option<RoutineToml> {
     toml::from_str(&text).ok()
 }
 
+/// Read `last_triggered_at` from a routine's `state.local.toml` sidecar, returning `None` when the
+/// sidecar is absent or unparsable (e.g. before the routine has ever been triggered).
+fn read_runtime_state(dir_name: &str) -> Option<u64> {
+    let text = std::fs::read_to_string(routine_state_path(dir_name)).ok()?;
+    toml::from_str::<RuntimeState>(&text)
+        .ok()?
+        .last_triggered_at
+}
+
 /// Load a routine from `{routines_dir}/{dir_name}/routine.toml`.
 ///
 /// `dir_name` is the slug (title-derived folder name). The routine's UUID `id` is read from
 /// `routine.toml`; for legacy dirs created before this change `id` falls back to `dir_name`.
+///
+/// `last_triggered_at` is read from the `state.local.toml` sidecar, falling back to the legacy
+/// `routine.toml` field for routines written before the runtime state was split out.
 fn load_routine_from_dir(dir_name: &str) -> Option<Routine> {
     let toml = read_routine_toml(&routine_toml_path(dir_name))?;
     let title = toml.title?;
     let id = toml.id.unwrap_or_else(|| dir_name.to_string());
+    let last_triggered_at = read_runtime_state(dir_name).or(toml.last_triggered_at);
     Some(Routine {
         id,
         schedule: toml.schedule?,
@@ -65,15 +95,18 @@ fn load_routine_from_dir(dir_name: &str) -> Option<Routine> {
         source: "managed".to_string(),
         created_at: toml.created_at.unwrap_or(0),
         updated_at: toml.updated_at.unwrap_or(0),
-        last_triggered_at: toml.last_triggered_at,
+        last_triggered_at,
         ttl_secs: toml.ttl_secs,
     })
 }
 
-/// Write `routine` to disk: `routine.toml`, the composed `prompt.md`, and `.gitignore` if absent.
+/// Write `routine` to disk: `routine.toml` (tracked config), the composed `prompt.md`, the
+/// gitignored `state.local.toml` runtime sidecar, and `.gitignore` if absent.
 ///
 /// The folder is named after the slugified title (`slugify(&routine.title)`). The UUID `id` is
-/// stored inside `routine.toml` so it survives a rename.
+/// stored inside `routine.toml` so it survives a rename. Daemon-written runtime state
+/// (`last_triggered_at`) goes to the sidecar, not `routine.toml`, so a trigger never churns the
+/// version-controlled config file.
 pub fn write_routine(routine: &Routine) -> std::io::Result<()> {
     let slug = slugify(&routine.title);
     let dir = routine_dir(&slug);
@@ -94,7 +127,9 @@ pub fn write_routine(routine: &Routine) -> std::io::Result<()> {
         enabled: Some(routine.enabled),
         created_at: Some(routine.created_at),
         updated_at: Some(routine.updated_at),
-        last_triggered_at: routine.last_triggered_at,
+        // Runtime state is written to the sidecar below, never to the tracked `routine.toml`
+        // (`skip_serializing` also keeps this field out regardless of its value).
+        last_triggered_at: None,
         ttl_secs: routine.ttl_secs,
     };
     let text = toml::to_string_pretty(&toml_routine).map_err(std::io::Error::other)?;
@@ -106,6 +141,28 @@ pub fn write_routine(routine: &Routine) -> std::io::Result<()> {
         &routine_prompt_path(&slug),
         compose_prompt(routine).as_bytes(),
     )?;
+    write_runtime_state(&slug, routine.last_triggered_at)?;
+    Ok(())
+}
+
+/// Persist a routine's runtime state to its gitignored `state.local.toml` sidecar.
+///
+/// Writes the sidecar (atomically) when `last_triggered_at` is set, and removes any stale sidecar
+/// when it is `None`, so the on-disk state always mirrors the in-memory routine.
+fn write_runtime_state(slug: &str, last_triggered_at: Option<u64>) -> std::io::Result<()> {
+    let path = routine_state_path(slug);
+    match last_triggered_at {
+        Some(_) => {
+            let state = RuntimeState { last_triggered_at };
+            let text = toml::to_string_pretty(&state).map_err(std::io::Error::other)?;
+            atomic_write(&path, text.as_bytes())?;
+        }
+        None => {
+            if path.exists() {
+                std::fs::remove_file(&path)?;
+            }
+        }
+    }
     Ok(())
 }
 

--- a/src/routine_storage_tests.rs
+++ b/src/routine_storage_tests.rs
@@ -153,6 +153,101 @@ fn load_routine_from_dir_missing_returns_none() {
 }
 
 #[test]
+fn last_triggered_at_persists_to_sidecar_not_routine_toml() {
+    // Runtime trigger state is written to the gitignored `state.local.toml` sidecar and kept out
+    // of the version-controlled `routine.toml`, then read back from the sidecar on load.
+    let title = "Rs Sidecar Routine";
+    let slug = slugify(title);
+    let mut routine = make_routine("rs-sidecar-id", title);
+    routine.last_triggered_at = Some(12345);
+    write_routine(&routine).unwrap();
+
+    // The tracked config file does not carry the runtime timestamp...
+    let toml_text = std::fs::read_to_string(crate::paths::routine_toml_path(&slug)).unwrap();
+    assert!(
+        !toml_text.contains("last_triggered_at"),
+        "routine.toml must not carry runtime trigger state: {toml_text}"
+    );
+    // ...the gitignored sidecar does, and it round-trips through load.
+    assert!(crate::paths::routine_state_path(&slug).exists());
+    let state_text = std::fs::read_to_string(crate::paths::routine_state_path(&slug)).unwrap();
+    assert!(state_text.contains("last_triggered_at"));
+    assert_eq!(
+        load_routine_from_dir(&slug).unwrap().last_triggered_at,
+        Some(12345)
+    );
+
+    remove_routine_dir(&slug).unwrap();
+}
+
+#[test]
+fn write_routine_clears_stale_sidecar_when_untriggered() {
+    // Re-writing a routine whose trigger state has been cleared removes the now-stale sidecar, so
+    // the on-disk state mirrors the in-memory `None`.
+    let title = "Rs Clear Sidecar Routine";
+    let slug = slugify(title);
+    let mut routine = make_routine("rs-clear-id", title);
+    routine.last_triggered_at = Some(999);
+    write_routine(&routine).unwrap();
+    assert!(crate::paths::routine_state_path(&slug).exists());
+
+    routine.last_triggered_at = None;
+    write_routine(&routine).unwrap();
+    assert!(
+        !crate::paths::routine_state_path(&slug).exists(),
+        "sidecar should be removed when there is no trigger state"
+    );
+    assert_eq!(
+        load_routine_from_dir(&slug).unwrap().last_triggered_at,
+        None
+    );
+
+    remove_routine_dir(&slug).unwrap();
+}
+
+#[test]
+fn load_routine_falls_back_to_legacy_last_triggered_in_routine_toml() {
+    // A routine written by an older daemon stored `last_triggered_at` inside `routine.toml` and
+    // has no sidecar. Load still surfaces the timestamp via the legacy-field fallback.
+    let slug = "rs-legacy-trigger-routine";
+    let dir = crate::paths::routine_dir(slug);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        crate::paths::routine_toml_path(slug),
+        "schedule = \"@daily\"\ntitle = \"Rs Legacy Trigger\"\nagent = \"claude\"\nlast_triggered_at = 777\n",
+    )
+    .unwrap();
+    // No sidecar exists yet.
+    assert!(!crate::paths::routine_state_path(slug).exists());
+
+    assert_eq!(
+        load_routine_from_dir(slug).unwrap().last_triggered_at,
+        Some(777)
+    );
+
+    remove_routine_dir(slug).unwrap();
+}
+
+#[test]
+fn load_routine_ignores_unparsable_sidecar() {
+    // A malformed `state.local.toml` parses to `None` (rather than crashing the load), and with no
+    // legacy field in `routine.toml` the routine loads with no trigger timestamp.
+    let slug = "rs-bad-sidecar-routine";
+    let dir = crate::paths::routine_dir(slug);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        crate::paths::routine_toml_path(slug),
+        "schedule = \"@daily\"\ntitle = \"Rs Bad Sidecar\"\nagent = \"claude\"\n",
+    )
+    .unwrap();
+    std::fs::write(crate::paths::routine_state_path(slug), "= not valid toml =").unwrap();
+
+    assert_eq!(load_routine_from_dir(slug).unwrap().last_triggered_at, None);
+
+    remove_routine_dir(slug).unwrap();
+}
+
+#[test]
 fn torn_routine_toml_loads_as_none() {
     // A truncated/garbage routine.toml (e.g. left by a crash mid-write) must not panic or load a
     // half-baked routine; the loader returns None and the routine is simply absent.


### PR DESCRIPTION
## Problem

`last_triggered_at` is daemon-written **runtime state**, but it lived inside `routine.toml` — the file intended to be version-controlled. Every manual/scheduled trigger calls `record_trigger` → `write_routine`, rewriting `routine.toml` with a fresh timestamp. Some routines fire every 5 minutes, so a tracked config file mutates constantly, producing noisy, meaningless git diffs.

## Change

Split runtime state into a gitignored sidecar (Option 1 from the issue):

- **New `routine_state_path`** → `{routine_dir}/state.local.toml`. The `.local.` infix matches the `*.local.*` pattern already seeded into each routine's `.gitignore`, so trigger churn never reaches version control.
- **`write_routine`** writes `last_triggered_at` to the sidecar, and removes a stale sidecar when the value is `None`, so on-disk state mirrors the in-memory routine. `routine.toml` now carries only user-authored config; `#[serde(skip_serializing)]` guarantees the runtime field is never written back to it.
- **`load_routine_from_dir`** reads the sidecar, falling back to the legacy `routine.toml` field for routines written by older daemons. The legacy value migrates into the sidecar on the next write — no data loss, no manual migration step.

`created_at` / `updated_at` deliberately stay in `routine.toml`: they change only on create/update (legitimate, infrequent config edits), not on every run, so they aren't the source of the churn this issue targets.

## Scope

Routines only, kept small and reviewable. The cron-job storage path (`src/storage.rs`) shares the same pattern and is a good follow-up in its own focused PR.

## Tests

- `last_triggered_at` round-trips through the sidecar and is **absent** from `routine.toml`
- stale sidecar removed when a routine is re-written untriggered
- legacy `routine.toml` `last_triggered_at` still loads (back-compat fallback)
- unparsable sidecar tolerated (loads with no timestamp rather than crashing)
- `routine_state_path` shape

## Verification

`cargo fmt --check`, `cargo clippy --all-targets`, and `cargo test` all pass. The touched files (`routine_storage.rs`, `paths/mod.rs`) are at **100% line coverage**; the only uncovered lines in a local `cargo llvm-cov` run are pre-existing and in untouched files (an environment-specific macOS quirk, per CLAUDE.md's note that the local coverage gate "has historically failed on current stable").

Closes #127

---
🤖 This pull request was opened by the "Implement my assigned issues without a PR (daemon + landing)" routine of moadim. cc @tupe12334