### PR TITLE
fix(openapi): host-relative servers URL so Swagger "Try it out" follows the live origin (#385)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Fixed
 
+- The OpenAPI `servers` URL is now host-relative (`/api/v1`) instead of a
+  hardcoded `http://127.0.0.1:5784/api/v1`. Swagger UI's "Try it out" now targets
+  the origin the docs were served from, so it follows a custom `MOADIM_BIND_ADDR`
+  port or a reverse proxy instead of failing against an address the daemon may not
+  be bound to. (#385)
 - A malformed (present-but-unparseable) agent TOML is no longer misreported as
   "agent config not found". `load_agent_command` now returns a `Result` with a
   distinct `Missing` vs. `Parse` failure, so the sync/trigger skip diagnostics

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -11,8 +11,8 @@
   },
   "servers": [
     {
-      "url": "http://127.0.0.1:5784/api/v1",
-      "description": "Local development"
+      "url": "/api/v1",
+      "description": "This server"
     }
   ],
   "paths": {

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -3,7 +3,10 @@
 #[derive(utoipa::OpenApi)]
 #[openapi(
     info(title = "Moadim Server API", version = "0.1.0", description = "REST API for managing cron jobs"),
-    servers((url = "http://127.0.0.1:5784/api/v1", description = "Local development")),
+    // Host-relative server URL: Swagger UI resolves "Try it out" requests against the origin the
+    // docs were loaded from, so it follows a custom MOADIM_BIND_ADDR port or a reverse proxy instead
+    // of a hardcoded 127.0.0.1:5784 that breaks the moment the daemon isn't bound there (issue #385).
+    servers((url = "/api/v1", description = "This server")),
     paths(
         crate::routes::http::health,
         crate::routes::http::shutdown,

--- a/src/openapi_tests.rs
+++ b/src/openapi_tests.rs
@@ -14,3 +14,17 @@ fn committed_spec_is_current() {
         panic!("apis/openapi.json was stale — regenerated; re-run tests and commit the change");
     }
 }
+
+/// The `servers` URL must stay host-relative so Swagger UI "Try it out" follows the live origin
+/// (a custom `MOADIM_BIND_ADDR` port or a reverse proxy) rather than a hardcoded host:port that is
+/// wrong everywhere but the default bind address (issue #385).
+#[test]
+fn server_url_is_host_relative() {
+    use utoipa::OpenApi as _;
+    let servers = ApiDoc::openapi().servers.unwrap_or_default();
+    let url = &servers.first().expect("a server entry is declared").url;
+    assert_eq!(
+        url, "/api/v1",
+        "server URL must be host-relative, not absolute"
+    );
+}


### PR DESCRIPTION
## Why

The OpenAPI document declared its single `servers` entry as a hardcoded
`http://127.0.0.1:5784/api/v1` (`src/openapi.rs`). Swagger UI uses that URL as the
base for every **"Try it out"** request, so it only works when the daemon is bound
to exactly that default address. The moment it isn't — a custom `MOADIM_BIND_ADDR`
port, or the daemon behind a reverse proxy — the embedded docs fire probes at an
address the server isn't listening on, and they all fail. (issue #385)

## What

Switch the declared URL to the **host-relative** `/api/v1`. OpenAPI 3.0 resolves a
relative server URL against the location the spec was served from, so:

- Swagger UI's "Try it out" now targets whatever origin loaded `/docs` — the real
  bind address **or** the reverse-proxy front door — with no compile-time knowledge
  of the port.
- The committed `apis/openapi.json` and any external consumer that resolves the spec
  relative to its fetch URL get the same correct behavior.

No runtime address plumbing is needed: one origin-agnostic URL is correct everywhere.

## Changes

- `src/openapi.rs` — `servers` URL → `/api/v1` (with a comment explaining why).
- `apis/openapi.json` — regenerated by the existing spec-sync test.
- `src/openapi_tests.rs` — added `server_url_is_host_relative` regression test.
- `CHANGELOG.md` — bullet under `[Unreleased] → Fixed`.

## Verification

- `cargo fmt --check`, `cargo clippy` — clean.
- `cargo test` — 479 pass (new test included).
- `openapi.rs` stays at 100% line coverage.

---

This pull request was opened by the **Daemon + Landing auto-improve PRs** routine of moadim.