### PR TITLE
fix: extract command before block-no-verify in PreToolUse hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pnpm exec block-no-verify"
+            "command": "jq -r '.tool_input.command' | pnpm exec block-no-verify"
           }
         ]
       },
@@ -25,7 +25,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pnpm exec block-no-verify"
+            "command": "jq -r '.tool_input.command' | pnpm exec block-no-verify"
           }
         ]
       }


### PR DESCRIPTION
Closes #236.

## Problem

`.claude/settings.json` wires `block-no-verify` as a `PreToolUse` hook to stop `git ... --no-verify` from bypassing git hooks. It never fires.

### Root cause

Claude Code pipes the **full JSON event** to a hook's stdin:

```json
{"tool_name":"Bash","tool_input":{"command":"git push --no-verify"}}
```

But `block-no-verify` expects the **raw command string**. Its `detectGitCommand` requires the char before `git` to be whitespace / `;` / `&`; in the JSON `git` is preceded by a double-quote (`:"git push`), so the word-boundary guard skips it, no git command is detected, and it exits 0 (allow).

### Repro

```sh
# broken (current wiring): exit 0
echo '{"tool_input":{"command":"git push --no-verify"}}' | pnpm exec block-no-verify; echo $?
# correct: exit 2 (BLOCKED)
echo '{"tool_input":{"command":"git push --no-verify"}}' | jq -r '.tool_input.command' | pnpm exec block-no-verify; echo $?
```

## Fix

Extract `.tool_input.command` with `jq` before piping, for both the `Bash` and `mcp__github__.*` hook entries. Verified: the hook now exits 2 (BLOCKED) on `git push --no-verify`; before it exited 0.

Config-only change (`.claude/settings.json`) — no `src/`/`ui/` touched, so no changelog entry required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)