### PR TITLE
docs(readme): document the MOADIM_BIND_ADDR override (#417)

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,26 @@ Starts on `http://127.0.0.1:5784`. On startup the server:
 2. Reads your crontab and applies any changes made to the moadim block while the server was stopped.
 3. Writes all enabled managed jobs back into the crontab block.
 
+### Bind address
+
+The server binds to `127.0.0.1:5784` by default — the same address every client command
+(`status`, `stop`, `cleanup`, …) probes. Override it with the `MOADIM_BIND_ADDR` environment
+variable, set identically for the server and any client you run against it:
+
+```sh
+# Bind the server to a different port (or interface)…
+MOADIM_BIND_ADDR=127.0.0.1:7000 moadim
+
+# …and point client commands at the same address.
+MOADIM_BIND_ADDR=127.0.0.1:7000 moadim status
+```
+
+Because the override changes both the bind and the probe target, a client started without it
+keeps looking at the default `127.0.0.1:5784` and will report the relocated server as not running.
+Export the variable in your shell profile to make the change stick across commands. All the
+`127.0.0.1:5784` addresses shown above and in the `--json` payloads reflect the default; they
+follow `MOADIM_BIND_ADDR` when it is set.
+
 ## MCP usage
 
 > _This is where the loop closes: your agent reads, schedules, and re-fires its own jobs. Loop engineering with a daemon in the middle._


### PR DESCRIPTION
## Why

The server resolves its bind/probe address from the `MOADIM_BIND_ADDR` environment variable, falling back to `127.0.0.1:5784` (`src/cli.rs`):

```rust
const BIND_ADDR_ENV: &str = "MOADIM_BIND_ADDR";
pub fn bind_addr() -> String {
    std::env::var(BIND_ADDR_ENV).unwrap_or_else(|_| BIND_ADDR.to_string())
}
```

But the README never documents it — the override was source-only, and every example (plus the `--json` payloads) hardcodes `127.0.0.1:5784`, which misleads anyone who relocates the server. Because the override changes both the bind **and** the client probe target, a client invoked without the same value keeps looking at the default port and wrongly reports the relocated server as not running.

## What

- Adds a **Bind address** subsection under *Running* documenting `MOADIM_BIND_ADDR`.
- Shows the server + client usage (both must share the value) and the export-it-to-persist tip.
- Notes that the `127.0.0.1:5784` addresses elsewhere in the docs/JSON are the default and follow `MOADIM_BIND_ADDR` when set.

Closes #417.

Docs-only change — no `src/`/`ui/` touched, so the changelog gate is exempt. `cargo fmt --check` and `typos` are clean.

---
This pull request was opened by the *Daemon + Landing auto-improve PRs* routine of moadim. @tupe12334