### PR TITLE
Enable clippy::dbg_macro lint rule

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,5 @@ all = "deny"
 missing_docs_in_private_items = "deny"
 # Reject single-character identifiers (threshold 1, the lint default).
 min_ident_chars = "deny"
+# Reject leftover `dbg!` debugging macros so they never ship to production.
+dbg_macro = "deny"


### PR DESCRIPTION
## Summary
Enables the Clippy lint **`clippy::dbg_macro`** at `deny` in the root `[lints.clippy]` table.

```toml
[lints.clippy]
all = "deny"
missing_docs_in_private_items = "deny"
min_ident_chars = "deny"
dbg_macro = "deny"   # <- added
```

## Why
`dbg!(...)` is a temporary development aid that prints to stderr. Leftover `dbg!` calls leak debug output to production and slip past review easily. `clippy::all` does **not** cover it (it lives in the `restriction` group), so it must be opted into explicitly.

## Impact
- **0** existing `dbg!` occurrences → no code changes needed, build stays green.
- Purely preventive: blocks future `dbg!` from landing.

## Verification
`cargo clippy --all-targets` → `Finished` with no warnings/errors.

Closes #420

---
*This pull request was opened by the "Add lint rule → issue + PR (owned repos + my orgs) → Slack" routine of moadim.* cc @tupe12334