### PR TITLE
docs(readme): correct workbench path to ~/.moadim/workbenches/

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ git-trackable just like jobs:
 | `ttl_secs`     | int    | no       | How long a finished run's workbench is retained before auto-cleanup. Caps the cron-derived retention lower — it can only shorten, never extend it. `None` uses the cron-derived value. |
 
 **Workbenches and cleanup:** each run executes in a workbench under
-`~/.config/moadim/workbenches/`. Finished, expired workbenches are reaped on an
+`~/.moadim/workbenches/`. Finished, expired workbenches are reaped on an
 hourly sweep so they don't accumulate; trigger a sweep on demand with
 `moadim cleanup`. Sessions still running are never reaped.
 


### PR DESCRIPTION
## What

The README's **Workbenches and cleanup** section claimed each routine run executes in a workbench under `~/.config/moadim/workbenches/`. That path is wrong — the daemon creates workbenches under `~/.moadim/workbenches/`.

## Why

Verified against the source:

- `src/paths/mod.rs`: `moadim_home()` → `~/.moadim`, and `workbenches_dir()` → `moadim_home().join("workbenches")` → `~/.moadim/workbenches/`.
- `src/routines/command.rs`: the generated `run.sh` sets `WB="$HOME/.moadim/workbenches/$SLUG-$TS"`.
- `Architecture.md` already documents `~/.moadim/workbenches/` correctly — the README was the lone outlier.

Note the daemon uses two roots: `~/.config/moadim/` for jobs/agents/pid/log, but `~/.moadim/workbenches/` for run workbenches. A user following the README to inspect runs or scope a `moadim cleanup` would have looked under the wrong (empty) `~/.config/moadim/workbenches/` path.

## Change

One-line doc correction. No code touched.

---
This pull request was opened by the **Daemon + Landing auto-improve PRs** routine of moadim.