### PR TITLE
chore(lint): enable clippy::uninlined_format_args (#296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   isolated test crontab seam.
 - moadim-generated `.gitignore` files (job and routine) now ignore
   user-specific `run.sh` scripts.
+- Enabled the `clippy::uninlined_format_args` lint (deny) and inlined the
+  existing positional format arguments (`"{}", x` → `"{x}"`) so log lines and
+  error messages read more directly. No behavior change.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,5 @@ all = "deny"
 missing_docs_in_private_items = "deny"
 # Reject single-character identifiers (threshold 1, the lint default).
 min_ident_chars = "deny"
+# Require inline format args (`{x}`) over positional (`{}`, x) where possible.
+uninlined_format_args = "deny"

--- a/src/cron_jobs.rs
+++ b/src/cron_jobs.rs
@@ -180,7 +180,7 @@ pub(crate) fn validate_cron(expr: &str) -> Result<(), AppError> {
     let normalized = normalize_schedule(expr.trim());
     normalized
         .parse::<Cron>()
-        .map_err(|err| AppError::BadRequest(format!("invalid cron expression: {}", err)))?;
+        .map_err(|err| AppError::BadRequest(format!("invalid cron expression: {err}")))?;
     Ok(())
 }
 
@@ -336,10 +336,10 @@ pub fn svc_trigger(store: &CronStore, id: &str) -> Result<CronJob, AppError> {
     let handler_path = crate::paths::handlers_dir().join(&job.handler);
     if handler_path.exists() {
         if let Err(err) = std::process::Command::new(&handler_path).spawn() {
-            log::warn!("trigger: failed to spawn handler {:?}: {err}", handler_path);
+            log::warn!("trigger: failed to spawn handler {handler_path:?}: {err}");
         }
     } else {
-        log::warn!("trigger: handler script not found at {:?}", handler_path);
+        log::warn!("trigger: handler script not found at {handler_path:?}");
     }
     Ok(job)
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,9 +24,9 @@ impl fmt::Display for AppError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             AppError::Internal => write!(f, "internal server error"),
-            AppError::BadRequest(msg) => write!(f, "bad request: {}", msg),
+            AppError::BadRequest(msg) => write!(f, "bad request: {msg}"),
             AppError::NotFound => write!(f, "not found"),
-            AppError::Conflict(msg) => write!(f, "conflict: {}", msg),
+            AppError::Conflict(msg) => write!(f, "conflict: {msg}"),
         }
     }
 }

--- a/src/middlewares/logger.rs
+++ b/src/middlewares/logger.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 pub async fn logger(req: Request, next: Next) -> Response {
     let method = req.method().clone();
     let path = req.uri().path().to_string();
-    log::info!("{} {}", method, path);
+    log::info!("{method} {path}");
     let start = Instant::now();
     let res = next.run(req).await;
     log::info!(

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -211,7 +211,7 @@ pub(crate) fn migrate_prompt_files_from_dir(dir: &std::path::Path) {
         let new = entry.path().join("prompt.md");
         if old.exists() && !new.exists() {
             if let Err(err) = std::fs::rename(&old, &new) {
-                log::warn!("migrate_prompt_files: failed to rename {:?}: {err}", old);
+                log::warn!("migrate_prompt_files: failed to rename {old:?}: {err}");
             }
         }
     }


### PR DESCRIPTION
## Why

Closes #296.

The crate already denies a curated set of clippy lints (`all`, `min_ident_chars`, and recently `doc_markdown` / `map_unwrap_or` in flight). `clippy::uninlined_format_args` is the natural next one: inline captured args (`"{x}"`) read more directly than positional (`"{}", x`), and enabling it at **deny** level keeps the format-string style consistent going forward and lets the pre-push/CI clippy gate enforce it.

## What

- `Cargo.toml`: add `uninlined_format_args = "deny"` under `[lints.clippy]`.
- Inline the 7 positional format args the lint flagged:
  - `src/cron_jobs.rs` (3: cron-validation error, two `trigger` warn logs)
  - `src/error.rs` (2: `Display` for `BadRequest` / `Conflict`)
  - `src/middlewares/logger.rs` (1: request log line)
  - `src/routine_storage.rs` (1: prompt-file migration warn log)

Pure mechanical change — no behavior difference.

## Verification

- `cargo fmt --check` ✅
- `cargo clippy --all-targets` ✅ (clean with the new deny-level lint)
- `cargo test` ✅ — 477 passed, 0 failed
- `CHANGELOG.md` updated under `## [Unreleased] → Changed`

---
This pull request was opened by the **Daemon + Landing auto-improve PRs** routine of moadim.