### PR TITLE
chore(release): v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-06-21
+
 ### Added
 
 - **Full action parity across the CLI, REST, and MCP surfaces.** Every cron-job
@@ -476,7 +478,11 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 - Ship the prebuilt UI in the published crate.
 - Rename the binary to `moadim` and add install docs.
 
-[Unreleased]: https://github.com/moadim-io/daemon/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/moadim-io/daemon/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/moadim-io/daemon/compare/v0.12.0...v0.13.0
+[0.12.0]: https://github.com/moadim-io/daemon/compare/v0.11.2...v0.12.0
+[0.11.2]: https://github.com/moadim-io/daemon/compare/v0.11.1...v0.11.2
+[0.11.1]: https://github.com/moadim-io/daemon/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/moadim-io/daemon/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/moadim-io/daemon/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/moadim-io/daemon/compare/v0.8.0...v0.9.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ opt-level = "z"
 
 [package]
 name = "moadim"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Moadim.io MCP/REST server for managing cron jobs"
 license = "MIT"


### PR DESCRIPTION
Release v0.13.0.

- Bump `version` 0.12.0 → 0.13.0 (Cargo.toml + Cargo.lock).
- Promote CHANGELOG `[Unreleased]` → `[0.13.0] - 2026-06-21`; fix stale/missing compare links (Unreleased, 0.13.0, 0.12.0, 0.11.2, 0.11.1).

Tag `v0.13.0` will be pushed onto the merged commit to fire the crates.io publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)