### PR TITLE
fix(routines): drop dangling repo header in prompt.md when no repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Fixed
 
+- The generated `prompt.md` no longer emits a dangling "These repositories are
+  relevant — clone any you need:" header with an empty bullet list when a routine
+  has no `repositories`. `compose_prompt` now writes a plain "You are working in
+  an empty directory." preamble in that case, so the agent isn't promised a repo
+  list with nothing under it.
 - A malformed (present-but-unparseable) agent TOML is no longer misreported as
   "agent config not found". `load_agent_command` now returns a `Result` with a
   distinct `Missing` vs. `Parse` failure, so the sync/trigger skip diagnostics

--- a/src/routines/command.rs
+++ b/src/routines/command.rs
@@ -30,15 +30,25 @@ pub(crate) fn slugify(title: &str) -> String {
 }
 
 /// Compose the `prompt.md` body: a repositories-as-context preamble followed by the prompt.
+///
+/// When the routine lists no repositories the preamble omits the "clone any you need:" sentence
+/// and its (otherwise empty) bullet list, so the agent never sees a dangling header promising a
+/// repo list with nothing under it.
 pub(crate) fn compose_prompt(routine: &Routine) -> String {
     let mut body = String::from("# Workbench\n");
-    body.push_str(
-        "You are working in an empty directory. These repositories are relevant — clone any you need:\n",
-    );
-    for repo in &routine.repositories {
-        match &repo.branch {
-            Some(branch) => body.push_str(&format!("- {} (branch {})\n", repo.repository, branch)),
-            None => body.push_str(&format!("- {}\n", repo.repository)),
+    if routine.repositories.is_empty() {
+        body.push_str("You are working in an empty directory.\n");
+    } else {
+        body.push_str(
+            "You are working in an empty directory. These repositories are relevant — clone any you need:\n",
+        );
+        for repo in &routine.repositories {
+            match &repo.branch {
+                Some(branch) => {
+                    body.push_str(&format!("- {} (branch {})\n", repo.repository, branch))
+                }
+                None => body.push_str(&format!("- {}\n", repo.repository)),
+            }
         }
     }
     body.push_str("\n---\n");

--- a/src/routines/mod_tests.rs
+++ b/src/routines/mod_tests.rs
@@ -58,6 +58,19 @@ fn compose_prompt_repo_without_branch() {
 }
 
 #[test]
+fn compose_prompt_without_repositories_omits_clone_header() {
+    let mut routine = make_routine("x");
+    routine.repositories = vec![];
+    let prompt = compose_prompt(&routine);
+    assert!(prompt.contains("# Workbench"));
+    assert!(prompt.contains("You are working in an empty directory.\n"));
+    // No dangling "clone any you need:" header (and no empty bullet list) when there are no repos.
+    assert!(!prompt.contains("clone any you need"));
+    assert!(!prompt.contains("\n- "));
+    assert!(prompt.contains("do the thing"));
+}
+
+#[test]
 fn substitute_replaces_placeholders() {
     assert_eq!(
         substitute("read {prompt_file} in {workbench}", ".", "prompt.md"),


### PR DESCRIPTION
## Why

`compose_prompt` always wrote the preamble:

> You are working in an empty directory. These repositories are relevant — clone any you need:

followed by the repo bullet list. When a routine has **no** `repositories`, the
list is empty, so the generated `prompt.md` ended with a header promising a repo
list with **nothing under it** — confusing context for the agent that directly
contradicts the "empty directory" framing.

## What

- `compose_prompt` now emits a plain `You are working in an empty directory.`
  preamble when `routine.repositories` is empty, and keeps the full
  clone-list preamble only when repos are actually present.
- Adds a unit test (`compose_prompt_without_repositories_omits_clone_header`)
  covering the empty-repositories branch — previously untested.

## Checks

- `cargo fmt --check` ✓
- `cargo clippy --all-targets --all-features` ✓ (clean)
- `cargo test` ✓ (478 passed)
- `cargo llvm-cov --fail-under-lines 100` ✓ (100% line coverage held)
- `CHANGELOG.md` updated under `## [Unreleased] / Fixed`.

Small, focused, no behaviour change when a routine has repositories.

---
This pull request was opened by the *Daemon + Landing auto-improve PRs* routine of moadim. @tupe12334