### PR TITLE
feat(routines): add ignore_until to snooze scheduled runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Added
 
+- Routines gained an **`ignore_until`** field (Unix seconds) that snoozes
+  *scheduled* runs until a given time without touching the cron entry. The
+  routine's generated `run.sh` carries a guard
+  (`if [ "$(date +%s)" -lt <ignore_until> ]; then exit 0; fi`) that exits before
+  launching the agent for any firing before the timestamp; because the guard
+  reads the live clock it lifts on its own once the time passes — no re-sync
+  needed. Manual triggers (`trigger_routine` / `POST .../trigger`) bypass the
+  snooze and always run. Settable on create and update (REST, OpenAPI, MCP);
+  `update` also accepts `clear_ignore_until: true` to unset an existing snooze,
+  which takes precedence over a supplied `ignore_until`. Persisted to the tracked
+  `routine.toml`.
 - `moadim stop` accepts a `--quiet`/`-q` flag that suppresses the human-readable
   status line (`moadim is shutting down` / `moadim is not running`) while keeping
   the exit-code contract (`0` when a server was stopped, `3` when none was

--- a/README.md
+++ b/README.md
@@ -213,6 +213,12 @@ git-trackable just like jobs:
 | `repositories` | list   | no       | Git repos listed in the prompt as context. Moadim does **not** clone them — the agent does.   |
 | `enabled`      | bool   | no       | Defaults to `true`. Set `false` to pause without deleting.                                    |
 | `ttl_secs`     | int    | no       | How long a finished run's workbench is retained before auto-cleanup. Caps the cron-derived retention lower — it can only shorten, never extend it. `None` uses the cron-derived value. |
+| `ignore_until` | int    | no       | Unix timestamp (seconds) until which **scheduled** runs are skipped (a snooze). The cron entry is left untouched — the generated `run.sh` exits early until the time passes, then resumes on its own. Manual triggers bypass it. On update, send `clear_ignore_until: true` to unset it. |
+
+**Snoozing a routine:** set `ignore_until` to a future Unix timestamp to pause
+the *scheduled* firings without editing the schedule or disabling the routine —
+the cron line stays in place and the routine resumes automatically once the time
+passes. A manual `POST /routines/{id}/trigger` runs regardless of the snooze.
 
 **Workbenches and cleanup:** each run executes in a workbench under
 `~/.config/moadim/workbenches/`. Finished, expired workbenches are reaped on an

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -800,6 +800,15 @@
             "type": "boolean",
             "description": "Whether to create the routine enabled (defaults to `true`)."
           },
+          "ignore_until": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Unix timestamp (seconds) until which scheduled runs are skipped (a snooze). `None` (or a\npast value) means not snoozed. Manual triggers bypass it.",
+            "minimum": 0
+          },
           "max_runtime_secs": {
             "type": [
               "integer",
@@ -1061,6 +1070,15 @@
             "type": "string",
             "description": "Unique identifier (UUID v4)."
           },
+          "ignore_until": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Unix timestamp (seconds) until which **scheduled** runs are skipped (a snooze). The cron\nentry is left untouched; the routine's `run.sh` guard exits early while `now < ignore_until`,\nresuming on its own once the time passes. Manual triggers (`trigger_routine`) bypass it.\n`None` (or a past value) means not snoozed.",
+            "minimum": 0
+          },
           "last_manual_trigger_at": {
             "type": [
               "integer",
@@ -1231,12 +1249,28 @@
             ],
             "description": "New agent key, or `None` to keep the existing value."
           },
+          "clear_ignore_until": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Set to `true` to clear an existing `ignore_until` snooze. Takes precedence over\n`ignore_until`. `None`/`false` leaves the current value untouched."
+          },
           "enabled": {
             "type": [
               "boolean",
               "null"
             ],
             "description": "New enabled state, or `None` to keep the existing value."
+          },
+          "ignore_until": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "New snooze timestamp (Unix seconds) until which scheduled runs are skipped, or `None` to\nkeep the existing value. To unset an existing snooze, send `clear_ignore_until: true`.",
+            "minimum": 0
           },
           "max_runtime_secs": {
             "type": [

--- a/src/routes/http_tests.rs
+++ b/src/routes/http_tests.rs
@@ -877,6 +877,7 @@ async fn router_serves_routines_ical_feed() {
             last_manual_trigger_at: None,
             ttl_secs: None,
             max_runtime_secs: None,
+            ignore_until: None,
         },
     );
     let resp = build_app(new_store(), routines)

--- a/src/routes/mcp.rs
+++ b/src/routes/mcp.rs
@@ -79,6 +79,12 @@ struct UpdateRoutineInput {
     /// New max runtime (seconds) for a single run before the watchdog kills it, or `None` to keep
     /// the existing value.
     max_runtime_secs: Option<u64>,
+    /// New snooze timestamp (Unix seconds) until which scheduled runs are skipped, or `None` to
+    /// keep the existing value. To unset an existing snooze, send `clear_ignore_until: true`.
+    ignore_until: Option<u64>,
+    /// Set to `true` to clear an existing `ignore_until` snooze. Takes precedence over
+    /// `ignore_until`.
+    clear_ignore_until: Option<bool>,
 }
 
 /// Wrap a serializable value in a successful `CallToolResult`.
@@ -277,6 +283,8 @@ impl MoadimMcp {
             enabled: input.enabled,
             ttl_secs: input.ttl_secs,
             max_runtime_secs: input.max_runtime_secs,
+            ignore_until: input.ignore_until,
+            clear_ignore_until: input.clear_ignore_until,
         };
         Ok(match routines::svc_update(&self.routines, &input.id, req) {
             Ok(resp) => ok(resp),

--- a/src/routes/mcp_tests.rs
+++ b/src/routes/mcp_tests.rs
@@ -315,6 +315,7 @@ fn make_create_routine_req() -> crate::routines::CreateRoutineRequest {
         enabled: true,
         ttl_secs: None,
         max_runtime_secs: None,
+        ignore_until: None,
     }
 }
 
@@ -386,6 +387,8 @@ fn create_get_update_trigger_delete_routine_success() {
             enabled: Some(false),
             ttl_secs: None,
             max_runtime_secs: None,
+            ignore_until: None,
+            clear_ignore_until: None,
         }))
         .unwrap();
     assert!(!result.is_error.unwrap_or(false));
@@ -431,6 +434,8 @@ fn update_routine_tool_not_found_is_error() {
             enabled: None,
             ttl_secs: None,
             max_runtime_secs: None,
+            ignore_until: None,
+            clear_ignore_until: None,
         }))
         .unwrap();
     assert!(result.is_error.unwrap_or(false));

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -51,6 +51,10 @@ struct RoutineToml {
     /// the daemon default.
     #[serde(default)]
     max_runtime_secs: Option<u64>,
+    /// Unix timestamp (seconds) until which scheduled runs are skipped (a snooze); absent means not
+    /// snoozed.
+    #[serde(default)]
+    ignore_until: Option<u64>,
 }
 
 /// Daemon-written runtime state for a routine, persisted to the gitignored `state.local.toml`
@@ -103,6 +107,7 @@ fn load_routine_from_dir(dir_name: &str) -> Option<Routine> {
         last_manual_trigger_at,
         ttl_secs: toml.ttl_secs,
         max_runtime_secs: toml.max_runtime_secs,
+        ignore_until: toml.ignore_until,
     })
 }
 
@@ -138,6 +143,7 @@ pub fn write_routine(routine: &Routine) -> std::io::Result<()> {
         last_manual_trigger_at: None,
         ttl_secs: routine.ttl_secs,
         max_runtime_secs: routine.max_runtime_secs,
+        ignore_until: routine.ignore_until,
     };
     let text = toml::to_string_pretty(&toml_routine).map_err(std::io::Error::other)?;
     // Atomic write (temp + rename) so any concurrent reader never observes a torn routine.toml —

--- a/src/routine_storage_tests.rs
+++ b/src/routine_storage_tests.rs
@@ -21,6 +21,7 @@ fn make_routine(id: &str, title: &str) -> Routine {
         last_manual_trigger_at: None,
         ttl_secs: None,
         max_runtime_secs: None,
+        ignore_until: None,
     }
 }
 
@@ -66,6 +67,39 @@ fn write_then_load_round_trips() {
 
     remove_routine_dir(&slug).unwrap();
     assert!(!crate::paths::routine_dir(&slug).exists());
+}
+
+#[test]
+fn ignore_until_round_trips_through_toml() {
+    // The snooze timestamp is tracked config: it must persist into routine.toml and load back.
+    let id = "rs-ignore-until-id";
+    let title = "Rs Ignore Until Routine";
+    let slug = slugify(title);
+    let mut routine = make_routine(id, title);
+    routine.ignore_until = Some(4_102_444_800);
+    write_routine(&routine).unwrap();
+
+    let toml = std::fs::read_to_string(crate::paths::routine_toml_path(&slug)).unwrap();
+    assert!(
+        toml.contains("ignore_until = 4102444800"),
+        "ignore_until missing from routine.toml: {toml}"
+    );
+    let loaded = load_routine_from_dir(&slug).unwrap();
+    assert_eq!(loaded.ignore_until, Some(4_102_444_800));
+
+    remove_routine_dir(&slug).unwrap();
+}
+
+#[test]
+fn ignore_until_absent_loads_as_none() {
+    // A routine.toml without an ignore_until key loads with the field defaulted to None.
+    let id = "rs-ignore-until-absent-id";
+    let title = "Rs Ignore Until Absent Routine";
+    let slug = slugify(title);
+    write_routine(&make_routine(id, title)).unwrap();
+    let loaded = load_routine_from_dir(&slug).unwrap();
+    assert_eq!(loaded.ignore_until, None);
+    remove_routine_dir(&slug).unwrap();
 }
 
 #[test]

--- a/src/routines/cleanup/cleanup_tests.rs
+++ b/src/routines/cleanup/cleanup_tests.rs
@@ -317,6 +317,7 @@ fn routine_with(schedule: &str, ttl_secs: Option<u64>) -> super::super::model::R
         last_manual_trigger_at: None,
         ttl_secs,
         max_runtime_secs: None,
+        ignore_until: None,
     }
 }
 

--- a/src/routines/cleanup/snapshot_tests.rs
+++ b/src/routines/cleanup/snapshot_tests.rs
@@ -21,6 +21,7 @@ fn routine_with(title: &str, schedule: &str, ttl_secs: Option<u64>) -> Routine {
         last_manual_trigger_at: None,
         ttl_secs,
         max_runtime_secs: None,
+        ignore_until: None,
     }
 }
 

--- a/src/routines/command_tests.rs
+++ b/src/routines/command_tests.rs
@@ -19,6 +19,7 @@ fn make_routine(title: &str) -> Routine {
         last_manual_trigger_at: None,
         ttl_secs: None,
         max_runtime_secs: None,
+        ignore_until: None,
     }
 }
 

--- a/src/routines/defaults.rs
+++ b/src/routines/defaults.rs
@@ -73,6 +73,7 @@ fn materialize(spec: &DefaultRoutine, now: u64) -> Routine {
         last_manual_trigger_at: None,
         ttl_secs: None,
         max_runtime_secs: None,
+        ignore_until: None,
     }
 }
 
@@ -82,7 +83,7 @@ fn materialize(spec: &DefaultRoutine, now: u64) -> Routine {
 /// repositories list) drifted from the spec and the routine must be rewritten, or `None` when `cur`
 /// already matches and no write is needed. The user-owned [`Routine::enabled`] toggle is always
 /// carried over from `cur` — so a default the user turned off stays off — as are its `id`,
-/// `created_at`, and `last_manual_trigger_at`.
+/// `created_at`, `last_manual_trigger_at`, and `ignore_until`.
 fn reconcile(spec: &DefaultRoutine, cur: &Routine, now: u64) -> Option<Routine> {
     let schedule = normalize_schedule(spec.schedule);
     let up_to_date = cur.schedule == schedule
@@ -107,6 +108,8 @@ fn reconcile(spec: &DefaultRoutine, cur: &Routine, now: u64) -> Option<Routine> 
         last_manual_trigger_at: cur.last_manual_trigger_at,
         ttl_secs: cur.ttl_secs,
         max_runtime_secs: cur.max_runtime_secs,
+        // Carry the user's snooze across reconciliation, like enabled/last_manual_trigger_at.
+        ignore_until: cur.ignore_until,
     })
 }
 

--- a/src/routines/ical_tests.rs
+++ b/src/routines/ical_tests.rs
@@ -19,6 +19,7 @@ fn routine_with(id: &str, schedule: &str, enabled: bool) -> Routine {
         last_manual_trigger_at: None,
         ttl_secs: None,
         max_runtime_secs: None,
+        ignore_until: None,
     }
 }
 

--- a/src/routines/mod_tests.rs
+++ b/src/routines/mod_tests.rs
@@ -20,6 +20,7 @@ fn make_routine(id: &str) -> Routine {
         last_manual_trigger_at: None,
         ttl_secs: None,
         max_runtime_secs: None,
+        ignore_until: None,
     }
 }
 
@@ -426,6 +427,7 @@ fn svc_create_invalid_cron_rejected() {
         enabled: true,
         ttl_secs: None,
         max_runtime_secs: None,
+        ignore_until: None,
     };
     assert!(svc_create(&store, req).is_err());
 }
@@ -444,6 +446,7 @@ fn svc_create_update_delete_lifecycle() {
             enabled: true,
             ttl_secs: None,
             max_runtime_secs: None,
+            ignore_until: None,
         },
     )
     .unwrap();
@@ -467,6 +470,8 @@ fn svc_create_update_delete_lifecycle() {
             enabled: Some(false),
             ttl_secs: None,
             max_runtime_secs: None,
+            ignore_until: None,
+            clear_ignore_until: None,
         },
     )
     .unwrap();
@@ -491,6 +496,8 @@ fn svc_update_not_found() {
         enabled: None,
         ttl_secs: None,
         max_runtime_secs: None,
+        ignore_until: None,
+        clear_ignore_until: None,
     };
     assert!(svc_update(&new_store(), "missing", req).is_err());
 }
@@ -511,6 +518,8 @@ fn svc_update_invalid_cron_rejected() {
         enabled: None,
         ttl_secs: None,
         max_runtime_secs: None,
+        ignore_until: None,
+        clear_ignore_until: None,
     };
     assert!(svc_update(&store, "id", req).is_err());
 }

--- a/src/routines/model.rs
+++ b/src/routines/model.rs
@@ -105,6 +105,12 @@ pub struct Routine {
     /// [`Routine::effective_max_runtime_secs`] live in the cleanup module.
     #[serde(default)]
     pub max_runtime_secs: Option<u64>,
+    /// Unix timestamp (seconds) until which **scheduled** runs are skipped (a snooze). The cron
+    /// entry is left untouched; the routine's `run.sh` guard exits early while `now < ignore_until`,
+    /// resuming on its own once the time passes. Manual triggers (`trigger_routine`) bypass it.
+    /// `None` (or a past value) means not snoozed.
+    #[serde(default)]
+    pub ignore_until: Option<u64>,
 }
 
 /// A [`Routine`] enriched with derived, non-persisted fields for API responses.
@@ -214,6 +220,10 @@ pub struct CreateRoutineRequest {
     /// session. `None` uses the default cap (`MAX_RUNTIME_SECS`).
     #[serde(default)]
     pub max_runtime_secs: Option<u64>,
+    /// Unix timestamp (seconds) until which scheduled runs are skipped (a snooze). `None` (or a
+    /// past value) means not snoozed. Manual triggers bypass it.
+    #[serde(default)]
+    pub ignore_until: Option<u64>,
 }
 
 /// Request body for partially updating an existing routine.
@@ -236,6 +246,13 @@ pub struct UpdateRoutineRequest {
     pub ttl_secs: Option<u64>,
     /// New max runtime (seconds) for a single run, or `None` to keep the existing value.
     pub max_runtime_secs: Option<u64>,
+    /// New snooze timestamp (Unix seconds) until which scheduled runs are skipped, or `None` to
+    /// keep the existing value. To unset an existing snooze, send `clear_ignore_until: true`.
+    pub ignore_until: Option<u64>,
+    /// Set to `true` to clear an existing `ignore_until` snooze. Takes precedence over
+    /// `ignore_until`. `None`/`false` leaves the current value untouched.
+    #[serde(default)]
+    pub clear_ignore_until: Option<bool>,
 }
 
 #[cfg(test)]

--- a/src/routines/model_tests.rs
+++ b/src/routines/model_tests.rs
@@ -40,6 +40,7 @@ fn from_routine_populates_derived_fields() {
         last_manual_trigger_at: None,
         ttl_secs: None,
         max_runtime_secs: None,
+        ignore_until: None,
     };
     let resp = RoutineResponse::from_routine(routine);
     assert!(resp.schedule_description.is_some());

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -195,6 +195,7 @@ pub fn svc_create(
         last_manual_trigger_at: None,
         ttl_secs: req.ttl_secs,
         max_runtime_secs: req.max_runtime_secs,
+        ignore_until: req.ignore_until,
     };
     write_routine(&routine).map_err(|_| AppError::Internal)?;
     store
@@ -267,6 +268,13 @@ pub fn svc_update(
     }
     if let Some(max_runtime) = req.max_runtime_secs {
         routine.max_runtime_secs = Some(max_runtime);
+    }
+    // `clear_ignore_until` wins over `ignore_until` so a caller can unambiguously unset the snooze;
+    // otherwise a present `ignore_until` sets it and absence leaves the current value untouched.
+    if req.clear_ignore_until == Some(true) {
+        routine.ignore_until = None;
+    } else if let Some(ignore_until) = req.ignore_until {
+        routine.ignore_until = Some(ignore_until);
     }
     routine.updated_at = now_secs();
     let routine = routine.clone();

--- a/src/routines/service_tests.rs
+++ b/src/routines/service_tests.rs
@@ -22,6 +22,7 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         last_manual_trigger_at: None,
         ttl_secs: None,
         max_runtime_secs: None,
+        ignore_until: None,
     }
 }
 
@@ -81,6 +82,7 @@ fn valid_create_request() -> CreateRoutineRequest {
         enabled: true,
         ttl_secs: None,
         max_runtime_secs: None,
+        ignore_until: None,
     }
 }
 
@@ -95,6 +97,8 @@ fn empty_update_request() -> UpdateRoutineRequest {
         enabled: None,
         ttl_secs: None,
         max_runtime_secs: None,
+        ignore_until: None,
+        clear_ignore_until: None,
     }
 }
 
@@ -232,6 +236,7 @@ fn svc_create_rejects_duplicate_slug() {
                 enabled: true,
                 ttl_secs: None,
                 max_runtime_secs: None,
+                ignore_until: None,
             },
         )
         .unwrap();
@@ -248,6 +253,7 @@ fn svc_create_rejects_duplicate_slug() {
                 enabled: true,
                 ttl_secs: None,
                 max_runtime_secs: None,
+                ignore_until: None,
             },
         );
         assert!(matches!(conflict, Err(AppError::Conflict(_))));
@@ -291,6 +297,8 @@ fn svc_update_rejects_renaming_into_existing_slug() {
                 enabled: None,
                 ttl_secs: None,
                 max_runtime_secs: None,
+                ignore_until: None,
+                clear_ignore_until: None,
             },
         );
         assert!(matches!(conflict, Err(AppError::Conflict(_))));
@@ -324,6 +332,8 @@ fn svc_update_sets_ttl_secs() {
                 enabled: None,
                 ttl_secs: Some(4242),
                 max_runtime_secs: None,
+                ignore_until: None,
+                clear_ignore_until: None,
             },
         )
         .unwrap();
@@ -360,6 +370,8 @@ fn svc_update_sets_max_runtime_secs() {
                 enabled: None,
                 ttl_secs: None,
                 max_runtime_secs: Some(1234),
+                ignore_until: None,
+                clear_ignore_until: None,
             },
         )
         .unwrap();
@@ -367,6 +379,118 @@ fn svc_update_sets_max_runtime_secs() {
     });
 
     let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
+}
+
+#[test]
+fn svc_create_sets_ignore_until() {
+    // Covers the `ignore_until: req.ignore_until` field on the created routine.
+    let title = "Svc Create Ignore Until ZZZ";
+    let store = new_store();
+    with_empty_path(|| {
+        let resp = svc_create(
+            &store,
+            CreateRoutineRequest {
+                title: title.into(),
+                ignore_until: Some(4_102_444_800),
+                ..valid_create_request()
+            },
+        )
+        .unwrap();
+        assert_eq!(resp.routine.ignore_until, Some(4_102_444_800));
+    });
+    let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
+}
+
+#[test]
+fn svc_update_sets_ignore_until() {
+    // Covers the `else if let Some(ignore_until)` apply branch in `svc_update`.
+    let title = "Svc Update Ignore Until ZZZ";
+    let store = new_store();
+    let routine = make_routine("ignore-until-id", title, 1, 1);
+    crate::routine_storage::write_routine(&routine).unwrap();
+    store
+        .lock()
+        .unwrap()
+        .insert("ignore-until-id".into(), routine);
+
+    with_empty_path(|| {
+        let updated = svc_update(
+            &store,
+            "ignore-until-id",
+            UpdateRoutineRequest {
+                ignore_until: Some(4_102_444_800),
+                ..empty_update_request()
+            },
+        )
+        .unwrap();
+        assert_eq!(updated.routine.ignore_until, Some(4_102_444_800));
+    });
+
+    let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
+}
+
+#[test]
+fn svc_update_clear_ignore_until_wins_over_value() {
+    // Covers the `clear_ignore_until == Some(true)` branch and its precedence over a present
+    // `ignore_until`: sending both clears the snooze rather than setting it.
+    let title = "Svc Update Clear Ignore Until ZZZ";
+    let store = new_store();
+    let mut routine = make_routine("clear-ignore-id", title, 1, 1);
+    routine.ignore_until = Some(4_102_444_800);
+    crate::routine_storage::write_routine(&routine).unwrap();
+    store
+        .lock()
+        .unwrap()
+        .insert("clear-ignore-id".into(), routine);
+
+    with_empty_path(|| {
+        let updated = svc_update(
+            &store,
+            "clear-ignore-id",
+            UpdateRoutineRequest {
+                ignore_until: Some(9_999_999_999),
+                clear_ignore_until: Some(true),
+                ..empty_update_request()
+            },
+        )
+        .unwrap();
+        assert_eq!(updated.routine.ignore_until, None);
+    });
+
+    let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
+}
+
+#[test]
+fn svc_update_keeps_ignore_until_when_unset_in_request() {
+    // A request with neither `ignore_until` nor `clear_ignore_until` leaves an existing snooze
+    // untouched.
+    let title = "Svc Update Keep Ignore Until ZZZ";
+    let store = new_store();
+    let mut routine = make_routine("keep-ignore-id", title, 1, 1);
+    routine.ignore_until = Some(4_102_444_800);
+    crate::routine_storage::write_routine(&routine).unwrap();
+    store
+        .lock()
+        .unwrap()
+        .insert("keep-ignore-id".into(), routine);
+
+    with_empty_path(|| {
+        let updated = svc_update(
+            &store,
+            "keep-ignore-id",
+            UpdateRoutineRequest {
+                title: Some("Svc Update Keep Ignore Until ZZZ Renamed".into()),
+                ..empty_update_request()
+            },
+        )
+        .unwrap();
+        assert_eq!(updated.routine.ignore_until, Some(4_102_444_800));
+    });
+
+    let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
+    let _ = crate::routine_storage::remove_routine_dir(&slugify(
+        "Svc Update Keep Ignore Until ZZZ Renamed",
+    ));
 }
 
 #[test]
@@ -524,6 +648,7 @@ fn svc_create_warns_when_crontab_sync_fails() {
                 enabled: true,
                 ttl_secs: None,
                 max_runtime_secs: None,
+                ignore_until: None,
             },
         )
         .unwrap();
@@ -553,6 +678,8 @@ fn svc_update_warns_when_crontab_sync_fails() {
                 enabled: None,
                 ttl_secs: None,
                 max_runtime_secs: None,
+                ignore_until: None,
+                clear_ignore_until: None,
             },
         )
         .unwrap();
@@ -627,6 +754,7 @@ fn svc_create_syncs_crontab_on_success() {
                 enabled: true,
                 ttl_secs: None,
                 max_runtime_secs: None,
+                ignore_until: None,
             },
         )
         .unwrap();
@@ -658,6 +786,8 @@ fn svc_update_syncs_crontab_on_success() {
                 enabled: None,
                 ttl_secs: None,
                 max_runtime_secs: None,
+                ignore_until: None,
+                clear_ignore_until: None,
             },
         )
         .unwrap();
@@ -724,6 +854,7 @@ fn create_req_with_title(title: &str) -> CreateRoutineRequest {
         enabled: true,
         ttl_secs: None,
         max_runtime_secs: None,
+        ignore_until: None,
     }
 }
 
@@ -771,6 +902,7 @@ fn svc_create_rejects_unknown_agent() {
             enabled: true,
             ttl_secs: None,
             max_runtime_secs: None,
+            ignore_until: None,
         },
     );
     assert!(matches!(result, Err(AppError::BadRequest(_))));
@@ -805,6 +937,8 @@ fn svc_update_rejects_blank_and_punctuation_titles() {
                 enabled: None,
                 ttl_secs: None,
                 max_runtime_secs: None,
+                ignore_until: None,
+                clear_ignore_until: None,
             },
         );
         assert!(
@@ -837,6 +971,7 @@ fn svc_create_accepts_builtin_agent() {
             enabled: true,
             ttl_secs: None,
             max_runtime_secs: None,
+            ignore_until: None,
         },
     )
     .unwrap();
@@ -868,6 +1003,8 @@ fn svc_update_rejects_unknown_agent() {
             enabled: None,
             ttl_secs: None,
             max_runtime_secs: None,
+            ignore_until: None,
+            clear_ignore_until: None,
         },
     );
     assert!(matches!(result, Err(AppError::BadRequest(_))));

--- a/src/sync/routines.rs
+++ b/src/sync/routines.rs
@@ -46,7 +46,15 @@ fn write_routine_script(routine: &Routine, agent: &AgentCommand) -> io::Result<s
     let path = routine_script_path(&slugify(&routine.title));
     std::fs::create_dir_all(path.parent().expect("routine script path has a parent dir"))?;
     let command = build_routine_command(routine, agent);
-    std::fs::write(&path, format!("#!/bin/sh\n{command}\n"))?;
+    // Snooze guard: when `ignore_until` is set the script exits early for any firing before that
+    // Unix timestamp, so the cron entry itself stays untouched and the routine resumes on its own
+    // once the time passes (the guard reads the live clock). Manual triggers bypass this — they run
+    // `build_routine_command` directly without the guard (see `svc_trigger`).
+    let guard = match routine.ignore_until {
+        Some(ts) => format!("if [ \"$(date +%s)\" -lt {ts} ]; then exit 0; fi\n"),
+        None => String::new(),
+    };
+    std::fs::write(&path, format!("#!/bin/sh\n{guard}{command}\n"))?;
     std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))?;
     Ok(path)
 }

--- a/src/sync/routines_sync_tests.rs
+++ b/src/sync/routines_sync_tests.rs
@@ -18,6 +18,7 @@ fn make_routine(id: &str, title: &str, agent: &str) -> Routine {
         last_manual_trigger_at: None,
         ttl_secs: None,
         max_runtime_secs: None,
+        ignore_until: None,
     }
 }
 
@@ -269,6 +270,48 @@ fn sync_writes_block_for_a_loaded_store() {
     assert!(shim.store_contents().contains("# moadim-routine:w"));
 
     std::fs::remove_file(&cfg).unwrap();
+    let _ = std::fs::remove_dir_all(crate::paths::routine_dir(&slug));
+}
+
+#[test]
+fn run_script_has_snooze_guard_when_ignore_until_set() {
+    // ignore_until set → the generated run.sh exits early for firings before the timestamp, so the
+    // cron entry stays untouched while scheduled runs are skipped. The guard reads the live clock,
+    // so it lifts on its own once the time passes.
+    let title = "Snooze Guard Sync Routine";
+    let slug = slugify(title);
+    let mut routine = make_routine("snoozed", title, "claude");
+    routine.ignore_until = Some(4_102_444_800);
+    let agent = AgentCommand {
+        command: "claude".to_string(),
+        args: vec![],
+        setup: None,
+    };
+    format_routine_line(&routine, &agent).unwrap();
+    let script = std::fs::read_to_string(crate::paths::routine_script_path(&slug)).unwrap();
+    let guard = r#"if [ "$(date +%s)" -lt 4102444800 ]; then exit 0; fi"#;
+    assert!(script.contains(guard), "missing snooze guard: {script}");
+    // The guard must run before the agent launches.
+    let guard_at = script.find(guard).unwrap();
+    let launch_at = script.find("tmux new-session").expect("launch present");
+    assert!(guard_at < launch_at, "guard must precede the launch");
+    let _ = std::fs::remove_dir_all(crate::paths::routine_dir(&slug));
+}
+
+#[test]
+fn run_script_has_no_guard_when_ignore_until_unset() {
+    // ignore_until None → no guard, the script launches immediately on every firing.
+    let title = "No Snooze Sync Routine";
+    let slug = slugify(title);
+    let routine = make_routine("not-snoozed", title, "claude");
+    let agent = AgentCommand {
+        command: "claude".to_string(),
+        args: vec![],
+        setup: None,
+    };
+    format_routine_line(&routine, &agent).unwrap();
+    let script = std::fs::read_to_string(crate::paths::routine_script_path(&slug)).unwrap();
+    assert!(!script.contains("-lt"), "unexpected snooze guard: {script}");
     let _ = std::fs::remove_dir_all(crate::paths::routine_dir(&slug));
 }
 


### PR DESCRIPTION
Closes #290.

## What

Adds an `ignore_until` field (Unix seconds) to routines: a **snooze** that skips *scheduled* runs until a given time **without touching the cron entry**.

## How it works

The per-routine `run.sh` (regenerated on each crontab sync) gains a guard:

```sh
if [ "$(date +%s)" -lt <ignore_until> ]; then exit 0; fi
```

- **Cron unchanged** — the crontab line (schedule + id) is left exactly as-is; the routine is never removed from or re-added to the block. Cron fires as usual; the script just exits early.
- **Self-expiring** — the guard reads the live clock, so once `ignore_until` passes the routine resumes on its own. No re-sync required.
- **Manual triggers bypass** — `trigger_routine` / `POST /routines/{id}/trigger` build the command directly (no guard) and always run, regardless of the snooze.

## API

- `Routine.ignore_until: Option<u64>` (exposed in responses)
- `CreateRoutineRequest.ignore_until`
- `UpdateRoutineRequest.ignore_until` (set) + `clear_ignore_until` (explicit unset; takes precedence)
- MCP `create_routine` / `update_routine` inputs threaded through
- Persisted to the tracked `routine.toml`
- OpenAPI spec regenerated

Default-routine reconciliation carries the user's snooze across, like `enabled` / `last_manual_trigger_at`.

## Tests

New tests cover: TOML round-trip (present + absent), `run.sh` guard injection (set + unset), service create/update set, `clear_ignore_until` precedence, and the keep-when-unset path. Full suite green (473 passing); `cargo llvm-cov --fail-under-lines 100` and `clippy --all-targets` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)