### PR TITLE
fix(cron): reject blank handler on cron job create/update

### DIFF
--- a/src/cron_jobs.rs
+++ b/src/cron_jobs.rs
@@ -184,6 +184,21 @@ pub(crate) fn validate_cron(expr: &str) -> Result<(), AppError> {
     Ok(())
 }
 
+/// Reject a blank handler identifier.
+///
+/// The handler names the script under the handlers directory to spawn when the
+/// schedule fires (`svc_trigger`). A blank or whitespace-only value would be
+/// persisted as a job that can never resolve to an executable, so it is caught
+/// here before anything is written to disk.
+fn validate_handler(handler: &str) -> Result<(), AppError> {
+    if handler.trim().is_empty() {
+        return Err(AppError::BadRequest(
+            "handler must not be empty".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 /// Request body for creating a new cron job.
 #[derive(Deserialize, JsonSchema, utoipa::ToSchema)]
 pub struct CreateRequest {
@@ -256,6 +271,7 @@ pub fn svc_create(
     req: CreateRequest,
 ) -> Result<CronJobResponse, AppError> {
     validate_cron(&req.schedule)?;
+    validate_handler(&req.handler)?;
     let now = now_secs();
     let job = CronJob {
         id: Uuid::new_v4().to_string(),
@@ -285,6 +301,9 @@ pub fn svc_update(
 ) -> Result<CronJobResponse, AppError> {
     if let Some(ref sched) = req.schedule {
         validate_cron(sched)?;
+    }
+    if let Some(ref handler) = req.handler {
+        validate_handler(handler)?;
     }
     let mut lock = store.lock().unwrap();
     let job = lock.get_mut(id).ok_or(AppError::NotFound)?;

--- a/src/cron_jobs_tests.rs
+++ b/src/cron_jobs_tests.rs
@@ -274,6 +274,50 @@ fn svc_create_invalid_cron_returns_err() {
 }
 
 #[test]
+fn svc_create_blank_handler_returns_err() {
+    let store = new_store();
+    for handler in ["", "   "] {
+        let req = CreateRequest {
+            schedule: "@daily".into(),
+            handler: handler.into(),
+            metadata: serde_json::Value::Null,
+            enabled: true,
+        };
+        assert!(svc_create(&store, &new_registry(), req).is_err());
+    }
+    assert!(store.lock().unwrap().is_empty());
+}
+
+#[test]
+fn svc_update_blank_handler_returns_err() {
+    let store = new_store();
+    let created = svc_create(
+        &store,
+        &new_registry(),
+        CreateRequest {
+            schedule: "@daily".into(),
+            handler: "keep".into(),
+            metadata: serde_json::Value::Null,
+            enabled: true,
+        },
+    )
+    .unwrap();
+    let id = created.job.id.clone();
+
+    let req = UpdateRequest {
+        schedule: None,
+        handler: Some("   ".into()),
+        metadata: None,
+        enabled: None,
+    };
+    assert!(svc_update(&store, &new_registry(), &id, req).is_err());
+    // The original handler is left untouched after a rejected update.
+    assert_eq!(store.lock().unwrap().get(&id).unwrap().handler, "keep");
+
+    crate::storage::remove_job_dir(&id).unwrap();
+}
+
+#[test]
 fn svc_update_changes_all_fields() {
     let store = new_store();
     let created = svc_create(


### PR DESCRIPTION
## Why

`svc_create` and `svc_update` in `src/cron_jobs.rs` validated the cron
schedule but accepted **any** handler string — including `""` or
whitespace-only. Such a job is happily persisted to disk, yet at fire
time `svc_trigger` joins the handler onto the handlers directory and
finds nothing executable, so the job silently does nothing. There is no
feedback to the API/MCP caller that the job is dead on arrival.

The routines module already guards against exactly this class of bug:
`reject_blank` in `src/routines/service.rs` rejects empty `title`/`prompt`
before persisting (issues #224/#226). Cron jobs lacked the equivalent.

## What

- Add `validate_handler` to `src/cron_jobs.rs`, rejecting a blank /
  whitespace-only handler with `400 BadRequest` (same shape as the
  existing `validate_cron`).
- Call it in `svc_create` (after `validate_cron`) and in `svc_update`
  (when a handler is supplied). Both the REST and MCP paths go through
  these, so both are covered.
- Tests: reject empty and whitespace-only handler on create (store stays
  empty); reject blank handler on update and assert the existing handler
  is left untouched.

## Checks

- `cargo fmt --check` — clean
- `cargo clippy --all-targets` — clean
- `cargo test cron_job` — all pass, including the two new tests

Both branches of `validate_handler` are exercised by tests, keeping the
100% coverage gate satisfied.

---
This pull request was opened by the *Daemon + Landing auto-improve PRs* routine of moadim.