### PR TITLE
docs(readme): add copy-pasteable exit-code snippets to Scripting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,28 @@ on stdout. Paired with the exit codes above, a caller gets the full contract wit
 Any other failure exits `1` with a message on stderr. The object is always a single line, so
 `moadim status --json | jq -r .pid` and similar pipelines work without buffering.
 
+Because the contract lives in the exit code, scripts can branch on `$?` without parsing any
+output. A common pattern — start the server only if it is not already running:
+
+```sh
+# Exit 0 = running, exit 3 = not running. Discard stdout; we only care about $?.
+if ! moadim status --json >/dev/null; then
+  moadim            # not running: start it detached in the background
+fi
+```
+
+Or wait for an already-running server before talking to it, and bail otherwise:
+
+```sh
+if moadim status >/dev/null; then
+  pid=$(moadim status --json | jq -r .pid)
+  echo "moadim is up (pid $pid)"
+else
+  echo "moadim is not running" >&2
+  exit 1
+fi
+```
+
 Because the default mode is detached, you stop the server **from the client**:
 press the **STOP** button in the UI header, run `moadim stop`, or send
 `POST /shutdown`. (During development, `cargo run -- --interactive` keeps it in

--- a/TODO.md
+++ b/TODO.md
@@ -29,5 +29,4 @@ This is a list of todos for consumption, in a pr remove the todo you have implem
 - Return the freed disk bytes alongside `removed` in `CleanupResponse` and surface "removed N (freed 12.4 MB)" in the UI cleanup toast
 - Auto-refresh the routine LOGS view (or show a removed badge) after a CLEANUP NOW sweep so stale run output isn't shown for reaped workbenches
 - Add the option to filter routines by repositories in the ui
-- Add a copy-pasteable shell snippet to the README "Scripting" section showing a real branch on `moadim status --json` exit codes (e.g. `if ! moadim status --json >/dev/null; then moadim; fi`) so readers see the contract in use, not just its shape
 - Run the README's fenced `sh`/`json` blocks through a docs lint in CI (e.g. a `markdownlint`/`mdsh` check or a `--json | jq -e` smoke test) so the documented JSON shapes can't drift from the actual CLI output silently


### PR DESCRIPTION
## What

Adds two runnable `sh` snippets to the README **Scripting** section that show the documented `status`/`cleanup`/`stop` exit-code contract *in use*, not just described:

- a start-if-not-running guard: `if ! moadim status --json >/dev/null; then moadim; fi`
- a wait-or-bail check that also reads the PID via `jq`

Also removes the corresponding entry from `TODO.md` now that it is implemented.

## Why

The Scripting section already documents the `--json` object shapes and the `0` running / `3` not-running exit codes, but only in prose and a table. A reader who wants to act on the contract has to assemble the actual shell idiom themselves. These snippets make the contract directly copy-pasteable and demonstrate the intended pattern (branch on `$?`, discard stdout), which is exactly what the `TODO.md` item asked for.

This is documentation-only: no source, build, or behavior changes.

## Verification

- `cargo fmt --all -- --check` — passes (exit 0)
- `cargo build -p moadim` — builds clean (exit 0)
- `cargo clippy -p moadim --bins` — no warnings/errors
- `typos README.md TODO.md` — passes (exit 0)

(Full-workspace clippy/coverage including the `ui` wasm crate was not re-run to completion due to a disk-space constraint in this environment; the change touches only Markdown, so it cannot affect compilation, lints, or coverage.)

---
This pull request was opened by the "Daemon + Landing auto-improve PRs" routine of moadim.