### PR TITLE
fix(triggers): reap manual trigger children to avoid zombie processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+### Fixed
+
+- Manually triggering a routine or cron job no longer leaks a `<defunct>`
+  (zombie) child process. Both trigger paths spawned a child and dropped the
+  `Child` without `wait()`, so the kernel kept a zombie for the daemon's
+  lifetime (Rust's stdlib does not reap on `Child` drop). A new
+  `utils::process::spawn_reaped` helper spawns the child and reaps it on a
+  detached thread, keeping the trigger fire-and-forget. ([#212])
+
+[#212]: https://github.com/moadim-io/daemon/issues/212
+
 ## [0.12.0] - 2026-06-18
 
 ### Added

--- a/src/cron_jobs.rs
+++ b/src/cron_jobs.rs
@@ -331,7 +331,9 @@ pub fn svc_trigger(store: &CronStore, id: &str) -> Result<CronJob, AppError> {
     write_job(&job).map_err(|_| AppError::Internal)?;
     let handler_path = crate::paths::handlers_dir().join(&job.handler);
     if handler_path.exists() {
-        if let Err(err) = std::process::Command::new(&handler_path).spawn() {
+        if let Err(err) =
+            crate::utils::process::spawn_reaped(&mut std::process::Command::new(&handler_path))
+        {
             log::warn!("trigger: failed to spawn handler {:?}: {err}", handler_path);
         }
     } else {

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -208,11 +208,9 @@ pub fn svc_trigger(store: &RoutineStore, id: &str) -> Result<Routine, AppError> 
             // `-lc` (login shell) mirrors the crontab invocation (`/bin/sh -l <run.sh>`), so a
             // manual trigger sources the user's `~/.profile` and the agent gets the same
             // environment whether fired by cron or on demand.
-            if let Err(err) = std::process::Command::new("sh")
-                .arg("-lc")
-                .arg(&cmd)
-                .spawn()
-            {
+            if let Err(err) = crate::utils::process::spawn_reaped(
+                std::process::Command::new("sh").arg("-lc").arg(&cmd),
+            ) {
                 log::warn!("trigger: failed to spawn routine command: {err}");
             }
         }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,7 @@
 /// Atomic file writes (write temp + rename) so readers never observe a torn file.
 pub mod atomic;
+/// Spawn child processes fire-and-forget while reaping them to avoid zombies.
+pub mod process;
 /// JSON Schema helpers for schemars.
 pub mod schema;
 /// Startup print printed to stdout when the server begins listening.

--- a/src/utils/process.rs
+++ b/src/utils/process.rs
@@ -1,0 +1,23 @@
+use std::process::Command;
+use std::thread::JoinHandle;
+
+/// Spawn `cmd` fire-and-forget, reaping the child on a detached thread.
+///
+/// Rust's stdlib does not `wait()` on a [`std::process::Child`] when it is dropped, so a child
+/// spawned and immediately discarded becomes a `<defunct>` zombie that the kernel keeps around for
+/// the daemon's entire lifetime. To avoid leaking zombies we hand the child to a detached thread
+/// that blocks on [`std::process::Child::wait`], reaping it once it exits without holding up the
+/// caller (the spawned tmux session / handler keeps running in the background).
+///
+/// Returns the reaper thread's [`JoinHandle`] on success so tests can join it and assert the child
+/// was reaped; production callers simply ignore it.
+pub fn spawn_reaped(cmd: &mut Command) -> std::io::Result<JoinHandle<()>> {
+    let mut child = cmd.spawn()?;
+    Ok(std::thread::spawn(move || {
+        let _ = child.wait();
+    }))
+}
+
+#[cfg(test)]
+#[path = "process_tests.rs"]
+mod process_tests;

--- a/src/utils/process_tests.rs
+++ b/src/utils/process_tests.rs
@@ -1,0 +1,19 @@
+#![allow(clippy::missing_docs_in_private_items)]
+
+use super::*;
+
+#[test]
+fn spawn_reaped_reaps_a_fast_exiting_child() {
+    // A child spawned and dropped without wait() would linger as a <defunct> zombie. The reaper
+    // thread must wait() on it; joining the handle here proves the wait() ran to completion.
+    let handle = spawn_reaped(&mut Command::new("true")).expect("spawn should succeed");
+    handle.join().expect("reaper thread should not panic");
+}
+
+#[test]
+fn spawn_reaped_returns_err_for_missing_binary() {
+    // A non-existent program must surface the spawn error to the caller (which logs it) rather
+    // than panicking or silently succeeding.
+    let result = spawn_reaped(&mut Command::new("definitely-not-a-real-binary-zxcv-212"));
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## What

Manual routine and cron-job triggers spawned a child process and immediately dropped the `Child` without `wait()`. Rust's stdlib does **not** reap a process on `Child` drop, so the kernel kept a `<defunct>` zombie around for the daemon's entire lifetime — one leaked per manual trigger.

Affected spawn sites (both functions named `svc_trigger`):
- `src/routines/service.rs` — `sh -lc <cmd>`
- `src/cron_jobs.rs` — the cron handler script

## Change

Add a small shared helper `utils::process::spawn_reaped(cmd: &mut Command) -> io::Result<JoinHandle<()>>` that:

- spawns the child, then
- hands it to a **detached thread** that blocks on `child.wait()`, reaping it once it exits.

This stays **fire-and-forget**: the request thread never blocks on the child's lifetime (the tmux session / handler keeps running in the background), but the OS no longer accumulates zombies. The helper returns the reaper `JoinHandle` so a test can join it and confirm the child was reaped.

Both spawn sites now call the helper, keeping the existing `log::warn!` spawn-failure messages and semantics intact.

## Tests

- `spawn_reaped_reaps_a_fast_exiting_child` — spawns a fast-exiting command and joins the reaper handle, proving `wait()` ran to completion (no lingering zombie).
- `spawn_reaped_returns_err_for_missing_binary` — a non-existent binary surfaces the spawn error to the caller (which logs it).

Verification gates all pass: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (437 passed). The new `src/utils/process.rs` reports 100% line coverage.

Closes #212

This pull request was opened by the 'Implement my assigned issues without a PR (daemon + landing)' routine of moadim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)