### PR TITLE
docs(architecture): routine prompt file is prompt.md, not prompt.txt (#271)

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -208,14 +208,14 @@ and a `title`. Routines are a separate type with their own store (`RoutineStore`
 (`/routines`), MCP tools (`create_routine`, …), and crontab block — they do not share `CronJob`.
 
 When a routine fires there is **no moadim process in the loop and no clone step**. At create/update
-time moadim composes `prompt.txt` (a repositories-as-context preamble + the prompt) into
+time moadim composes `prompt.md` (a repositories-as-context preamble + the prompt) into
 `~/.config/moadim/routines/<id>/`, then writes a single self-contained shell command into a dedicated
 crontab block:
 
 ```
 # BEGIN MOADIM-ROUTINES
 # Managed by moadim — routines (agent tmux sessions)
-<sched> TS=$(date +\%s); WB=…/workbenches/<slug>-$TS; mkdir -p $WB; cp …/prompt.txt $WB/; \
+<sched> TS=$(date +\%s); WB=…/workbenches/<slug>-$TS; mkdir -p $WB; cp …/prompt.md $WB/; \
   tmux new-session -d -s moadim-<slug>-$TS -c $WB '<agent-cmd>'; \
   tmux pipe-pane -o -t … "cat >> $WB/agent.log"   # moadim-routine:<id>
 # END MOADIM-ROUTINES
@@ -224,7 +224,7 @@ crontab block:
 OS cron runs that line directly: it makes a fresh empty workbench under `~/.moadim/workbenches/`,
 launches the agent **interactively** (no `-p`) in a detached tmux session rooted there, and captures
 output via `pipe-pane`. The prompt reaches the agent as a process **argument** (the `{prompt}`
-placeholder expands to `"$(cat prompt.txt)"`), so there is no keystroke-injection readiness race. The
+placeholder expands to `"$(cat prompt.md)"`), so there is no keystroke-injection readiness race. The
 agent decides whether to clone the listed repositories. `POST /routines/{id}/trigger` runs the
 identical command via `sh -c`.
 
@@ -242,13 +242,13 @@ recording the kill in the run's `agent.log`, after which the workbench is reaped
 `ttl_secs` rules.
 
 The agent command is resolved from a configurable registry at `~/.config/moadim/agents/<name>.toml`
-(`command`, `args`; placeholders `{prompt_file}` → `prompt.txt`, `{workbench}` → `.`,
-`{prompt}` → `"$(cat prompt.txt)"`).
+(`command`, `args`; placeholders `{prompt_file}` → `prompt.md`, `{workbench}` → `.`,
+`{prompt}` → `"$(cat prompt.md)"`).
 The resolved values are baked into the crontab line at sync time, so editing an agent config requires
 re-syncing routines that use it. Routines with no matching agent config are skipped (with a warning).
 
 Modules: `src/routines.rs` (model + service + command builder + handlers), `src/routine_storage.rs`
-(`routine.toml` + `prompt.txt` persistence), `src/sync/routines.rs` (the `MOADIM-ROUTINES` block).
+(`routine.toml` + `prompt.md` persistence), `src/sync/routines.rs` (the `MOADIM-ROUTINES` block).
 Reverse sync (crontab → store) is not implemented for routines.
 
 ## Error handling (`src/error.rs`)


### PR DESCRIPTION
Closes part of #271.

## What

`Architecture.md` referenced `prompt.txt` in six places, but the code writes and reads the routine prompt as **`prompt.md`** everywhere:

- `src/routines/command.rs` — `cp {src} "$WB/prompt.md"`, `{prompt}` → `"$(cat prompt.md)"`, `{prompt_file}` → `prompt.md`
- `src/routines/service.rs` — "persist (routine.toml + prompt.md)"
- `src/routines/defaults.rs` — default routine writes `prompt.md`

This PR replaces the six stale `prompt.txt` references with `prompt.md`, covering:
- the routine prompt-composition paragraph
- the `MOADIM-ROUTINES` crontab-block example (`cp …/prompt.md $WB/`)
- the `{prompt}` placeholder note (`"$(cat prompt.md)"`)
- the agent-registry placeholder notes (`{prompt_file}` → `prompt.md`, `{prompt}` → `"$(cat prompt.md)"`)
- the persistence module list (`routine.toml` + `prompt.md`)

## Why

The doc described a file that no longer exists, which is actively misleading to operators and to agents reading the architecture for context. This brings the doc back in sync with the implementation.

## Scope

Docs-only. No code paths touched, so build/lint/test/coverage are unaffected. The MAX_RUNTIME_SECS portion of #271 is already accurate in the current doc (it reads "1h", matching `MAX_RUNTIME_SECS = 60 * 60`), so this PR is scoped to the prompt-filename drift.

---
This pull request was opened by the **Daemon + Landing auto-improve PRs** routine of moadim.