### PR TITLE
chore: add GitHub issue forms & PR template (#347)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,108 @@
+name: Bug report
+description: Report something that doesn't work — a crash, a wrong result, or a routine that silently never runs.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. moadim runs as a background
+        daemon, so failures are often silent — the more of the context below you
+        can fill in, the faster this can be triaged. Please redact any secrets
+        (tokens, private repo names) before pasting logs.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you observe, and what did you expect instead?
+      placeholder: "I created a routine on a */5 schedule, but it never fires and no run workbench appears."
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The exact commands / API calls (and routine or cron-job config) that trigger the bug.
+      placeholder: |
+        1. moadim install
+        2. curl -X POST http://127.0.0.1:5784/api/v1/routines -d '{...}'
+        3. wait 5 minutes
+        4. ...
+      render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: moadim version
+      description: Output of `moadim --version`.
+      placeholder: "moadim 0.12.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Other (note in "What happened?")
+    validations:
+      required: true
+
+  - type: input
+    id: os-version
+    attributes:
+      label: OS version & architecture
+      description: e.g. `Ubuntu 24.04 / x86_64`, `macOS 15.5 / arm64`.
+      placeholder: "macOS 15.5 / arm64"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: How did you install moadim?
+      options:
+        - cargo install moadim
+        - Built from source (cargo build)
+        - Other (note in "What happened?")
+    validations:
+      required: true
+
+  - type: dropdown
+    id: run-mode
+    attributes:
+      label: How is the daemon running?
+      options:
+        - Installed OS service (moadim install — launchd / systemd)
+        - Background (moadim)
+        - Foreground (moadim --interactive / -i)
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: agent
+    attributes:
+      label: Agent (if relevant)
+      description: Which agent the affected routine uses — e.g. Claude, Codex, Hermes.
+      placeholder: "Claude"
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: |
+        Paste relevant lines from the daemon log (`~/.config/moadim/daemon.log`)
+        and, for a misbehaving run, that run's `agent.log` from its workbench.
+        Redact secrets first.
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+# Require a structured form for every issue: a blank free-text issue tends to
+# omit the OS / version / log context triage needs, which is exactly the
+# silent-failure gap this template set closes.
+blank_issues_enabled: false
+contact_links:
+  - name: Question or usage help
+    url: https://github.com/moadim-io/daemon/discussions
+    about: For questions, setup help, and open-ended discussion — please use Discussions rather than an issue.
+  - name: Security vulnerability
+    url: https://github.com/moadim-io/daemon/security/advisories/new
+    about: Report a security vulnerability privately. Do NOT open a public issue for security reports.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,28 @@
+name: Feature request
+description: Suggest a new capability or an improvement to an existing one.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do, and where does moadim get in the way today?
+      placeholder: "There's no way to read a routine's latest run output without sshing in and finding the workbench."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should moadim do? A CLI command, REST/MCP endpoint, config field, UI affordance, …
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed, or current workarounds.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!--
+Thanks for contributing to moadim! Keep PRs small and focused — one logical
+change per PR. Fill in the sections below; delete any that don't apply.
+-->
+
+## What & why
+
+<!-- What does this change do, and what problem does it solve? -->
+
+Fixes #<!-- issue number, if any -->
+
+## Checklist
+
+The pre-push hook and CI enforce these — running them locally first avoids a red PR (see [CONTRIBUTING.md](../CONTRIBUTING.md)):
+
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy` is clean
+- [ ] `cargo test` passes
+- [ ] 100% line coverage holds (`cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'`)
+- [ ] Tests live in `*_tests.rs` sibling files (not inline `#[cfg(test)] mod foo { … }` blocks)
+- [ ] `CHANGELOG.md` has an entry under `## [Unreleased]` (required for any `src/` or `ui/` change)
+- [ ] Docs updated if behavior, CLI flags, or API shapes changed


### PR DESCRIPTION
## Why

moadim runs as a background daemon, so failures are **silent** — and bug reports filed without structure routinely omit the context triage needs: the `moadim --version`, the OS/arch, how it was installed, how the daemon is running, and the relevant `daemon.log` / `agent.log` lines. Closes #347.

## What

New `.github/` templates (docs only — no source or workflow changes):

- **`ISSUE_TEMPLATE/bug_report.yml`** — required fields for `moadim --version`, OS & architecture, install method, run mode (installed service / background / foreground), agent, reproduction steps, and a logs box that points at `~/.config/moadim/daemon.log` and the run's `agent.log`.
- **`ISSUE_TEMPLATE/feature_request.yml`** — problem / proposed solution / alternatives.
- **`ISSUE_TEMPLATE/config.yml`** — disables blank issues; routes questions to Discussions and security reports to private advisories.
- **`PULL_REQUEST_TEMPLATE.md`** — a checklist mirroring the pre-push / CI gates (fmt, clippy, test, 100% line coverage, `*_tests.rs` convention, `CHANGELOG.md`), with a link to `CONTRIBUTING.md`.

## Notes

Field options and log paths were taken from the actual CLI (`moadim --version` → `print_version`) and `README.md` (`~/.config/moadim/daemon.log`), so the form matches reality. All three YAML forms parse cleanly.

---
This pull request was opened by the **Daemon + Landing auto-improve PRs** routine of moadim. @tupe12334