### PR TITLE
test: structural spawn guards for routine sh + cron handler (#217)

### DIFF
--- a/src/cron_jobs.rs
+++ b/src/cron_jobs.rs
@@ -324,6 +324,27 @@ pub fn svc_delete(
     Ok(CronJobResponse::from_job(job, handlers))
 }
 
+/// Resolve the program actually spawned for a cron `handler`.
+///
+/// Mirrors the `crontab_bin()` structural guard (issues #217 / #175): the
+/// `MOADIM_HANDLER_BIN` shim is honoured first, and in **test builds** with no shim
+/// configured this never spawns the real resolved handler — it returns a path that
+/// cannot exist, so a test that drops a real executable into the handlers dir still
+/// cannot run it; the trigger only logs a warning. Production builds spawn the
+/// resolved handler unchanged.
+fn handler_bin(resolved: &std::path::Path) -> std::path::PathBuf {
+    if let Ok(bin) = std::env::var("MOADIM_HANDLER_BIN") {
+        return std::path::PathBuf::from(bin);
+    }
+    #[cfg(test)]
+    {
+        let _ = resolved;
+        std::path::PathBuf::from("/nonexistent/moadim-test-handler-guard")
+    }
+    #[cfg(not(test))]
+    resolved.to_path_buf()
+}
+
 /// Record a manual trigger for `id`, updating `last_manual_trigger_at` in-store and on disk,
 /// then spawn the handler script from the handlers directory if it exists.
 pub fn svc_trigger(store: &CronStore, id: &str) -> Result<CronJob, AppError> {
@@ -335,7 +356,7 @@ pub fn svc_trigger(store: &CronStore, id: &str) -> Result<CronJob, AppError> {
     write_job(&job).map_err(|_| AppError::Internal)?;
     let handler_path = crate::paths::handlers_dir().join(&job.handler);
     if handler_path.exists() {
-        if let Err(err) = std::process::Command::new(&handler_path).spawn() {
+        if let Err(err) = std::process::Command::new(handler_bin(&handler_path)).spawn() {
             log::warn!("trigger: failed to spawn handler {handler_path:?}: {err}");
         }
     } else {

--- a/src/cron_jobs_tests.rs
+++ b/src/cron_jobs_tests.rs
@@ -699,14 +699,22 @@ fn svc_trigger_logs_when_handler_spawn_fails() {
 }
 
 #[test]
-fn svc_trigger_spawns_existing_handler_script() {
-    // Place an executable handler script under the handlers dir so svc_trigger's
-    // `handler_path.exists()` branch is taken and the script is spawned.
+fn svc_trigger_guard_blocks_running_a_real_handler() {
+    // Structural guard for #217: an executable handler exists under the handlers dir,
+    // so `handler_path.exists()` is true and the spawn branch is taken — yet in a test
+    // build, with no `MOADIM_HANDLER_BIN` shim, `handler_bin()` resolves to a path that
+    // cannot exist, so the real handler is never executed. If it *were* run it would
+    // create the sentinel file; we assert that never happens.
     let handlers = crate::paths::handlers_dir();
     std::fs::create_dir_all(&handlers).unwrap();
     let handler_name = format!("cov-handler-{}", uuid::Uuid::new_v4());
     let handler_path = handlers.join(&handler_name);
-    std::fs::write(&handler_path, "#!/bin/sh\nexit 0\n").unwrap();
+    let sentinel = std::env::temp_dir().join(format!("moadim-sentinel-{}", uuid::Uuid::new_v4()));
+    std::fs::write(
+        &handler_path,
+        format!("#!/bin/sh\ntouch {}\n", sentinel.display()),
+    )
+    .unwrap();
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt as _;
@@ -731,9 +739,55 @@ fn svc_trigger_spawns_existing_handler_script() {
 
     let triggered = svc_trigger(&store, &id).unwrap();
     assert!(triggered.last_manual_trigger_at.is_some());
+    assert!(
+        !sentinel.exists(),
+        "the test-build guard must stop the real handler from executing"
+    );
 
     crate::storage::remove_job_dir(&id).unwrap();
     let _ = std::fs::remove_file(&handler_path);
+    let _ = std::fs::remove_file(&sentinel);
+}
+
+#[test]
+fn handler_bin_never_resolves_to_real_handler_in_test_builds() {
+    // With no `MOADIM_HANDLER_BIN` shim, a test build must never spawn the real
+    // resolved handler: the returned path differs from the resolved one and cannot
+    // exist, so the eventual spawn fails harmlessly (mirror of the crontab guard).
+    let saved = std::env::var_os("MOADIM_HANDLER_BIN");
+    // SAFETY: single-threaded test harness (RUST_TEST_THREADS=1); restored below.
+    unsafe {
+        std::env::remove_var("MOADIM_HANDLER_BIN");
+    }
+    let resolved = crate::paths::handlers_dir().join("some-real-handler");
+    let bin = handler_bin(&resolved);
+    unsafe {
+        match saved {
+            Some(value) => std::env::set_var("MOADIM_HANDLER_BIN", value),
+            None => std::env::remove_var("MOADIM_HANDLER_BIN"),
+        }
+    }
+    assert_ne!(bin, resolved, "test build must not spawn the real handler");
+    assert!(!bin.exists(), "guard path must not exist");
+}
+
+#[test]
+fn handler_bin_honours_shim_override() {
+    // The `MOADIM_HANDLER_BIN` shim is honoured first, so a test that needs a working
+    // spawn can point the handler at a harmless stand-in binary.
+    let saved = std::env::var_os("MOADIM_HANDLER_BIN");
+    // SAFETY: single-threaded test harness (RUST_TEST_THREADS=1); restored below.
+    unsafe {
+        std::env::set_var("MOADIM_HANDLER_BIN", "/some/shim/handler");
+    }
+    let bin = handler_bin(std::path::Path::new("/ignored/real/handler"));
+    unsafe {
+        match saved {
+            Some(value) => std::env::set_var("MOADIM_HANDLER_BIN", value),
+            None => std::env::remove_var("MOADIM_HANDLER_BIN"),
+        }
+    }
+    assert_eq!(bin, std::path::PathBuf::from("/some/shim/handler"));
 }
 
 #[tokio::test]

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -345,6 +345,24 @@ pub fn svc_delete(store: &RoutineStore, id: &str) -> Result<RoutineResponse, App
 }
 
 /// Record a manual trigger for `id` and spawn the same command the crontab would run.
+/// Resolve the shell binary used to launch a routine's agent command.
+///
+/// Mirrors the `crontab_bin()` structural guard (issues #217 / #175): the
+/// `MOADIM_SH_BIN` shim is honoured first, and in **test builds** with no shim
+/// configured this never falls back to the real `sh` — it returns a path that cannot
+/// exist, so the spawn fails harmlessly and the trigger only logs a warning instead
+/// of executing a real agent command on the developer's machine.
+fn sh_bin() -> String {
+    if let Ok(bin) = std::env::var("MOADIM_SH_BIN") {
+        return bin;
+    }
+    #[cfg(test)]
+    let fallback = "/nonexistent/moadim-test-sh-guard".to_string();
+    #[cfg(not(test))]
+    let fallback = "sh".to_string();
+    fallback
+}
+
 pub fn svc_trigger(store: &RoutineStore, id: &str) -> Result<Routine, AppError> {
     let mut lock = store.lock().unwrap();
     let routine = lock.get_mut(id).ok_or(AppError::NotFound)?;
@@ -358,7 +376,7 @@ pub fn svc_trigger(store: &RoutineStore, id: &str) -> Result<Routine, AppError> 
             // `-lc` (login shell) mirrors the crontab invocation (`/bin/sh -l <run.sh>`), so a
             // manual trigger sources the user's `~/.profile` and the agent gets the same
             // environment whether fired by cron or on demand.
-            if let Err(err) = std::process::Command::new("sh")
+            if let Err(err) = std::process::Command::new(sh_bin())
                 .arg("-lc")
                 .arg(&cmd)
                 .spawn()

--- a/src/routines/service_tests.rs
+++ b/src/routines/service_tests.rs
@@ -782,6 +782,50 @@ fn svc_trigger_warns_when_spawn_fails() {
     let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
 }
 
+#[test]
+fn sh_bin_never_resolves_to_real_sh_in_test_builds() {
+    // Structural guard for #217: with no `MOADIM_SH_BIN` shim, a test build must never
+    // fall back to the real `sh`, so a trigger test that forgets to isolate the
+    // environment cannot execute a real agent command. The resolved path must not
+    // exist, so the eventual spawn fails harmlessly (mirror of the crontab guard).
+    let saved = std::env::var_os("MOADIM_SH_BIN");
+    // SAFETY: single-threaded test harness (RUST_TEST_THREADS=1); restored below.
+    unsafe {
+        std::env::remove_var("MOADIM_SH_BIN");
+    }
+    let bin = sh_bin();
+    unsafe {
+        match saved {
+            Some(value) => std::env::set_var("MOADIM_SH_BIN", value),
+            None => std::env::remove_var("MOADIM_SH_BIN"),
+        }
+    }
+    assert_ne!(bin, "sh", "test build must not fall back to the real sh");
+    assert!(
+        !std::path::Path::new(&bin).exists(),
+        "guard path must not exist"
+    );
+}
+
+#[test]
+fn sh_bin_honours_shim_override() {
+    // The `MOADIM_SH_BIN` shim is honoured first, so a test that needs a working spawn
+    // can point the shell at a harmless stand-in.
+    let saved = std::env::var_os("MOADIM_SH_BIN");
+    // SAFETY: single-threaded test harness (RUST_TEST_THREADS=1); restored below.
+    unsafe {
+        std::env::set_var("MOADIM_SH_BIN", "/some/shim/sh");
+    }
+    let bin = sh_bin();
+    unsafe {
+        match saved {
+            Some(value) => std::env::set_var("MOADIM_SH_BIN", value),
+            None => std::env::remove_var("MOADIM_SH_BIN"),
+        }
+    }
+    assert_eq!(bin, "/some/shim/sh");
+}
+
 /// Build a create request with the given title and an otherwise-valid body.
 fn create_req_with_title(title: &str) -> CreateRoutineRequest {
     CreateRoutineRequest {


### PR DESCRIPTION
## What

Both external-process spawn sites were isolated in tests only by *convention* (empty `PATH` / fake handler paths), not structurally:

- `src/routines/service.rs` — `svc_trigger` runs the agent command via `sh -lc`.
- `src/cron_jobs.rs` — `svc_trigger` spawns the cron `handler_path`.

A test that triggered a routine/handler without clearing `PATH` or using a fake path could execute a real agent command or handler script on the developer's machine. `svc_trigger_spawns_existing_handler_script` did exactly this — it dropped a real `#!/bin/sh` handler into the handlers dir and actually spawned it.

## Change

Route both spawns through small `*_bin()` seams mirroring the existing `crontab_bin()` guard (issue #175):

- **`routines::service::sh_bin()`** — resolves the shell. `MOADIM_SH_BIN` shim honoured first; in **test builds** with no shim it returns a path that cannot exist, so the spawn fails harmlessly and the trigger only logs a warning.
- **`cron_jobs::handler_bin()`** — resolves the handler program. `MOADIM_HANDLER_BIN` shim honoured first; in **test builds** with no shim it returns a non-existent path, so a real executable in the handlers dir is never run.

Production behaviour is unchanged (real `sh` / resolved handler).

## Tests

- Repurposed the cron handler test to **prove** the guard blocks a real handler, via a sentinel file the handler would create if run.
- Added unit tests for both seams (shim-honoured + test-build guard), mirroring `crontab_bin_never_resolves_to_real_crontab_in_test_builds`.

## Gates (all green locally)

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (490 passed), and `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (100% lines).

tmux/kill (#215) and launchctl (#211/#213) seams remain tracked separately, as the issue notes.

Closes #217

---
This pull request was opened by the "Implement my assigned issues without a PR (daemon + landing)" routine of moadim.