### PR TITLE
docs(readme): document the `max_runtime_secs` routine field

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ git-trackable just like jobs:
 | `repositories` | list   | no       | Git repos listed in the prompt as context. Moadim does **not** clone them — the agent does.   |
 | `enabled`      | bool   | no       | Defaults to `true`. Set `false` to pause without deleting.                                    |
 | `ttl_secs`     | int    | no       | How long a finished run's workbench is retained before auto-cleanup. Caps the cron-derived retention lower — it can only shorten, never extend it. `None` uses the cron-derived value. |
+| `max_runtime_secs` | int | no       | Max wall-clock seconds a single run may execute before the cleanup watchdog force-kills its (hung) tmux session; the workbench is then reaped under the normal TTL rules. Caps the cron-derived runtime (`min(MAX_RUNTIME_SECS, cron interval)`) lower — it can only shorten, never extend it. `None` uses the cron-derived value. |
 
 **Workbenches and cleanup:** each run executes in a workbench under
 `~/.config/moadim/workbenches/`. Finished, expired workbenches are reaped on an


### PR DESCRIPTION
## Why

The routine field table in the README documents every user-settable field — `schedule`, `title`, `agent`, `prompt`, `repositories`, `enabled`, `ttl_secs` — but **omits `max_runtime_secs`**.

That field is real and validated, not internal-only:
- declared on the `Routine` model with a doc comment (`src/routines/model.rs`),
- accepted on both the create and update request bodies (`model.rs`),
- rejected when zero via `reject_zero_secs("max_runtime_secs", …)` (`src/routines/service.rs`).

A user reading the README has no way to discover the per-run runtime watchdog cap, even though it sits right next to the documented `ttl_secs`.

## What

Add one table row after `ttl_secs` describing `max_runtime_secs`: the wall-clock ceiling after which the cleanup watchdog force-kills a hung run, that it only caps the cron-derived runtime lower, and that `None` uses the derived value — mirroring the wording already used for `ttl_secs`.

Docs-only; touches only `README.md` (no `src/`/`ui/` changes, so no CHANGELOG entry required).

---

*This pull request was opened by the Daemon + Landing auto-improve PRs routine of moadim.* cc @tupe12334