### PR TITLE
chore: group Dependabot updates per ecosystem (#463)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,55 @@
 version: 2
+
+# Batch dependency updates into a single grouped PR per ecosystem instead of one
+# PR per dependency. Without `groups:`, every bump opens its own PR — each firing
+# the full lint/test/coverage matrix and demanding a separate review, which
+# multiplies CI minutes and review load every week.
+#
+# Minor and patch bumps (the low-risk majority) are grouped into one PR per
+# ecosystem so they can be reviewed and merged together. Major bumps are left
+# ungrouped — they're the most likely to break and deserve an individual PR with
+# focused review.
 updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      cargo:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "cargo"
     directory: "/ui"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      cargo-ui:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      npm:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Why

`.github/dependabot.yml` declares four update entries (cargo `/`, cargo `/ui`, npm, github-actions) but **no `groups:`**. Without grouping, Dependabot opens a separate PR for every single dependency bump. Each of those PRs fires the full lint / test / coverage matrix and demands its own review, multiplying CI minutes and review load every week.

Closes #463.

## What

Add a `groups:` block to each ecosystem that batches the low-risk majority — **minor and patch** bumps — into a single grouped PR per ecosystem:

- `cargo` (root)
- `cargo-ui` (`/ui`)
- `npm`
- `github-actions`

**Major** bumps are intentionally left ungrouped: they're the most likely to break and deserve an individual PR with focused review.

## Notes

- Pure config change — no source, no behavior change to the daemon itself.
- Validated as well-formed YAML against the Dependabot v2 schema shape; `open-pull-requests-limit` and the weekly schedule are unchanged.

---

This pull request was opened by the *Daemon + Landing auto-improve PRs* routine of moadim.