### PR TITLE
docs: fix broken intra-doc links so rustdoc builds clean (#390)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Fixed
 
+- Repaired eleven broken `rustdoc` intra-doc links so `cargo doc` builds clean
+  again. The crate root's `#![deny(warnings)]` implies
+  `deny(rustdoc::broken_intra_doc_links)`, but nothing ran `cargo doc` in CI or
+  the pre-push hook, so the rotted links sat on `main` and made `cargo doc` fail
+  with "could not document `moadim`". Links to private submodules in
+  `src/routines/mod.rs` were demoted to plain code spans, and the remaining
+  links in `cleanup`, `sync`, and `utils::atomic` were fully qualified. (#390)
 - A malformed (present-but-unparseable) agent TOML is no longer misreported as
   "agent config not found". `load_agent_command` now returns a `Result` with a
   distinct `Missing` vs. `Parse` failure, so the sync/trigger skip diagnostics

--- a/src/routines/cleanup/mod.rs
+++ b/src/routines/cleanup/mod.rs
@@ -4,8 +4,10 @@
 //! agent in a tmux session named `moadim-{slug}-{ts}`. When the agent exits the session ends, but
 //! the workbench (prompt, logs, cloned repos) lingers forever. This module reaps those leftovers: a
 //! workbench is removed once its run has *finished* (no live tmux session) **and** it is older than
-//! the owning routine's [`Routine::effective_ttl_secs`]. A still-running session within its
-//! [`Routine::effective_max_runtime_secs`] is never touched; one that has *exceeded* that bound is
+//! the owning routine's [`Routine::effective_ttl_secs`](crate::routines::Routine::effective_ttl_secs).
+//! A still-running session within its
+//! [`Routine::effective_max_runtime_secs`](crate::routines::Routine::effective_max_runtime_secs)
+//! is never touched; one that has *exceeded* that bound is
 //! a hung run, so a watchdog force-kills its tmux session (recording the reason in the run's
 //! `agent.log`), after which the workbench is reaped under the normal TTL rules. Orphaned
 //! workbenches (routine since deleted) fall back to `MAX_TTL_SECS` / `MAX_RUNTIME_SECS`.

--- a/src/routines/mod.rs
+++ b/src/routines/mod.rs
@@ -6,14 +6,14 @@
 //! them in the prompt as context and the agent clones any it needs.
 //!
 //! The module is split by concern:
-//! - [`model`] — persisted types, API responses, and request bodies.
-//! - [`agents`] — the agent registry and built-in default agent configs.
-//! - [`defaults`] — built-in default routines seeded on startup when absent.
-//! - [`command`] — prompt composition and the single-line launch command builder.
-//! - [`service`] — store-mutating service functions (list/get/create/update/delete/trigger/logs).
-//! - [`cleanup`] — auto-removal of finished, expired run workbenches (per-routine TTL).
-//! - [`ical`] — iCalendar (`.ics`) export of upcoming routine fire times.
-//! - [`handlers`] — the Axum HTTP handlers.
+//! - `model` — persisted types, API responses, and request bodies.
+//! - `agents` — the agent registry and built-in default agent configs.
+//! - `defaults` — built-in default routines seeded on startup when absent.
+//! - `command` — prompt composition and the single-line launch command builder.
+//! - `service` — store-mutating service functions (list/get/create/update/delete/trigger/logs).
+//! - `cleanup` — auto-removal of finished, expired run workbenches (per-routine TTL).
+//! - `ical` — iCalendar (`.ics`) export of upcoming routine fire times.
+//! - `handlers` — the Axum HTTP handlers.
 
 mod agents;
 mod cleanup;

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -14,7 +14,7 @@
 //! This is the only sync direction the daemon runs.
 //!
 //! **Reverse sync** (crontab → moadim) is *not* wired up. The functions that
-//! implement it ([`sync_from_crontab`] and its `parse_block` /
+//! implement it ([`sync_from_crontab`](crate::sync::sync_from_crontab) and its `parse_block` /
 //! `parse_moadim_line` / `to_moadim_schedule` / `handler_from_command` helpers)
 //! exist and are unit-tested, but no caller invokes them on any interval or at
 //! startup — see issue #218. As a result, manual edits to the block do **not**

--- a/src/utils/atomic.rs
+++ b/src/utils/atomic.rs
@@ -1,7 +1,7 @@
 //! Atomic file writes: write to a temp file in the same directory, then rename into place.
 //!
 //! `std::fs::write` truncates-then-writes in place, so a crash mid-write leaves a torn file holding
-//! neither the old nor the new complete contents. [`atomic_write`] avoids that by writing to a
+//! neither the old nor the new complete contents. [`atomic_write`](crate::utils::atomic::atomic_write) avoids that by writing to a
 //! uniquely-named sibling temp file and renaming it over the target, so a concurrent reader always
 //! observes one complete version. This mirrors the durability guarantee the daemon already gives
 //! `~/.claude.json` (write temp + `os.replace`).


### PR DESCRIPTION
## Why

The crate root sets `#![deny(warnings)]`, which implies `deny(rustdoc::broken_intra_doc_links)`. Eleven intra-doc links had rotted, so `cargo doc` fails outright:

```
error: unresolved link to `model`
...
error: could not document `moadim`
```

Nothing ran `cargo doc` in CI or the pre-push hook (only `fmt`, `clippy`, coverage), so the breakage sat on `main` and would ship with the published crate's docs. This is the underlying problem behind #390.

## What

- **`src/routines/mod.rs`** — the module-overview bullets linked to the private submodules (`model`, `agents`, `defaults`, `command`, `service`, `ical`, `handlers`). These are private (`mod x;`) in a binary crate, so they are not in the documented item graph and can't be linked even when fully qualified. Demoted to plain code spans (reads identically).
- **`src/routines/cleanup/mod.rs`** — qualified `Routine::effective_ttl_secs` / `Routine::effective_max_runtime_secs` to `crate::routines::Routine::…`.
- **`src/sync/mod.rs`** — qualified `sync_from_crontab` to `crate::sync::…`.
- **`src/utils/atomic.rs`** — qualified `atomic_write` to `crate::utils::atomic::…`.

## Verification

```
RUSTDOCFLAGS="-D warnings" cargo doc --no-deps   # builds clean
cargo fmt --check                                # passes
```

Comment-only change — no behavior change.

## Note

Issue #390 also asks for a CI rustdoc gate (`.github/workflows/doc.yml` running `cargo doc` with `RUSTDOCFLAGS=-D warnings`). That workflow file was dropped from this PR because the routine's token lacks the GitHub `workflow` scope to push workflow changes; it can land in a follow-up. This PR fixes the underlying breakage so such a gate would pass.

---
This pull request was opened by the **Daemon + Landing auto-improve PRs** routine of moadim. @tupe12334