### PR TITLE
docs(readme): document the global user_prompt.md prompt layer (#458)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ attached to your terminal instead, use `moadim --interactive`.
 │       └── .gitignore         # generated — excludes *.local.* and *.log
 ├── agents/                    # registered coding agents referenced by routines
 │   └── claude.toml
+├── user_prompt.md             # optional — appended to every routine's prompt (see ## Routines)
 └── workbenches/               # per-run throwaway dirs, reaped on the hourly sweep
 ```
 
@@ -267,6 +268,23 @@ GET    /routines.ics          # subscribe to fire times as a calendar feed
 `~/.config/moadim/agents/<agent>.toml`. API responses include
 `agent_registered` so callers can tell whether the named agent is configured on
 the host.
+
+### Global user prompt
+
+An optional `~/.config/moadim/user_prompt.md` lets you inject persistent,
+host-wide instructions into **every** routine. At launch each run renders a
+`CLAUDE.md` in its workbench from two layers:
+
+1. **Moadim preamble** — the daemon-managed header, the routine-origin
+   disclosure (naming the routine), and the run-date/timezone stamp.
+2. **Your user prompt** — if `user_prompt.md` exists, its contents are appended
+   below a `---` separator.
+
+Use it for standing guidance that should apply to all routines regardless of
+their individual `prompt` — coding conventions, who to tag, tone, or a default
+identity. It is purely additive: a missing file is skipped silently, and it
+never replaces a routine's own `prompt`. Because it is user-scope (not per
+routine), it lives at the config root rather than inside a routine folder.
 
 ## Running
 


### PR DESCRIPTION
## Why

`~/.config/moadim/user_prompt.md` is a shipped feature: its contents are appended to the per-run `CLAUDE.md` of **every** routine (see `src/routines/command.rs` `system_prompt_stmts` and `src/paths/mod.rs` `user_prompt_path`). But it was source-only — the README never mentioned it, so users had no way to discover the global prompt-injection hook. Closes #458.

## What

- New **Global user prompt** subsection under `## Routines` describing the two-layer `CLAUDE.md`: the daemon-managed Moadim preamble (origin disclosure + run-date stamp) followed by the appended `user_prompt.md`, below a `---` separator.
- Entry for `user_prompt.md` in the **Directory layout** tree.

Documents existing behavior accurately: the file is optional, purely additive, never replaces a routine's own `prompt`, and is user-scope (lives at the config root, not in a routine folder).

## Scope

Docs-only — no `src/` or `ui/` changes, so the changelog gate is exempt and build/lint/test are unaffected.

---
This pull request was opened by the **Daemon + Landing auto-improve PRs** routine of moadim.