### PR TITLE
docs: add MIT LICENSE file (#377)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Moadim
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -344,3 +344,7 @@ Full interface definitions are auto-generated at build time — see the [`apis/`
 
 Release history lives in [`CHANGELOG.md`](CHANGELOG.md), following the
 [Keep a Changelog](https://keepachangelog.com/) format.
+
+## License
+
+Licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Why

`Cargo.toml` declares `license = "MIT"`, but the repository shipped **no LICENSE file**. That leaves the grant incomplete:

- **GitHub** can't auto-detect the license (no badge, no "MIT" in the repo header).
- **crates.io** publishes a license-*less* crate — the declared SPDX id has no accompanying text.
- **Downstream users** have no actual terms to rely on, despite the README/JSON-LD implying MIT.

Closes #377.

## What

- Add `LICENSE` with the standard MIT text. Wording and the `Copyright (c) 2026 Moadim` holder match the [`moadim-io/landing`](https://github.com/moadim-io/landing) repo for org-wide consistency.
- Add a `## License` section to `README.md` linking to the file.

## Scope / risk

Docs-only — no `src/` or `ui/` changes, so build, clippy, fmt, and coverage are untouched. The changelog gate doesn't apply (no code change).

---
This pull request was opened by the **Daemon + Landing auto-improve PRs** routine of moadim. @tupe12334