### PR TITLE
fix: fold iCal content lines per RFC 5545 §3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Fixed
 
+- iCal feeds now fold long content lines at 75 octets per RFC 5545 §3.1, using a
+  UTF-8-aware byte budget so multi-byte characters are never split across a fold
+  boundary. Previously over-long `SUMMARY`/`DESCRIPTION` lines were emitted
+  unfolded, which some calendar clients reject.
 - `now_secs()` no longer panics when the system clock reads before the Unix
   epoch (1970). A VM or container booted with a dead real-time clock could make
   `SystemTime::duration_since` fail and crash the daemon; such readings are now

--- a/src/routines/ical.rs
+++ b/src/routines/ical.rs
@@ -33,6 +33,36 @@ fn format_utc(dt: DateTime<Utc>) -> String {
     dt.format("%Y%m%dT%H%M%SZ").to_string()
 }
 
+/// Maximum octets per physical content line per RFC 5545 §3.1 (excluding CRLF).
+const FOLD_LIMIT: usize = 75;
+
+/// Fold a content line per RFC 5545 §3.1 so no physical line exceeds
+/// [`FOLD_LIMIT`] octets (excluding the CRLF terminator).
+///
+/// Continuation lines are introduced with `CRLF` followed by a single leading
+/// space, and that space counts toward the octet limit. Folding measures **octets**
+/// (UTF-8 byte length) but only ever breaks on character boundaries, so a multibyte
+/// character is never split across a fold.
+fn fold_line(line: &str) -> String {
+    if line.len() <= FOLD_LIMIT {
+        return line.to_string();
+    }
+    let mut out = String::with_capacity(line.len() + line.len() / FOLD_LIMIT + 1);
+    // First physical line gets the full budget; each continuation spends one octet
+    // on its leading space.
+    let mut budget = FOLD_LIMIT;
+    for ch in line.chars() {
+        let clen = ch.len_utf8();
+        if clen > budget {
+            out.push_str("\r\n ");
+            budget = FOLD_LIMIT - 1;
+        }
+        out.push(ch);
+        budget -= clen;
+    }
+    out
+}
+
 /// Render upcoming fire times of every enabled routine as an iCalendar (`.ics`) feed.
 ///
 /// Each enabled routine with a parseable schedule contributes one `VEVENT` per fire time in
@@ -75,8 +105,13 @@ pub fn build_ical(routines: &[Routine], now: DateTime<Local>) -> String {
         }
     }
     lines.push("END:VCALENDAR".to_string());
-    // RFC 5545 mandates CRLF line endings, including a trailing CRLF after the final line.
-    let mut out = lines.join("\r\n");
+    // RFC 5545 mandates CRLF line endings, including a trailing CRLF after the final
+    // line. Each content line is folded (§3.1) so no physical line exceeds 75 octets.
+    let mut out = lines
+        .iter()
+        .map(|line| fold_line(line))
+        .collect::<Vec<_>>()
+        .join("\r\n");
     out.push_str("\r\n");
     out
 }

--- a/src/routines/ical.rs
+++ b/src/routines/ical.rs
@@ -52,13 +52,13 @@ fn fold_line(line: &str) -> String {
     // on its leading space.
     let mut budget = FOLD_LIMIT;
     for ch in line.chars() {
-        let clen = ch.len_utf8();
-        if clen > budget {
+        let char_len = ch.len_utf8();
+        if char_len > budget {
             out.push_str("\r\n ");
             budget = FOLD_LIMIT - 1;
         }
         out.push(ch);
-        budget -= clen;
+        budget -= char_len;
     }
     out
 }

--- a/src/routines/ical_tests.rs
+++ b/src/routines/ical_tests.rs
@@ -80,6 +80,70 @@ fn text_fields_are_escaped() {
     assert!(ics.contains("SUMMARY:a\\,b\\;c\\\\d\\ne\r\n"));
 }
 
+/// Assert no physical line in `ics` exceeds 75 octets (excluding the CRLF).
+fn assert_all_lines_within_75_octets(ics: &str) {
+    for line in ics.split("\r\n") {
+        assert!(
+            line.len() <= 75,
+            "line exceeds 75 octets ({}): {line:?}",
+            line.len()
+        );
+    }
+}
+
+#[test]
+fn short_value_is_left_unfolded() {
+    assert_eq!(fold_line("SUMMARY:hello"), "SUMMARY:hello");
+    // exactly 75 octets stays on one line
+    let exact = "A".repeat(75);
+    assert_eq!(fold_line(&exact), exact);
+}
+
+#[test]
+fn long_line_is_folded_with_leading_space() {
+    let line = format!("DESCRIPTION:{}", "x".repeat(200));
+    let folded = fold_line(&line);
+    let physical: Vec<&str> = folded.split("\r\n").collect();
+    assert!(physical.len() > 1, "expected multiple folded lines");
+    assert!(physical[0].len() <= 75);
+    for cont in &physical[1..] {
+        assert!(
+            cont.starts_with(' '),
+            "continuation must start with a space"
+        );
+        assert!(cont.len() <= 75, "continuation exceeds 75 octets");
+    }
+    // unfolding (strip CRLF + single leading space) restores the original
+    let unfolded = folded.replace("\r\n ", "");
+    assert_eq!(unfolded, line);
+}
+
+#[test]
+fn fold_never_splits_multibyte_character() {
+    // 'é' is 2 octets in UTF-8; place a run straddling the 75-octet boundary.
+    let line = format!("SUMMARY:{}", "é".repeat(80));
+    let folded = fold_line(&line);
+    for cont in folded.split("\r\n") {
+        assert!(cont.len() <= 75);
+    }
+    // Every physical line must be valid UTF-8 with no replacement chars,
+    // i.e. no character was split mid-codepoint.
+    let unfolded = folded.replace("\r\n ", "");
+    assert_eq!(unfolded, line);
+    assert!(!folded.contains('\u{FFFD}'));
+}
+
+#[test]
+fn feed_with_long_prompt_is_fully_folded() {
+    let mut routine = routine_with("r1", "@daily", true);
+    routine.prompt = "lorem ipsum dolor sit amet ".repeat(20);
+    routine.title = "A very long routine title ".repeat(5);
+    let ics = build_ical(&[routine], fixed_now());
+    assert_all_lines_within_75_octets(&ics);
+    // DESCRIPTION was long enough to require at least one continuation line.
+    assert!(ics.contains("\r\n "), "expected folded continuation lines");
+}
+
 #[test]
 fn svc_ical_reads_store() {
     let store = new_store();


### PR DESCRIPTION
## Summary

`build_ical` (`src/routines/ical.rs`) emitted each property as a single joined line and never applied RFC 5545 §3.1 content-line folding. `DESCRIPTION` (which embeds the routine's full prompt), `SUMMARY` (title), and `UID` routinely exceed the mandated 75-octet limit, so strict iCalendar parsers (Apple Calendar, Thunderbird/Lightning, many libraries) may reject, truncate, or mis-render the feed. Lenient clients like Google Calendar tolerate it, which is why this slipped through.

## Changes

- Added `fold_line` (`src/routines/ical.rs`): folds a content line so no physical line exceeds **75 octets** (excluding CRLF). Continuation lines begin with a single leading space, and that space counts toward the limit. Folding measures **octets** (UTF-8 byte length) but only ever breaks on character boundaries, so a multibyte character is never split across a fold.
- `build_ical` now folds every emitted content line before joining. Existing CRLF termination (including the trailing CRLF) is preserved.

## Tests

- `short_value_is_left_unfolded` — short lines and an exactly-75-octet line pass through untouched
- `long_line_is_folded_with_leading_space` — long line splits into ≤75-octet physical lines; continuations start with a space; unfolding restores the original
- `fold_never_splits_multibyte_character` — a run of `é` straddling the boundary stays valid UTF-8 (no `U+FFFD`); unfolding round-trips
- `feed_with_long_prompt_is_fully_folded` — full feed with a long prompt/title has every physical line ≤75 octets

## Verification

- `cargo test ical` — all pass (13/13)
- `cargo fmt --check` — clean
- `cargo clippy --all-targets` — clean

Out of scope (noted in the issue): `DTEND`/`DURATION` on `VEVENT`s.

Closes #180

---
This pull request was opened by the "Open issues → fix PRs (owned repos + my orgs)" routine of moadim. @tupe12334

🤖 Generated with [Claude Code](https://claude.com/claude-code)