### PR TITLE
chore(cargo): add crates.io keywords + categories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ description = "Moadim.io MCP/REST server for managing cron jobs"
 license = "MIT"
 repository = "https://github.com/moadim-io/daemon"
 homepage = "https://github.com/moadim-io/daemon"
+keywords = ["cron", "scheduler", "mcp", "automation", "rest"]
+categories = ["command-line-utilities", "web-programming::http-server"]
 
 [dependencies]
 anyhow = "1"


### PR DESCRIPTION
## Why

The crate's `[package]` metadata declared no `keywords` or `categories`. Two consequences:

- `cargo publish` emits a warning for the missing fields.
- The published crate has **zero discoverability** on crates.io — it never appears in category browsing or keyword search, so people looking for a cron/scheduler/MCP tool can't find it.

## What

Add the recommended discoverability metadata to `Cargo.toml`:

```toml
keywords = ["cron", "scheduler", "mcp", "automation", "rest"]
categories = ["command-line-utilities", "web-programming::http-server"]
```

Both category slugs are from the canonical crates.io category list, and there are exactly five keywords (the crates.io max). This matches what moadim is: a cron/scheduler daemon exposing a REST + MCP HTTP server.

## Verification

- No code or behavior change — manifest-only.
- `cargo verify-project` → `{"success":"true"}`
- `cargo package --list` succeeds (validates keyword/category constraints).
- `cargo fmt --check` and `cargo clippy --all-targets --all-features` both clean.

---

This pull request was opened by the *Daemon + Landing auto-improve PRs* routine of moadim. /cc @tupe12334