### PR TITLE
fix(security): add defense-in-depth response headers to UI & API (#406)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   persisted, and surviving entries are trimmed. Malformed `repositories` lists
   are now caught at the API boundary rather than surfacing later as a confusing
   run-time failure (#241).
+- Defense-in-depth security response headers are now injected on every HTTP
+  response served by the daemon (web UI + `/api/v1`): `X-Frame-Options: DENY`
+  and a `frame-ancestors 'none'` CSP block clickjacking of the dashboard's
+  destructive controls, `X-Content-Type-Options: nosniff` stops content
+  sniffing, and `Referrer-Policy: no-referrer` keeps the loopback URL from
+  leaking to third parties. The CSP is intentionally scoped to `frame-ancestors`
+  only so the existing inline + WASM SPA and Swagger UI keep working untouched
+  (#406).
 
 ### Changed
 

--- a/src/middlewares/mod.rs
+++ b/src/middlewares/mod.rs
@@ -2,3 +2,5 @@
 pub mod fs_location;
 /// Middleware that logs request method, path, status, and latency.
 pub mod logger;
+/// Middleware that adds defense-in-depth security response headers.
+pub mod security_headers;

--- a/src/middlewares/security_headers.rs
+++ b/src/middlewares/security_headers.rs
@@ -1,0 +1,47 @@
+use axum::{
+    extract::Request,
+    http::{header::HeaderName, HeaderValue},
+    middleware::Next,
+    response::Response,
+};
+
+/// Defense-in-depth response headers applied to every HTTP response (UI + `/api/v1`).
+///
+/// The daemon serves a browser dashboard whose buttons drive an unauthenticated loopback API
+/// (create / trigger / delete routines, `POST /shutdown`), so the served responses are hardened
+/// against the cheap framing / sniffing vectors:
+///
+/// - `X-Frame-Options: DENY` + CSP `frame-ancestors 'none'` — block clickjacking of the
+///   dashboard's destructive controls via `<iframe src="http://localhost:5784/">`.
+/// - `X-Content-Type-Options: nosniff` — stop browsers content-sniffing a response into an
+///   unintended type.
+/// - `Referrer-Policy: no-referrer` — never leak the loopback URL to third parties.
+///
+/// The CSP is intentionally scoped to `frame-ancestors` only: it closes the framing gap without
+/// constraining `script-src` / `style-src`, so the existing inline + WASM SPA and the Swagger UI
+/// keep working untouched. A fuller `script-src`/`style-src` policy is left as follow-up once it
+/// can be verified against the bundled UI.
+const SECURITY_HEADERS: &[(&str, &str)] = &[
+    ("x-frame-options", "DENY"),
+    ("x-content-type-options", "nosniff"),
+    ("referrer-policy", "no-referrer"),
+    ("content-security-policy", "frame-ancestors 'none'"),
+];
+
+/// Inject the [`SECURITY_HEADERS`] onto every response.
+pub async fn security_headers(req: Request, next: Next) -> Response {
+    let mut res = next.run(req).await;
+    let headers = res.headers_mut();
+    for (name, value) in SECURITY_HEADERS {
+        // Names and values are static, lowercase, printable ASCII, so `from_static` cannot panic.
+        headers.insert(
+            HeaderName::from_static(name),
+            HeaderValue::from_static(value),
+        );
+    }
+    res
+}
+
+#[cfg(test)]
+#[path = "security_headers_tests.rs"]
+mod security_headers_tests;

--- a/src/middlewares/security_headers_tests.rs
+++ b/src/middlewares/security_headers_tests.rs
@@ -1,0 +1,49 @@
+#![allow(clippy::missing_docs_in_private_items)]
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    middleware,
+    routing::get,
+    Router,
+};
+use tower::ServiceExt;
+
+use super::{security_headers, SECURITY_HEADERS};
+
+fn app() -> Router {
+    Router::new()
+        .route("/", get(|| async { "ok" }))
+        .layer(middleware::from_fn(security_headers))
+}
+
+#[tokio::test]
+async fn security_headers_present_on_response() {
+    let resp = app()
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    for (name, value) in SECURITY_HEADERS {
+        assert_eq!(
+            resp.headers().get(*name).map(|hv| hv.to_str().unwrap()),
+            Some(*value),
+            "missing or wrong {name} header"
+        );
+    }
+}
+
+#[tokio::test]
+async fn frame_ancestors_blocks_framing() {
+    let resp = app()
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.headers().get("x-frame-options").unwrap(), "DENY");
+    assert_eq!(
+        resp.headers().get("content-security-policy").unwrap(),
+        "frame-ancestors 'none'"
+    );
+}

--- a/src/routes/http.rs
+++ b/src/routes/http.rs
@@ -205,6 +205,9 @@ pub(crate) fn build_app_with_shutdown(
         // SPA fallback: client-routed pages (`/cron-jobs`, `/routines`) and refreshes on them return
         // the app HTML so the Yew router can resolve the path on load.
         .fallback(get(index))
+        .layer(middleware::from_fn(
+            middlewares::security_headers::security_headers,
+        ))
         .layer(middleware::from_fn(middlewares::fs_location::fs_location))
         .layer(middleware::from_fn(middlewares::logger::logger))
         .with_state(app_state)

--- a/src/routes/http_tests.rs
+++ b/src/routes/http_tests.rs
@@ -82,6 +82,31 @@ async fn build_app_serves_root() {
 }
 
 #[tokio::test]
+async fn build_app_sets_security_headers_on_ui_and_api() {
+    // The whole router carries the security headers (issue #406): assert on a representative
+    // UI response (the SPA at `/`) and a representative API response (`/api/v1/health`).
+    for uri in ["/", "/api/v1/health"] {
+        let resp = build_app(new_store(), crate::routines::new_store())
+            .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.headers().get("x-frame-options").unwrap(), "DENY");
+        assert_eq!(
+            resp.headers().get("x-content-type-options").unwrap(),
+            "nosniff"
+        );
+        assert_eq!(
+            resp.headers().get("referrer-policy").unwrap(),
+            "no-referrer"
+        );
+        assert_eq!(
+            resp.headers().get("content-security-policy").unwrap(),
+            "frame-ancestors 'none'"
+        );
+    }
+}
+
+#[tokio::test]
 async fn build_app_serves_agents() {
     let app = build_app(new_store(), crate::routines::new_store());
     let resp = app


### PR DESCRIPTION
## Why

The daemon serves a full browser dashboard (the SPA at `/`, plus client-routed `/cron-jobs`, `/routines`) and an **unauthenticated loopback REST API** on the same port. The dashboard's buttons drive state-changing endpoints (create / trigger / delete routines, `POST /shutdown`), yet a grep over `src/` finds **no security response headers** anywhere — the only response-header middleware (`fs_location`) *adds* path-leaking headers, none harden the response.

That leaves two cheap vectors open:
- **Clickjacking** — a malicious page can `<iframe src="http://localhost:5784/">` the dashboard and trick the operator into clicking *Trigger* / *Delete* / *Stop*.
- **MIME sniffing** — without `nosniff`, a browser may content-sniff a response into an unintended type.

Closes #406.

## What

New `middlewares::security_headers` layer, applied to **all** responses (UI + `/api/v1/*`, including 404/error responses), setting:

| Header | Value |
|---|---|
| `X-Frame-Options` | `DENY` |
| `Content-Security-Policy` | `frame-ancestors 'none'` |
| `X-Content-Type-Options` | `nosniff` |
| `Referrer-Policy` | `no-referrer` |

The CSP is intentionally scoped to `frame-ancestors` only: it closes the framing gap **without** constraining `script-src` / `style-src`, so the existing inline + WASM SPA and the Swagger UI at `/docs` keep working untouched. A fuller `script-src`/`style-src` policy is left as follow-up once it can be verified against the bundled UI.

Complementary to (not a duplicate of) #356 (removing path-leaking headers) and #266 (Host/Origin validation).

## Tests
- `security_headers_present_on_response` / `frame_ancestors_blocks_framing` — middleware unit tests.
- `build_app_sets_security_headers_on_ui_and_api` — asserts the headers on a representative UI response (`/`) and API response (`/api/v1/health`) through the real router.

`cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass clean.

---
This pull request was opened by the **Daemon + Landing auto-improve PRs** routine of moadim. @tupe12334