### PR TITLE
test(restart): deflake force-kill stop test by widening timing margins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Fixed
 
+- Deflaked `stop_running_and_wait_force_kills_then_succeeds_when_server_goes_down`:
+  the test raced a ~35ms window between the restart timeout (80ms) and the server
+  drop (130ms), so a coverage-instrumented or loaded CI run could miss the post-kill
+  `wait_until_stopped` window and fail the assertion. The margins are now 300ms /
+  450ms, giving ~150ms of slack on each side of the deadline while still exercising
+  the same force-kill-then-stops path.
 - A malformed (present-but-unparseable) agent TOML is no longer misreported as
   "agent config not found". `load_agent_command` now returns a `Result` with a
   distinct `Missing` vs. `Parse` failure, so the sync/trigger skip diagnostics

--- a/src/restart_tests.rs
+++ b/src/restart_tests.rs
@@ -137,12 +137,15 @@ fn stop_running_and_wait_force_kills_then_succeeds_when_server_goes_down() {
     let home = temp_home("kill-success");
     let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", home.to_str().unwrap());
     let _addr = EnvGuard::set("MOADIM_BIND_ADDR", &server.addr);
-    let _timeout = EnvGuard::set("MOADIM_RESTART_TIMEOUT_MS", "80");
-    let _poll = EnvGuard::set("MOADIM_RESTART_POLL_MS", "10");
+    let _timeout = EnvGuard::set("MOADIM_RESTART_TIMEOUT_MS", "300");
+    let _poll = EnvGuard::set("MOADIM_RESTART_POLL_MS", "15");
     let mut child = spawn_dummy_with_pid_file();
-    // The first wait (80ms) times out with the server still up, then the server is taken down
-    // at 130ms — well inside the post-kill wait's window — so that wait observes it stopped.
-    server.stop_after(Duration::from_millis(130));
+    // The first wait (300ms) times out with the server still up, then the server is taken down
+    // at 450ms — well inside the post-kill wait's window — so that wait observes it stopped.
+    // The ~150ms of slack on each side of the post-kill deadline keeps the test off the timing
+    // knife-edge it used to sit on (80ms timeout / 130ms drop left only ~35ms of margin, which
+    // a coverage-instrumented or otherwise loaded CI run could blow, flaking this assertion).
+    server.stop_after(Duration::from_millis(450));
     stop_running_and_wait().expect("server stops after force-kill -> success");
     let _ = child.wait();
     let _ = std::fs::remove_dir_all(&home);


### PR DESCRIPTION
## Why

`stop_running_and_wait_force_kills_then_succeeds_when_server_goes_down` (in `src/restart_tests.rs`) sits on a timing knife-edge. It set:

- `MOADIM_RESTART_TIMEOUT_MS = 80`
- the fake server drop at `130ms`

`stop_running_and_wait()` runs `wait_until_stopped` (times out at ~80ms, server still up), force-kills, then runs a **second** `wait_until_stopped` whose deadline is ~`T_kill + 80ms`. The server is only meant to disappear at 130ms, leaving roughly **~35ms of slack** for that second window to observe the drop.

On a bare, idle machine that holds. But under the project's own pre-push gate — `cargo llvm-cov --fail-under-lines 100`, which instruments every probe — or any loaded CI runner, the first wait can overrun, the `kill` fork/exec adds latency, and each loopback `is_running()` probe adds jitter. When that pushes the second deadline or a poll tick out of the shrinking window, the second `wait_until_stopped` returns `false` and the assertion flakes. This is the kind of intermittent failure that makes the coverage gate look red for reasons unrelated to the change under test.

## What

Widen the margins to **300ms timeout / 450ms server drop** (poll 15ms), giving ~150ms of slack on each side of the post-kill deadline. The test still drives the exact same path: first wait times out with the server up → force-kill → second wait observes the server going down → success.

- `src/restart_tests.rs`: bump the three timing constants + refresh the explanatory comment.
- `CHANGELOG.md`: bullet under `[Unreleased] → Fixed`.

**Test-only change — no production code touched.** The sibling bail/override tests are unaffected (they assert the timeout path, which only needs the deadline to expire, not a narrow hit window).

## Verify

```
cargo test --bin moadim restart_tests::   # 7 passed
cargo fmt --check                          # clean
```

---
This pull request was opened by the *Daemon + Landing auto-improve PRs* routine of moadim.