### PR TITLE
chore: add .gitattributes for generated/vendored files (#425)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Normalize line endings: Git stores text with LF, checks out native EOL.
+* text=auto
+
+# Generated and vendored files. Marking them `linguist-generated` collapses
+# their diffs in pull requests and excludes them from GitHub's repository
+# language statistics, so the ~1.1 MB embedded UI bundle and the lockfiles
+# stop skewing the language breakdown and flooding code review.
+#
+# This mirrors the generated/vendored set already excluded from spell-check in
+# `typos.toml` (see CONTRIBUTING.md): the embedded UI HTML, lockfiles, the
+# OpenAPI document, and the generated JSON Schema.
+prebuilt.html      linguist-generated -diff
+Cargo.lock         linguist-generated
+pnpm-lock.yaml     linguist-generated
+apis/openapi.json  linguist-generated
+schemas/job.schema.json linguist-generated


### PR DESCRIPTION
## Why

The repository ships a ~1.1 MB generated UI bundle (`prebuilt.html`) and several lockfiles/generated docs, but has no `.gitattributes`. As a result:

- **PR diffs are flooded** — any regeneration of `prebuilt.html` dumps a million-line diff into review.
- **GitHub language stats are skewed** — the large generated HTML bundle dominates the repo's language breakdown, mislabeling this Rust project.
- **No EOL normalization** — line endings aren't normalized across platforms.

Closes #425.

## What

Add a root `.gitattributes` that:

- marks the generated/vendored files as `linguist-generated` so they collapse in PR diffs and drop out of language stats;
- additionally marks `prebuilt.html` `-diff` (it's an inlined-WASM blob, not meaningfully reviewable as text);
- sets `* text=auto` for consistent LF normalization.

The marked set mirrors exactly the generated/vendored files already excluded from the `typos` spell-checker in `typos.toml` (documented in `CONTRIBUTING.md`): `prebuilt.html`, the lockfiles, `apis/openapi.json`, and the generated `schemas/job.schema.json`.

## Risk

None at runtime — config-only, no `src/`/`ui/` changes (no CHANGELOG entry required), touches no Rust. `linguist-generated` affects only GitHub's diff rendering and language stats; `-diff` affects only local/PR diff display, not content.

---
This pull request was opened by the **Daemon + Landing auto-improve PRs** routine of moadim.
