### PR TITLE
docs(readme): add crates.io / docs.rs / CI / license badges (#451)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # moadim
 
+[![crates.io](https://img.shields.io/crates/v/moadim.svg)](https://crates.io/crates/moadim)
+[![docs.rs](https://img.shields.io/docsrs/moadim)](https://docs.rs/moadim)
+[![CI](https://img.shields.io/github/actions/workflow/status/moadim-io/daemon/test.yml?branch=main&label=CI)](https://github.com/moadim-io/daemon/actions/workflows/test.yml)
+[![License: MIT](https://img.shields.io/crates/l/moadim.svg)](https://opensource.org/licenses/MIT)
+
 > **Loop engineering, on a schedule.** Stop prompting your agents — design the loop that prompts them.
 >
 > **Cron jobs that run while you sleep.** One port. Three interfaces. Zero drift.


### PR DESCRIPTION
## Why

`README.md` opened straight into prose with **no status/identity badges**. For a crate already published to crates.io (`moadim` is at `0.12.0`), that leaves the first thing a crates.io / GitHub visitor reads with no at-a-glance signal: the latest published version, whether CI is green, the license, or that API docs exist — all of which currently require clicking through to crates.io, the Actions tab, or `Cargo.toml`.

## What

Add a single badge row immediately below the `# moadim` heading:

- **crates.io version** → links to the crate page
- **docs.rs** → links to the rendered API docs
- **CI build status** (the existing `test.yml` workflow on `main`) → links to the Actions runs
- **License: MIT** → links to the MIT SPDX page

All four are live shields.io endpoints that pull from crates.io / GitHub / docs.rs, so they can't go stale the way a hardcoded version string would.

### Note on the license link

The repo has **no `LICENSE` file yet** (tracked in #377/#378), so the license badge links to the MIT SPDX page (`https://opensource.org/licenses/MIT`) rather than a `./LICENSE` path that would 404. It can be repointed at the file once that PR lands.

## Verification

- `typos README.md` passes (the spellcheck CI gate).
- README is docs-only — no `src/`/`ui/` change, so the CHANGELOG gate does not apply; fmt/clippy/test are unaffected.

Distinct from #314 (Cargo.toml `keywords`/`categories` metadata) — this is README presentation only.

Closes #451

---
🤖 This pull request was opened by the **Daemon + Landing auto-improve PRs** routine of moadim.