### PR TITLE
fix(cron-jobs): validate handler on create/update (#252)

### DIFF
--- a/src/cron_jobs.rs
+++ b/src/cron_jobs.rs
@@ -184,6 +184,25 @@ pub(crate) fn validate_cron(expr: &str) -> Result<(), AppError> {
     Ok(())
 }
 
+/// Validate a handler identifier, returning `BadRequest` if it is unusable.
+///
+/// The handler name is interpolated verbatim into a crontab line by the sync layer, so an
+/// empty or whitespace-only value writes a broken entry and an embedded newline would inject
+/// additional, attacker-controlled crontab lines. Reject both.
+pub(crate) fn validate_handler(handler: &str) -> Result<(), AppError> {
+    if handler.trim().is_empty() {
+        return Err(AppError::BadRequest(
+            "handler must not be empty or whitespace-only".to_string(),
+        ));
+    }
+    if handler.chars().any(char::is_control) {
+        return Err(AppError::BadRequest(
+            "handler must not contain control characters".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 /// Request body for creating a new cron job.
 #[derive(Deserialize, JsonSchema, utoipa::ToSchema)]
 pub struct CreateRequest {
@@ -256,6 +275,7 @@ pub fn svc_create(
     req: CreateRequest,
 ) -> Result<CronJobResponse, AppError> {
     validate_cron(&req.schedule)?;
+    validate_handler(&req.handler)?;
     let now = now_secs();
     let job = CronJob {
         id: Uuid::new_v4().to_string(),
@@ -285,6 +305,9 @@ pub fn svc_update(
 ) -> Result<CronJobResponse, AppError> {
     if let Some(ref sched) = req.schedule {
         validate_cron(sched)?;
+    }
+    if let Some(ref handler) = req.handler {
+        validate_handler(handler)?;
     }
     let mut lock = store.lock().unwrap();
     let job = lock.get_mut(id).ok_or(AppError::NotFound)?;

--- a/src/cron_jobs_tests.rs
+++ b/src/cron_jobs_tests.rs
@@ -190,6 +190,59 @@ fn svc_trigger_not_found() {
 }
 
 #[test]
+fn validate_handler_accepts_normal_identifier() {
+    assert!(validate_handler("send-report").is_ok());
+    assert!(validate_handler("send-report.sh").is_ok());
+}
+
+#[test]
+fn validate_handler_rejects_empty_and_whitespace() {
+    for bad in ["", "   ", "\t"] {
+        let err = validate_handler(bad);
+        assert!(
+            matches!(err, Err(AppError::BadRequest(_))),
+            "{bad:?} should be rejected with BadRequest"
+        );
+    }
+}
+
+#[test]
+fn validate_handler_rejects_control_characters() {
+    // A newline would inject extra crontab lines when the handler is written out.
+    for bad in ["a\nb", "a\rb", "evil # moadim:x\n* * * * * /bin/sh"] {
+        let err = validate_handler(bad);
+        assert!(
+            matches!(err, Err(AppError::BadRequest(_))),
+            "{bad:?} should be rejected with BadRequest"
+        );
+    }
+}
+
+#[test]
+fn svc_create_invalid_handler_returns_err() {
+    let store = new_store();
+    let req = CreateRequest {
+        schedule: "@daily".into(),
+        handler: "bad\nhandler".into(),
+        metadata: serde_json::Value::Null,
+        enabled: true,
+    };
+    assert!(svc_create(&store, &new_registry(), req).is_err());
+}
+
+#[test]
+fn svc_update_invalid_handler_rejected() {
+    let store = make_store_with("id");
+    let req = UpdateRequest {
+        schedule: None,
+        handler: Some("  ".into()),
+        metadata: None,
+        enabled: None,
+    };
+    assert!(svc_update(&store, &new_registry(), "id", req).is_err());
+}
+
+#[test]
 fn svc_trigger_sets_last_manual_trigger_at() {
     let store = make_store_with("id");
     assert!(store


### PR DESCRIPTION
## Why

The cron-job `handler` field is never validated on create or update. It is later interpolated **verbatim** into a crontab line by the sync layer:

```
<schedule> <handlers_dir>/<handler> # moadim:<id>
```

(`src/sync/mod.rs::format_crontab_line`). Two concrete problems follow (issue #252):

- An **empty / whitespace-only** handler writes a broken, dangling crontab entry.
- A handler containing a **newline injects additional, attacker-controlled crontab lines** — a classic CRLF-style injection: `"evil # moadim:x\n* * * * * /bin/sh ..."` would smuggle a second schedule into the user's crontab.

`schedule` is already guarded by `validate_cron`; `handler` had no equivalent gate.

## What

- Add `validate_handler`, which rejects empty/whitespace-only values and any value containing control characters (covers `\n`, `\r`, `\t`).
- Call it from `svc_create` and `svc_update`, alongside the existing `validate_cron` check and before any store mutation.
- Add unit tests for `validate_handler` (accept + both reject paths) and service-layer tests that `svc_create` / `svc_update` return `BadRequest` for a bad handler.

Focused, test-only + a small validation helper — no behavior change for valid handlers.

## Verify

```
cargo fmt --check      # clean
cargo clippy --all-targets --all-features   # clean
cargo test cron_jobs   # 46 passed, incl. the new accept/reject tests
```

---
This pull request was opened by the "Daemon + Landing auto-improve PRs" routine of moadim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)