### PR TITLE
chore: add .github/CODEOWNERS to auto-request owner review (#447)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# Code owners for the Moadim daemon.
+#
+# GitHub auto-requests a review from the owners listed here on every pull
+# request that touches matching paths. With a single catch-all rule, the
+# repository owner is requested on all PRs — including automated Dependabot
+# dependency bumps — so nothing merges without an owner in the loop.
+#
+# Docs: https://docs.github.com/articles/about-code-owners
+
+# Default owner for everything in the repo.
+*       @tupe12334
+
+# Release-critical paths — keep the owner explicitly on the hook for anything
+# that can publish a crate, cut a release, or shift the dependency graph, even
+# if finer-grained ownership is added above later.
+/.github/workflows/publish.yml   @tupe12334
+/.github/workflows/release.yml   @tupe12334
+/Cargo.toml                      @tupe12334
+/Cargo.lock                      @tupe12334


### PR DESCRIPTION
## Why

Fixes #447.

The repo has **no CODEOWNERS file** (checked `.github/CODEOWNERS`, root `CODEOWNERS`, and `docs/CODEOWNERS` — all absent). As a result, opening a PR auto-requests review from **nobody**: no rule maps any path to a default reviewer, so the owner isn't pulled onto a PR unless they happen to notice it. The owner has explicitly asked to be looped in on all changes.

This is the CODEOWNERS follow-up that #347 (issue forms + PR template) deliberately left out. The sibling **`landing`** repo already adopted CODEOWNERS (#166), so the two repos are currently inconsistent on review routing — this closes that gap.

## What

Add `.github/CODEOWNERS`:

- Catch-all `* @tupe12334` so **every** PR (including Dependabot bumps) auto-requests the owner's review and GitHub surfaces an Owner badge in the reviewers list.
- Explicit ownership of release-critical paths (`publish.yml`, `release.yml`, `Cargo.toml`, `Cargo.lock`) per the issue's optional acceptance criterion.

Form mirrors the `landing` repo's CODEOWNERS to keep the two repos consistent.

## Notes

- No code or runtime change — `clippy` / `fmt` / coverage are unaffected.
- Touches only `.github/` (not `src/`/`ui/`), so the changelog gate is exempt.

---
This pull request was opened by the **Daemon + Landing auto-improve PRs** routine of moadim.