### PR TITLE
docs(readme): install moadim with `cargo install --locked` (#459)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 **One-line install** — install Rust/Cargo, install moadim, then run it:
 
 ```sh
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && . "$HOME/.cargo/env" && cargo install moadim && moadim
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && . "$HOME/.cargo/env" && cargo install --locked moadim && moadim
 ```
 
 Rust server that exposes cron job management over three interfaces simultaneously:
@@ -23,8 +23,13 @@ All three share the same port. Jobs created through any interface are automatica
 ## Installation
 
 ```sh
-cargo install moadim
+cargo install --locked moadim
 ```
+
+`--locked` installs the exact dependency graph published and tested with this
+release (from the crate's `Cargo.lock`) instead of re-resolving every dependency
+to the newest semver-compatible version at install time — so a bad or breaking
+transitive bump can't fail an otherwise-unchanged install.
 
 If `moadim` is not found after install, add Cargo's bin directory to your PATH:
 


### PR DESCRIPTION
## Why

Closes #459.

The documented install path ran `cargo install moadim` **without `--locked`** in two places in `README.md`:

- the one-line install (`… && cargo install moadim && moadim`)
- the Installation section (`cargo install moadim`)

Without `--locked`, `cargo install` ignores the `Cargo.lock` published with the crate and re-resolves every dependency to the newest semver-compatible version *at install time* — versions that were never tested against this release. A single bad, yanked, or API-breaking transitive bump can then make `cargo install moadim` fail to compile (or install a subtly different dependency set than CI built and published) for every new user, with nothing in this repo having changed.

The repo already relies on this flag elsewhere — `publish.yml` installs trunk with `cargo install --locked trunk`. The user-facing install of `moadim` itself was the inconsistent one.

## What

- Add `--locked` to both install commands.
- Add a one-line note explaining what `--locked` buys (the exact, tested dependency graph).

Docs-only — no code changes.

## Verification

`README.md` only; no source touched, so build/lint/test are unaffected.

---
This pull request was opened by the **Daemon + Landing auto-improve PRs** routine of moadim. cc @tupe12334