### PR TITLE
fix: clamp now_secs() to 0 instead of panicking on a pre-1970 clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+### Fixed
+
+- `now_secs()` no longer panics when the system clock reads before the Unix
+  epoch (1970). A VM or container booted with a dead real-time clock could make
+  `SystemTime::duration_since` fail and crash the daemon; such readings are now
+  clamped to `0` until the clock is corrected.
+
 ## [0.11.2] - 2026-06-17
 
 ### Fixed

--- a/src/utils/time.rs
+++ b/src/utils/time.rs
@@ -2,10 +2,20 @@ use std::time::SystemTime;
 
 /// Return current Unix time in whole seconds.
 pub fn now_secs() -> u64 {
-    SystemTime::now()
+    secs_since_epoch(SystemTime::now())
+}
+
+/// Whole seconds between the Unix epoch and `moment`.
+///
+/// A clock that reads before 1970 — as happens on a VM or container booted
+/// with a dead real-time clock — would make `duration_since` return an error.
+/// We clamp those to `0` rather than panicking so the daemon stays up until
+/// the clock is corrected.
+fn secs_since_epoch(moment: SystemTime) -> u64 {
+    moment
         .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_secs()
+        .map(|elapsed| elapsed.as_secs())
+        .unwrap_or(0)
 }
 
 #[cfg(test)]

--- a/src/utils/time_tests.rs
+++ b/src/utils/time_tests.rs
@@ -1,6 +1,20 @@
 #![allow(clippy::missing_docs_in_private_items)]
 
 use super::*;
+use std::time::Duration;
+
+#[test]
+fn secs_since_epoch_clamps_pre_1970_clock_to_zero() {
+    // A clock that reads before the Unix epoch must not panic.
+    let before_epoch = SystemTime::UNIX_EPOCH - Duration::from_secs(60);
+    assert_eq!(secs_since_epoch(before_epoch), 0);
+}
+
+#[test]
+fn secs_since_epoch_returns_whole_seconds() {
+    let moment = SystemTime::UNIX_EPOCH + Duration::from_millis(1_577_836_800_500);
+    assert_eq!(secs_since_epoch(moment), 1_577_836_800);
+}
 
 #[test]
 fn now_secs_after_year_2020() {


### PR DESCRIPTION
## Why

`now_secs()` (`src/utils/time.rs`) unwrapped the result of
`SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)`:

```rust
pub fn now_secs() -> u64 {
    SystemTime::now()
        .duration_since(SystemTime::UNIX_EPOCH)
        .unwrap()
        .as_secs()
}
```

`duration_since` returns `Err` whenever the clock reads **before** the Unix
epoch. That is a real boot-time condition on VMs and containers whose
real-time clock is dead or uninitialised (the clock starts at, or before,
1970 until NTP corrects it). A single such reading would panic the daemon —
and `now_secs()` is on hot paths (uptime, workbench TTL/cleanup, timestamps).

The codebase already defends against the *opposite* direction (backward clock
skew) with `saturating_sub`, so the pre-epoch case deserves the same
treatment rather than a crash.

## What

- Extract a small documented helper `secs_since_epoch(SystemTime) -> u64`
  that maps the duration to whole seconds and clamps the pre-epoch `Err`
  case to `0`.
- `now_secs()` delegates to it. No behaviour change for normal clocks.
- Add unit tests for both the normal and pre-1970 paths, keeping the module
  at 100% line coverage.

## Checks

- `cargo fmt --check` — clean
- `cargo clippy --all-targets` — clean
- `cargo test` — all tests pass (incl. the two new cases)

> Note: the repo's full `cargo llvm-cov --fail-under-lines 100` gate could not
> be run to completion in this environment because the build host's disk was
> full; the change is structured so both new branches are covered, so the
> line-coverage total is preserved.

---
This pull request was opened by the **Daemon + Landing auto-improve PRs** routine of moadim.