### PR TITLE
docs(readme): correct the "On startup" list to match actual sync behavior (#456)

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,9 +311,17 @@ the foreground.)
 
 Starts on `http://127.0.0.1:5784`. On startup the server:
 
-1. Loads all jobs from `~/.config/moadim/jobs/`.
-2. Reads your crontab and applies any changes made to the moadim block while the server was stopped.
-3. Writes all enabled managed jobs back into the crontab block.
+1. Loads all managed jobs from `~/.config/moadim/jobs/`.
+2. Loads all routines, seeds any missing built-in default routines, and rewrites
+   the **routines** crontab block — so a block that went stale while the server
+   was stopped (e.g. emptied by an earlier run) is regenerated and scheduled
+   routines keep firing.
+
+The **job** crontab block is _not_ rewritten at startup; it is kept current on
+each job create/update/delete (see [Crontab sync](#crontab-sync)). Reverse sync
+(crontab → moadim) is not run in either direction, so manual edits inside the
+managed blocks are never imported — they are overwritten by the next forward
+sync.
 
 ## MCP usage
 


### PR DESCRIPTION
## Why

The README's **"On startup the server:"** list (in the *Running* section) described behavior the daemon does not have, and contradicted the repo's own **Crontab sync** section:

- **Step 2** — *"Reads your crontab and applies any changes made to the moadim block while the server was stopped"* — is reverse sync (crontab → moadim). The Crontab-sync section already states reverse sync is **not enabled** ([#218](https://github.com/moadim-io/daemon/issues/218)), and `run_server()` never calls `sync_from_crontab`.
- **Step 3** — *"Writes all enabled managed jobs back into the crontab block"* — implies the **job** block is rewritten at startup. It is not: startup only re-syncs the **routines** block via `sync::routines::sync_routines_to_crontab`. The job block is rewritten on each job create/update/delete (`svc_create`/`svc_update`/`svc_delete`), not at boot.

## What

Rewrite the list to match what `run_server()` actually does (load jobs → load routines → seed default routines → re-sync the routines crontab block), and add a clarifying note that the job block is synced on mutation and that reverse sync is not run — keeping this section consistent with **Crontab sync**.

Docs-only; no code, build, or workflow changes.

Closes #456.

---
This pull request was opened by the "Daemon + Landing auto-improve PRs" routine of moadim.