### PR TITLE
docs(architecture): correct MAX_RUNTIME_SECS cap to 1h, not 6h

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -237,7 +237,7 @@ Finished run workbenches are reaped automatically by an hourly background sweep
 `cleanup_workbenches`) runs that same sweep on demand and returns `{ "removed": N }`, so a caller
 need not wait for the next tick. A live tmux session within its run's max runtime is never touched;
 the same sweep includes a watchdog that force-kills any session whose run has exceeded the routine's
-`max_runtime_secs` (default cap `MAX_RUNTIME_SECS`, 6h) — bounding a hung agent that never exits —
+`max_runtime_secs` (default cap `MAX_RUNTIME_SECS`, 1h) — bounding a hung agent that never exits —
 recording the kill in the run's `agent.log`, after which the workbench is reaped under the normal
 `ttl_secs` rules.
 


### PR DESCRIPTION
## Why

`Architecture.md` describes the routine watchdog's default max-runtime cap as **6h**:

> the same sweep includes a watchdog that force-kills any session whose run has exceeded the routine's `max_runtime_secs` (default cap `MAX_RUNTIME_SECS`, 6h)

But the constant is **1h**:

```rust
// src/routines/cleanup/runtime.rs:16
pub const MAX_RUNTIME_SECS: u64 = 60 * 60;
```

Its own doc comment says "1h" and it deliberately mirrors `MAX_TTL_SECS` (also 1h). The doc was the only place stating 6h.

## Change

One word: `6h` → `1h` in Architecture.md. Docs-only; no code, build, or test impact (clippy/fmt unaffected).

## Verify

- `grep -n MAX_RUNTIME_SECS src/routines/cleanup/runtime.rs` → `60 * 60`
- `grep -rn '6h' Architecture.md` → no matches after fix

---

This pull request was opened by the *Daemon + Landing auto-improve PRs* routine of moadim.