### PR TITLE
chore: release v0.12.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: GitHub Release
+
+# Cut a GitHub Release whenever a `v*` tag is pushed (same trigger that drives
+# the crates.io publish in publish.yml). Release notes are extracted from the
+# matching version section in CHANGELOG.md so the published notes stay in sync
+# with the changelog. Runs independently of publish.yml — neither blocks the
+# other.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Extract changelog section for this tag
+        id: notes
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          # Pull lines between '## [VERSION]' and the next '## [' heading.
+          awk -v ver="$VERSION" '
+            $0 ~ "^## \\[" ver "\\]" { capture=1; next }
+            capture && /^## \[/ { exit }
+            capture { print }
+          ' CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "No changelog section found for [$VERSION]" >&2
+            exit 1
+          fi
+          echo "Release notes for $VERSION:"
+          cat release-notes.md
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          body_path: release-notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-06-18
+
 ### Added
 
 - Per-routine **max-runtime watchdog** bounds hung agent runs. Routines carry an
@@ -25,6 +27,18 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   Previously a hung run (waiting on stdin, looping, blocked on a stuck
   network/git op) lived forever and stacked one zombie session + workbench per
   cron tick, since the TTL reaper only governs *finished* runs.
+- `moadim install` / `moadim uninstall` register the daemon as an OS service so
+  it starts at login and is restarted on crash, keeping scheduled routines firing
+  across reboots. macOS writes a per-user launchd LaunchAgent
+  (`~/Library/LaunchAgents/io.moadim.daemon.plist`, loaded with `launchctl`);
+  Linux writes a systemd **user** service (`~/.config/systemd/user/moadim.service`,
+  enabled with `systemctl --user enable --now`). Both run the daemon in the
+  foreground (`moadim --interactive`) so the service manager supervises it; other
+  platforms report that the command is not yet supported.
+- **Hermes** is now a built-in agent alongside `claude` and `codex`. A default
+  `hermes.toml` (`hermes exec {prompt_file}`, mirroring Codex) is seeded into
+  `~/.config/moadim/agents/` on startup, and `hermes` appears in
+  `available_agents()` / `GET /agents`, so routines can launch Hermes.
 
 ### Changed
 
@@ -84,14 +98,6 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Added
 
-- `moadim install` / `moadim uninstall` register the daemon as an OS service so
-  it starts at login and is restarted on crash, keeping scheduled routines firing
-  across reboots. macOS writes a per-user launchd LaunchAgent
-  (`~/Library/LaunchAgents/io.moadim.daemon.plist`, loaded with `launchctl`);
-  Linux writes a systemd **user** service (`~/.config/systemd/user/moadim.service`,
-  enabled with `systemctl --user enable --now`). Both run the daemon in the
-  foreground (`moadim --interactive`) so the service manager supervises it; other
-  platforms report that the command is not yet supported.
 - The moadim-managed system prompt (`CLAUDE.md`) now carries a **routine-origin
   disclosure** section that instructs the agent to reveal, in every
   outward-facing communication (GitHub issues/PRs/comments, Slack, email, etc.),
@@ -109,10 +115,6 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   `{"running":false}` when none was reachable), completing the `--json`
   contract alongside `status` and `cleanup`. The exit code is unchanged
   (`0` running, `3` not).
-- **Hermes** is now a built-in agent alongside `claude` and `codex`. A default
-  `hermes.toml` (`hermes exec {prompt_file}`, mirroring Codex) is seeded into
-  `~/.config/moadim/agents/` on startup, and `hermes` appears in
-  `available_agents()` / `GET /agents`, so routines can launch Hermes.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ opt-level = "z"
 
 [package]
 name = "moadim"
-version = "0.11.2"
+version = "0.12.0"
 edition = "2021"
 description = "Moadim.io MCP/REST server for managing cron jobs"
 license = "MIT"


### PR DESCRIPTION
## Release v0.12.0

Minor bump `0.11.2` → `0.12.0`. Promotes CHANGELOG to `[0.12.0]` (2026-06-18).

### Shipping in this release (everything since v0.11.2)
- **Added:** per-routine **max-runtime watchdog** (`max_runtime_secs`) force-kills hung agent sessions; `moadim install`/`uninstall` register the daemon as an **OS service** (launchd / systemd user service); **Hermes** built-in agent.
- **Changed:** routine runtime state moved to a git-ignored sidecar file (#127).
- **Fixed:** iCal content-line folding per RFC 5545 §3.1; `now_secs()` clamps pre-1970 clocks instead of panicking; `svc_*` tests no longer clobber the real user crontab (#175).

> **Changelog correction:** the OS-service and Hermes entries had been misfiled under the already-released `[0.11.0]` heading, but that tag (and its code) predates them — they ship for the first time in 0.12.0. Moved to `[0.12.0]`.

### New: GitHub Release automation
Adds `.github/workflows/release.yml` — on a `v*` tag push, creates a GitHub Release with notes extracted from the matching `CHANGELOG.md` section. Runs alongside the existing crates.io publish workflow (`publish.yml`).

### Release flow
1. Merge this PR.
2. Tag `v0.12.0` on `main` → triggers crates.io publish **and** the new GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)