### PR TITLE
chore: add root .editorconfig (#422)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+# EditorConfig — shared whitespace baseline for this polyglot tree.
+# https://editorconfig.org
+#
+# This complements (does not duplicate) rustfmt/clippy/typos: it pins the
+# editor-level whitespace rules those tools don't cover, and applies to the
+# YAML/JSON/TOML/MD/HTML files they never format. Values are chosen to agree
+# with the current rustfmt output and existing files, so adopting this file
+# produces no reformatting churn — it just keeps future edits (human and agent)
+# from drifting on indentation, final newlines, and trailing whitespace.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Match rustfmt's defaults so the two never conflict.
+[*.rs]
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,json,toml,html}]
+indent_style = space
+indent_size = 2
+
+# In Markdown, two trailing spaces are a hard line break — don't strip them.
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Why

The repo has no `.editorconfig`. Whitespace is enforced only *per language* by `rustfmt`, `clippy`, and `crate-ci/typos` — none of which cover the editor-level whitespace rules an `.editorconfig` standardizes, and none of which touch the non-Rust files (YAML/JSON/TOML/MD/HTML) at all. In this heavily agent-edited tree that drift shows up as noisy, whitespace-only diff churn in review.

Closes #422.

## What

A root `.editorconfig` (`root = true`) with a baseline chosen to **agree with the current rustfmt output and existing files**, so adopting it reformats nothing:

- `[*]` — `charset = utf-8`, `end_of_line = lf`, `insert_final_newline = true`, `trim_trailing_whitespace = true`
- `[*.rs]` — `indent_style = space`, `indent_size = 4` (matches rustfmt defaults, so the two never conflict)
- `[*.{yml,yaml,json,toml,html}]` — `indent_style = space`, `indent_size = 2` (matches the existing workflows/configs)
- `[*.md]` — `trim_trailing_whitespace = false` (two trailing spaces are a hard line break in Markdown)

It **complements** rustfmt/clippy/typos rather than duplicating them, and cuts whitespace-only churn from the PR stream.

## Scope / risk

Editor-config only — no `src/` or `ui/` change, no behavioral change. `.editorconfig` is advisory (editors read it; it reformats nothing on its own).

---
This pull request was opened by the **Daemon + Landing auto-improve PRs** routine of moadim.