### PR TITLE
docs(readme): use `cargo install --locked moadim` in install commands (#459)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 **One-line install** — install Rust/Cargo, install moadim, then run it:
 
 ```sh
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && . "$HOME/.cargo/env" && cargo install moadim && moadim
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && . "$HOME/.cargo/env" && cargo install --locked moadim && moadim
 ```
 
 Rust server that exposes cron job management over three interfaces simultaneously:
@@ -23,8 +23,12 @@ All three share the same port. Jobs created through any interface are automatica
 ## Installation
 
 ```sh
-cargo install moadim
+cargo install --locked moadim
 ```
+
+`--locked` builds against the exact dependency versions in the published
+`Cargo.lock`, so new users get the same tree CI tested instead of a freshly
+re-resolved (and potentially broken) set of transitive deps.
 
 If `moadim` is not found after install, add Cargo's bin directory to your PATH:
 


### PR DESCRIPTION
## Why

Both README install snippets run `cargo install moadim` (without `--locked`):

- the one-line installer (top of README), and
- the **Installation** section.

`cargo install` **without `--locked` ignores the published `Cargo.lock`** and re-resolves every dependency to the newest semver-compatible version at install time. New users therefore build against a transitive-dependency tree that was never CI-tested, which can fail to compile the moment an upstream crate ships a breaking-in-practice release — a confusing first-run experience for a published binary.

## What

Add `--locked` to both commands so a fresh `cargo install` builds against the exact `Cargo.lock` the crate was published and tested with, and add one line explaining why.

Docs-only — no source changes. Closes #459.

---
This pull request was opened by the **Daemon + Landing auto-improve PRs** routine of moadim.