### PR TITLE
fix: structural spawn seams for routine (sh) and cron handler triggers (#217)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,14 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   returning a non-existent path so the spawn fails harmlessly. This is a
   structural safety net: no test — current or future — can clobber the
   developer's live crontab even if it forgets to isolate the binary (#175).
+- Routine triggers and cron-job triggers now resolve their spawn target through a
+  structural seam instead of hard-coding it. The routine trigger reads `sh` via a
+  `MOADIM_SH_BIN` resolver that, mirroring `crontab_bin()`, refuses to fall back to
+  the real `sh` in test builds (returning a non-existent path) so a trigger test
+  can never accidentally launch a live shell or agent. The cron handler spawn
+  honours an opt-in `MOADIM_HANDLER_SPAWN` override so a test can redirect a
+  handler spawn to a shim even when a real executable handler exists on disk
+  (#217).
 
 ## [0.11.2] - 2026-06-17
 

--- a/src/cron_jobs.rs
+++ b/src/cron_jobs.rs
@@ -331,13 +331,32 @@ pub fn svc_trigger(store: &CronStore, id: &str) -> Result<CronJob, AppError> {
     write_job(&job).map_err(|_| AppError::Internal)?;
     let handler_path = crate::paths::handlers_dir().join(&job.handler);
     if handler_path.exists() {
-        if let Err(err) = std::process::Command::new(&handler_path).spawn() {
+        if let Err(err) = std::process::Command::new(handler_spawn_target(&handler_path)).spawn() {
             log::warn!("trigger: failed to spawn handler {:?}: {err}", handler_path);
         }
     } else {
         log::warn!("trigger: handler script not found at {:?}", handler_path);
     }
     Ok(job)
+}
+
+/// Resolve the program to spawn for a triggered cron handler.
+///
+/// Returns `handler_path` (the resolved handler script) unchanged in normal
+/// operation. The `MOADIM_HANDLER_SPAWN` environment variable, when set, overrides
+/// the spawn target with a shim instead — a structural seam (issue #217) that lets
+/// a test redirect a handler spawn to a harmless shim even when a real, executable
+/// handler file exists on disk. Unlike the `sh`/`crontab` seams this does *not*
+/// default-deny under `cfg(test)`: the handler is a user-controlled path (not a
+/// looked-up binary), and an existing test deliberately spawns a real executable
+/// handler script, so a blanket cfg(test) guard would break it. The opt-in
+/// override is the minimal robust improvement that adds the safety seam without
+/// regressing existing tests.
+fn handler_spawn_target(handler_path: &std::path::Path) -> std::path::PathBuf {
+    if let Ok(shim) = std::env::var("MOADIM_HANDLER_SPAWN") {
+        return std::path::PathBuf::from(shim);
+    }
+    handler_path.to_path_buf()
 }
 
 // --- Axum HTTP handlers ---

--- a/src/cron_jobs_tests.rs
+++ b/src/cron_jobs_tests.rs
@@ -579,6 +579,35 @@ fn svc_trigger_spawns_existing_handler_script() {
     let _ = std::fs::remove_file(&handler_path);
 }
 
+#[test]
+fn handler_spawn_target_honours_override() {
+    // Regression guard for issue #217: by default the spawn target is the resolved
+    // handler path, but `MOADIM_HANDLER_SPAWN` redirects the spawn to a shim so a
+    // test can avoid executing a real handler.
+    let handler = std::path::Path::new("/tmp/moadim-real-handler");
+
+    let saved = std::env::var_os("MOADIM_HANDLER_SPAWN");
+    unsafe {
+        std::env::remove_var("MOADIM_HANDLER_SPAWN");
+    }
+    assert_eq!(handler_spawn_target(handler), handler.to_path_buf());
+
+    unsafe {
+        std::env::set_var("MOADIM_HANDLER_SPAWN", "/tmp/moadim-handler-shim");
+    }
+    assert_eq!(
+        handler_spawn_target(handler),
+        std::path::PathBuf::from("/tmp/moadim-handler-shim")
+    );
+
+    unsafe {
+        match saved {
+            Some(value) => std::env::set_var("MOADIM_HANDLER_SPAWN", value),
+            None => std::env::remove_var("MOADIM_HANDLER_SPAWN"),
+        }
+    }
+}
+
 #[tokio::test]
 async fn replace_handler_updates_job() {
     use axum::extract::{Path, State};

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -194,6 +194,32 @@ pub fn svc_delete(store: &RoutineStore, id: &str) -> Result<RoutineResponse, App
     Ok(RoutineResponse::from_routine(routine))
 }
 
+/// Resolve the shell binary used to spawn a manual trigger.
+///
+/// Honours the `MOADIM_SH_BIN` environment variable when set, falling back to the
+/// system `sh` otherwise. The override exists so tests can point the trigger spawn
+/// at a shim instead of launching a real shell (and, transitively, a real agent).
+///
+/// In **test builds**, when no `MOADIM_SH_BIN` shim is configured this never falls
+/// back to the real system `sh`: it returns a path that cannot exist, so the spawn
+/// fails harmlessly and the trigger logs a warning instead of actually running an
+/// agent. This is a structural safety net (issue #217) mirroring [`crontab_bin`]
+/// (`crate::sync`): a trigger test that forgets to clear `PATH` or install a shim
+/// still cannot launch a live agent process. Tests that need a working spawn set
+/// `MOADIM_SH_BIN` to a shim, which is honoured first.
+///
+/// [`crontab_bin`]: crate::sync
+fn sh_bin() -> String {
+    if let Ok(bin) = std::env::var("MOADIM_SH_BIN") {
+        return bin;
+    }
+    #[cfg(test)]
+    let fallback = "/nonexistent/moadim-test-sh-guard".to_string();
+    #[cfg(not(test))]
+    let fallback = "sh".to_string();
+    fallback
+}
+
 /// Record a manual trigger for `id` and spawn the same command the crontab would run.
 pub fn svc_trigger(store: &RoutineStore, id: &str) -> Result<Routine, AppError> {
     let mut lock = store.lock().unwrap();
@@ -208,7 +234,7 @@ pub fn svc_trigger(store: &RoutineStore, id: &str) -> Result<Routine, AppError> 
             // `-lc` (login shell) mirrors the crontab invocation (`/bin/sh -l <run.sh>`), so a
             // manual trigger sources the user's `~/.profile` and the agent gets the same
             // environment whether fired by cron or on demand.
-            if let Err(err) = std::process::Command::new("sh")
+            if let Err(err) = std::process::Command::new(sh_bin())
                 .arg("-lc")
                 .arg(&cmd)
                 .spawn()

--- a/src/routines/service_tests.rs
+++ b/src/routines/service_tests.rs
@@ -463,3 +463,35 @@ fn svc_trigger_warns_when_spawn_fails() {
     let _ = std::fs::remove_file(&cfg);
     let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
 }
+
+#[test]
+fn sh_bin_default_denies_in_test_builds() {
+    // Regression guard for issue #217: with no `MOADIM_SH_BIN` shim configured, the
+    // resolver must NOT return the real `sh` under `cfg(test)`. Otherwise a trigger
+    // test could accidentally launch a live shell (and agent). It returns a path
+    // that cannot exist, so the spawn fails harmlessly.
+    let guard = PATH_GUARD
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    let saved = std::env::var_os("MOADIM_SH_BIN");
+    unsafe {
+        std::env::remove_var("MOADIM_SH_BIN");
+    }
+    let resolved = sh_bin();
+    assert_ne!(resolved, "sh");
+    assert!(!std::path::Path::new(&resolved).exists());
+
+    // The override is honoured when set.
+    unsafe {
+        std::env::set_var("MOADIM_SH_BIN", "/tmp/moadim-sh-shim");
+    }
+    assert_eq!(sh_bin(), "/tmp/moadim-sh-shim");
+
+    unsafe {
+        match saved {
+            Some(value) => std::env::set_var("MOADIM_SH_BIN", value),
+            None => std::env::remove_var("MOADIM_SH_BIN"),
+        }
+    }
+    drop(guard);
+}


### PR DESCRIPTION
## Problem (issue #217, LOW)

Two trigger spawn sites were isolated in tests only by convention:

- `src/routines/service.rs` — `svc_trigger` ran the agent command via `Command::new("sh")`. The only test (`svc_trigger_warns_when_spawn_fails`) forced a spawn failure by clearing `PATH`. There was no structural guarantee a future test couldn't launch a live shell/agent.
- `src/cron_jobs.rs` — `svc_trigger` spawned the resolved `handler_path` directly. Existing tests passed non-existent paths (fail-safe) or, in one case, a **real executable** handler script.

## Investigation

- **No** routine-trigger test needs `sh` to actually run — the sole test forces failure via empty `PATH`.
- The cron test `svc_trigger_spawns_existing_handler_script` **does** create a real executable handler and relies on `.exists()` + a successful spawn. A blanket `cfg(test)` default-deny would break it.

## Fix — choice per site

- **`sh` spawn:** added a `MOADIM_SH_BIN` resolver mirroring `crontab_bin()` (`src/sync/mod.rs`). Since no test needs real `sh`, it **default-denies under `cfg(test)`** to a non-existent path (`/nonexistent/moadim-test-sh-guard`), so trigger spawns are harmless no-ops in tests; the env override is honoured first for shims. In non-test builds it falls back to `"sh"`.
- **Cron handler:** added an **opt-in `MOADIM_HANDLER_SPAWN` override** (defaults to the resolved handler path). The handler is a user-controlled path (not a looked-up binary) and an existing test deliberately spawns a real executable handler, so a `cfg(test)` default-deny was not viable. The opt-in override is the minimal robust seam that lets a future test redirect a spawn to a shim without regressing existing behaviour.

## Tests

- `sh_bin_default_denies_in_test_builds` — resolver never returns `"sh"` / a real path under `cfg(test)`, and honours `MOADIM_SH_BIN`.
- `handler_spawn_target_honours_override` — defaults to the handler path, honours `MOADIM_HANDLER_SPAWN`.

Full suite (437 tests) passes single-threaded; clippy `--all-targets` clean. Did not touch crontab/launchctl/tmux/kill code.

Fixes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)