### PR TITLE
feat: embed git commit SHA + build date in `--version` and `/health` (#367)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Added
 
+- The binary now embeds the git commit it was built from, so you can tell
+  exactly which build is running rather than only the released crate version
+  (which changes only on a `v*` tag). `moadim --version` prints
+  `moadim <version> (<short-sha> <date>)`, and the `GET /api/v1/health` response
+  gained `git_sha` and `build_date` fields alongside `version`. `build.rs`
+  resolves the fields from git at compile time and falls back to `"unknown"`
+  when the source isn't a git checkout (e.g. a crates.io tarball), so published
+  builds still compile and report sensibly (#367).
 - `moadim stop` accepts a `--quiet`/`-q` flag that suppresses the human-readable
   status line (`moadim is shutting down` / `moadim is not running`) while keeping
   the exit-code contract (`0` when a server was stopped, `3` when none was

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -985,9 +985,19 @@
           "status",
           "uptime_secs",
           "running",
-          "version"
+          "version",
+          "git_sha",
+          "build_date"
         ],
         "properties": {
+          "build_date": {
+            "type": "string",
+            "description": "Committer date (`YYYY-MM-DD`) of the build commit, or `\"unknown\"` outside a git checkout."
+          },
+          "git_sha": {
+            "type": "string",
+            "description": "Short git commit SHA the daemon was built from, or `\"unknown\"` outside a git checkout."
+          },
           "running": {
             "type": "boolean",
             "description": "Whether the server is running."

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,38 @@ fn main() {
     println!("cargo:rerun-if-changed=ui/index.html");
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=schemas/job.schema.json");
+    // Re-stamp the embedded git provenance whenever HEAD moves (new commit or
+    // checkout). Harmless when `.git/HEAD` is absent (e.g. a crates.io tarball):
+    // cargo just watches a path that never changes.
+    println!("cargo:rerun-if-changed=.git/HEAD");
+
+    // Embed the commit the binary is built from so `--version` and `GET /health`
+    // can identify the exact build, not just the crate version. Falls back to
+    // "unknown" outside a git checkout so published builds still compile.
+    println!(
+        "cargo:rustc-env=MOADIM_GIT_SHA={}",
+        git_output(&["rev-parse", "--short", "HEAD"])
+    );
+    println!(
+        "cargo:rustc-env=MOADIM_GIT_DATE={}",
+        git_output(&["show", "-s", "--format=%cs", "HEAD"])
+    );
 
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     build::run(&manifest_dir);
+}
+
+/// Run `git <args>` and return its trimmed stdout, or `"unknown"` when git is
+/// missing, exits non-zero, or the output is empty (e.g. building from a
+/// crates.io tarball with no `.git` directory).
+fn git_output(args: &[&str]) -> String {
+    std::process::Command::new("git")
+        .args(args)
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .and_then(|out| String::from_utf8(out.stdout).ok())
+        .map(|stdout| stdout.trim().to_string())
+        .filter(|stdout| !stdout.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
 }

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -1,0 +1,43 @@
+//! Compile-time build provenance: the crate version plus the git commit the
+//! binary was built from and that commit's date.
+//!
+//! `--version` and `GET /health` surface these so an operator can tell exactly
+//! which build is running — not just the crate version, which only changes on a
+//! release tag and so can't distinguish two builds of the same `0.x.y` cut.
+//!
+//! `build.rs` resolves the git fields at compile time and substitutes
+//! `"unknown"` when the source tree isn't a git checkout (e.g. a crates.io
+//! tarball, where `.git` is absent), so a published build still compiles and
+//! reports a sensible value.
+
+/// Crate version from `Cargo.toml` (`CARGO_PKG_VERSION`).
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Short git commit SHA the binary was built from, or `"unknown"` outside a git checkout.
+pub const GIT_SHA: &str = env!("MOADIM_GIT_SHA");
+
+/// Committer date (`YYYY-MM-DD`) of [`GIT_SHA`], or `"unknown"` outside a git checkout.
+pub const BUILD_DATE: &str = env!("MOADIM_GIT_DATE");
+
+/// Human-readable one-line version string, e.g. `0.1.0 (a1b2c3d 2026-06-19)`.
+///
+/// When the git provenance is unavailable (`GIT_SHA == "unknown"`), the suffix is
+/// dropped and the bare crate version is returned.
+pub fn long_version() -> String {
+    format_version(VERSION, GIT_SHA, BUILD_DATE)
+}
+
+/// Pure formatting core for [`long_version`], split out so both the
+/// git-available and the `"unknown"` fallback branches are unit-testable
+/// regardless of how the test binary itself was built.
+fn format_version(version: &str, sha: &str, date: &str) -> String {
+    if sha == "unknown" {
+        version.to_string()
+    } else {
+        format!("{version} ({sha} {date})")
+    }
+}
+
+#[cfg(test)]
+#[path = "build_info_tests.rs"]
+mod build_info_tests;

--- a/src/build_info_tests.rs
+++ b/src/build_info_tests.rs
@@ -1,0 +1,39 @@
+//! Tests for [`super`] build-provenance formatting.
+
+use super::{format_version, long_version, BUILD_DATE, GIT_SHA, VERSION};
+
+#[test]
+fn format_version_includes_sha_and_date_when_known() {
+    assert_eq!(
+        format_version("0.1.0", "a1b2c3d", "2026-06-19"),
+        "0.1.0 (a1b2c3d 2026-06-19)"
+    );
+}
+
+#[test]
+fn format_version_drops_suffix_when_sha_unknown() {
+    // Outside a git checkout build.rs sets the SHA to "unknown"; the provenance
+    // suffix must be dropped, leaving only the bare crate version.
+    assert_eq!(format_version("0.1.0", "unknown", "unknown"), "0.1.0");
+}
+
+#[test]
+fn long_version_starts_with_the_crate_version() {
+    // Regardless of whether this test binary was built inside a git checkout,
+    // the rendered string always begins with the crate version.
+    assert!(long_version().starts_with(VERSION));
+}
+
+#[test]
+fn long_version_reflects_the_embedded_git_fields() {
+    // Mirror the production branch: when the SHA is embedded, the rendered line
+    // carries both git fields; otherwise it is exactly the crate version.
+    if GIT_SHA == "unknown" {
+        assert_eq!(long_version(), VERSION);
+    } else {
+        assert_eq!(
+            long_version(),
+            format!("{VERSION} ({GIT_SHA} {BUILD_DATE})")
+        );
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -154,9 +154,10 @@ pub fn print_help() {
     );
 }
 
-/// Print the binary version to stdout.
+/// Print the binary version to stdout, including the git commit and date it was
+/// built from when available (e.g. `moadim 0.1.0 (a1b2c3d 2026-06-19)`).
 pub fn print_version() {
-    println!("moadim {}", env!("CARGO_PKG_VERSION"));
+    println!("moadim {}", crate::build_info::long_version());
 }
 
 /// Start the server as a detached background process and return immediately.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 #![deny(warnings)]
 //! Moadim server binary. Runs the Axum HTTP server with REST and MCP transports.
 
+/// Compile-time build provenance (crate version + git commit/date).
+mod build_info;
 /// Command-line interface and background-process lifecycle.
 mod cli;
 mod cron_jobs;

--- a/src/routes/http.rs
+++ b/src/routes/http.rs
@@ -27,6 +27,10 @@ pub struct HealthResponse {
     pub running: bool,
     /// Daemon version (from `CARGO_PKG_VERSION`).
     pub version: String,
+    /// Short git commit SHA the daemon was built from, or `"unknown"` outside a git checkout.
+    pub git_sha: String,
+    /// Committer date (`YYYY-MM-DD`) of the build commit, or `"unknown"` outside a git checkout.
+    pub build_date: String,
 }
 
 /// Request body for `POST /echo`.
@@ -74,7 +78,9 @@ pub async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
         // (panic in debug, wrap to a huge value in release) — clamp to 0 instead.
         uptime_secs: now_secs().saturating_sub(state.uptime_start),
         running: true,
-        version: env!("CARGO_PKG_VERSION").to_string(),
+        version: crate::build_info::VERSION.to_string(),
+        git_sha: crate::build_info::GIT_SHA.to_string(),
+        build_date: crate::build_info::BUILD_DATE.to_string(),
     })
 }
 


### PR DESCRIPTION
## Why

Closes #367.

`moadim --version` and `GET /api/v1/health` both reported only the crate version (`CARGO_PKG_VERSION`). That value changes only when a `v*` release tag is cut, so two different builds of the same `0.x.y` — a local dev build, a CI build, last night's `main` — are indistinguishable. When triaging "which build is actually running?" there was no answer.

## What

Add a small `build_info` module fed by `build.rs`:

- **`build.rs`** resolves the short git SHA (`git rev-parse --short HEAD`) and committer date (`git show -s --format=%cs HEAD`) at compile time and emits them as `rustc-env` vars. If git is missing/errors or the tree isn't a checkout (e.g. a **crates.io tarball**, where `.git` is absent), each field falls back to `"unknown"` — so a published build still compiles and reports sensibly. A `rerun-if-changed=.git/HEAD` keeps the stamp fresh as HEAD moves.
- **`moadim --version`** now prints `moadim <version> (<short-sha> <date>)`, e.g. `moadim 0.12.0 (552a875 2026-06-19)`.
- **`GET /api/v1/health`** gains `git_sha` and `build_date` fields. The existing `version` field is **unchanged** (still `CARGO_PKG_VERSION`), so existing consumers and the `json["version"]` health test keep passing. The new fields are additive — `apis/openapi.json` is regenerated accordingly.

## Verification

Run locally on stable (rustc 1.96.0):

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — all pass (the one intermittent `restart` force-kill test, tracked in #321, was a stray daemon holding the port; green once cleared)
- `./target/debug/moadim --version` → `moadim 0.12.0 (552a875 2026-06-19)`
- New `build_info_tests` cover both the git-available and `"unknown"` fallback branches.

CHANGELOG updated under `[Unreleased]`.

---
This pull request was opened by the **Daemon + Landing auto-improve PRs** routine of moadim.