### PR TITLE
fix(ui): box the large Routine variant in RAction to satisfy clippy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,13 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   harmless shim instead of signalling a real PID. The default stays the platform
   killer (`kill` / `taskkill`), so the existing self-contained test that kills
   its own spawned child still works. (#216)
+- The `ui` crate's `RAction::Upsert` variant now boxes its `Routine`
+  (`Upsert(Box<Routine>)`). The variant carried a ~272-byte `Routine` by value
+  while the next-largest variant was 48 bytes, tripping
+  `clippy::large_enum_variant` under the crate's `[lints.clippy] all = "deny"`,
+  so `cargo clippy --all-targets` failed to compile. The reducer derefs the box
+  once before the existing upsert logic, and the construction sites wrap the
+  value.
 
 ## [0.12.0] - 2026-06-18
 

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -290,7 +290,7 @@ pub enum RAction {
     SetRepoFilter(String),
     SetSort(RSort),
     ToggleSortDir,
-    Upsert(Routine),
+    Upsert(Box<Routine>),
     Remove(String),
 }
 
@@ -317,6 +317,7 @@ impl Reducible for RState {
             RAction::SetSort(sort) => s.sort = sort,
             RAction::ToggleSortDir => s.sort_desc = !s.sort_desc,
             RAction::Upsert(routine) => {
+                let routine = *routine;
                 if let Some(i) = s.routines.iter().position(|x| x.id == routine.id) {
                     s.routines[i] = routine;
                 } else {
@@ -418,7 +419,7 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
             spawn_local(async move {
                 match api_create(&req).await {
                     Ok(r) => {
-                        state.dispatch(RAction::Upsert(r));
+                        state.dispatch(RAction::Upsert(Box::new(r)));
                         state.dispatch(RAction::GoToList);
                         ok("Routine created");
                     }
@@ -457,7 +458,7 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
             spawn_local(async move {
                 match api_trigger(&id).await {
                     Ok(r) => {
-                        state.dispatch(RAction::Upsert(r));
+                        state.dispatch(RAction::Upsert(Box::new(r)));
                         ok("Routine triggered");
                     }
                     Err(e) => toast.emit((format!("Trigger failed: {e}"), ToastKind::Err)),
@@ -481,7 +482,7 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
                 };
                 match api_update(&id, &req).await {
                     Ok(r) => {
-                        state.dispatch(RAction::Upsert(r));
+                        state.dispatch(RAction::Upsert(Box::new(r)));
                         ok(if enabled {
                             "Routine enabled"
                         } else {
@@ -517,7 +518,7 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
                     };
                     match api_update(id, &upd).await {
                         Ok(r) => {
-                            state.dispatch(RAction::Upsert(r));
+                            state.dispatch(RAction::Upsert(Box::new(r)));
                             state.dispatch(RAction::CloseModal);
                             ok("Routine updated");
                         }


### PR DESCRIPTION
## Why

The `ui` crate enforces `[lints.clippy] all = "deny"`, yet `cargo clippy --all-targets` currently **fails to compile** it on current stable (cargo 1.96.0):

```
error: large size difference between variants
   --> ui/src/routines.rs:281:1
    |
293 |     Upsert(Routine),
    |     --------------- the largest variant contains at least 272 bytes
    | the second-largest variant contains at least 48 bytes
    = note: `-D clippy::large-enum-variant` implied by `-D clippy::all`
```

`RAction::Upsert` held a whole `Routine` (~272 bytes) by value while every other variant is ≤48 bytes, so each dispatched action paid for the largest variant on the stack. This is a real build break for any UI work and for the lint gate the crate opts into.

## What

- `Upsert(Routine)` → `Upsert(Box<Routine>)`.
- Reducer derefs once (`let routine = *routine;`) before the unchanged upsert logic.
- Wrap the four `RAction::Upsert(r)` construction sites in `Box::new(r)`.

## Verification

```
cargo clippy --all-targets   # clean
cargo fmt --check            # clean
```

Focused, behavior-preserving change — no API or UI-behavior difference.

---
This pull request was opened by the **Daemon + Landing auto-improve PRs** routine of moadim. @tupe12334