### PR TITLE
chore(lint): deny clippy::unwrap_used in non-test code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,10 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   so one panicking handler can't cascade into every later request taking the same
   lock. The two `get_mut(id).unwrap()` invariant unwraps in `svc_update`/
   `svc_trigger` became `ok_or(AppError::NotFound)?`, removing the last panicking
-  unwraps from the production code paths.
+  unwraps from the production code paths. A new
+  `#![cfg_attr(not(test), deny(clippy::unwrap_used))]` crate lint now keeps
+  `.unwrap()` out of non-test code so the panic can't creep back in (tests still
+  use `.unwrap()` freely, where panicking is the intended failure mode).
 - Managed cron jobs are now re-synced to the OS crontab on daemon startup,
   mirroring the routines sync that already ran. Previously the cron-job block was
   only written on a job create/update/delete, so if it was lost or emptied

--- a/build.rs
+++ b/build.rs
@@ -24,7 +24,8 @@ fn main() {
         git_output(&["show", "-s", "--format=%cs", "HEAD"])
     );
 
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let manifest_dir =
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is always set by cargo");
     build::run(&manifest_dir);
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,8 @@
 #![deny(warnings)]
+// Forbid `.unwrap()` in production code so a poisoned lock or other panic
+// cannot take the daemon down. Tests use `.unwrap()` freely (panicking is the
+// desired failure mode there), so the lint is scoped to non-test builds.
+#![cfg_attr(not(test), deny(clippy::unwrap_used))]
 //! Moadim server binary. Runs the Axum HTTP server with REST and MCP transports.
 
 /// Compile-time build provenance (crate version + git commit/date).


### PR DESCRIPTION
Follow-up to #496 (the unwrap removal, now merged). Locks the win in place so a panicking `.unwrap()` can't return to production paths.

## What

- Add a crate-level `#![cfg_attr(not(test), deny(clippy::unwrap_used))]` in `src/main.rs`. The lint is scoped to non-test builds, so production code can no longer use `.unwrap()`, while tests keep using it freely (panicking is the intended failure mode there). `clippy --all-targets` lints the bin target without `cfg(test)` → deny active; the test target builds with `cfg(test)` → exempt.
- Convert `build.rs`'s `CARGO_MANIFEST_DIR` `.unwrap()` to `.expect(..)` — the last `.unwrap()` outside tests.
- CHANGELOG note appended to the existing unwrap-removal entry.

## Verification

- `cargo fmt --check` ✓
- `cargo clippy --all-targets -- -D warnings` ✓ (deny active on prod, tests exempt)
- 100% line coverage gate ✓ (pre-push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)