### PR TITLE
docs: PUT /routines & /cron-jobs are PATCH aliases, not full replace

### DIFF
--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -134,7 +134,7 @@
         "tags": [
           "crate::cron_jobs"
         ],
-        "summary": "`PUT /cron-jobs/{id}` — fully replace a cron job (behaves identically to PATCH).",
+        "summary": "`PUT /cron-jobs/{id}` — alias for PATCH: a partial merge, **not** a full replacement. Fields\nomitted from the body are retained from the existing cron job (they are not reset to defaults),\nbecause `UpdateRequest` uses all-`Option` fields. Delegates to [`update`].",
         "operationId": "replace",
         "parameters": [
           {
@@ -533,7 +533,7 @@
         "tags": [
           "crate::routines"
         ],
-        "summary": "`PUT /routines/{id}` — fully replace a routine (behaves identically to PATCH).",
+        "summary": "`PUT /routines/{id}` — alias for PATCH: a partial merge, **not** a full replacement. Fields\nomitted from the body are retained from the existing routine (they are not reset to defaults),\nbecause `UpdateRoutineRequest` uses all-`Option` fields. Delegates to [`update`].",
         "operationId": "replace",
         "parameters": [
           {

--- a/src/cron_jobs.rs
+++ b/src/cron_jobs.rs
@@ -391,7 +391,9 @@ pub async fn update(
     Ok(Json(svc_update(&state.store, &state.handlers, &id, body)?))
 }
 
-/// `PUT /cron-jobs/{id}` — fully replace a cron job (behaves identically to PATCH).
+/// `PUT /cron-jobs/{id}` — alias for PATCH: a partial merge, **not** a full replacement. Fields
+/// omitted from the body are retained from the existing cron job (they are not reset to defaults),
+/// because `UpdateRequest` uses all-`Option` fields. Delegates to [`update`].
 #[utoipa::path(put, path = "/cron-jobs/{id}",
     params(("id" = String, Path, description = "Cron job UUID")),
     request_body = UpdateRequest,

--- a/src/routines/handlers.rs
+++ b/src/routines/handlers.rs
@@ -71,7 +71,9 @@ pub async fn update(
     Ok(Json(svc_update(&store, &id, body)?))
 }
 
-/// `PUT /routines/{id}` — fully replace a routine (behaves identically to PATCH).
+/// `PUT /routines/{id}` — alias for PATCH: a partial merge, **not** a full replacement. Fields
+/// omitted from the body are retained from the existing routine (they are not reset to defaults),
+/// because `UpdateRoutineRequest` uses all-`Option` fields. Delegates to [`update`].
 #[utoipa::path(put, path = "/routines/{id}",
     params(("id" = String, Path, description = "Routine UUID")),
     request_body = UpdateRoutineRequest,


### PR DESCRIPTION
## Problem

`PUT /routines/{id}` and `PUT /cron-jobs/{id}` are documented as "fully replace ... behaves identically to PATCH" — self-contradictory wording. Both `replace` handlers simply delegate to the PATCH `update` handler, so they apply **partial-merge** semantics: because `UpdateRoutineRequest` / `UpdateRequest` use all-`Option` fields, any omitted field is silently retained from the existing record, never reset. A client doing a `PUT` with a complete desired-state body (expecting omitted optionals to clear) gets stale values merged in.

## Decision

Take the **documented-alias** resolution (option 2 in the issue) — no behavior change, just make the contract honest:

- Rewrote both handler doc comments to state PUT is an alias for PATCH (partial merge), spelling out that omitted fields are retained because the request types use all-`Option` fields, and removed the "fully replace ... behaves identically to PATCH" wording.
- Regenerated `apis/openapi.json` (via the `committed_spec_is_current` sync test) so the OpenAPI summaries match the corrected doc comments.

The true-replace alternative was not chosen: it would require new non-`Option` request types and explicit null handling, a larger behavior-changing surface that is out of scope for a focused docs-correctness fix.

Closes #242

---
*This pull request was opened by the "Implement my assigned issues without a PR (daemon + landing)" routine of moadim.*