### PR TITLE
feat: full action parity across CLI, REST, and MCP (#493)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Added
 
+- **Full action parity across the CLI, REST, and MCP surfaces.** Every cron-job
+  and routine action is now reachable from all three.
+  - **New CLI data commands** (thin clients over the running server's REST API,
+    built on `clap`): `moadim cron-jobs <create|list|get|update|replace|delete|trigger|logs>`,
+    `moadim routines <create|list|get|update|replace|delete|trigger|logs|ical>`,
+    `moadim agents`, and `moadim echo <message>`. They print the server's JSON
+    response and exit `3` ("not running") when no daemon is reachable, matching
+    the existing `status`/`stop`/`cleanup` contract. (`cron`/`routine` are
+    accepted as aliases.)
+  - **New MCP tools** filling the gaps versus REST: `list_agents`,
+    `cron_job_logs`, `routine_logs`, `shutdown`, and `restart`.
+  - **New `POST /api/v1/restart` route** (plus the matching `restart` MCP tool):
+    stops the running server and starts a fresh instance via a detached helper
+    process, since an in-process server cannot rebind its own port. Documented in
+    the OpenAPI spec.
 - The MCP `health` tool now reports build provenance — `version`, `git_sha`, and
   `build_date` — bringing it to parity with `GET /api/v1/health` and
   `moadim --version`, so an MCP client can tell exactly which build is running

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1518,6 +1558,7 @@ dependencies = [
  "anyhow",
  "axum",
  "chrono",
+ "clap",
  "croner",
  "dirs",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ categories = ["command-line-utilities", "web-programming::http-server"]
 anyhow = "1"
 axum = "0.8"
 chrono = "0.4"
+clap = { version = "4", features = ["derive"] }
 croner = "3"
 dirs = "6"
 env_logger = "0.11"

--- a/README.md
+++ b/README.md
@@ -317,6 +317,43 @@ on `$?` without parsing stdout: they exit `0` when a server is running (and `cle
 asked it to shut down) and `3` when no server is reachable. Any other failure exits non-zero (`1`)
 with a message on stderr.
 
+### Data commands
+
+Beyond lifecycle, the CLI exposes **every** cron-job and routine action the REST API and MCP tools
+do — they are thin clients that send the same JSON to the running server and print its response
+(pretty-printed JSON, or raw text for logs / the iCalendar feed). Like `status`/`stop`/`cleanup`,
+they exit `3` when no server is reachable and `1` on a non-2xx response.
+
+```sh
+# Cron jobs (alias: `cron`)
+moadim cron-jobs create --schedule "0 9 * * *" --handler send-report
+moadim cron-jobs list
+moadim cron-jobs get <id>
+moadim cron-jobs update <id> --schedule "0 10 * * *" --enabled false
+moadim cron-jobs replace <id> --schedule "0 9 * * *" --handler send-report
+moadim cron-jobs trigger <id>
+moadim cron-jobs logs <id>
+moadim cron-jobs delete <id>
+
+# Routines (alias: `routine`)
+moadim routines create --schedule "0 8 * * *" --title "Daily" --agent claude --prompt "..." \
+  --repositories '[{"repository":"https://github.com/me/repo","branch":"main"}]'
+moadim routines list
+moadim routines update <id> --title "Renamed" --ttl-secs 3600
+moadim routines trigger <id>
+moadim routines logs <id>
+moadim routines ical          # iCalendar feed of upcoming fire times
+moadim routines delete <id>
+
+# Misc
+moadim agents                 # list available agent keys
+moadim echo "hello"           # echo via the server (with a server timestamp)
+```
+
+Pass `--help` to any subcommand (e.g. `moadim routines create --help`) for the full flag list.
+`--metadata` (cron) and `--repositories` (routines) take raw JSON. Optional flags map to a PATCH so
+only what you pass changes; `create`/`replace` send the full object.
+
 ### Scripting
 
 `status`, `cleanup`, and `stop` each accept `--json` for a single-line, machine-readable object

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -374,6 +374,31 @@
         }
       }
     },
+    "/restart": {
+      "post": {
+        "tags": [
+          "crate::routes::http"
+        ],
+        "summary": "`POST /restart` — stop this server and start a fresh instance.",
+        "description": "The running server cannot rebind its own port, so it spawns a detached `moadim restart` helper\nthat stops it and starts a new process, mirroring the `moadim restart` CLI command and the\n`restart` MCP tool. Responds with the helper's PID before the restart completes.",
+        "operationId": "restart",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestartResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "could not spawn the restart helper"
+          }
+        }
+      }
+    },
     "/routines": {
       "get": {
         "tags": [
@@ -1035,6 +1060,26 @@
           "repository": {
             "type": "string",
             "description": "Git remote URL."
+          }
+        }
+      },
+      "RestartResponse": {
+        "type": "object",
+        "description": "Response body for `POST /restart`.",
+        "required": [
+          "status",
+          "helper_pid"
+        ],
+        "properties": {
+          "helper_pid": {
+            "type": "integer",
+            "format": "int32",
+            "description": "PID of the detached helper process performing the stop-old-then-start-new restart.",
+            "minimum": 0
+          },
+          "status": {
+            "type": "string",
+            "description": "Acknowledgement status (always `\"restarting\"`)."
           }
         }
       },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,7 +42,7 @@ fn liveness_exit_code(running: bool) -> i32 {
 }
 
 /// The action the user asked for on the command line.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Command {
     /// Run the server in the foreground, attached to the terminal (interactive mode).
     Foreground,
@@ -77,7 +77,15 @@ pub enum Command {
     Help,
     /// Print the binary version.
     Version,
+    /// A data-plane subcommand (`cron-jobs`, `routines`, `agents`, `echo`) handled by the clap-based
+    /// [`crate::commands`] dispatcher, which talks to the running server over HTTP. Carries the raw
+    /// argv (including the subcommand keyword) for clap to parse.
+    Data(Vec<String>),
 }
+
+/// First-argument keywords that select a data-plane subcommand handled by [`crate::commands`]
+/// rather than the lifecycle commands parsed here. Kept in sync with the clap subcommands.
+pub(crate) const DATA_COMMANDS: &[&str] = &["cron-jobs", "routines", "agents", "echo"];
 
 /// Parse CLI arguments (excluding the program name) into a [`Command`].
 ///
@@ -87,6 +95,7 @@ pub fn parse(args: impl IntoIterator<Item = String>) -> Command {
     let args: Vec<String> = args.into_iter().collect();
     match args.first().map(String::as_str) {
         None => Command::Background,
+        Some(first) if DATA_COMMANDS.contains(&first) => Command::Data(args),
         Some("restart") => Command::Restart,
         Some("stop") => Command::Stop {
             json: wants_json(&args[1..]),
@@ -144,6 +153,12 @@ pub fn print_help() {
          \x20   uninstall              remove the OS service registration\n\
          \x20   help, -h, --help       show this help\n\
          \x20   version, -V            show the version\n\
+         \n\
+         DATA COMMANDS (talk to the running server over HTTP; pass --help for flags):\n\
+         \x20   cron-jobs <create|list|get|update|replace|delete|trigger|logs> ...\n\
+         \x20   routines  <create|list|get|update|replace|delete|trigger|logs|ical> ...\n\
+         \x20   agents                 list available agent keys\n\
+         \x20   echo <message>         echo a message via the server\n\
          \n\
          Pass --json to `stop`/`status`/`cleanup` for a single-line machine-readable object.\n\
          `status`/`cleanup`/`stop` exit 0 when a server is running and 3 when none is, so scripts\n\
@@ -406,17 +421,49 @@ pub(crate) fn http_request(method: &str, path: &str) -> std::io::Result<u16> {
     http_request_with_body(method, path).map(|(status, _)| status)
 }
 
-/// Send a minimal HTTP/1.1 request and return the response status code together with its body.
+/// How long to wait on a data-plane request (`create`/`trigger`/etc.). More generous than
+/// [`PROBE_TIMEOUT`] because these routes can do real work (crontab sync, workbench spawn) before
+/// responding, whereas a liveness probe only needs the server to answer `GET /health` promptly.
+const DATA_OP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Send a minimal HTTP/1.1 request (no body) and return the response status code with its body.
 fn http_request_with_body(method: &str, path: &str) -> std::io::Result<(u16, String)> {
+    http_request_core(method, path, None, PROBE_TIMEOUT)
+}
+
+/// Send a minimal HTTP/1.1 request with an optional JSON `body` and return the response status code
+/// together with its body, using the generous [`DATA_OP_TIMEOUT`]. Data-plane CLI subcommands
+/// ([`crate::commands`]) use this to drive the running server's `/api/v1` routes over the same
+/// loopback client the lifecycle commands use.
+pub(crate) fn http_request_json(
+    method: &str,
+    path: &str,
+    body: Option<&str>,
+) -> std::io::Result<(u16, String)> {
+    http_request_core(method, path, body, DATA_OP_TIMEOUT)
+}
+
+/// Core minimal HTTP/1.1 client: connect to the local server, send `method path` with an optional
+/// JSON `body`, and return the response status code together with its body. `timeout` bounds the
+/// connect/read/write so a hung or absent server fails fast.
+fn http_request_core(
+    method: &str,
+    path: &str,
+    body: Option<&str>,
+    timeout: Duration,
+) -> std::io::Result<(u16, String)> {
     let addr_str = bind_addr();
     let addr: SocketAddr = addr_str
         .parse()
         .expect("bind address is a valid socket address");
-    let mut stream = std::net::TcpStream::connect_timeout(&addr, PROBE_TIMEOUT)?;
-    stream.set_read_timeout(Some(PROBE_TIMEOUT))?;
-    stream.set_write_timeout(Some(PROBE_TIMEOUT))?;
+    let mut stream = std::net::TcpStream::connect_timeout(&addr, timeout)?;
+    stream.set_read_timeout(Some(timeout))?;
+    stream.set_write_timeout(Some(timeout))?;
+    let payload = body.unwrap_or_default();
     let req = format!(
-        "{method} {path} HTTP/1.1\r\nHost: {addr_str}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        "{method} {path} HTTP/1.1\r\nHost: {addr_str}\r\nContent-Type: application/json\r\n\
+         Content-Length: {}\r\nConnection: close\r\n\r\n{payload}",
+        payload.len()
     );
     stream.write_all(req.as_bytes())?;
     let mut resp = String::new();
@@ -455,6 +502,30 @@ fn parse_removed_count(body: &str) -> Option<usize> {
 /// The child runs with `--interactive` (so it actually serves), in its own process group so a
 /// terminal SIGINT to the launcher does not reach it, with stdio redirected to the daemon log.
 fn spawn_detached() -> anyhow::Result<u32> {
+    spawn_detached_with(|cmd| {
+        cmd.arg("--interactive").env(DAEMONIZED_ENV, "1");
+    })
+}
+
+/// Spawn a detached helper that stops the currently-running server and starts a fresh one,
+/// returning the helper's PID. Used by the `/api/v1/restart` route and the `restart` MCP tool so the
+/// daemon can be cycled from any surface, not just the CLI: the in-process server cannot rebind its
+/// own port, so it delegates the stop-old-then-start-new dance to this separate process.
+///
+/// The helper is launched with the `--background` flag rather than the `restart` subcommand on
+/// purpose: `moadim --background` ([`run_background`]) already stops a running instance before
+/// starting a fresh one, and passing a flag (not a bare positional) means that under the test
+/// harness — where `current_exe` is the test binary — the child is rejected immediately instead of
+/// being interpreted as a test-name filter that would re-enter these very tests.
+pub fn spawn_restart() -> anyhow::Result<u32> {
+    spawn_detached_with(|cmd| {
+        cmd.arg("--background");
+    })
+}
+
+/// Spawn a detached copy of this binary with stdio redirected to the daemon log and its own process
+/// group, applying `configure` to set the subcommand/flags before launch. Returns the child PID.
+fn spawn_detached_with(configure: impl FnOnce(&mut std::process::Command)) -> anyhow::Result<u32> {
     use std::process::{Command as Proc, Stdio};
 
     let exe = std::env::current_exe()?;
@@ -467,11 +538,10 @@ fn spawn_detached() -> anyhow::Result<u32> {
     let err = out.try_clone()?;
 
     let mut cmd = Proc::new(exe);
-    cmd.arg("--interactive")
-        .env(DAEMONIZED_ENV, "1")
-        .stdin(Stdio::null())
+    cmd.stdin(Stdio::null())
         .stdout(Stdio::from(out))
         .stderr(Stdio::from(err));
+    configure(&mut cmd);
     detach(&mut cmd);
 
     let child = cmd.spawn()?;

--- a/src/cli_tests.rs
+++ b/src/cli_tests.rs
@@ -196,6 +196,24 @@ fn unknown_arg_falls_back_to_help() {
 }
 
 #[test]
+fn data_keywords_route_to_data_command_with_full_argv() {
+    for keyword in DATA_COMMANDS {
+        let args = argv(&[keyword, "list"]);
+        assert_eq!(
+            parse(args.clone()),
+            Command::Data(args),
+            "keyword {keyword}"
+        );
+    }
+    // The keyword itself with no further args still routes to the data dispatcher (which then
+    // surfaces clap's usage error), rather than the lifecycle parser.
+    assert_eq!(
+        parse(argv(&["cron-jobs"])),
+        Command::Data(argv(&["cron-jobs"]))
+    );
+}
+
+#[test]
 fn parses_http_status_code() {
     assert_eq!(parse_status_code("HTTP/1.1 200 OK\r\n\r\n"), Some(200));
     assert_eq!(
@@ -544,5 +562,18 @@ fn restart_replaces_running_server() {
     write_pid_file().unwrap();
     server.stop_after(Duration::from_millis(80));
     restart().unwrap();
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+#[test]
+fn spawn_restart_launches_a_detached_helper() {
+    // The helper is `current_exe --background`; under the test harness that exe is the test binary,
+    // which rejects `--background` and exits immediately, so this only verifies the spawn succeeds
+    // and returns a PID without leaving a real server behind.
+    let home = temp_home("spawn-restart");
+    let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", home.to_str().unwrap());
+    let _addr = EnvGuard::set(BIND_ADDR_ENV, UNREACHABLE_ADDR);
+    let pid = spawn_restart().unwrap();
+    assert!(pid > 0);
     let _ = std::fs::remove_dir_all(&home);
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,0 +1,540 @@
+//! Data-plane CLI subcommands.
+//!
+//! These mirror the daemon's `/api/v1` REST routes (and the MCP tools) so every action is reachable
+//! from the command line too. Each subcommand is a thin client: it serializes its flags into the
+//! same JSON the REST API expects, sends it to the running server over the loopback HTTP client in
+//! [`crate::cli`], and prints the server's response. The daemon must already be running
+//! (`moadim` / `moadim -i`); when it is not, these commands report that and exit
+//! [`crate::cli::EXIT_NOT_RUNNING`].
+
+use clap::{Parser, Subcommand};
+use serde_json::{Map, Value};
+
+/// Top-level parser for the data-plane subcommands, parsed from argv with the leading `moadim`
+/// binary name already stripped (`no_binary_name`), so the first token is the subcommand keyword.
+#[derive(Parser)]
+#[command(
+    name = "moadim",
+    version,
+    no_binary_name = true,
+    about = "moadim data commands"
+)]
+struct DataCli {
+    /// The selected data subcommand.
+    #[command(subcommand)]
+    command: DataCommand,
+}
+
+/// The data subcommand groups: cron jobs, routines, agents, and echo.
+#[derive(Subcommand)]
+enum DataCommand {
+    /// Manage cron jobs (create/list/get/update/replace/delete/trigger/logs).
+    #[command(subcommand, visible_alias = "cron")]
+    CronJobs(CronCmd),
+    /// Manage routines (create/list/get/update/replace/delete/trigger/logs/ical).
+    #[command(subcommand, visible_alias = "routine")]
+    Routines(RoutineCmd),
+    /// List the available agent registry keys.
+    Agents,
+    /// Echo a message back via the server, with a server timestamp.
+    Echo {
+        /// The message to echo.
+        message: String,
+    },
+}
+
+/// Cron-job operations, each mapping to a `/api/v1/cron-jobs` REST route.
+#[derive(Subcommand)]
+enum CronCmd {
+    /// Create a new cron job.
+    Create {
+        /// Cron expression (host local timezone, not UTC).
+        #[arg(long)]
+        schedule: String,
+        /// Handler identifier to invoke when the schedule fires.
+        #[arg(long)]
+        handler: String,
+        /// Optional metadata as a JSON value (object/array/scalar).
+        #[arg(long)]
+        metadata: Option<String>,
+        /// Create the job disabled instead of enabled (the default).
+        #[arg(long)]
+        disabled: bool,
+    },
+    /// List all cron jobs.
+    List,
+    /// Get a single cron job by ID.
+    Get {
+        /// UUID of the cron job.
+        id: String,
+    },
+    /// Update fields of an existing cron job (only the flags you pass change).
+    Update {
+        /// UUID of the cron job to update.
+        id: String,
+        /// New cron expression (host local timezone, not UTC).
+        #[arg(long)]
+        schedule: Option<String>,
+        /// New handler identifier.
+        #[arg(long)]
+        handler: Option<String>,
+        /// New metadata as a JSON value.
+        #[arg(long)]
+        metadata: Option<String>,
+        /// New enabled state (`true`/`false`).
+        #[arg(long)]
+        enabled: Option<bool>,
+    },
+    /// Replace a cron job wholesale (all fields, like create but for an existing ID).
+    Replace {
+        /// UUID of the cron job to replace.
+        id: String,
+        /// Cron expression (host local timezone, not UTC).
+        #[arg(long)]
+        schedule: String,
+        /// Handler identifier to invoke when the schedule fires.
+        #[arg(long)]
+        handler: String,
+        /// Optional metadata as a JSON value.
+        #[arg(long)]
+        metadata: Option<String>,
+        /// Replace into a disabled state instead of enabled (the default).
+        #[arg(long)]
+        disabled: bool,
+    },
+    /// Delete a cron job by ID.
+    Delete {
+        /// UUID of the cron job to delete.
+        id: String,
+    },
+    /// Manually trigger a cron job outside its schedule.
+    Trigger {
+        /// UUID of the cron job to trigger.
+        id: String,
+    },
+    /// Print a cron job's log file.
+    Logs {
+        /// UUID of the cron job whose logs to print.
+        id: String,
+    },
+}
+
+/// Routine operations, each mapping to a `/api/v1/routines` REST route.
+#[derive(Subcommand)]
+enum RoutineCmd {
+    /// Create a new routine.
+    Create {
+        /// Cron expression (host local timezone, not UTC).
+        #[arg(long)]
+        schedule: String,
+        /// Human-readable title.
+        #[arg(long)]
+        title: String,
+        /// Agent registry key to launch.
+        #[arg(long)]
+        agent: String,
+        /// Task prompt.
+        #[arg(long)]
+        prompt: String,
+        /// Repositories as a JSON array (e.g. `[{"repository":"url","branch":"main"}]`).
+        #[arg(long)]
+        repositories: Option<String>,
+        /// Workbench TTL in seconds for finished runs.
+        #[arg(long)]
+        ttl_secs: Option<u64>,
+        /// Max runtime in seconds before the watchdog kills a run.
+        #[arg(long)]
+        max_runtime_secs: Option<u64>,
+        /// Create the routine disabled instead of enabled (the default).
+        #[arg(long)]
+        disabled: bool,
+    },
+    /// List all routines.
+    List,
+    /// Get a single routine by ID.
+    Get {
+        /// UUID of the routine.
+        id: String,
+    },
+    /// Update fields of an existing routine (only the flags you pass change).
+    Update {
+        /// UUID of the routine to update.
+        id: String,
+        /// New cron expression (host local timezone, not UTC).
+        #[arg(long)]
+        schedule: Option<String>,
+        /// New title.
+        #[arg(long)]
+        title: Option<String>,
+        /// New agent registry key.
+        #[arg(long)]
+        agent: Option<String>,
+        /// New prompt.
+        #[arg(long)]
+        prompt: Option<String>,
+        /// New repositories as a JSON array.
+        #[arg(long)]
+        repositories: Option<String>,
+        /// New enabled state (`true`/`false`).
+        #[arg(long)]
+        enabled: Option<bool>,
+        /// New workbench TTL in seconds.
+        #[arg(long)]
+        ttl_secs: Option<u64>,
+        /// New max runtime in seconds.
+        #[arg(long)]
+        max_runtime_secs: Option<u64>,
+    },
+    /// Replace a routine wholesale (all fields, like create but for an existing ID).
+    Replace {
+        /// UUID of the routine to replace.
+        id: String,
+        /// Cron expression (host local timezone, not UTC).
+        #[arg(long)]
+        schedule: String,
+        /// Human-readable title.
+        #[arg(long)]
+        title: String,
+        /// Agent registry key to launch.
+        #[arg(long)]
+        agent: String,
+        /// Task prompt.
+        #[arg(long)]
+        prompt: String,
+        /// Repositories as a JSON array.
+        #[arg(long)]
+        repositories: Option<String>,
+        /// Workbench TTL in seconds for finished runs.
+        #[arg(long)]
+        ttl_secs: Option<u64>,
+        /// Max runtime in seconds before the watchdog kills a run.
+        #[arg(long)]
+        max_runtime_secs: Option<u64>,
+        /// Replace into a disabled state instead of enabled (the default).
+        #[arg(long)]
+        disabled: bool,
+    },
+    /// Delete a routine by ID.
+    Delete {
+        /// UUID of the routine to delete.
+        id: String,
+    },
+    /// Manually trigger a routine outside its schedule.
+    Trigger {
+        /// UUID of the routine to trigger.
+        id: String,
+    },
+    /// Print a routine's newest run log.
+    Logs {
+        /// UUID of the routine whose logs to print.
+        id: String,
+    },
+    /// Print the iCalendar feed of upcoming routine fire times.
+    Ical,
+}
+
+/// Parse `args` (argv with the binary name stripped) and run the selected data subcommand against
+/// the running server, returning the process exit code to surface.
+///
+/// On a clap parse error (bad flags, `--help`, `--version`) the formatted message is printed and the
+/// matching code returned (`0` for help/version, `2` for a usage error), mirroring clap conventions
+/// without aborting the process so the path stays unit-testable.
+pub fn run(args: Vec<String>) -> i32 {
+    match DataCli::try_parse_from(args) {
+        Ok(cli) => dispatch(cli.command),
+        Err(err) => {
+            let _ = err.print();
+            match err.kind() {
+                clap::error::ErrorKind::DisplayHelp | clap::error::ErrorKind::DisplayVersion => 0,
+                _ => 2,
+            }
+        }
+    }
+}
+
+/// Route a parsed [`DataCommand`] to the matching REST call.
+fn dispatch(command: DataCommand) -> i32 {
+    match command {
+        DataCommand::CronJobs(cmd) => dispatch_cron(cmd),
+        DataCommand::Routines(cmd) => dispatch_routine(cmd),
+        DataCommand::Agents => request("GET", "/api/v1/agents", None),
+        DataCommand::Echo { message } => {
+            let body = object([("message", Value::String(message))]);
+            request("POST", "/api/v1/echo", Some(&body))
+        }
+    }
+}
+
+/// Route a parsed [`CronCmd`] to the matching `/cron-jobs` REST call.
+fn dispatch_cron(cmd: CronCmd) -> i32 {
+    match cmd {
+        CronCmd::Create {
+            schedule,
+            handler,
+            metadata,
+            disabled,
+        } => match cron_body(schedule, handler, metadata, disabled) {
+            Ok(body) => request("POST", "/api/v1/cron-jobs", Some(&body)),
+            Err(code) => code,
+        },
+        CronCmd::List => request("GET", "/api/v1/cron-jobs", None),
+        CronCmd::Get { id } => request("GET", &cron_path(&id), None),
+        CronCmd::Update {
+            id,
+            schedule,
+            handler,
+            metadata,
+            enabled,
+        } => {
+            let mut map = Map::new();
+            insert_opt(&mut map, "schedule", schedule.map(Value::String));
+            insert_opt(&mut map, "handler", handler.map(Value::String));
+            match insert_json_opt(&mut map, "metadata", metadata) {
+                Ok(()) => {}
+                Err(code) => return code,
+            }
+            insert_opt(&mut map, "enabled", enabled.map(Value::Bool));
+            request("PATCH", &cron_path(&id), Some(&to_body(map)))
+        }
+        CronCmd::Replace {
+            id,
+            schedule,
+            handler,
+            metadata,
+            disabled,
+        } => match cron_body(schedule, handler, metadata, disabled) {
+            Ok(body) => request("PUT", &cron_path(&id), Some(&body)),
+            Err(code) => code,
+        },
+        CronCmd::Delete { id } => request("DELETE", &cron_path(&id), None),
+        CronCmd::Trigger { id } => request("POST", &format!("{}/trigger", cron_path(&id)), None),
+        CronCmd::Logs { id } => request("GET", &format!("{}/logs", cron_path(&id)), None),
+    }
+}
+
+/// Route a parsed [`RoutineCmd`] to the matching `/routines` REST call.
+fn dispatch_routine(cmd: RoutineCmd) -> i32 {
+    match cmd {
+        RoutineCmd::Create {
+            schedule,
+            title,
+            agent,
+            prompt,
+            repositories,
+            ttl_secs,
+            max_runtime_secs,
+            disabled,
+        } => match routine_body(
+            schedule,
+            title,
+            agent,
+            prompt,
+            repositories,
+            ttl_secs,
+            max_runtime_secs,
+            disabled,
+        ) {
+            Ok(body) => request("POST", "/api/v1/routines", Some(&body)),
+            Err(code) => code,
+        },
+        RoutineCmd::List => request("GET", "/api/v1/routines", None),
+        RoutineCmd::Get { id } => request("GET", &routine_path(&id), None),
+        RoutineCmd::Update {
+            id,
+            schedule,
+            title,
+            agent,
+            prompt,
+            repositories,
+            enabled,
+            ttl_secs,
+            max_runtime_secs,
+        } => {
+            let mut map = Map::new();
+            insert_opt(&mut map, "schedule", schedule.map(Value::String));
+            insert_opt(&mut map, "title", title.map(Value::String));
+            insert_opt(&mut map, "agent", agent.map(Value::String));
+            insert_opt(&mut map, "prompt", prompt.map(Value::String));
+            match insert_json_opt(&mut map, "repositories", repositories) {
+                Ok(()) => {}
+                Err(code) => return code,
+            }
+            insert_opt(&mut map, "enabled", enabled.map(Value::Bool));
+            insert_opt(&mut map, "ttl_secs", ttl_secs.map(Value::from));
+            insert_opt(
+                &mut map,
+                "max_runtime_secs",
+                max_runtime_secs.map(Value::from),
+            );
+            request("PATCH", &routine_path(&id), Some(&to_body(map)))
+        }
+        RoutineCmd::Replace {
+            id,
+            schedule,
+            title,
+            agent,
+            prompt,
+            repositories,
+            ttl_secs,
+            max_runtime_secs,
+            disabled,
+        } => match routine_body(
+            schedule,
+            title,
+            agent,
+            prompt,
+            repositories,
+            ttl_secs,
+            max_runtime_secs,
+            disabled,
+        ) {
+            Ok(body) => request("PUT", &routine_path(&id), Some(&body)),
+            Err(code) => code,
+        },
+        RoutineCmd::Delete { id } => request("DELETE", &routine_path(&id), None),
+        RoutineCmd::Trigger { id } => {
+            request("POST", &format!("{}/trigger", routine_path(&id)), None)
+        }
+        RoutineCmd::Logs { id } => request("GET", &format!("{}/logs", routine_path(&id)), None),
+        RoutineCmd::Ical => request("GET", "/api/v1/routines.ics", None),
+    }
+}
+
+/// Build the `/api/v1/cron-jobs/{id}` path for a job ID.
+fn cron_path(id: &str) -> String {
+    format!("/api/v1/cron-jobs/{id}")
+}
+
+/// Build the `/api/v1/routines/{id}` path for a routine ID.
+fn routine_path(id: &str) -> String {
+    format!("/api/v1/routines/{id}")
+}
+
+/// Build the full create/replace JSON body for a cron job, validating optional `metadata` as JSON.
+/// Returns the serialized body, or an exit code (`2`) when `metadata` is not valid JSON.
+fn cron_body(
+    schedule: String,
+    handler: String,
+    metadata: Option<String>,
+    disabled: bool,
+) -> Result<String, i32> {
+    let mut map = Map::new();
+    map.insert("schedule".to_string(), Value::String(schedule));
+    map.insert("handler".to_string(), Value::String(handler));
+    insert_json_opt(&mut map, "metadata", metadata)?;
+    map.insert("enabled".to_string(), Value::Bool(!disabled));
+    Ok(to_body(map))
+}
+
+/// Build the full create/replace JSON body for a routine, validating optional `repositories` as a
+/// JSON array. Returns the serialized body, or an exit code (`2`) when `repositories` is invalid.
+#[allow(clippy::too_many_arguments)]
+fn routine_body(
+    schedule: String,
+    title: String,
+    agent: String,
+    prompt: String,
+    repositories: Option<String>,
+    ttl_secs: Option<u64>,
+    max_runtime_secs: Option<u64>,
+    disabled: bool,
+) -> Result<String, i32> {
+    let mut map = Map::new();
+    map.insert("schedule".to_string(), Value::String(schedule));
+    map.insert("title".to_string(), Value::String(title));
+    map.insert("agent".to_string(), Value::String(agent));
+    map.insert("prompt".to_string(), Value::String(prompt));
+    insert_json_opt(&mut map, "repositories", repositories)?;
+    insert_opt(&mut map, "ttl_secs", ttl_secs.map(Value::from));
+    insert_opt(
+        &mut map,
+        "max_runtime_secs",
+        max_runtime_secs.map(Value::from),
+    );
+    map.insert("enabled".to_string(), Value::Bool(!disabled));
+    Ok(to_body(map))
+}
+
+/// Insert `key => value` into `map` only when `value` is `Some`, leaving the key absent otherwise so
+/// PATCH bodies carry just the fields the user supplied.
+fn insert_opt(map: &mut Map<String, Value>, key: &str, value: Option<Value>) {
+    if let Some(value) = value {
+        map.insert(key.to_string(), value);
+    }
+}
+
+/// Parse an optional raw-JSON flag and insert it under `key` when present. Returns an exit code
+/// (`2`) and prints a diagnostic when the supplied string is not valid JSON.
+fn insert_json_opt(
+    map: &mut Map<String, Value>,
+    key: &str,
+    raw: Option<String>,
+) -> Result<(), i32> {
+    let Some(raw) = raw else { return Ok(()) };
+    match serde_json::from_str::<Value>(&raw) {
+        Ok(value) => {
+            map.insert(key.to_string(), value);
+            Ok(())
+        }
+        Err(err) => {
+            eprintln!("error: --{key} is not valid JSON: {err}");
+            Err(2)
+        }
+    }
+}
+
+/// Build a small JSON object body from key/value pairs.
+fn object<const N: usize>(pairs: [(&str, Value); N]) -> String {
+    let mut map = Map::new();
+    for (key, value) in pairs {
+        map.insert(key.to_string(), value);
+    }
+    to_body(map)
+}
+
+/// Serialize a JSON object map into a compact request body string.
+fn to_body(map: Map<String, Value>) -> String {
+    Value::Object(map).to_string()
+}
+
+/// Send `method path` (with optional JSON `body`) to the running server, print the response, and map
+/// it to a process exit code: `0` on a 2xx, `1` on any other HTTP status (the server's error body is
+/// printed to stderr), and [`crate::cli::EXIT_NOT_RUNNING`] when no server is reachable.
+fn request(method: &str, path: &str, body: Option<&str>) -> i32 {
+    match crate::cli::http_request_json(method, path, body) {
+        Ok((status, resp)) if (200..300).contains(&status) => {
+            print_body(&resp);
+            0
+        }
+        Ok((status, resp)) => {
+            eprintln!("error: server returned HTTP {status}");
+            if !resp.is_empty() {
+                eprintln!("{resp}");
+            }
+            1
+        }
+        Err(_) => {
+            eprintln!("moadim is not running");
+            crate::cli::EXIT_NOT_RUNNING
+        }
+    }
+}
+
+/// Print a successful response body, pretty-printing it when it parses as JSON and echoing it raw
+/// (e.g. plain-text logs / iCalendar feeds) otherwise.
+fn print_body(body: &str) {
+    if body.is_empty() {
+        return;
+    }
+    match serde_json::from_str::<Value>(body) {
+        Ok(value) => println!(
+            "{}",
+            serde_json::to_string_pretty(&value).unwrap_or_default()
+        ),
+        Err(_) => println!("{body}"),
+    }
+}
+
+#[cfg(test)]
+#[path = "commands_tests.rs"]
+mod commands_tests;

--- a/src/commands_tests.rs
+++ b/src/commands_tests.rs
@@ -1,0 +1,446 @@
+//! Tests for the data-plane CLI subcommands.
+//!
+//! These drive [`run`] end to end against a throwaway loopback server (so the HTTP client path is
+//! exercised) and unit-test the JSON body builders. They rely on the `MOADIM_BIND_ADDR` seam to
+//! target an ephemeral port and on the single-threaded test harness so env mutation is race-free.
+
+use super::*;
+use std::io::{Read as _, Write as _};
+use std::net::TcpListener;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Environment variable that points the CLI's HTTP client at a chosen address.
+const BIND_ENV: &str = "MOADIM_BIND_ADDR";
+
+/// A loopback port nothing listens on, so probes fail fast with a refused connection.
+const UNREACHABLE_ADDR: &str = "127.0.0.1:1";
+
+/// Build a `Vec<String>` argv from string literals.
+fn argv(args: &[&str]) -> Vec<String> {
+    args.iter().map(|arg| arg.to_string()).collect()
+}
+
+/// Save an env var's prior value and restore it on drop so a test's override never leaks.
+struct EnvGuard {
+    /// The environment variable name being temporarily overridden.
+    name: &'static str,
+    /// The value present before this guard set it, restored on drop.
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvGuard {
+    /// Set `name` to `value`, remembering the prior value for restoration.
+    fn set(name: &'static str, value: &str) -> EnvGuard {
+        let previous = std::env::var_os(name);
+        // SAFETY: tests in this crate run single-threaded per binary.
+        unsafe {
+            std::env::set_var(name, value);
+        }
+        EnvGuard { name, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: single-threaded test execution.
+        unsafe {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.name, value),
+                None => std::env::remove_var(self.name),
+            }
+        }
+    }
+}
+
+/// A throwaway loopback HTTP server that answers every request with a canned status and body.
+struct FakeServer {
+    /// The `host:port` the server is listening on, for `MOADIM_BIND_ADDR`.
+    addr: String,
+    /// Signals the accept loop to exit.
+    stop: Arc<AtomicBool>,
+    /// The accept-loop thread handle, joined on drop.
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl FakeServer {
+    /// Start a server on an ephemeral port answering every connection with `status` and `body`.
+    fn start(status: u16, body: &str) -> FakeServer {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let addr = listener.local_addr().expect("local addr").to_string();
+        listener.set_nonblocking(true).expect("set nonblocking");
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_loop = Arc::clone(&stop);
+        let response = format!(
+            "HTTP/1.1 {status} OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        let handle = std::thread::spawn(move || {
+            while !stop_loop.load(Ordering::SeqCst) {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        let mut buf = [0u8; 2048];
+                        let _ = stream.read(&mut buf);
+                        let _ = stream.write_all(response.as_bytes());
+                    }
+                    Err(ref err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(2));
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+        FakeServer {
+            addr,
+            stop,
+            handle: Some(handle),
+        }
+    }
+}
+
+impl Drop for FakeServer {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+// ─── Parse-level behavior (no server needed) ─────────────────────────────────
+
+#[test]
+fn help_and_version_return_zero() {
+    assert_eq!(run(argv(&["--help"])), 0);
+    assert_eq!(run(argv(&["cron-jobs", "--help"])), 0);
+    assert_eq!(run(argv(&["--version"])), 0);
+}
+
+#[test]
+fn usage_errors_return_two() {
+    // No subcommand, an unknown subcommand, and a missing required group all map to exit 2.
+    assert_eq!(run(argv(&[])), 2);
+    assert_eq!(run(argv(&["nonsense"])), 2);
+    assert_eq!(run(argv(&["cron-jobs"])), 2);
+}
+
+#[test]
+fn invalid_json_flags_return_two_without_a_server() {
+    // Body builders reject malformed JSON before any request is sent.
+    assert_eq!(
+        run(argv(&[
+            "cron-jobs",
+            "create",
+            "--schedule",
+            "* * * * *",
+            "--handler",
+            "h",
+            "--metadata",
+            "{bad",
+        ])),
+        2
+    );
+    assert_eq!(
+        run(argv(&[
+            "cron-jobs",
+            "replace",
+            "id",
+            "--schedule",
+            "* * * * *",
+            "--handler",
+            "h",
+            "--metadata",
+            "{bad",
+        ])),
+        2
+    );
+    assert_eq!(
+        run(argv(&["cron-jobs", "update", "id", "--metadata", "{bad"])),
+        2
+    );
+    assert_eq!(
+        run(argv(&[
+            "routines",
+            "create",
+            "--schedule",
+            "* * * * *",
+            "--title",
+            "t",
+            "--agent",
+            "a",
+            "--prompt",
+            "p",
+            "--repositories",
+            "{bad",
+        ])),
+        2
+    );
+    assert_eq!(
+        run(argv(&[
+            "routines",
+            "replace",
+            "id",
+            "--schedule",
+            "* * * * *",
+            "--title",
+            "t",
+            "--agent",
+            "a",
+            "--prompt",
+            "p",
+            "--repositories",
+            "{bad",
+        ])),
+        2
+    );
+    assert_eq!(
+        run(argv(&[
+            "routines",
+            "update",
+            "id",
+            "--repositories",
+            "{bad"
+        ])),
+        2
+    );
+}
+
+// ─── End-to-end dispatch against a fake server ───────────────────────────────
+
+#[test]
+fn every_subcommand_succeeds_against_a_2xx_server() {
+    let server = FakeServer::start(200, "{\"ok\":true}");
+    let _addr = EnvGuard::set(BIND_ENV, &server.addr);
+
+    let calls: &[&[&str]] = &[
+        // cron jobs
+        &[
+            "cron-jobs",
+            "create",
+            "--schedule",
+            "* * * * *",
+            "--handler",
+            "h",
+        ],
+        &[
+            "cron-jobs",
+            "create",
+            "--schedule",
+            "* * * * *",
+            "--handler",
+            "h",
+            "--disabled",
+            "--metadata",
+            "{\"a\":1}",
+        ],
+        &["cron-jobs", "list"],
+        &["cron", "get", "abc"],
+        &[
+            "cron-jobs",
+            "update",
+            "abc",
+            "--schedule",
+            "* * * * *",
+            "--metadata",
+            "{\"a\":1}",
+            "--enabled",
+            "true",
+        ],
+        &[
+            "cron-jobs",
+            "replace",
+            "abc",
+            "--schedule",
+            "* * * * *",
+            "--handler",
+            "h",
+        ],
+        &["cron-jobs", "delete", "abc"],
+        &["cron-jobs", "trigger", "abc"],
+        &["cron-jobs", "logs", "abc"],
+        // routines
+        &[
+            "routines",
+            "create",
+            "--schedule",
+            "* * * * *",
+            "--title",
+            "t",
+            "--agent",
+            "a",
+            "--prompt",
+            "p",
+        ],
+        &[
+            "routine",
+            "create",
+            "--schedule",
+            "* * * * *",
+            "--title",
+            "t",
+            "--agent",
+            "a",
+            "--prompt",
+            "p",
+            "--disabled",
+            "--repositories",
+            "[]",
+        ],
+        &["routines", "list"],
+        &["routines", "get", "rid"],
+        &[
+            "routines",
+            "update",
+            "rid",
+            "--title",
+            "t2",
+            "--repositories",
+            "[]",
+            "--enabled",
+            "false",
+            "--ttl-secs",
+            "10",
+            "--max-runtime-secs",
+            "20",
+        ],
+        &[
+            "routines",
+            "replace",
+            "rid",
+            "--schedule",
+            "* * * * *",
+            "--title",
+            "t",
+            "--agent",
+            "a",
+            "--prompt",
+            "p",
+        ],
+        &["routines", "delete", "rid"],
+        &["routines", "trigger", "rid"],
+        &["routines", "logs", "rid"],
+        &["routines", "ical"],
+        // top-level
+        &["agents"],
+        &["echo", "hello"],
+    ];
+    for call in calls {
+        assert_eq!(run(argv(call)), 0, "call {call:?}");
+    }
+}
+
+#[test]
+fn logs_print_raw_when_body_is_not_json() {
+    let server = FakeServer::start(200, "plain log line\nsecond line");
+    let _addr = EnvGuard::set(BIND_ENV, &server.addr);
+    assert_eq!(run(argv(&["cron-jobs", "logs", "abc"])), 0);
+}
+
+#[test]
+fn empty_body_prints_nothing_and_succeeds() {
+    let server = FakeServer::start(200, "");
+    let _addr = EnvGuard::set(BIND_ENV, &server.addr);
+    assert_eq!(run(argv(&["agents"])), 0);
+}
+
+#[test]
+fn non_2xx_status_returns_one() {
+    // A non-empty error body exercises the "print the body" branch.
+    {
+        let server = FakeServer::start(404, "{\"error\":\"not found\"}");
+        let _addr = EnvGuard::set(BIND_ENV, &server.addr);
+        assert_eq!(run(argv(&["cron-jobs", "get", "missing"])), 1);
+    }
+    // An empty error body exercises the "skip the body" branch.
+    {
+        let server = FakeServer::start(500, "");
+        let _addr = EnvGuard::set(BIND_ENV, &server.addr);
+        assert_eq!(run(argv(&["cron-jobs", "list"])), 1);
+    }
+}
+
+#[test]
+fn no_server_returns_not_running_exit_code() {
+    let _addr = EnvGuard::set(BIND_ENV, UNREACHABLE_ADDR);
+    assert_eq!(
+        run(argv(&["cron-jobs", "list"])),
+        crate::cli::EXIT_NOT_RUNNING
+    );
+}
+
+// ─── Body-builder unit tests ─────────────────────────────────────────────────
+
+#[test]
+fn insert_opt_only_inserts_present_values() {
+    let mut map = Map::new();
+    insert_opt(&mut map, "a", Some(Value::Bool(true)));
+    insert_opt(&mut map, "b", None);
+    assert_eq!(map.get("a"), Some(&Value::Bool(true)));
+    assert!(!map.contains_key("b"));
+}
+
+#[test]
+fn object_and_to_body_build_compact_json() {
+    let body = object([("message", Value::String("hi".to_string()))]);
+    assert_eq!(body, "{\"message\":\"hi\"}");
+}
+
+#[test]
+fn cron_body_sets_enabled_from_disabled_flag() {
+    let enabled: Value =
+        serde_json::from_str(&cron_body("* * * * *".into(), "h".into(), None, false).unwrap())
+            .unwrap();
+    assert_eq!(enabled["enabled"], Value::Bool(true));
+    let disabled: Value =
+        serde_json::from_str(&cron_body("* * * * *".into(), "h".into(), None, true).unwrap())
+            .unwrap();
+    assert_eq!(disabled["enabled"], Value::Bool(false));
+}
+
+#[test]
+fn cron_body_rejects_bad_metadata() {
+    assert_eq!(
+        cron_body("* * * * *".into(), "h".into(), Some("{bad".into()), false),
+        Err(2)
+    );
+}
+
+#[test]
+fn routine_body_serializes_all_fields() {
+    let value: Value = serde_json::from_str(
+        &routine_body(
+            "* * * * *".into(),
+            "title".into(),
+            "agent".into(),
+            "prompt".into(),
+            Some("[]".into()),
+            Some(30),
+            Some(60),
+            false,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(value["title"], Value::String("title".to_string()));
+    assert_eq!(value["repositories"], Value::Array(vec![]));
+    assert_eq!(value["ttl_secs"], Value::from(30));
+    assert_eq!(value["enabled"], Value::Bool(true));
+}
+
+#[test]
+fn routine_body_rejects_bad_repositories() {
+    assert_eq!(
+        routine_body(
+            "* * * * *".into(),
+            "t".into(),
+            "a".into(),
+            "p".into(),
+            Some("{bad".into()),
+            None,
+            None,
+            false,
+        ),
+        Err(2)
+    );
+}

--- a/src/cron_jobs.rs
+++ b/src/cron_jobs.rs
@@ -434,6 +434,17 @@ pub fn svc_logs_path(store: &CronStore, id: &str) -> Result<std::path::PathBuf, 
     Ok(crate::paths::job_log_path(id))
 }
 
+/// Read job `id`'s log file to a string, or `NotFound` if no such job exists. Returns an empty
+/// string when the job exists but has not produced a log file yet. Shared by the REST `get_logs`
+/// handler and the `cron_job_logs` MCP tool so both surfaces read logs identically.
+pub fn svc_logs(store: &CronStore, id: &str) -> Result<String, AppError> {
+    let log_path = svc_logs_path(store, id)?;
+    if !log_path.exists() {
+        return Ok(String::new());
+    }
+    std::fs::read_to_string(&log_path).map_err(|_| AppError::Internal)
+}
+
 /// `GET /cron-jobs/{id}/logs` — return the contents of the job's log file as plain text.
 #[utoipa::path(get, path = "/cron-jobs/{id}/logs",
     params(("id" = String, Path, description = "Cron job UUID")),
@@ -442,13 +453,7 @@ pub async fn get_logs(
     State(store): State<CronStore>,
     Path(id): Path<String>,
 ) -> Result<String, AppError> {
-    let log_path = svc_logs_path(&store, &id)?;
-    if !log_path.exists() {
-        return Ok(String::new());
-    }
-    tokio::fs::read_to_string(&log_path)
-        .await
-        .map_err(|_| AppError::Internal)
+    svc_logs(&store, &id)
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@
 mod build_info;
 /// Command-line interface and background-process lifecycle.
 mod cli;
+/// Data-plane CLI subcommands (clap) that drive the running server over HTTP.
+mod commands;
 mod cron_jobs;
 mod error;
 /// Server filesystem location helpers.
@@ -50,6 +52,7 @@ async fn main() -> anyhow::Result<()> {
         cli::Command::Restart => cli::restart(),
         cli::Command::Install => service::install(),
         cli::Command::Uninstall => service::uninstall(),
+        cli::Command::Data(args) => std::process::exit(commands::run(args)),
         cli::Command::Foreground => run_server().await,
     }
 }

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -7,6 +7,7 @@
     paths(
         crate::routes::http::health,
         crate::routes::http::shutdown,
+        crate::routes::http::restart,
         crate::routes::http::echo,
         crate::cron_jobs::list,
         crate::cron_jobs::create,
@@ -44,6 +45,7 @@
         crate::routines::SortOrder,
         crate::routes::http::HealthResponse,
         crate::routes::http::ShutdownResponse,
+        crate::routes::http::RestartResponse,
         crate::routes::http::EchoRequest,
         crate::routes::http::EchoResponse,
     ))

--- a/src/routes/http.rs
+++ b/src/routes/http.rs
@@ -105,6 +105,30 @@ pub async fn shutdown(State(state): State<AppState>) -> Json<ShutdownResponse> {
     })
 }
 
+/// Response body for `POST /restart`.
+#[derive(Serialize, utoipa::ToSchema)]
+pub struct RestartResponse {
+    /// Acknowledgement status (always `"restarting"`).
+    pub status: String,
+    /// PID of the detached helper process performing the stop-old-then-start-new restart.
+    pub helper_pid: u32,
+}
+
+/// `POST /restart` — stop this server and start a fresh instance.
+///
+/// The running server cannot rebind its own port, so it spawns a detached `moadim restart` helper
+/// that stops it and starts a new process, mirroring the `moadim restart` CLI command and the
+/// `restart` MCP tool. Responds with the helper's PID before the restart completes.
+#[utoipa::path(post, path = "/restart",
+    responses((status = 200, body = RestartResponse), (status = 500, description = "could not spawn the restart helper")))]
+pub async fn restart() -> Result<Json<RestartResponse>, AppError> {
+    let helper_pid = crate::cli::spawn_restart().map_err(|_| AppError::Internal)?;
+    Ok(Json(RestartResponse {
+        status: "restarting".to_string(),
+        helper_pid,
+    }))
+}
+
 /// `POST /echo` — parse a JSON body and return the message with a server timestamp.
 #[utoipa::path(post, path = "/echo",
     request_body = EchoRequest,
@@ -149,6 +173,7 @@ pub(crate) fn build_app_with_shutdown(
     let mcp_handlers = app_state.handlers.clone();
     let mcp_routines = routines.clone();
     let uptime_start = app_state.uptime_start;
+    let mcp_shutdown = app_state.shutdown.clone();
     let mcp_service = StreamableHttpService::new(
         move || {
             Ok(MoadimMcp::new(
@@ -156,6 +181,7 @@ pub(crate) fn build_app_with_shutdown(
                 mcp_handlers.clone(),
                 mcp_routines.clone(),
                 uptime_start,
+                mcp_shutdown.clone(),
             ))
         },
         LocalSessionManager::default().into(),
@@ -167,6 +193,7 @@ pub(crate) fn build_app_with_shutdown(
     let api = Router::new()
         .route("/health", get(health))
         .route("/shutdown", post(shutdown))
+        .route("/restart", post(restart))
         .route("/echo", post(echo))
         .route("/cron-jobs", get(cron_jobs::list).post(cron_jobs::create))
         .route(

--- a/src/routes/http_tests.rs
+++ b/src/routes/http_tests.rs
@@ -793,6 +793,32 @@ async fn build_app_shutdown_route_acknowledges() {
 }
 
 #[tokio::test]
+async fn build_app_restart_route_acknowledges() {
+    // The route spawns a detached `current_exe --background` helper; under the test harness that exe
+    // is the test binary, which rejects `--background` and exits at once, so no real server starts.
+    // TempHome keeps the helper's log file out of the real home.
+    let _home = TempHome::set();
+    let app = build_app(new_store(), crate::routines::new_store());
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/restart")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["status"], "restarting");
+    assert!(json["helper_pid"].as_u64().unwrap() > 0);
+}
+
+#[tokio::test]
 async fn shutdown_route_stops_the_serving_loop() {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 

--- a/src/routes/mcp.rs
+++ b/src/routes/mcp.rs
@@ -8,7 +8,9 @@ use rmcp::{
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-use crate::cron_jobs::{self, CreateRequest, CronStore, HandlerRegistry, UpdateRequest};
+use crate::cron_jobs::{
+    self, CreateRequest, CronStore, HandlerRegistry, ShutdownSignal, UpdateRequest,
+};
 use crate::routines::{self, CreateRoutineRequest, RoutineStore, UpdateRoutineRequest};
 use crate::utils::time::now_secs;
 
@@ -23,6 +25,9 @@ pub struct MoadimMcp {
     routines: RoutineStore,
     /// Unix timestamp (seconds) recorded at server startup.
     uptime_start: u64,
+    /// Notify handle that triggers a graceful server shutdown (the `shutdown` tool fires it,
+    /// mirroring `POST /api/v1/shutdown` and `moadim stop`).
+    shutdown: ShutdownSignal,
 }
 
 /// Input for the `echo` MCP tool.
@@ -101,12 +106,14 @@ impl MoadimMcp {
         handlers: HandlerRegistry,
         routines: RoutineStore,
         uptime_start: u64,
+        shutdown: ShutdownSignal,
     ) -> Self {
         Self {
             store,
             handlers,
             routines,
             uptime_start,
+            shutdown,
         }
     }
 
@@ -321,6 +328,60 @@ impl MoadimMcp {
     )]
     fn cleanup_workbenches(&self) -> Result<CallToolResult, rmcp::ErrorData> {
         Ok(ok(routines::svc_cleanup(&self.routines)))
+    }
+
+    /// List the available agent registry keys a routine can launch.
+    #[tool(description = "List the available agent registry keys a routine can launch")]
+    fn list_agents(&self) -> Result<CallToolResult, rmcp::ErrorData> {
+        Ok(ok(routines::available_agents()))
+    }
+
+    /// Return the contents of a cron job's log file, or an error if the job does not exist.
+    #[tool(description = "Get a cron job's log file contents by ID")]
+    fn cron_job_logs(
+        &self,
+        Parameters(IdInput { id }): Parameters<IdInput>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        Ok(match cron_jobs::svc_logs(&self.store, &id) {
+            Ok(logs) => ok(serde_json::json!({ "logs": logs })),
+            Err(error) => err(error),
+        })
+    }
+
+    /// Return the newest run log for a routine, or an error if the routine does not exist.
+    #[tool(description = "Get a routine's newest run log by ID")]
+    fn routine_logs(
+        &self,
+        Parameters(IdInput { id }): Parameters<IdInput>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        Ok(match routines::svc_logs(&self.routines, &id) {
+            Ok(logs) => ok(serde_json::json!({ "logs": logs })),
+            Err(error) => err(error),
+        })
+    }
+
+    /// Ask the server to stop gracefully, mirroring `POST /api/v1/shutdown` and `moadim stop`.
+    #[tool(
+        description = "Stop the running server gracefully. Mirrors the POST /api/v1/shutdown route and `moadim stop`."
+    )]
+    fn shutdown(&self) -> Result<CallToolResult, rmcp::ErrorData> {
+        log::info!("shutdown requested via MCP");
+        self.shutdown.notify_one();
+        Ok(ok(serde_json::json!({ "status": "shutting down" })))
+    }
+
+    /// Stop this server and start a fresh instance, mirroring `POST /api/v1/restart` and
+    /// `moadim restart`. Delegates to a detached helper process that performs the swap.
+    #[tool(
+        description = "Restart the server: stop it and start a fresh instance. Mirrors the POST /api/v1/restart route and `moadim restart`."
+    )]
+    fn restart(&self) -> Result<CallToolResult, rmcp::ErrorData> {
+        log::info!("restart requested via MCP");
+        Ok(crate::cli::spawn_restart()
+            .map(|helper_pid| {
+                ok(serde_json::json!({ "status": "restarting", "helper_pid": helper_pid }))
+            })
+            .unwrap_or_else(err))
     }
 }
 

--- a/src/routes/mcp_tests.rs
+++ b/src/routes/mcp_tests.rs
@@ -5,7 +5,19 @@ use crate::cron_jobs::{new_registry, new_store};
 use super::*;
 
 fn make_handler() -> MoadimMcp {
-    MoadimMcp::new(new_store(), new_registry(), crate::routines::new_store(), 0)
+    MoadimMcp::new(
+        new_store(),
+        new_registry(),
+        crate::routines::new_store(),
+        0,
+        test_shutdown(),
+    )
+}
+
+/// A throwaway shutdown signal for constructing a handler in tests; the `shutdown` tool fires it but
+/// nothing awaits it, so notifying is a harmless no-op.
+fn test_shutdown() -> crate::cron_jobs::ShutdownSignal {
+    std::sync::Arc::new(tokio::sync::Notify::new())
 }
 
 /// Point `MOADIM_HOME_OVERRIDE` at a fresh, empty temp home for the duration of a test, removing it
@@ -144,7 +156,13 @@ fn trigger_cron_job_not_found_is_error() {
 fn create_cron_job_tool_invalid_cron_is_error() {
     use rmcp::handler::server::wrapper::Parameters;
     let store = crate::cron_jobs::new_store();
-    let handler = MoadimMcp::new(store, new_registry(), crate::routines::new_store(), 0);
+    let handler = MoadimMcp::new(
+        store,
+        new_registry(),
+        crate::routines::new_store(),
+        0,
+        test_shutdown(),
+    );
     let req = crate::cron_jobs::CreateRequest {
         schedule: "not-a-cron".into(),
         handler: "h".into(),
@@ -163,6 +181,7 @@ fn update_cron_job_tool_not_found_is_error() {
         new_registry(),
         crate::routines::new_store(),
         0,
+        test_shutdown(),
     );
     let result = handler
         .update_cron_job(Parameters(UpdateInput {
@@ -192,7 +211,13 @@ fn delete_cron_job_tool_success() {
     )
     .unwrap();
     let id = created.job.id.clone();
-    let handler = MoadimMcp::new(store, new_registry(), crate::routines::new_store(), 0);
+    let handler = MoadimMcp::new(
+        store,
+        new_registry(),
+        crate::routines::new_store(),
+        0,
+        test_shutdown(),
+    );
     let result = handler.delete_cron_job(Parameters(IdInput { id })).unwrap();
     assert!(!result.is_error.unwrap_or(false));
 }
@@ -213,7 +238,13 @@ fn trigger_cron_job_tool_success() {
     )
     .unwrap();
     let id = created.job.id.clone();
-    let handler = MoadimMcp::new(store, new_registry(), crate::routines::new_store(), 0);
+    let handler = MoadimMcp::new(
+        store,
+        new_registry(),
+        crate::routines::new_store(),
+        0,
+        test_shutdown(),
+    );
     let result = handler
         .trigger_cron_job(Parameters(IdInput { id: id.clone() }))
         .unwrap();
@@ -225,7 +256,13 @@ fn trigger_cron_job_tool_success() {
 fn create_cron_job_tool_success() {
     use rmcp::handler::server::wrapper::Parameters;
     let store = crate::cron_jobs::new_store();
-    let handler = MoadimMcp::new(store, new_registry(), crate::routines::new_store(), 0);
+    let handler = MoadimMcp::new(
+        store,
+        new_registry(),
+        crate::routines::new_store(),
+        0,
+        test_shutdown(),
+    );
     let req = crate::cron_jobs::CreateRequest {
         schedule: "@daily".into(),
         handler: "mcp-handler".into(),
@@ -260,7 +297,13 @@ fn get_cron_job_tool_success() {
         last_manual_trigger_at: None,
     };
     store.lock().unwrap().insert("get-test-id".into(), job);
-    let handler = MoadimMcp::new(store, new_registry(), crate::routines::new_store(), 0);
+    let handler = MoadimMcp::new(
+        store,
+        new_registry(),
+        crate::routines::new_store(),
+        0,
+        test_shutdown(),
+    );
     let result = handler
         .get_cron_job(Parameters(IdInput {
             id: "get-test-id".into(),
@@ -278,6 +321,7 @@ fn update_cron_job_tool_success() {
         new_registry(),
         crate::routines::new_store(),
         0,
+        test_shutdown(),
     );
     // Create a job first
     let created = crate::cron_jobs::svc_create(
@@ -356,7 +400,13 @@ fn create_get_update_trigger_delete_routine_success() {
     use rmcp::handler::server::wrapper::Parameters;
     let _home = TempHome::set();
     let routines = crate::routines::new_store();
-    let handler = MoadimMcp::new(new_store(), new_registry(), routines.clone(), 0);
+    let handler = MoadimMcp::new(
+        new_store(),
+        new_registry(),
+        routines.clone(),
+        0,
+        test_shutdown(),
+    );
 
     // create
     let result = handler
@@ -462,4 +512,148 @@ fn trigger_routine_tool_not_found_is_error() {
         }))
         .unwrap();
     assert!(result.is_error.unwrap_or(false));
+}
+
+// ── parity tools: agents / logs / shutdown ──────────────────────────────────────
+
+#[test]
+fn list_agents_tool_returns_array() {
+    let _home = TempHome::set();
+    let handler = make_handler();
+    let result = handler.list_agents().unwrap();
+    assert!(!result.is_error.unwrap_or(false));
+    let text = match &result.content[0].raw {
+        rmcp::model::RawContent::Text(txt) => txt.text.clone(),
+        _ => panic!("expected text content"),
+    };
+    let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert!(val.is_array());
+}
+
+#[test]
+fn cron_job_logs_tool_returns_logs_for_existing_job() {
+    use rmcp::handler::server::wrapper::Parameters;
+    let store = crate::cron_jobs::new_store();
+    let created = crate::cron_jobs::svc_create(
+        &store,
+        &new_registry(),
+        crate::cron_jobs::CreateRequest {
+            schedule: "@daily".into(),
+            handler: "h".into(),
+            metadata: serde_json::Value::Null,
+            enabled: true,
+        },
+    )
+    .unwrap();
+    let id = created.job.id.clone();
+    let handler = MoadimMcp::new(
+        store,
+        new_registry(),
+        crate::routines::new_store(),
+        0,
+        test_shutdown(),
+    );
+    let result = handler
+        .cron_job_logs(Parameters(IdInput { id: id.clone() }))
+        .unwrap();
+    assert!(!result.is_error.unwrap_or(false));
+    let text = match &result.content[0].raw {
+        rmcp::model::RawContent::Text(txt) => txt.text.clone(),
+        _ => panic!("expected text content"),
+    };
+    let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+    // No log file has been produced yet, so the contents are empty (but the key is present).
+    assert_eq!(val["logs"], "");
+    crate::storage::remove_job_dir(&id).unwrap();
+}
+
+#[test]
+fn cron_job_logs_tool_not_found_is_error() {
+    use rmcp::handler::server::wrapper::Parameters;
+    let handler = make_handler();
+    let result = handler
+        .cron_job_logs(Parameters(IdInput {
+            id: "no-such".into(),
+        }))
+        .unwrap();
+    assert!(result.is_error.unwrap_or(false));
+}
+
+#[test]
+fn routine_logs_tool_returns_logs_for_existing_routine() {
+    use rmcp::handler::server::wrapper::Parameters;
+    let _home = TempHome::set();
+    let routines = crate::routines::new_store();
+    let handler = MoadimMcp::new(
+        new_store(),
+        new_registry(),
+        routines.clone(),
+        0,
+        test_shutdown(),
+    );
+    let created = handler
+        .create_routine(Parameters(make_create_routine_req()))
+        .unwrap();
+    let text = match &created.content[0].raw {
+        rmcp::model::RawContent::Text(txt) => txt.text.clone(),
+        _ => panic!("expected text content"),
+    };
+    let id = serde_json::from_str::<serde_json::Value>(&text).unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let result = handler
+        .routine_logs(Parameters(IdInput { id: id.clone() }))
+        .unwrap();
+    assert!(!result.is_error.unwrap_or(false));
+    let text = match &result.content[0].raw {
+        rmcp::model::RawContent::Text(txt) => txt.text.clone(),
+        _ => panic!("expected text content"),
+    };
+    let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+    // No run has executed, so there is no newest workbench log yet — empty contents.
+    assert_eq!(val["logs"], "");
+}
+
+#[test]
+fn routine_logs_tool_not_found_is_error() {
+    use rmcp::handler::server::wrapper::Parameters;
+    let handler = make_handler();
+    let result = handler
+        .routine_logs(Parameters(IdInput {
+            id: "no-such".into(),
+        }))
+        .unwrap();
+    assert!(result.is_error.unwrap_or(false));
+}
+
+#[test]
+fn shutdown_tool_acknowledges() {
+    let handler = make_handler();
+    let result = handler.shutdown().unwrap();
+    assert!(!result.is_error.unwrap_or(false));
+    let text = match &result.content[0].raw {
+        rmcp::model::RawContent::Text(txt) => txt.text.clone(),
+        _ => panic!("expected text content"),
+    };
+    let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(val["status"], "shutting down");
+}
+
+#[test]
+fn restart_tool_spawns_helper_and_acknowledges() {
+    // The tool spawns a detached `current_exe --background` helper; under the test harness that exe
+    // is the test binary, which rejects `--background` and exits at once, so no real server starts.
+    // TempHome keeps the helper's log file out of the real home.
+    let _home = TempHome::set();
+    let handler = make_handler();
+    let result = handler.restart().unwrap();
+    assert!(!result.is_error.unwrap_or(false));
+    let text = match &result.content[0].raw {
+        rmcp::model::RawContent::Text(txt) => txt.text.clone(),
+        _ => panic!("expected text content"),
+    };
+    let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(val["status"], "restarting");
+    assert!(val["helper_pid"].as_u64().unwrap() > 0);
 }


### PR DESCRIPTION
Closes #493.

Brings every cron-job and routine action to all three surfaces. The service layer (`svc_*`) stays the single source of truth; the CLI data commands are thin clients over the running server's REST API, and the MCP tools call `svc_*` directly.

## CLI (new — built on `clap`)

Thin clients over the running daemon's `/api/v1` routes. They print the server's JSON response, exit `3` when no daemon is reachable and `1` on a non-2xx, mirroring the existing `status`/`stop`/`cleanup` contract.

- `cron-jobs create|list|get|update|replace|delete|trigger|logs` (alias `cron`)
- `routines create|list|get|update|replace|delete|trigger|logs|ical` (alias `routine`)
- `agents`, `echo`

Lifecycle parsing (`-i`/`-b`/`status`/`stop`/…) stays hand-rolled; clap is introduced only for the new data subcommands, where many flags/subcommands actually benefit from it.

## MCP (new tools)

`list_agents`, `cron_job_logs`, `routine_logs`, `shutdown`, `restart`.

## Lifecycle over HTTP/MCP

`POST /api/v1/restart` route + `restart` MCP tool. An in-process server cannot rebind its own port, so it spawns a detached `--background` helper that stops the old instance and starts a fresh one. The helper is launched with a flag (not a bare positional) so that under the test harness — where `current_exe` is the test binary — it is rejected immediately instead of being interpreted as a test-name filter that would re-enter these tests.

## Notes

- `cron_jobs::svc_logs` extracted and shared by the REST `get_logs` handler and the new MCP tool.
- OpenAPI spec regenerated (`apis/openapi.json`); README and CHANGELOG updated.

### Intentional scope calls

- `start` / `install` / `uninstall` stay CLI-only — they act on the local OS/process and have nothing to operate on for a remote or not-yet-running daemon.
- MCP `replace` (PUT) tools skipped — MCP `update` (PATCH) already covers mutation. (CLI does ship `replace`, matching REST.)

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo llvm-cov --fail-under-lines 100` all pass; 510 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)