### PR TITLE
fix(cron): project 6-field schedules to a valid OS crontab line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Fixed
 
+- 6-field cron schedules (`sec min hour dom month dow`, accepted by `croner`)
+  are now projected to a valid 5-field OS crontab line instead of being written
+  verbatim. Previously only 7-field expressions had their leading seconds
+  stripped, so a valid 6-field schedule reached the crontab unchanged — where
+  vixie-cron/cronie either rejects the line (silently dropping every managed
+  job) or misreads seconds as minutes (shifting the schedule). `normalize_schedule`
+  and `to_os_schedule` now handle the 6-field form the same way as 7-field.
 - A malformed (present-but-unparseable) agent TOML is no longer misreported as
   "agent config not found". `load_agent_command` now returns a `Result` with a
   distinct `Missing` vs. `Parse` failure, so the sync/trigger skip diagnostics

--- a/src/cron_jobs.rs
+++ b/src/cron_jobs.rs
@@ -158,7 +158,10 @@ pub fn new_registry() -> HandlerRegistry {
 
 /// Normalize `expr` to 5-field OS cron format for consistent storage.
 ///
-/// Strips the seconds (field 0) and year (field 6) from any 7-field expression.
+/// Both the 6-field (`sec min hour dom month dow`) and 7-field
+/// (`sec min hour dom month dow year`) forms accepted by `croner` carry a
+/// leading seconds field that the OS crontab cannot express; it is dropped (as
+/// is the trailing year), projecting onto the 5-field `min hour dom month dow`.
 /// `@keyword` schedules and already-5-field expressions are returned unchanged.
 pub(crate) fn normalize_schedule(expr: &str) -> String {
     let trimmed = expr.trim();
@@ -167,7 +170,7 @@ pub(crate) fn normalize_schedule(expr: &str) -> String {
     }
     let fields: Vec<&str> = trimmed.split_ascii_whitespace().collect();
     match fields.len() {
-        7 => fields[1..6].join(" "),
+        6 | 7 => fields[1..6].join(" "),
         _ => trimmed.to_string(),
     }
 }

--- a/src/cron_jobs_tests.rs
+++ b/src/cron_jobs_tests.rs
@@ -44,6 +44,24 @@ fn validate_cron_rejects_invalid() {
 }
 
 #[test]
+fn validate_cron_accepts_6_field() {
+    // croner accepts 6-field `sec min hour dom month dow`; validate_cron
+    // normalizes it down before parsing, so it must be accepted.
+    assert!(validate_cron("0 30 9 * * 1-5").is_ok());
+    assert!(validate_cron("*/30 * * * * *").is_ok());
+}
+
+#[test]
+fn normalize_schedule_projects_to_5_field() {
+    // 6- and 7-field schedules both lose their leading seconds (and trailing
+    // year) so the stored/crontab form is a valid 5-field expression.
+    assert_eq!(normalize_schedule("0 30 9 * * 1-5"), "30 9 * * 1-5");
+    assert_eq!(normalize_schedule("0 30 9 * * 1-5 *"), "30 9 * * 1-5");
+    assert_eq!(normalize_schedule("30 9 * * 1-5"), "30 9 * * 1-5");
+    assert_eq!(normalize_schedule("@daily"), "@daily");
+}
+
+#[test]
 fn validate_cron_accepts_all_documented_keywords() {
     for kw in [
         "@hourly",

--- a/src/sync/cron_sync_tests.rs
+++ b/src/sync/cron_sync_tests.rs
@@ -127,6 +127,14 @@ fn to_os_schedule_7field_drops_sec_and_year() {
 }
 
 #[test]
+fn to_os_schedule_6field_drops_seconds() {
+    // croner accepts 6-field `sec min hour dom month dow`; the OS crontab has no
+    // seconds column, so the leading field is dropped to a valid 5-field line.
+    assert_eq!(to_os_schedule("0 30 9 * * 1-5"), "30 9 * * 1-5");
+    assert_eq!(to_os_schedule("*/30 * * * * *"), "* * * * *");
+}
+
+#[test]
 fn to_os_schedule_passthrough_keyword() {
     assert_eq!(to_os_schedule("@daily"), "@daily");
     assert_eq!(to_os_schedule("@reboot"), "@reboot");

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -75,11 +75,14 @@ impl From<std::io::Error> for SyncError {
 
 // ─── Schedule conversion ───────────────────────────────────────────────────
 
-/// Convert a 7-field moadim schedule (`sec min hour dom month dow year`) to
-/// a 5-field OS crontab schedule (`min hour dom month dow`).
+/// Convert a moadim schedule to a 5-field OS crontab schedule
+/// (`min hour dom month dow`).
 ///
-/// `@keyword` schedules are passed through unchanged.
-/// The seconds (field 0) and year (field 6) are dropped.
+/// `croner` accepts both 6-field (`sec min hour dom month dow`) and 7-field
+/// (`sec min hour dom month dow year`) forms. Both carry a leading seconds field
+/// the OS crontab cannot express, so it is dropped (along with the trailing
+/// year), projecting onto 5 fields. `@keyword` and already-5-field schedules are
+/// passed through unchanged.
 pub(crate) fn to_os_schedule(schedule: &str) -> String {
     let trimmed = schedule.trim();
     if trimmed.starts_with('@') {
@@ -87,8 +90,7 @@ pub(crate) fn to_os_schedule(schedule: &str) -> String {
     }
     let fields: Vec<&str> = trimmed.split_ascii_whitespace().collect();
     match fields.len() {
-        7 => fields[1..6].join(" "),
-        5 => trimmed.to_string(),
+        6 | 7 => fields[1..6].join(" "),
         _ => trimmed.to_string(),
     }
 }


### PR DESCRIPTION
## Why

`croner` (the validator) accepts **6-field** cron expressions —
`sec min hour dom month dow` — and `validate_cron` normalizes a schedule before
parsing, so the REST/MCP layer happily accepts a 6-field schedule on routine and
cron-job create/update. I confirmed the leading field is seconds: `*/30 * * * * *`
parses and fires every 30 **seconds**, and `0 30 9 * * 1-5` fires at 09:30 on
weekdays.

But the two functions that produce the OS-crontab line only special-cased the
**7-field** form:

- `normalize_schedule` (`src/cron_jobs.rs`)
- `to_os_schedule` (`src/sync/mod.rs`)

A 6-field schedule fell through their `_` arm and was written into the OS crontab
**verbatim**. A 6-field line is not valid vixie-cron/cronie syntax, so the
`crontab` install either:

- **rejects the whole line** → every managed job is silently dropped, or
- **misreads the leading seconds as minutes** → the schedule is shifted.

Either way `/health` stays green while the routine silently mis-fires or never
fires — the same "valid input → silent breakage" class as recent fixes (#230, #246).

## What

Handle the 6-field form exactly like 7-field: strip the leading seconds (and, for
7-field, the trailing year), projecting onto the canonical 5-field
`min hour dom month dow`. `@keyword` and already-5-field schedules are unchanged.

`*/30 * * * * *` → `* * * * *` (every minute — the finest resolution the OS
crontab can express, matching how 7-field seconds were already dropped).

## Tests

- `to_os_schedule_6field_drops_seconds` (`src/sync/cron_sync_tests.rs`)
- `validate_cron_accepts_6_field` + `normalize_schedule_projects_to_5_field`
  (`src/cron_jobs_tests.rs`)

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and the cron
test suite all pass; the new arms are exercised, preserving the 100% line-coverage
floor. CHANGELOG `## [Unreleased] → Fixed` updated.

---
This pull request was opened by the **Daemon + Landing auto-improve PRs** routine of moadim.