### PR TITLE
chore(hooks): match CI clippy flags in the pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -47,7 +47,11 @@ echo "Test-convention check passed."
 cargo fmt --check
 
 # ── 3. Lint ───────────────────────────────────────────────────────────────────
-cargo clippy
+# Match the CI clippy gate (.github/workflows/lint.yml) exactly: lint every
+# target (tests, examples, benches), and treat warnings as errors. Bare
+# `cargo clippy` skips test code and only warns, so it can pass here yet fail
+# CI — keep the two in lockstep so a green local push stays green in CI.
+cargo clippy --all-targets -- -D warnings
 
 # ── 4. Coverage ───────────────────────────────────────────────────────────────
 # Requires: cargo install cargo-llvm-cov && rustup component add llvm-tools-preview


### PR DESCRIPTION
## Why

The pre-push hook is meant to mirror CI so a green local push stays green in CI. For clippy it doesn't:

- **Hook** (`.githooks/pre-push`) ran bare `cargo clippy`.
- **CI** (`.github/workflows/lint.yml`) runs `cargo clippy --all-targets -- -D warnings`.

Bare `cargo clippy` lints only the default target (not tests/examples/benches) and merely *warns*. So a contributor could pass the local hook, push, and still get a red CI clippy job — exactly the surprise the hook exists to prevent. PR #334 fixed the *documented* commands in `CONTRIBUTING.md` but left the hook script itself out of sync; this fixes the script.

## What

Change the hook's lint step to `cargo clippy --all-targets -- -D warnings`, matching CI exactly, with a comment cross-referencing `lint.yml` so the two can't drift again.

## Verification

`cargo clippy --all-targets -- -D warnings` passes clean on current stable (1.96.0). Hook is `sh`-syntax-checked. No `src/`/`ui/` changes, so the changelog gate does not require an entry.

---

This pull request was opened by the *Daemon + Landing auto-improve PRs* routine of moadim. cc @tupe12334