### PR TITLE
fix(sync): guard cron-jobs sync against wiping the block on an empty store (#450)

### DIFF
--- a/src/sync/cron_sync_tests.rs
+++ b/src/sync/cron_sync_tests.rs
@@ -540,6 +540,35 @@ fn sync_to_crontab_writes_block_and_is_idempotent() {
     drop(shim);
 }
 
+#[test]
+fn sync_refuses_to_wipe_job_lines_when_store_is_empty() {
+    // Footgun guard (#450): an empty store must NOT overwrite a populated job block — that would
+    // silently drop every managed cron line. Mirrors the routines-block guard.
+    let populated = "\
+# BEGIN MOADIM
+# Managed by moadim
+30 9 * * 1-5 /handlers/keep-me # moadim:keep-me
+# END MOADIM
+";
+    let shim = CronShim::new(Some(populated));
+    sync_to_crontab(&store_with(vec![])).unwrap();
+    // The crontab is left untouched: the managed job line survives.
+    assert_eq!(shim.store_contents(), populated);
+    assert!(shim.store_contents().contains("# moadim:keep-me"));
+    drop(shim);
+}
+
+#[test]
+fn sync_proceeds_when_store_empty_but_no_job_lines() {
+    // Guard's second operand is false (no `# moadim:` marker), so sync proceeds; the block is
+    // already empty so the result equals the input and the idempotent check returns without writing.
+    let empty_block = format!("{BLOCK_BEGIN}\n{BLOCK_HEADER}\n{BLOCK_END}\n");
+    let shim = CronShim::new(Some(&empty_block));
+    sync_to_crontab(&store_with(vec![])).unwrap();
+    assert!(!shim.store_contents().contains("# moadim:"));
+    drop(shim);
+}
+
 // ─── sync_from_crontab ───────────────────────────────────────────────────────
 
 #[test]

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -360,12 +360,29 @@ pub(crate) fn parse_block(crontab: &str) -> HashMap<String, (String, String)> {
 
 // ─── Public sync API ───────────────────────────────────────────────────────
 
+/// Substring identifying a managed job line inside the crontab block (`# moadim:<id>`).
+const JOB_LINE_MARKER: &str = "# moadim:";
+
 /// Write all enabled managed jobs from `store` into the OS crontab block.
 ///
 /// Idempotent: skips the `crontab -` call when the crontab would not change.
 /// Call this after every job mutation. Errors are logged by the caller.
+///
+/// Footgun guard (mirrors [`routines::sync_routines_to_crontab`]): refuses to overwrite a populated
+/// job block when the store is *empty*. An empty store at sync time means the store failed to load
+/// (or a second daemon is racing this one), not a genuine "no jobs" state — so without this guard
+/// the sync would write a bare block and silently drop every managed cron line. A store that loaded
+/// fine but holds only disabled/unmanaged jobs is *not* empty, so legitimately clearing the last
+/// job still works.
 pub fn sync_to_crontab(store: &CronStore) -> Result<(), SyncError> {
     let current = read_crontab()?;
+    if store.lock().unwrap().is_empty() && current.contains(JOB_LINE_MARKER) {
+        log::warn!(
+            "cron sync: store is empty but the crontab still has managed job lines; refusing to \
+             wipe the moadim block (suspected load failure or a concurrent daemon)"
+        );
+        return Ok(());
+    }
     let block = build_block(store);
     let new_crontab = replace_block(&current, &block);
     if new_crontab == current {


### PR DESCRIPTION
## Why

`sync_to_crontab` (the cron-jobs forward sync) rebuilt the managed-jobs crontab block from the store on **every** mutation, with no guard. If the store was empty at sync time — a failed or partial load on startup, or a second daemon racing this one — `build_block` emitted a bare block and the sync overwrote the crontab, **silently dropping every managed job line** until the next successful mutation re-populated it.

The routines block already defends against this exact footgun in `sync_routines_to_crontab` (added for the routines incident). The cron-jobs path was missing the equivalent guard — issue #450.

## What

Mirror the routines guard in `sync_to_crontab`:

- When the store is empty **and** the crontab still carries managed job lines (`# moadim:`), log a warning and skip the write.
- A store that loaded fine but legitimately holds only disabled/unmanaged jobs is *not* empty, so clearing the last job still works as before.

The new `JOB_LINE_MARKER` (`# moadim:`) does not match the routines marker (`# moadim-routine:`), so the two blocks stay independent.

## Tests

Adds two tests covering both guard branches, matching the routines-guard test pair:

- `sync_refuses_to_wipe_job_lines_when_store_is_empty` — populated block + empty store ⇒ crontab untouched.
- `sync_proceeds_when_store_empty_but_no_job_lines` — empty store, no job marker ⇒ guard's second operand is false, sync proceeds (idempotent no-op).

## Verification (local)

- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo test sync::cron_sync_tests::sync_refuses_to_wipe_job_lines_when_store_is_empty sync::cron_sync_tests::sync_proceeds_when_store_empty_but_no_job_lines` — `2 passed; 0 failed`.

---

This pull request was opened by the *Daemon + Landing auto-improve PRs* routine of moadim. @tupe12334