### PR TITLE
test: stop svc_* tests from clobbering the real user crontab (#175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   epoch (1970). A VM or container booted with a dead real-time clock could make
   `SystemTime::duration_since` fail and crash the daemon; such readings are now
   clamped to `0` until the clock is corrected.
+- Several `svc_*` routine-service tests no longer overwrite the developer's real
+  user crontab. `svc_create`/`svc_update`/`svc_delete` sync the crontab, and four
+  tests exercised them without isolating the `crontab` binary, so running the
+  suite locally replaced the live routines block with a single test fixture line.
+  The tests now run under an empty `PATH` so the sync cannot spawn `crontab`
+  (#175).
 
 ## [0.11.2] - 2026-06-17
 

--- a/src/routines/service_tests.rs
+++ b/src/routines/service_tests.rs
@@ -76,38 +76,42 @@ fn svc_create_rejects_duplicate_slug() {
     // title slugifies to the same value forces a `Conflict`.
     let title = "Svc Create Dup ZZZ";
     let store = new_store();
-    let first = svc_create(
-        &store,
-        CreateRoutineRequest {
-            schedule: "@daily".into(),
-            title: title.into(),
-            agent: "claude".into(),
-            prompt: "p".into(),
-            repositories: vec![],
-            enabled: true,
-            ttl_secs: None,
-            max_runtime_secs: None,
-        },
-    )
-    .unwrap();
+    // `with_empty_path` so the post-create/delete crontab sync cannot spawn the
+    // real `crontab` binary and clobber the developer's live crontab (issue #175).
+    with_empty_path(|| {
+        let first = svc_create(
+            &store,
+            CreateRoutineRequest {
+                schedule: "@daily".into(),
+                title: title.into(),
+                agent: "claude".into(),
+                prompt: "p".into(),
+                repositories: vec![],
+                enabled: true,
+                ttl_secs: None,
+                max_runtime_secs: None,
+            },
+        )
+        .unwrap();
 
-    let conflict = svc_create(
-        &store,
-        CreateRoutineRequest {
-            schedule: "@daily".into(),
-            // Different casing/spacing, same slug.
-            title: "  svc create   DUP zzz ".into(),
-            agent: "claude".into(),
-            prompt: "p".into(),
-            repositories: vec![],
-            enabled: true,
-            ttl_secs: None,
-            max_runtime_secs: None,
-        },
-    );
-    assert!(matches!(conflict, Err(AppError::Conflict(_))));
+        let conflict = svc_create(
+            &store,
+            CreateRoutineRequest {
+                schedule: "@daily".into(),
+                // Different casing/spacing, same slug.
+                title: "  svc create   DUP zzz ".into(),
+                agent: "claude".into(),
+                prompt: "p".into(),
+                repositories: vec![],
+                enabled: true,
+                ttl_secs: None,
+                max_runtime_secs: None,
+            },
+        );
+        assert!(matches!(conflict, Err(AppError::Conflict(_))));
 
-    svc_delete(&store, &first.routine.id).unwrap();
+        svc_delete(&store, &first.routine.id).unwrap();
+    });
     let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
 }
 
@@ -129,22 +133,26 @@ fn svc_update_rejects_renaming_into_existing_slug() {
         .unwrap()
         .insert("other-id".into(), routine_other);
 
-    let conflict = svc_update(
-        &store,
-        "other-id",
-        UpdateRoutineRequest {
-            schedule: None,
-            // Rename "other" into the slug already owned by "keep".
-            title: Some(title_keep.into()),
-            agent: None,
-            prompt: None,
-            repositories: None,
-            enabled: None,
-            ttl_secs: None,
-            max_runtime_secs: None,
-        },
-    );
-    assert!(matches!(conflict, Err(AppError::Conflict(_))));
+    // Wrapped defensively: the rename short-circuits on `Conflict` before the
+    // sync, but `with_empty_path` guarantees no real crontab write either way (#175).
+    with_empty_path(|| {
+        let conflict = svc_update(
+            &store,
+            "other-id",
+            UpdateRoutineRequest {
+                schedule: None,
+                // Rename "other" into the slug already owned by "keep".
+                title: Some(title_keep.into()),
+                agent: None,
+                prompt: None,
+                repositories: None,
+                enabled: None,
+                ttl_secs: None,
+                max_runtime_secs: None,
+            },
+        );
+        assert!(matches!(conflict, Err(AppError::Conflict(_))));
+    });
 
     let _ = crate::routine_storage::remove_routine_dir(&slugify(title_keep));
     let _ = crate::routine_storage::remove_routine_dir(&slugify(title_other));
@@ -159,22 +167,26 @@ fn svc_update_sets_ttl_secs() {
     crate::routine_storage::write_routine(&routine).unwrap();
     store.lock().unwrap().insert("ttl-id".into(), routine);
 
-    let updated = svc_update(
-        &store,
-        "ttl-id",
-        UpdateRoutineRequest {
-            schedule: None,
-            title: None,
-            agent: None,
-            prompt: None,
-            repositories: None,
-            enabled: None,
-            ttl_secs: Some(4242),
-            max_runtime_secs: None,
-        },
-    )
-    .unwrap();
-    assert_eq!(updated.routine.ttl_secs, Some(4242));
+    // `with_empty_path` keeps the post-update crontab sync from touching the real
+    // crontab (issue #175): the update succeeds, the sync just warns.
+    with_empty_path(|| {
+        let updated = svc_update(
+            &store,
+            "ttl-id",
+            UpdateRoutineRequest {
+                schedule: None,
+                title: None,
+                agent: None,
+                prompt: None,
+                repositories: None,
+                enabled: None,
+                ttl_secs: Some(4242),
+                max_runtime_secs: None,
+            },
+        )
+        .unwrap();
+        assert_eq!(updated.routine.ttl_secs, Some(4242));
+    });
 
     let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
 }
@@ -191,22 +203,26 @@ fn svc_update_sets_max_runtime_secs() {
         .unwrap()
         .insert("max-runtime-id".into(), routine);
 
-    let updated = svc_update(
-        &store,
-        "max-runtime-id",
-        UpdateRoutineRequest {
-            schedule: None,
-            title: None,
-            agent: None,
-            prompt: None,
-            repositories: None,
-            enabled: None,
-            ttl_secs: None,
-            max_runtime_secs: Some(1234),
-        },
-    )
-    .unwrap();
-    assert_eq!(updated.routine.max_runtime_secs, Some(1234));
+    // `with_empty_path` keeps the post-update crontab sync from touching the real
+    // crontab (issue #175): the update succeeds, the sync just warns.
+    with_empty_path(|| {
+        let updated = svc_update(
+            &store,
+            "max-runtime-id",
+            UpdateRoutineRequest {
+                schedule: None,
+                title: None,
+                agent: None,
+                prompt: None,
+                repositories: None,
+                enabled: None,
+                ttl_secs: None,
+                max_runtime_secs: Some(1234),
+            },
+        )
+        .unwrap();
+        assert_eq!(updated.routine.max_runtime_secs, Some(1234));
+    });
 
     let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
 }


### PR DESCRIPTION
## Problem

Closes #175.

`svc_create` / `svc_update` / `svc_delete` call `sync_routines_to_crontab` → `write_crontab` → `crontab -`. The binary is resolved via `crontab_bin()` (`src/sync/mod.rs`), falling back to the real `crontab` when `MOADIM_CRONTAB_BIN` is unset.

Four tests in `src/routines/service_tests.rs` exercised those `svc_*` calls without isolating the crontab — they set neither the `MOADIM_CRONTAB_BIN` shim nor an empty `PATH`:

- `svc_create_rejects_duplicate_slug`
- `svc_update_rejects_renaming_into_existing_slug`
- `svc_update_sets_ttl_secs`
- `svc_update_sets_max_runtime_secs`

So running the suite locally hit `/usr/bin/crontab` and **overwrote the developer's real user crontab** — the whole routines block was replaced with a single fixture line (`svc-update-ttl-zzz` / `moadim-routine:ttl-id`, straight from `make_routine("ttl-id", "Svc Update Ttl ZZZ", …)`), dropping every real routine until the daemon next re-synced.

## Fix

Wrap the offending `svc_*` calls in `with_empty_path(...)`, matching the sibling `*_warns_when_crontab_sync_fails` tests already in the file. With `PATH` cleared the `crontab` binary can't be spawned, the post-mutation sync fails harmlessly (logs a warning), and the real crontab is never touched. The conflict-path tests are wrapped defensively too.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets` — clean
- `RUST_TEST_THREADS=1 cargo test` — 434 passed
- Coverage: this change is coverage-neutral — `cargo llvm-cov --fail-under-lines 100` reports an identical summary on this branch and on pristine `origin/main` (both 98.26% on this machine, same files), so no lines are gained or lost by the edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)