### PR TITLE
feat: track last_scheduled_trigger_at for routines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Added
 
+- Routines now track **`last_scheduled_trigger_at`** (Unix seconds), the mirror of
+  `last_manual_trigger_at` for scheduled cron firings, surfaced in the REST/OpenAPI
+  routine response. Because the OS crontab runs a routine's generated `run.sh`
+  directly — the daemon never observes a scheduled fire — the script itself stamps
+  the fire time into a new gitignored `scheduled.local.toml` sidecar, which the
+  daemon reads back on load. The sidecar is daemon-read-only and kept separate from
+  the manual-trigger `state.local.toml`, so re-persisting a routine can't clobber a
+  scheduler-written timestamp. This makes scheduled vs. manual runs distinguishable
+  and lets you spot schedules that have never actually fired (#155).
+
 - `moadim stop` accepts a `--quiet`/`-q` flag that suppresses the human-readable
   status line (`moadim is shutting down` / `moadim is not running`) while keeping
   the exit-code contract (`0` when a server was stopped, `3` when none was

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -1070,6 +1070,15 @@
             "description": "Unix timestamp (seconds) when the routine was last manually triggered, if ever.\n\nOnly manual triggers (`trigger_routine`) update this; scheduled cron firings run the built\ncommand directly and do not. Accepts the legacy `last_triggered_at` key on deserialize.",
             "minimum": 0
           },
+          "last_scheduled_trigger_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Unix timestamp (seconds) when the routine was last fired by its cron schedule, if ever.\n\nThe mirror of [`Routine::last_manual_trigger_at`] for scheduled runs: a manual trigger\nupdates only the manual field, a scheduled firing updates only this one. The scheduler is\nthe host OS crontab, which runs the routine's generated `run.sh` directly without going\nthrough the daemon — so the script itself stamps this timestamp into the gitignored\n`scheduled.local.toml` sidecar at fire time, and the daemon reads it back on load. The\ndaemon never writes this field (it is absent from `routine.toml` and the daemon-owned\n`state.local.toml`), so re-persisting a routine can't clobber it.",
+            "minimum": 0
+          },
           "max_runtime_secs": {
             "type": [
               "integer",

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -113,6 +113,18 @@ pub fn routine_state_path(id: &str) -> PathBuf {
     routine_dir(id).join("state.local.toml")
 }
 
+/// Returns the path to `{routines_dir}/{id}/scheduled.local.toml`, the gitignored sidecar that
+/// records `last_scheduled_trigger_at`.
+///
+/// Unlike [`routine_state_path`] this sidecar is written by the routine's generated `run.sh` at
+/// each scheduled cron firing (the daemon is not in the loop then), and is only ever *read* by the
+/// daemon — kept in its own file so a daemon-side re-persist of `state.local.toml` can't clobber
+/// the scheduler-written timestamp. The `.local.` infix matches the `*.local.*` `.gitignore`
+/// pattern, so scheduled-fire churn never produces version-control diffs.
+pub fn routine_scheduled_state_path(id: &str) -> PathBuf {
+    routine_dir(id).join("scheduled.local.toml")
+}
+
 /// Returns the path to `{routines_dir}/{id}/run.sh`, the generated launch script invoked by cron.
 pub fn routine_script_path(id: &str) -> PathBuf {
     routine_dir(id).join("run.sh")

--- a/src/routes/http_tests.rs
+++ b/src/routes/http_tests.rs
@@ -875,6 +875,7 @@ async fn router_serves_routines_ical_feed() {
             created_at: 0,
             updated_at: 0,
             last_manual_trigger_at: None,
+            last_scheduled_trigger_at: None,
             ttl_secs: None,
             max_runtime_secs: None,
         },

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -6,8 +6,8 @@ use std::sync::{Arc, Mutex};
 use serde::{Deserialize, Serialize};
 
 use crate::paths::{
-    routine_dir, routine_gitignore_path, routine_prompt_path, routine_state_path,
-    routine_toml_path, routines_dir,
+    routine_dir, routine_gitignore_path, routine_prompt_path, routine_scheduled_state_path,
+    routine_state_path, routine_toml_path, routines_dir,
 };
 use crate::routines::{compose_prompt, slugify, Repository, Routine, RoutineStore};
 use crate::utils::atomic::atomic_write;
@@ -62,6 +62,19 @@ struct RuntimeState {
     last_manual_trigger_at: Option<u64>,
 }
 
+/// Scheduler-written runtime state for a routine, persisted to the gitignored
+/// `scheduled.local.toml` sidecar.
+///
+/// Written by the routine's generated `run.sh` at each scheduled cron firing (the daemon is not in
+/// the loop then) and only ever read here — kept separate from [`RuntimeState`] so a daemon-side
+/// re-persist of `state.local.toml` can never clobber the scheduler's timestamp.
+#[derive(Debug, Deserialize, Serialize)]
+struct ScheduledState {
+    /// Unix timestamp of the last scheduled (cron) firing, or `None` if it has never fired.
+    #[serde(default)]
+    last_scheduled_trigger_at: Option<u64>,
+}
+
 /// Parse a routine TOML file at `path`, returning `None` on any error.
 fn read_routine_toml(path: &std::path::PathBuf) -> Option<RoutineToml> {
     let text = std::fs::read_to_string(path).ok()?;
@@ -77,6 +90,16 @@ fn read_runtime_state(dir_name: &str) -> Option<u64> {
         .last_manual_trigger_at
 }
 
+/// Read `last_scheduled_trigger_at` from a routine's `scheduled.local.toml` sidecar, returning
+/// `None` when the sidecar is absent or unparsable (e.g. before the routine's schedule has ever
+/// fired). The daemon only reads this file; it is written by the routine's `run.sh` at fire time.
+fn read_scheduled_state(dir_name: &str) -> Option<u64> {
+    let text = std::fs::read_to_string(routine_scheduled_state_path(dir_name)).ok()?;
+    toml::from_str::<ScheduledState>(&text)
+        .ok()?
+        .last_scheduled_trigger_at
+}
+
 /// Load a routine from `{routines_dir}/{dir_name}/routine.toml`.
 ///
 /// `dir_name` is the slug (title-derived folder name). The routine's UUID `id` is read from
@@ -89,6 +112,7 @@ fn load_routine_from_dir(dir_name: &str) -> Option<Routine> {
     let title = toml.title?;
     let id = toml.id.unwrap_or_else(|| dir_name.to_string());
     let last_manual_trigger_at = read_runtime_state(dir_name).or(toml.last_manual_trigger_at);
+    let last_scheduled_trigger_at = read_scheduled_state(dir_name);
     Some(Routine {
         id,
         schedule: toml.schedule?,
@@ -101,6 +125,7 @@ fn load_routine_from_dir(dir_name: &str) -> Option<Routine> {
         created_at: toml.created_at.unwrap_or(0),
         updated_at: toml.updated_at.unwrap_or(0),
         last_manual_trigger_at,
+        last_scheduled_trigger_at,
         ttl_secs: toml.ttl_secs,
         max_runtime_secs: toml.max_runtime_secs,
     })

--- a/src/routine_storage_tests.rs
+++ b/src/routine_storage_tests.rs
@@ -19,6 +19,7 @@ fn make_routine(id: &str, title: &str) -> Routine {
         created_at: 5,
         updated_at: 6,
         last_manual_trigger_at: None,
+        last_scheduled_trigger_at: None,
         ttl_secs: None,
         max_runtime_secs: None,
     }
@@ -267,6 +268,87 @@ fn load_routine_ignores_unparsable_sidecar() {
     );
 
     remove_routine_dir(slug).unwrap();
+}
+
+#[test]
+fn load_routine_reads_scheduled_trigger_from_sidecar() {
+    // `last_scheduled_trigger_at` lives in its own gitignored `scheduled.local.toml` sidecar,
+    // written by the routine's `run.sh` at cron fire time, and is read back on load — independently
+    // of the manual-trigger sidecar.
+    let title = "Rs Scheduled Sidecar Routine";
+    let slug = slugify(title);
+    write_routine(&make_routine("rs-scheduled-id", title)).unwrap();
+    std::fs::write(
+        crate::paths::routine_scheduled_state_path(&slug),
+        "last_scheduled_trigger_at = 4242\n",
+    )
+    .unwrap();
+
+    let loaded = load_routine_from_dir(&slug).unwrap();
+    assert_eq!(loaded.last_scheduled_trigger_at, Some(4242));
+    // The scheduled timestamp is distinct from the (unset) manual one.
+    assert_eq!(loaded.last_manual_trigger_at, None);
+
+    remove_routine_dir(&slug).unwrap();
+}
+
+#[test]
+fn load_routine_ignores_unparsable_scheduled_sidecar() {
+    // A malformed `scheduled.local.toml` parses to `None` rather than crashing the load.
+    let slug = "rs-bad-scheduled-sidecar-routine";
+    let dir = crate::paths::routine_dir(slug);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        crate::paths::routine_toml_path(slug),
+        "schedule = \"@daily\"\ntitle = \"Rs Bad Scheduled Sidecar\"\nagent = \"claude\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        crate::paths::routine_scheduled_state_path(slug),
+        "= not valid toml =",
+    )
+    .unwrap();
+
+    assert_eq!(
+        load_routine_from_dir(slug)
+            .unwrap()
+            .last_scheduled_trigger_at,
+        None
+    );
+
+    remove_routine_dir(slug).unwrap();
+}
+
+#[test]
+fn write_routine_preserves_scheduler_written_scheduled_sidecar() {
+    // The daemon never writes the scheduled sidecar, so re-persisting a routine (e.g. on startup or
+    // an update) must leave the scheduler-stamped `scheduled.local.toml` untouched — the bug this
+    // separate-file design exists to prevent.
+    let title = "Rs Preserve Scheduled Routine";
+    let slug = slugify(title);
+    let mut routine = make_routine("rs-preserve-scheduled-id", title);
+    write_routine(&routine).unwrap();
+
+    // Simulate a scheduled cron firing stamping the sidecar.
+    std::fs::write(
+        crate::paths::routine_scheduled_state_path(&slug),
+        "last_scheduled_trigger_at = 55\n",
+    )
+    .unwrap();
+
+    // A subsequent daemon-side write (manual trigger recorded, routine updated, repersist, …).
+    routine.last_manual_trigger_at = Some(7);
+    write_routine(&routine).unwrap();
+
+    assert!(
+        crate::paths::routine_scheduled_state_path(&slug).exists(),
+        "daemon write must not remove the scheduler-owned sidecar"
+    );
+    let loaded = load_routine_from_dir(&slug).unwrap();
+    assert_eq!(loaded.last_scheduled_trigger_at, Some(55));
+    assert_eq!(loaded.last_manual_trigger_at, Some(7));
+
+    remove_routine_dir(&slug).unwrap();
 }
 
 #[test]

--- a/src/routines/cleanup/cleanup_tests.rs
+++ b/src/routines/cleanup/cleanup_tests.rs
@@ -315,6 +315,7 @@ fn routine_with(schedule: &str, ttl_secs: Option<u64>) -> super::super::model::R
         created_at: 0,
         updated_at: 0,
         last_manual_trigger_at: None,
+        last_scheduled_trigger_at: None,
         ttl_secs,
         max_runtime_secs: None,
     }

--- a/src/routines/cleanup/snapshot_tests.rs
+++ b/src/routines/cleanup/snapshot_tests.rs
@@ -19,6 +19,7 @@ fn routine_with(title: &str, schedule: &str, ttl_secs: Option<u64>) -> Routine {
         created_at: 0,
         updated_at: 0,
         last_manual_trigger_at: None,
+        last_scheduled_trigger_at: None,
         ttl_secs,
         max_runtime_secs: None,
     }

--- a/src/routines/command.rs
+++ b/src/routines/command.rs
@@ -1,6 +1,6 @@
 //! Prompt composition, slug/shell helpers, and the single-line tmux launch command builder.
 
-use crate::paths::routine_prompt_path;
+use crate::paths::{routine_prompt_path, routine_scheduled_state_path};
 
 use super::agents::AgentCommand;
 use super::model::Routine;
@@ -179,6 +179,9 @@ pub(crate) fn system_prompt_stmts(user_prompt_path: &str, routine_title: &str) -
 pub(crate) fn build_routine_command(routine: &Routine, agent: &AgentCommand) -> String {
     let slug = slugify(&routine.title);
     let prompt_path = routine_prompt_path(&slug).to_string_lossy().into_owned();
+    let scheduled_state_path = routine_scheduled_state_path(&slug)
+        .to_string_lossy()
+        .into_owned();
 
     let prompt_file_ref = "prompt.md";
     let workbench_ref = ".";
@@ -202,6 +205,16 @@ pub(crate) fn build_routine_command(routine: &Routine, agent: &AgentCommand) -> 
         // unchanged.
         format!("export PATH={}", shell_quote(&cron_path(&agent.command))),
         r#"TS="$(date +%s)""#.to_string(),
+        // Record this scheduled firing. The daemon never sees a cron run (the OS crontab executes
+        // this script directly), so the script itself stamps the fire time into the routine's
+        // gitignored `scheduled.local.toml` sidecar; the daemon reads it back into
+        // `last_scheduled_trigger_at` on load. Written before the prompt-copy guard below so an
+        // aborted run still records that the schedule fired, and best-effort (`|| true`) so a
+        // sidecar write failure never blocks launching the agent.
+        format!(
+            r#"printf 'last_scheduled_trigger_at = %s\n' "$TS" > {} || true"#,
+            shell_quote(&scheduled_state_path)
+        ),
         format!("SLUG={}", shell_quote(&slug)),
         r#"WB="$HOME/.moadim/workbenches/$SLUG-$TS""#.to_string(),
         r#"SESS="moadim-$SLUG-$TS""#.to_string(),

--- a/src/routines/command_tests.rs
+++ b/src/routines/command_tests.rs
@@ -17,6 +17,7 @@ fn make_routine(title: &str) -> Routine {
         created_at: 0,
         updated_at: 0,
         last_manual_trigger_at: None,
+        last_scheduled_trigger_at: None,
         ttl_secs: None,
         max_runtime_secs: None,
     }
@@ -75,6 +76,34 @@ fn build_routine_command_resolves_bin_dir_when_tool_on_path() {
     });
 
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn build_routine_command_stamps_scheduled_trigger_sidecar() {
+    // The generated launch script records each scheduled firing by writing `$TS` into the
+    // routine's `scheduled.local.toml` sidecar (best-effort, before the prompt-copy guard), since
+    // the OS crontab runs this script directly without the daemon observing the fire.
+    let routine = make_routine("Cmd Scheduled Stamp Routine");
+    let agent = AgentCommand {
+        command: "claude".to_string(),
+        args: vec![],
+        setup: None,
+    };
+    let cmd = build_routine_command(&routine, &agent);
+    let sidecar = crate::paths::routine_scheduled_state_path(&slugify(&routine.title))
+        .to_string_lossy()
+        .into_owned();
+    assert!(
+        cmd.contains(&format!(
+            r#"printf 'last_scheduled_trigger_at = %s\n' "$TS" > {} || true"#,
+            shell_quote(&sidecar)
+        )),
+        "expected scheduled-trigger sidecar stamp in: {cmd}"
+    );
+    // It must run before the prompt-copy guard so an aborted run still records the firing.
+    let stamp = cmd.find("last_scheduled_trigger_at").unwrap();
+    let copy = cmd.find("/prompt.md\"").unwrap();
+    assert!(stamp < copy, "sidecar stamp must precede the prompt copy");
 }
 
 #[test]

--- a/src/routines/defaults.rs
+++ b/src/routines/defaults.rs
@@ -71,6 +71,7 @@ fn materialize(spec: &DefaultRoutine, now: u64) -> Routine {
         created_at: now,
         updated_at: now,
         last_manual_trigger_at: None,
+        last_scheduled_trigger_at: None,
         ttl_secs: None,
         max_runtime_secs: None,
     }
@@ -82,7 +83,7 @@ fn materialize(spec: &DefaultRoutine, now: u64) -> Routine {
 /// repositories list) drifted from the spec and the routine must be rewritten, or `None` when `cur`
 /// already matches and no write is needed. The user-owned [`Routine::enabled`] toggle is always
 /// carried over from `cur` — so a default the user turned off stays off — as are its `id`,
-/// `created_at`, and `last_manual_trigger_at`.
+/// `created_at`, `last_manual_trigger_at`, and `last_scheduled_trigger_at`.
 fn reconcile(spec: &DefaultRoutine, cur: &Routine, now: u64) -> Option<Routine> {
     let schedule = normalize_schedule(spec.schedule);
     let up_to_date = cur.schedule == schedule
@@ -105,6 +106,7 @@ fn reconcile(spec: &DefaultRoutine, cur: &Routine, now: u64) -> Option<Routine> 
         created_at: cur.created_at,
         updated_at: now,
         last_manual_trigger_at: cur.last_manual_trigger_at,
+        last_scheduled_trigger_at: cur.last_scheduled_trigger_at,
         ttl_secs: cur.ttl_secs,
         max_runtime_secs: cur.max_runtime_secs,
     })

--- a/src/routines/ical_tests.rs
+++ b/src/routines/ical_tests.rs
@@ -17,6 +17,7 @@ fn routine_with(id: &str, schedule: &str, enabled: bool) -> Routine {
         created_at: 0,
         updated_at: 0,
         last_manual_trigger_at: None,
+        last_scheduled_trigger_at: None,
         ttl_secs: None,
         max_runtime_secs: None,
     }

--- a/src/routines/mod_tests.rs
+++ b/src/routines/mod_tests.rs
@@ -18,6 +18,7 @@ fn make_routine(id: &str) -> Routine {
         created_at: 0,
         updated_at: 0,
         last_manual_trigger_at: None,
+        last_scheduled_trigger_at: None,
         ttl_secs: None,
         max_runtime_secs: None,
     }

--- a/src/routines/model.rs
+++ b/src/routines/model.rs
@@ -92,6 +92,17 @@ pub struct Routine {
     /// command directly and do not. Accepts the legacy `last_triggered_at` key on deserialize.
     #[serde(alias = "last_triggered_at")]
     pub last_manual_trigger_at: Option<u64>,
+    /// Unix timestamp (seconds) when the routine was last fired by its cron schedule, if ever.
+    ///
+    /// The mirror of [`Routine::last_manual_trigger_at`] for scheduled runs: a manual trigger
+    /// updates only the manual field, a scheduled firing updates only this one. The scheduler is
+    /// the host OS crontab, which runs the routine's generated `run.sh` directly without going
+    /// through the daemon — so the script itself stamps this timestamp into the gitignored
+    /// `scheduled.local.toml` sidecar at fire time, and the daemon reads it back on load. The
+    /// daemon never writes this field (it is absent from `routine.toml` and the daemon-owned
+    /// `state.local.toml`), so re-persisting a routine can't clobber it.
+    #[serde(default)]
+    pub last_scheduled_trigger_at: Option<u64>,
     /// How long (seconds) a finished run's workbench is retained before auto-cleanup removes it.
     /// Caps the cron-derived retention (`min(MAX_TTL_SECS, cron interval)`) lower; it can only
     /// shorten, never extend it. `None` uses the cron-derived value. Sessions still running are

--- a/src/routines/model_tests.rs
+++ b/src/routines/model_tests.rs
@@ -38,6 +38,7 @@ fn from_routine_populates_derived_fields() {
         created_at: 0,
         updated_at: 0,
         last_manual_trigger_at: None,
+        last_scheduled_trigger_at: None,
         ttl_secs: None,
         max_runtime_secs: None,
     };

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -240,6 +240,7 @@ pub fn svc_create(
         created_at: now,
         updated_at: now,
         last_manual_trigger_at: None,
+        last_scheduled_trigger_at: None,
         ttl_secs: req.ttl_secs,
         max_runtime_secs: req.max_runtime_secs,
     };

--- a/src/routines/service_tests.rs
+++ b/src/routines/service_tests.rs
@@ -20,6 +20,7 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         created_at,
         updated_at,
         last_manual_trigger_at: None,
+        last_scheduled_trigger_at: None,
         ttl_secs: None,
         max_runtime_secs: None,
     }

--- a/src/sync/routines_sync_tests.rs
+++ b/src/sync/routines_sync_tests.rs
@@ -16,6 +16,7 @@ fn make_routine(id: &str, title: &str, agent: &str) -> Routine {
         created_at: 0,
         updated_at: 0,
         last_manual_trigger_at: None,
+        last_scheduled_trigger_at: None,
         ttl_secs: None,
         max_runtime_secs: None,
     }


### PR DESCRIPTION
Closes #155.

## Problem

`Routine` exposed `last_manual_trigger_at`, but nothing recorded when a routine last fired via its **cron schedule**. From the API/model you couldn't tell a scheduled run from a manual one, or spot a schedule that has never actually fired — only manual triggers left a timestamp.

## Why this needs a sidecar (not just a field write)

A routine's scheduled run is executed by the **OS crontab**, which invokes the routine's generated `run.sh` directly. The daemon is *not* in the loop at fire time, so there is no daemon code path that could update a timestamp on a scheduled firing (this is exactly why `last_manual_trigger_at` only ever tracked manual triggers).

So the **script itself** stamps the fire time. `build_routine_command` now emits, at the top of `run.sh`:

```sh
printf 'last_scheduled_trigger_at = %s\n' "$TS" > '<routine dir>/scheduled.local.toml' || true
```

written before the prompt-copy guard (so an aborted run still records that the schedule fired) and best-effort (`|| true`, so a sidecar write failure never blocks launching the agent). The daemon reads it back into `Routine.last_scheduled_trigger_at` on load.

### No-clobber design

The scheduled timestamp lives in its **own** gitignored `scheduled.local.toml`, separate from the daemon-owned `state.local.toml` (which holds `last_manual_trigger_at`). The daemon only ever *reads* the scheduled sidecar. That means a daemon-side re-persist (startup repersist, recording a manual trigger, a routine update) can never clobber a scheduler-written timestamp — a guarantee covered by a dedicated test. The `.local.` infix matches the existing `*.local.*` `.gitignore` pattern, so scheduled-fire churn produces no version-control diffs.

## Changes

- `src/routines/model.rs` — new `last_scheduled_trigger_at: Option<u64>` (serde `default`), documented; flows into the OpenAPI routine schema automatically (regenerated `apis/openapi.json`).
- `src/paths/mod.rs` — `routine_scheduled_state_path()`.
- `src/routines/command.rs` — `run.sh` stamps the sidecar at fire time.
- `src/routine_storage.rs` — `ScheduledState` + `read_scheduled_state()`, merged in `load_routine_from_dir`.
- Tests: read/merge, unparsable-sidecar tolerance, the no-clobber guarantee, and the `run.sh` stamp + ordering. Construction sites updated across the suite.

## Checks

`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, and the 100% line-coverage gate (`cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'`) all pass locally. (The pre-existing flaky `restart_tests::stop_running_and_wait_force_kills_then_succeeds_when_server_goes_down` — already tracked separately — is unrelated to this change.)

## Scope

Scoped to **routines**, kept small and reviewable. Cron-job parity (`CronJob.last_scheduled_trigger_at`) and UI surfacing of the new field are natural focused follow-ups. @tupe12334

---
*This pull request was opened by the "Implement my assigned issues without a PR (daemon + landing)" routine of moadim.*