### PR TITLE
docs(readme): correct the workbench path to ~/.moadim, not the config dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ attached to your terminal instead, use `moadim --interactive`.
 - Handlers are executable scripts in `~/.config/moadim/handlers/` — any language, also git-trackable
 - **Routines** schedule an AI agent instead of a script — a prompt + schedule + agent, stored in `~/.config/moadim/routines/` (see [Routines](#routines))
 - **Agents** are a registry of coding agents (`claude`, …) under `~/.config/moadim/agents/<name>.toml`, referenced by routines
-- Each routine run executes in a throwaway **workbench** under `~/.config/moadim/workbenches/`, reaped on an hourly cleanup sweep
+- Each routine run executes in a throwaway **workbench** under `~/.moadim/workbenches/` (a separate tree from the config dir), reaped on an hourly cleanup sweep
 - `job.local.toml` per job for secrets and machine-specific overrides that stay off-git
 - Same REST and MCP interface — no logic duplication between protocols
 - API spec auto-generated at build time into `apis/`
@@ -96,7 +96,9 @@ attached to your terminal instead, use `moadim --interactive`.
 │       └── .gitignore         # generated — excludes *.local.* and *.log
 ├── agents/                    # registered coding agents referenced by routines
 │   └── claude.toml
-├── user_prompt.md             # optional — appended to every routine's prompt (see ## Routines)
+└── user_prompt.md             # optional — appended to every routine's prompt (see ## Routines)
+
+~/.moadim/                     # runtime tree, separate from the config dir above
 └── workbenches/               # per-run throwaway dirs, reaped on the hourly sweep
 ```
 


### PR DESCRIPTION
This pull request was opened by the **Daemon + Landing auto-improve PRs** routine of moadim.

## Why

The README documents the per-run **workbench** location in three places, and two of them are wrong — they contradict both the code and the README's own Routines section.

- `README.md:67` (How it works): `~/.config/moadim/workbenches/`
- `README.md` Directory-layout diagram: `workbenches/` nested under the `~/.config/moadim/` tree
- `README.md:243-244` (Routines → Workbenches and cleanup): `~/.moadim/workbenches/` ✅ correct

The code is authoritative — workbenches live in a **separate runtime tree**, not the config dir:

```rust
// src/paths/mod.rs:202-213
pub fn moadim_home() -> PathBuf { moadim_home_from_home(home()) }      // ~/.moadim/
pub fn workbenches_dir() -> PathBuf { moadim_home().join("workbenches") } // ~/.moadim/workbenches/
```

So a reader following the "How it works" bullet or the directory diagram would look under the wrong path (and the diagram implies workbenches are git-adjacent to the tracked config tree, which they are not).

## What

- Fix the `README.md:67` bullet: `~/.config/moadim/workbenches/` → `~/.moadim/workbenches/`, noting it is a separate tree from the config dir.
- Split the directory-layout diagram so the runtime `~/.moadim/` tree (holding `workbenches/`) is shown separately from the `~/.config/moadim/` config tree, matching the real on-disk layout.

Now all three mentions agree with `src/paths/mod.rs`.

## Scope

Docs-only (`README.md`). No code, no behavior change.