### PR TITLE
feat: trigger routines from cron via `moadim schedule trigger <id>` (no run.sh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,9 +71,10 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
     accepted as aliases.)
   - **New MCP tools** filling the gaps versus REST: `list_agents`,
     `cron_job_logs`, `routine_logs`, `shutdown`, and `restart`.
-- **New `moadim schedule trigger <id>` CLI command.** Triggers a routine or cron
-  job by ID, whichever owns it (the routine route is tried first, falling back to
-  the cron-job route on a 404). Generated routine `run.sh` wrappers use it.
+- **New `moadim schedule trigger <id>` CLI command** and matching
+  `POST /api/v1/routines/{id}/scheduled-trigger` route. Runs a routine on its
+  schedule, recording a *scheduled* (not manual) trigger. The generated crontab
+  line invokes it directly at each fire time.
   - **New `POST /api/v1/restart` route** (plus the matching `restart` MCP tool):
     stops the running server and starts a fresh instance via a detached helper
     process, since an in-process server cannot rebind its own port. Documented in
@@ -140,13 +141,15 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   isolated test crontab seam.
 - moadim-generated `.gitignore` files (job and routine) now ignore
   user-specific `run.sh` scripts.
-- Routine `run.sh` scripts are now thin wrappers that re-invoke the daemon via
-  `moadim schedule trigger <id>` instead of inlining the full launch command. The
-  daemon is the single source of truth for launch logic, eliminating the
-  duplication between the cron path and the manual-trigger path. **Scheduled
-  routines now require the daemon to be running** (it is installed as an OS
-  service for this reason); the agent still inherits the user's login environment
-  via the daemon's `sh -lc` spawn.
+- Routines no longer generate a per-routine `run.sh` launch script. The crontab
+  line now invokes the `moadim` binary directly
+  (`<schedule> <moadim> schedule trigger <id>`), and the running daemon is the
+  single source of truth for launch logic — eliminating the duplication between
+  the cron path and the manual-trigger path. Stale `run.sh` files left by older
+  daemons are removed on the next persist. **Scheduled routines now require the
+  daemon to be running** (it is installed as an OS service for this reason); the
+  agent still inherits the user's login environment via the daemon's `sh -lc`
+  spawn.
 - Enabled the `clippy::uninlined_format_args` lint (deny) and inlined the
   existing positional format arguments (`"{}", x` → `"{x}"`) so log lines and
   error messages read more directly. No behavior change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
     accepted as aliases.)
   - **New MCP tools** filling the gaps versus REST: `list_agents`,
     `cron_job_logs`, `routine_logs`, `shutdown`, and `restart`.
+- **New `moadim schedule trigger <id>` CLI command.** Triggers a routine or cron
+  job by ID, whichever owns it (the routine route is tried first, falling back to
+  the cron-job route on a 404). Generated routine `run.sh` wrappers use it.
   - **New `POST /api/v1/restart` route** (plus the matching `restart` MCP tool):
     stops the running server and starts a fresh instance via a detached helper
     process, since an in-process server cannot rebind its own port. Documented in
@@ -137,6 +140,13 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   isolated test crontab seam.
 - moadim-generated `.gitignore` files (job and routine) now ignore
   user-specific `run.sh` scripts.
+- Routine `run.sh` scripts are now thin wrappers that re-invoke the daemon via
+  `moadim schedule trigger <id>` instead of inlining the full launch command. The
+  daemon is the single source of truth for launch logic, eliminating the
+  duplication between the cron path and the manual-trigger path. **Scheduled
+  routines now require the daemon to be running** (it is installed as an OS
+  service for this reason); the agent still inherits the user's login environment
+  via the daemon's `sh -lc` spawn.
 - Enabled the `clippy::uninlined_format_args` lint (deny) and inlined the
   existing positional format arguments (`"{}", x` → `"{x}"`) so log lines and
   error messages read more directly. No behavior change.

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -708,6 +708,42 @@
         }
       }
     },
+    "/routines/{id}/scheduled-trigger": {
+      "post": {
+        "tags": [
+          "crate::routines"
+        ],
+        "summary": "`POST /routines/{id}/scheduled-trigger` — run a routine on its schedule.",
+        "description": "The daemon-side endpoint the generated crontab line invokes (`moadim schedule trigger <id>`).\nUnlike [`trigger`] it does not record a manual trigger; the spawned command records the scheduled\ntimestamp itself. See [`svc_trigger_scheduled`].",
+        "operationId": "scheduled_trigger",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Routine UUID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Routine"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
     "/routines/{id}/trigger": {
       "post": {
         "tags": [
@@ -1131,7 +1167,7 @@
               "null"
             ],
             "format": "int64",
-            "description": "Unix timestamp (seconds) when the routine was last fired by its cron schedule, if ever.\n\nThe mirror of [`Routine::last_manual_trigger_at`] for scheduled runs: a manual trigger\nupdates only the manual field, a scheduled firing updates only this one. The scheduler is\nthe host OS crontab, which runs the routine's generated `run.sh` directly without going\nthrough the daemon — so the script itself stamps this timestamp into the gitignored\n`scheduled.local.toml` sidecar at fire time, and the daemon reads it back on load. The\ndaemon never writes this field (it is absent from `routine.toml` and the daemon-owned\n`state.local.toml`), so re-persisting a routine can't clobber it.",
+            "description": "Unix timestamp (seconds) when the routine was last fired by its cron schedule, if ever.\n\nThe mirror of [`Routine::last_manual_trigger_at`] for scheduled runs: a manual trigger\nupdates only the manual field, a scheduled firing updates only this one. The host OS crontab\nline runs `moadim schedule trigger <id>`, and the launch command the daemon spawns stamps this\ntimestamp into the gitignored `scheduled.local.toml` sidecar at fire time (via its `printf`\nstep); the daemon reads it back on load. The daemon never writes this field directly (it is\nabsent from `routine.toml` and the daemon-owned `state.local.toml`), so re-persisting a\nroutine can't clobber it.",
             "minimum": 0
           },
           "max_runtime_secs": {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -85,7 +85,7 @@ pub enum Command {
 
 /// First-argument keywords that select a data-plane subcommand handled by [`crate::commands`]
 /// rather than the lifecycle commands parsed here. Kept in sync with the clap subcommands.
-pub(crate) const DATA_COMMANDS: &[&str] = &["cron-jobs", "routines", "agents", "echo"];
+pub(crate) const DATA_COMMANDS: &[&str] = &["cron-jobs", "routines", "schedule", "agents", "echo"];
 
 /// Parse CLI arguments (excluding the program name) into a [`Command`].
 ///
@@ -157,6 +157,7 @@ pub fn print_help() {
          DATA COMMANDS (talk to the running server over HTTP; pass --help for flags):\n\
          \x20   cron-jobs <create|list|get|update|replace|delete|trigger|logs> ...\n\
          \x20   routines  <create|list|get|update|replace|delete|trigger|logs|ical> ...\n\
+         \x20   schedule  trigger <id> trigger a routine or cron job by ID (used by run.sh wrappers)\n\
          \x20   agents                 list available agent keys\n\
          \x20   echo <message>         echo a message via the server\n\
          \n\

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -34,7 +34,7 @@ enum DataCommand {
     /// Manage routines (create/list/get/update/replace/delete/trigger/logs/ical).
     #[command(subcommand, visible_alias = "routine")]
     Routines(RoutineCmd),
-    /// Trigger a scheduled routine or cron job by ID (used by generated run.sh wrappers).
+    /// Trigger a routine on its schedule by ID (invoked by the generated crontab line).
     #[command(subcommand, visible_alias = "sched")]
     Schedule(ScheduleCmd),
     /// List the available agent registry keys.
@@ -122,15 +122,16 @@ enum CronCmd {
     },
 }
 
-/// Schedule operations spanning both routines and cron jobs, keyed only by ID.
+/// Schedule operations driven by the OS crontab, keyed only by ID.
 #[derive(Subcommand)]
 enum ScheduleCmd {
-    /// Trigger a routine or cron job by ID, whichever it names.
+    /// Run a routine on its schedule by ID.
     ///
-    /// Used by generated `run.sh` wrappers so cron need not know whether the ID is a routine or a
-    /// cron job: the routine trigger route is tried first, and a 404 falls back to the cron-job one.
+    /// This is what the generated crontab line invokes at each fire time. It records a *scheduled*
+    /// trigger (not a manual one), so it maps to the routine's `scheduled-trigger` route rather than
+    /// the manual `trigger` route.
     Trigger {
-        /// UUID of the routine or cron job to trigger.
+        /// UUID of the routine to trigger.
         id: String,
     },
 }
@@ -273,7 +274,11 @@ fn dispatch(command: DataCommand) -> i32 {
     match command {
         DataCommand::CronJobs(cmd) => dispatch_cron(cmd),
         DataCommand::Routines(cmd) => dispatch_routine(cmd),
-        DataCommand::Schedule(ScheduleCmd::Trigger { id }) => trigger_schedule(&id),
+        DataCommand::Schedule(ScheduleCmd::Trigger { id }) => request(
+            "POST",
+            &format!("{}/scheduled-trigger", routine_path(&id)),
+            None,
+        ),
         DataCommand::Agents => request("GET", "/api/v1/agents", None),
         DataCommand::Echo { message } => {
             let body = object([("message", Value::String(message))]);
@@ -518,14 +523,7 @@ fn to_body(map: Map<String, Value>) -> String {
 /// it to a process exit code: `0` on a 2xx, `1` on any other HTTP status (the server's error body is
 /// printed to stderr), and [`crate::cli::EXIT_NOT_RUNNING`] when no server is reachable.
 fn request(method: &str, path: &str, body: Option<&str>) -> i32 {
-    handle_response(crate::cli::http_request_json(method, path, body))
-}
-
-/// Print an HTTP response and map it to a process exit code, shared by [`request`] and
-/// [`trigger_schedule`]: `0` on a 2xx, `1` on any other status (printing the server's error body to
-/// stderr), and [`crate::cli::EXIT_NOT_RUNNING`] when no server is reachable.
-fn handle_response(result: std::io::Result<(u16, String)>) -> i32 {
-    match result {
+    match crate::cli::http_request_json(method, path, body) {
         Ok((status, resp)) if (200..300).contains(&status) => {
             print_body(&resp);
             0
@@ -541,20 +539,6 @@ fn handle_response(result: std::io::Result<(u16, String)>) -> i32 {
             eprintln!("moadim is not running");
             crate::cli::EXIT_NOT_RUNNING
         }
-    }
-}
-
-/// Trigger a routine or cron job by `id`, whichever store owns it.
-///
-/// The routine trigger route is tried first; a 404 (no routine with that ID) falls back to the
-/// cron-job trigger route. UUIDs do not collide across the two stores, so at most one ever matches.
-/// This lets a generated `run.sh` wrapper trigger its target without knowing which kind it is.
-fn trigger_schedule(id: &str) -> i32 {
-    let routine =
-        crate::cli::http_request_json("POST", &format!("{}/trigger", routine_path(id)), None);
-    match routine {
-        Ok((404, _)) => request("POST", &format!("{}/trigger", cron_path(id)), None),
-        other => handle_response(other),
     }
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -34,6 +34,9 @@ enum DataCommand {
     /// Manage routines (create/list/get/update/replace/delete/trigger/logs/ical).
     #[command(subcommand, visible_alias = "routine")]
     Routines(RoutineCmd),
+    /// Trigger a scheduled routine or cron job by ID (used by generated run.sh wrappers).
+    #[command(subcommand, visible_alias = "sched")]
+    Schedule(ScheduleCmd),
     /// List the available agent registry keys.
     Agents,
     /// Echo a message back via the server, with a server timestamp.
@@ -115,6 +118,19 @@ enum CronCmd {
     /// Print a cron job's log file.
     Logs {
         /// UUID of the cron job whose logs to print.
+        id: String,
+    },
+}
+
+/// Schedule operations spanning both routines and cron jobs, keyed only by ID.
+#[derive(Subcommand)]
+enum ScheduleCmd {
+    /// Trigger a routine or cron job by ID, whichever it names.
+    ///
+    /// Used by generated `run.sh` wrappers so cron need not know whether the ID is a routine or a
+    /// cron job: the routine trigger route is tried first, and a 404 falls back to the cron-job one.
+    Trigger {
+        /// UUID of the routine or cron job to trigger.
         id: String,
     },
 }
@@ -257,6 +273,7 @@ fn dispatch(command: DataCommand) -> i32 {
     match command {
         DataCommand::CronJobs(cmd) => dispatch_cron(cmd),
         DataCommand::Routines(cmd) => dispatch_routine(cmd),
+        DataCommand::Schedule(ScheduleCmd::Trigger { id }) => trigger_schedule(&id),
         DataCommand::Agents => request("GET", "/api/v1/agents", None),
         DataCommand::Echo { message } => {
             let body = object([("message", Value::String(message))]);
@@ -501,7 +518,14 @@ fn to_body(map: Map<String, Value>) -> String {
 /// it to a process exit code: `0` on a 2xx, `1` on any other HTTP status (the server's error body is
 /// printed to stderr), and [`crate::cli::EXIT_NOT_RUNNING`] when no server is reachable.
 fn request(method: &str, path: &str, body: Option<&str>) -> i32 {
-    match crate::cli::http_request_json(method, path, body) {
+    handle_response(crate::cli::http_request_json(method, path, body))
+}
+
+/// Print an HTTP response and map it to a process exit code, shared by [`request`] and
+/// [`trigger_schedule`]: `0` on a 2xx, `1` on any other status (printing the server's error body to
+/// stderr), and [`crate::cli::EXIT_NOT_RUNNING`] when no server is reachable.
+fn handle_response(result: std::io::Result<(u16, String)>) -> i32 {
+    match result {
         Ok((status, resp)) if (200..300).contains(&status) => {
             print_body(&resp);
             0
@@ -517,6 +541,20 @@ fn request(method: &str, path: &str, body: Option<&str>) -> i32 {
             eprintln!("moadim is not running");
             crate::cli::EXIT_NOT_RUNNING
         }
+    }
+}
+
+/// Trigger a routine or cron job by `id`, whichever store owns it.
+///
+/// The routine trigger route is tried first; a 404 (no routine with that ID) falls back to the
+/// cron-job trigger route. UUIDs do not collide across the two stores, so at most one ever matches.
+/// This lets a generated `run.sh` wrapper trigger its target without knowing which kind it is.
+fn trigger_schedule(id: &str) -> i32 {
+    let routine =
+        crate::cli::http_request_json("POST", &format!("{}/trigger", routine_path(id)), None);
+    match routine {
+        Ok((404, _)) => request("POST", &format!("{}/trigger", cron_path(id)), None),
+        other => handle_response(other),
     }
 }
 

--- a/src/commands_tests.rs
+++ b/src/commands_tests.rs
@@ -321,7 +321,7 @@ fn every_subcommand_succeeds_against_a_2xx_server() {
         &["routines", "trigger", "rid"],
         &["routines", "logs", "rid"],
         &["routines", "ical"],
-        // schedule (routine trigger succeeds on the first try; fallback never reached)
+        // schedule (posts to the routine scheduled-trigger route)
         &["schedule", "trigger", "sid"],
         &["sched", "trigger", "sid"],
         // top-level
@@ -370,29 +370,11 @@ fn no_server_returns_not_running_exit_code() {
         run(argv(&["cron-jobs", "list"])),
         crate::cli::EXIT_NOT_RUNNING
     );
-    // `schedule trigger` reaches the same not-running path on its first (routine) request.
+    // `schedule trigger` reaches the same not-running path.
     assert_eq!(
         run(argv(&["schedule", "trigger", "sid"])),
         crate::cli::EXIT_NOT_RUNNING
     );
-}
-
-#[test]
-fn schedule_trigger_falls_back_to_cron_on_routine_404() {
-    // The routine trigger 404s (no routine with that ID), so `schedule trigger` retries against the
-    // cron-job route. The fake server 404s both, so the fallback's non-2xx maps to exit 1 — but the
-    // fallback request branch is what we exercise here.
-    let server = FakeServer::start(404, "{\"error\":\"not found\"}");
-    let _addr = EnvGuard::set(BIND_ENV, &server.addr);
-    assert_eq!(run(argv(&["schedule", "trigger", "sid"])), 1);
-}
-
-#[test]
-fn schedule_trigger_surfaces_non_404_routine_error() {
-    // A non-404 routine error must not fall back to cron; it maps straight to exit 1.
-    let server = FakeServer::start(500, "");
-    let _addr = EnvGuard::set(BIND_ENV, &server.addr);
-    assert_eq!(run(argv(&["schedule", "trigger", "sid"])), 1);
 }
 
 // ─── Body-builder unit tests ─────────────────────────────────────────────────

--- a/src/commands_tests.rs
+++ b/src/commands_tests.rs
@@ -321,6 +321,9 @@ fn every_subcommand_succeeds_against_a_2xx_server() {
         &["routines", "trigger", "rid"],
         &["routines", "logs", "rid"],
         &["routines", "ical"],
+        // schedule (routine trigger succeeds on the first try; fallback never reached)
+        &["schedule", "trigger", "sid"],
+        &["sched", "trigger", "sid"],
         // top-level
         &["agents"],
         &["echo", "hello"],
@@ -367,6 +370,29 @@ fn no_server_returns_not_running_exit_code() {
         run(argv(&["cron-jobs", "list"])),
         crate::cli::EXIT_NOT_RUNNING
     );
+    // `schedule trigger` reaches the same not-running path on its first (routine) request.
+    assert_eq!(
+        run(argv(&["schedule", "trigger", "sid"])),
+        crate::cli::EXIT_NOT_RUNNING
+    );
+}
+
+#[test]
+fn schedule_trigger_falls_back_to_cron_on_routine_404() {
+    // The routine trigger 404s (no routine with that ID), so `schedule trigger` retries against the
+    // cron-job route. The fake server 404s both, so the fallback's non-2xx maps to exit 1 — but the
+    // fallback request branch is what we exercise here.
+    let server = FakeServer::start(404, "{\"error\":\"not found\"}");
+    let _addr = EnvGuard::set(BIND_ENV, &server.addr);
+    assert_eq!(run(argv(&["schedule", "trigger", "sid"])), 1);
+}
+
+#[test]
+fn schedule_trigger_surfaces_non_404_routine_error() {
+    // A non-404 routine error must not fall back to cron; it maps straight to exit 1.
+    let server = FakeServer::start(500, "");
+    let _addr = EnvGuard::set(BIND_ENV, &server.addr);
+    assert_eq!(run(argv(&["schedule", "trigger", "sid"])), 1);
 }
 
 // ─── Body-builder unit tests ─────────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,20 +73,21 @@ async fn run_server() -> anyhow::Result<()> {
         .try_init();
     routines::ensure_default_agents();
     let store = storage::load_store();
-    // Rename any prompt.txt sidecars to prompt.md before rewriting run.sh scripts; otherwise the
-    // first cron trigger after upgrade would fail on the cp step.
+    // Rename any prompt.txt sidecars to prompt.md before the crontab resync; otherwise the first
+    // cron trigger after upgrade would fail on the launch command's `cp prompt.md` step.
     routine_storage::migrate_prompt_files();
     // Move legacy UUID-named routine dirs to the current slug-based layout before loading, so the
-    // store reflects the canonical dirs the crontab sync and run.sh `cp prompt.md` both target.
+    // store reflects the canonical dirs the crontab sync and the launch command's `cp prompt.md`
+    // both target.
     routine_storage::migrate_routine_dirs();
     let routines = routine_storage::load_store();
     // Seed any missing built-in default routines (e.g. the daily moadim cargo update check) so a
     // fresh install ships with them, and a default deleted while stopped is restored. Existing
     // routines are never overwritten. Must run before the crontab sync so the defaults schedule.
     routines::ensure_default_routines(&routines);
-    // The crontab sync writes only run.sh; re-persist so every routine also has its routine.toml +
-    // prompt.md sidecar in the slug dir, healing dirs left with run.sh but no prompt (otherwise the
-    // cron `cp prompt.md` fails and the agent launches with an empty prompt).
+    // Re-persist so every routine has its routine.toml + prompt.md sidecar in the slug dir (and any
+    // stale legacy run.sh is removed), healing dirs left without a prompt (otherwise the launch
+    // command's `cp prompt.md` fails and the agent launches with an empty prompt).
     routine_storage::repersist_routines(&routines);
     // Re-sync routines to the crontab on startup; otherwise a block that went stale (e.g. emptied
     // by an earlier run before agent configs existed) would never be regenerated until the next

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -28,6 +28,7 @@
         crate::routines::update,
         crate::routines::delete,
         crate::routines::trigger,
+        crate::routines::scheduled_trigger,
         crate::routines::cleanup,
         crate::routines::get_logs,
         crate::routines::ical_feed,

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -116,16 +116,20 @@ pub fn routine_state_path(id: &str) -> PathBuf {
 /// Returns the path to `{routines_dir}/{id}/scheduled.local.toml`, the gitignored sidecar that
 /// records `last_scheduled_trigger_at`.
 ///
-/// Unlike [`routine_state_path`] this sidecar is written by the routine's generated `run.sh` at
-/// each scheduled cron firing (the daemon is not in the loop then), and is only ever *read* by the
-/// daemon — kept in its own file so a daemon-side re-persist of `state.local.toml` can't clobber
-/// the scheduler-written timestamp. The `.local.` infix matches the `*.local.*` `.gitignore`
-/// pattern, so scheduled-fire churn never produces version-control diffs.
+/// Unlike [`routine_state_path`] this sidecar is written by the routine's launch command (the
+/// `printf` step of [`crate::routines::build_routine_command`]) at each scheduled cron firing, and is
+/// only ever *read* by the daemon — kept in its own file so a daemon-side re-persist of
+/// `state.local.toml` can't clobber the scheduler-written timestamp. The `.local.` infix matches the
+/// `*.local.*` `.gitignore` pattern, so scheduled-fire churn never produces version-control diffs.
 pub fn routine_scheduled_state_path(id: &str) -> PathBuf {
     routine_dir(id).join("scheduled.local.toml")
 }
 
-/// Returns the path to `{routines_dir}/{id}/run.sh`, the generated launch script invoked by cron.
+/// Returns the path to `{routines_dir}/{id}/run.sh`, a legacy per-routine launch script.
+///
+/// No longer generated — the crontab line now invokes `moadim schedule trigger <id>` directly. The
+/// path is retained so [`crate::routine_storage::write_routine`] can delete any stale script left by
+/// an older daemon.
 pub fn routine_script_path(id: &str) -> PathBuf {
     routine_dir(id).join("run.sh")
 }

--- a/src/routes/http.rs
+++ b/src/routes/http.rs
@@ -217,6 +217,10 @@ pub(crate) fn build_app_with_shutdown(
                 .delete(routines::delete),
         )
         .route("/routines/{id}/trigger", post(routines::trigger))
+        .route(
+            "/routines/{id}/scheduled-trigger",
+            post(routines::scheduled_trigger),
+        )
         .route("/routines/{id}/logs", get(routines::get_logs))
         // Own fallback so unknown `/api/v1` paths return a JSON 404 instead of inheriting
         // the outer SPA fallback and answering with `index.html`/`200` (issue #270).

--- a/src/routes/http_tests.rs
+++ b/src/routes/http_tests.rs
@@ -682,6 +682,19 @@ async fn router_routine_full_lifecycle() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
 
+    // scheduled-trigger (the crontab-invoked path; runs the routine and returns OK)
+    let resp = build_app(store.clone(), routines.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/routines/{id}/scheduled-trigger"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
     // logs (empty)
     let resp = build_app(store.clone(), routines.clone())
         .oneshot(
@@ -733,6 +746,7 @@ async fn router_routine_not_found_paths() {
         ("GET", ""),
         ("DELETE", ""),
         ("POST", "/trigger"),
+        ("POST", "/scheduled-trigger"),
         ("GET", "/logs"),
     ] {
         let resp = build_app(new_store(), crate::routines::new_store())

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::paths::{
     routine_dir, routine_gitignore_path, routine_prompt_path, routine_scheduled_state_path,
-    routine_state_path, routine_toml_path, routines_dir,
+    routine_script_path, routine_state_path, routine_toml_path, routines_dir,
 };
 use crate::routines::{compose_prompt, slugify, Repository, Routine, RoutineStore};
 use crate::utils::atomic::atomic_write;
@@ -66,9 +66,9 @@ struct RuntimeState {
 /// Scheduler-written runtime state for a routine, persisted to the gitignored
 /// `scheduled.local.toml` sidecar.
 ///
-/// Written by the routine's generated `run.sh` at each scheduled cron firing (the daemon is not in
-/// the loop then) and only ever read here — kept separate from [`RuntimeState`] so a daemon-side
-/// re-persist of `state.local.toml` can never clobber the scheduler's timestamp.
+/// Written by the routine's launch command (the `printf` step of `build_routine_command`) at each
+/// scheduled cron firing and only ever read here — kept separate from [`RuntimeState`] so a
+/// daemon-side re-persist of `state.local.toml` can never clobber the scheduler's timestamp.
 #[derive(Debug, Deserialize, Serialize)]
 struct ScheduledState {
     /// Unix timestamp of the last scheduled (cron) firing, or `None` if it has never fired.
@@ -93,7 +93,8 @@ fn read_runtime_state(dir_name: &str) -> Option<u64> {
 
 /// Read `last_scheduled_trigger_at` from a routine's `scheduled.local.toml` sidecar, returning
 /// `None` when the sidecar is absent or unparsable (e.g. before the routine's schedule has ever
-/// fired). The daemon only reads this file; it is written by the routine's `run.sh` at fire time.
+/// fired). The daemon only reads this file; it is written by the routine's launch command at fire
+/// time.
 fn read_scheduled_state(dir_name: &str) -> Option<u64> {
     let text = std::fs::read_to_string(routine_scheduled_state_path(dir_name)).ok()?;
     toml::from_str::<ScheduledState>(&text)
@@ -148,6 +149,11 @@ pub fn write_routine(routine: &Routine) -> std::io::Result<()> {
     if !gitignore.exists() {
         std::fs::write(&gitignore, "*.local.*\n*.log\nrun.sh\n")?;
     }
+
+    // Remove any stale `run.sh` left by an older daemon that generated per-routine launch scripts;
+    // the crontab line now invokes the binary directly, so the script is obsolete. Best-effort: a
+    // missing file is fine. Startup re-persists every routine, so this heals existing installs.
+    let _ = std::fs::remove_file(routine_script_path(&slug));
 
     let toml_routine = RoutineToml {
         id: Some(routine.id.clone()),
@@ -295,10 +301,10 @@ pub(crate) fn migrate_routine_dirs_from_dir(dir: &std::path::Path) {
 /// Re-persist every loaded routine to disk, recreating `routine.toml`, `prompt.md`, and `.gitignore`
 /// in its canonical slug directory.
 ///
-/// The crontab sync writes only `run.sh`; nothing else rewrites the prompt sidecar on startup. So a
-/// slug dir that ends up with `run.sh` but no `prompt.md` (e.g. after the UUID→slug migration, or if
-/// the sidecar was lost) would fail the cron `cp prompt.md`. Re-persisting from the in-memory store
-/// heals those dirs. Idempotent; safe to call on every startup after [`load_store`].
+/// Nothing else rewrites the prompt sidecar on startup, so a slug dir missing its `prompt.md` (e.g.
+/// after the UUID→slug migration, or if the sidecar was lost) would fail the launch command's
+/// `cp prompt.md`. Re-persisting from the in-memory store heals those dirs (and removes any stale
+/// legacy `run.sh`). Idempotent; safe to call on every startup after [`load_store`].
 pub fn repersist_routines(store: &RoutineStore) {
     let routines: Vec<Routine> = store.lock_recover().values().cloned().collect();
     for routine in &routines {

--- a/src/routines/cleanup/cleanup_tests.rs
+++ b/src/routines/cleanup/cleanup_tests.rs
@@ -47,6 +47,111 @@ fn tmux_bin_falls_back_to_a_nonexistent_path_under_cfg_test() {
 }
 
 #[test]
+fn tmux_session_alive_reflects_the_bin_exit_status() {
+    // Point the tmux seam at real binaries that exit 0 / non-zero so the `has-session` status
+    // actually resolves, exercising the `.map(|status| status.success())` branch in both directions
+    // (the cfg(test) fallback path never spawns a real process, so this is the only place it runs).
+    let previous = std::env::var_os("MOADIM_TMUX_BIN");
+    let set = |bin: &str| {
+        // SAFETY: tests in this crate run single-threaded (RUST_TEST_THREADS=1).
+        unsafe { std::env::set_var("MOADIM_TMUX_BIN", bin) };
+    };
+
+    set("/usr/bin/true");
+    assert!(
+        super::session::tmux_session_alive("moadim-anything"),
+        "a 0-exit tmux stub reads as alive"
+    );
+    set("/usr/bin/false");
+    assert!(
+        !super::session::tmux_session_alive("moadim-anything"),
+        "a non-zero-exit tmux stub reads as not alive"
+    );
+
+    // SAFETY: single-threaded harness; restore the saved override.
+    unsafe {
+        match previous {
+            Some(value) => std::env::set_var("MOADIM_TMUX_BIN", value),
+            None => std::env::remove_var("MOADIM_TMUX_BIN"),
+        }
+    }
+}
+
+#[test]
+fn note_forced_kill_is_silent_when_log_cannot_be_opened() {
+    // The workbench directory does not exist, so opening `agent.log` (append+create) fails because
+    // its parent is absent — exercising the `if let Ok` fall-through (the best-effort Err branch).
+    let missing = std::env::temp_dir().join(format!("moadim-nfk-missing-{}", uuid::Uuid::new_v4()));
+    let _ = std::fs::remove_dir_all(&missing);
+    super::session::note_forced_kill(&missing);
+    // Nothing is created when the open fails.
+    assert!(!missing.exists());
+}
+
+#[test]
+fn cleanup_expired_workbenches_kills_a_live_expired_session() {
+    // With the tmux seam pointed at a 0-exit stub every session reads as *alive*, so the watchdog's
+    // `alive && is_expired(.., max_runtime_for(slug))` actually evaluates the `max_runtime_for`
+    // closure (the existing test's absent-tmux path short-circuits before it). The expired workbench
+    // is force-killed and reaped.
+    let home = std::env::temp_dir().join(format!("moadim-cleanup-live-{}", uuid::Uuid::new_v4()));
+    let prev_home = std::env::var_os("MOADIM_HOME_OVERRIDE");
+    let prev_tmux = std::env::var_os("MOADIM_TMUX_BIN");
+    // SAFETY: tests in this crate run single-threaded (RUST_TEST_THREADS=1); restored below.
+    unsafe {
+        std::env::set_var("MOADIM_HOME_OVERRIDE", &home);
+        std::env::set_var("MOADIM_TMUX_BIN", "/usr/bin/true");
+    }
+
+    let workbenches = crate::paths::workbenches_dir();
+    std::fs::create_dir_all(&workbenches).unwrap();
+    // Timestamp 1 → far past any default max-runtime ceiling → expired, so the live session is killed.
+    std::fs::create_dir_all(workbenches.join("alive-1")).unwrap();
+
+    let store = super::super::model::new_store();
+    let removed = cleanup_expired_workbenches(&store);
+    assert!(
+        removed >= 1,
+        "the live, expired workbench is killed and reaped"
+    );
+    assert!(!workbenches.join("alive-1").exists());
+
+    // SAFETY: single-threaded harness; restore the saved overrides.
+    unsafe {
+        match prev_home {
+            Some(value) => std::env::set_var("MOADIM_HOME_OVERRIDE", value),
+            None => std::env::remove_var("MOADIM_HOME_OVERRIDE"),
+        }
+        match prev_tmux {
+            Some(value) => std::env::set_var("MOADIM_TMUX_BIN", value),
+            None => std::env::remove_var("MOADIM_TMUX_BIN"),
+        }
+    }
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+#[test]
+fn tmux_bin_honors_the_override_env_var() {
+    // With `MOADIM_TMUX_BIN` set, `tmux_bin` returns it verbatim, ahead of the cfg(test) fallback —
+    // the seam that lets a test point probes/kills at a controlled stub.
+    let previous = std::env::var_os("MOADIM_TMUX_BIN");
+    // SAFETY: tests in this crate run single-threaded (RUST_TEST_THREADS=1); restored below.
+    unsafe {
+        std::env::set_var("MOADIM_TMUX_BIN", "/tmp/moadim-test-tmux-override");
+    }
+
+    assert_eq!(super::session::tmux_bin(), "/tmp/moadim-test-tmux-override");
+
+    // SAFETY: single-threaded harness; restore the saved override.
+    unsafe {
+        match previous {
+            Some(value) => std::env::set_var("MOADIM_TMUX_BIN", value),
+            None => std::env::remove_var("MOADIM_TMUX_BIN"),
+        }
+    }
+}
+
+#[test]
 fn parse_workbench_name_splits_slug_and_timestamp() {
     assert_eq!(parse_workbench_name("foo-123"), Some(("foo", 123)));
     // Slug may contain dashes; only the final all-digit segment is the timestamp.

--- a/src/routines/command.rs
+++ b/src/routines/command.rs
@@ -215,12 +215,13 @@ pub(crate) fn build_routine_command(routine: &Routine, agent: &AgentCommand) -> 
         // unchanged.
         format!("export PATH={}", shell_quote(&cron_path(&agent.command))),
         r#"TS="$(date +%s)""#.to_string(),
-        // Record this scheduled firing. The daemon never sees a cron run (the OS crontab executes
-        // this script directly), so the script itself stamps the fire time into the routine's
+        // Record this scheduled firing. This command stamps the fire time into the routine's
         // gitignored `scheduled.local.toml` sidecar; the daemon reads it back into
-        // `last_scheduled_trigger_at` on load. Written before the prompt-copy guard below so an
-        // aborted run still records that the schedule fired, and best-effort (`|| true`) so a
-        // sidecar write failure never blocks launching the agent.
+        // `last_scheduled_trigger_at` on load. (The cron line calls `moadim schedule trigger`, which
+        // spawns this command via the daemon's scheduled-trigger path without recording a *manual*
+        // trigger.) Written before the prompt-copy guard below so an aborted run still records that
+        // the schedule fired, and best-effort (`|| true`) so a sidecar write failure never blocks
+        // launching the agent.
         format!(
             r#"printf 'last_scheduled_trigger_at = %s\n' "$TS" > {} || true"#,
             shell_quote(&scheduled_state_path)

--- a/src/routines/handlers.rs
+++ b/src/routines/handlers.rs
@@ -15,7 +15,8 @@ use super::model::{
     RoutineStore, UpdateRoutineRequest,
 };
 use super::service::{
-    svc_cleanup, svc_create, svc_delete, svc_get, svc_list, svc_logs, svc_trigger, svc_update,
+    svc_cleanup, svc_create, svc_delete, svc_get, svc_list, svc_logs, svc_trigger,
+    svc_trigger_scheduled, svc_update,
 };
 
 /// `POST /routines` — create a new routine.
@@ -104,6 +105,21 @@ pub async fn trigger(
     Path(id): Path<String>,
 ) -> Result<Json<Routine>, AppError> {
     Ok(Json(svc_trigger(&store, &id)?))
+}
+
+/// `POST /routines/{id}/scheduled-trigger` — run a routine on its schedule.
+///
+/// The daemon-side endpoint the generated crontab line invokes (`moadim schedule trigger <id>`).
+/// Unlike [`trigger`] it does not record a manual trigger; the spawned command records the scheduled
+/// timestamp itself. See [`svc_trigger_scheduled`].
+#[utoipa::path(post, path = "/routines/{id}/scheduled-trigger",
+    params(("id" = String, Path, description = "Routine UUID")),
+    responses((status = 200, body = Routine), (status = 404, description = "Not found")))]
+pub async fn scheduled_trigger(
+    State(store): State<RoutineStore>,
+    Path(id): Path<String>,
+) -> Result<Json<Routine>, AppError> {
+    Ok(Json(svc_trigger_scheduled(&store, &id)?))
 }
 
 /// `GET /routines.ics` — iCalendar feed of every enabled routine's upcoming fire times.

--- a/src/routines/model.rs
+++ b/src/routines/model.rs
@@ -95,12 +95,12 @@ pub struct Routine {
     /// Unix timestamp (seconds) when the routine was last fired by its cron schedule, if ever.
     ///
     /// The mirror of [`Routine::last_manual_trigger_at`] for scheduled runs: a manual trigger
-    /// updates only the manual field, a scheduled firing updates only this one. The scheduler is
-    /// the host OS crontab, which runs the routine's generated `run.sh` directly without going
-    /// through the daemon — so the script itself stamps this timestamp into the gitignored
-    /// `scheduled.local.toml` sidecar at fire time, and the daemon reads it back on load. The
-    /// daemon never writes this field (it is absent from `routine.toml` and the daemon-owned
-    /// `state.local.toml`), so re-persisting a routine can't clobber it.
+    /// updates only the manual field, a scheduled firing updates only this one. The host OS crontab
+    /// line runs `moadim schedule trigger <id>`, and the launch command the daemon spawns stamps this
+    /// timestamp into the gitignored `scheduled.local.toml` sidecar at fire time (via its `printf`
+    /// step); the daemon reads it back on load. The daemon never writes this field directly (it is
+    /// absent from `routine.toml` and the daemon-owned `state.local.toml`), so re-persisting a
+    /// routine can't clobber it.
     #[serde(default)]
     pub last_scheduled_trigger_at: Option<u64>,
     /// How long (seconds) a finished run's workbench is retained before auto-cleanup removes it.

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -412,8 +412,7 @@ pub fn svc_trigger(store: &RoutineStore, id: &str) -> Result<Routine, AppError> 
 /// two paths distinct preserves the manual-vs-scheduled distinction the timestamps exist to capture.
 pub fn svc_trigger_scheduled(store: &RoutineStore, id: &str) -> Result<Routine, AppError> {
     let routine = store
-        .lock()
-        .unwrap()
+        .lock_recover()
         .get(id)
         .cloned()
         .ok_or(AppError::NotFound)?;

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -398,12 +398,39 @@ pub fn svc_trigger(store: &RoutineStore, id: &str) -> Result<Routine, AppError> 
     let routine = routine.clone();
     drop(lock);
     write_routine(&routine).map_err(|_| AppError::Internal)?;
+    spawn_routine_command(&routine);
+    Ok(routine)
+}
+
+/// Run a routine on its schedule: spawn the command the crontab line invokes, without recording a
+/// *manual* trigger.
+///
+/// This is the daemon-side endpoint that the generated crontab line drives
+/// (`moadim schedule trigger <id>`). Unlike [`svc_trigger`] it leaves `last_manual_trigger_at`
+/// untouched — the spawned command records `last_scheduled_trigger_at` in the routine's
+/// `scheduled.local.toml` sidecar itself, which the daemon reads back on the next load. Keeping the
+/// two paths distinct preserves the manual-vs-scheduled distinction the timestamps exist to capture.
+pub fn svc_trigger_scheduled(store: &RoutineStore, id: &str) -> Result<Routine, AppError> {
+    let routine = store
+        .lock()
+        .unwrap()
+        .get(id)
+        .cloned()
+        .ok_or(AppError::NotFound)?;
+    spawn_routine_command(&routine);
+    Ok(routine)
+}
+
+/// Spawn the launch command for `routine` under a login shell, logging (rather than failing) when
+/// the agent config cannot be loaded or the process cannot be spawned.
+///
+/// `sh -lc` sources the user's `~/.profile`, so the agent inherits their environment (`GH_TOKEN`,
+/// API keys, …) regardless of the minimal environment the daemon (or cron) runs under. Shared by the
+/// manual ([`svc_trigger`]) and scheduled ([`svc_trigger_scheduled`]) paths.
+fn spawn_routine_command(routine: &Routine) {
     match load_agent_command(&routine.agent) {
         Ok(agent) => {
-            let cmd = build_routine_command(&routine, &agent);
-            // `-lc` (login shell) mirrors the crontab invocation (`/bin/sh -l <run.sh>`), so a
-            // manual trigger sources the user's `~/.profile` and the agent gets the same
-            // environment whether fired by cron or on demand.
+            let cmd = build_routine_command(routine, &agent);
             if let Err(err) = std::process::Command::new("sh")
                 .arg("-lc")
                 .arg(&cmd)
@@ -419,7 +446,6 @@ pub fn svc_trigger(store: &RoutineStore, id: &str) -> Result<Routine, AppError> 
             routine.id
         ),
     }
-    Ok(routine)
 }
 
 /// Reap finished, expired run workbenches immediately, returning how many were removed.

--- a/src/routines/service_tests.rs
+++ b/src/routines/service_tests.rs
@@ -888,6 +888,43 @@ fn svc_trigger_warns_when_spawn_fails() {
     let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
 }
 
+#[test]
+fn svc_trigger_scheduled_missing_routine_not_found() {
+    assert!(matches!(
+        svc_trigger_scheduled(&new_store(), "nope"),
+        Err(AppError::NotFound)
+    ));
+}
+
+#[test]
+fn svc_trigger_scheduled_spawns_without_recording_manual_trigger() {
+    // The scheduled path must leave `last_manual_trigger_at` untouched (it is for *manual* triggers
+    // only); `with_empty_path` makes the spawn fail so the test never launches a real session, while
+    // still exercising the spawn branch.
+    let agent_name = "svc-trigger-scheduled-agent-zzz";
+    std::fs::create_dir_all(crate::paths::agents_dir()).unwrap();
+    let cfg = crate::paths::agent_toml_path(agent_name);
+    std::fs::write(&cfg, "command = \"true\"\nargs = []\n").unwrap();
+
+    let title = "Svc Trigger Scheduled ZZZ";
+    let store = new_store();
+    let mut routine = make_routine("trig-sched-id", title, 1, 1);
+    routine.agent = agent_name.into();
+    crate::routine_storage::write_routine(&routine).unwrap();
+    store
+        .lock()
+        .unwrap()
+        .insert("trig-sched-id".into(), routine);
+
+    with_empty_path(|| {
+        let triggered = svc_trigger_scheduled(&store, "trig-sched-id").unwrap();
+        assert!(triggered.last_manual_trigger_at.is_none());
+    });
+
+    let _ = std::fs::remove_file(&cfg);
+    let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
+}
+
 /// Build a create request with the given title and an otherwise-valid body.
 fn create_req_with_title(title: &str) -> CreateRoutineRequest {
     CreateRoutineRequest {

--- a/src/sync/routines.rs
+++ b/src/sync/routines.rs
@@ -9,16 +9,18 @@
 //! # END MOADIM-ROUTINES
 //! ```
 //!
-//! Each routine's full launch command is written to a per-routine `run.sh` script; the crontab line
-//! is just `<schedule> /bin/sh -l '<run.sh>' # moadim-routine:<id>`. Inlining the whole command
-//! (which includes a long per-agent `setup` step) pushed lines past cron's ~1000-char per-line
-//! limit, which cron silently drops.
+//! Each routine's `run.sh` is a thin wrapper that re-invokes the `moadim` binary to trigger the
+//! routine by ID (`moadim schedule trigger <id>`); the crontab line is just
+//! `<schedule> /bin/sh -l '<run.sh>' # moadim-routine:<id>`. The wrapper hands off to the running
+//! daemon, which is the single source of truth for launch logic
+//! ([`crate::routines::build_routine_command`] + spawn). This means **scheduled routines require the
+//! daemon to be running** — it is installed as an OS service (launchd / systemd user) for exactly
+//! this reason. The earlier design inlined the whole launch command into `run.sh`, which both
+//! duplicated the build logic and pushed lines past cron's ~1000-char per-line limit.
 //!
-//! The `-l` makes `run.sh` execute under a **login** shell so it sources the user's `~/.profile`,
-//! giving the agent the environment variables (`GH_TOKEN`, API keys, …) an interactive login shell
-//! has. Cron's own environment is minimal and outside the GUI login session, so without `-l` the
-//! agent would launch with no credentials. (`run.sh` still replaces `PATH` with its own curated
-//! list, so binary resolution is unaffected — only env vars are gained.) Reverse sync is not
+//! The agent still inherits the user's login environment (`GH_TOKEN`, API keys, …): the daemon's
+//! trigger path spawns the agent under `sh -lc`, which sources `~/.profile`. The crontab line's `-l`
+//! is retained defensively so the wrapper itself runs under a login shell. Reverse sync is not
 //! implemented — routines are managed only through the API.
 
 use crate::utils::lock::LockRecover;
@@ -26,10 +28,7 @@ use std::io;
 use std::os::unix::fs::PermissionsExt;
 
 use crate::paths::routine_script_path;
-use crate::routines::{
-    build_routine_command, load_agent_command, shell_quote, slugify, AgentCommand, Routine,
-    RoutineStore,
-};
+use crate::routines::{load_agent_command, shell_quote, slugify, Routine, RoutineStore};
 use crate::sync::{read_crontab, replace_block_with, to_os_schedule, write_crontab, SyncError};
 
 /// Delimiter marking the start of the moadim routines crontab block.
@@ -39,14 +38,22 @@ const BLOCK_END: &str = "# END MOADIM-ROUTINES";
 /// Human-readable header comment written inside the block.
 const BLOCK_HEADER: &str = "# Managed by moadim — routines (agent tmux sessions)";
 
-/// Write the routine's launch command to its `run.sh` script and return the path.
+/// Write the routine's `run.sh` wrapper and return its path.
 ///
-/// The script holds the full self-contained command from [`build_routine_command`], so the crontab
-/// line that calls it stays short regardless of how long the command is.
-fn write_routine_script(routine: &Routine, agent: &AgentCommand) -> io::Result<std::path::PathBuf> {
+/// The script is a thin wrapper that re-invokes the `moadim` binary to trigger this routine by ID
+/// (`moadim schedule trigger <id>`), so the daemon owns the launch logic. It calls the daemon's own
+/// executable by absolute path ([`std::env::current_exe`]) so resolution does not depend on cron's
+/// `PATH`. The previous design inlined the whole launch command here, duplicating
+/// [`crate::routines::build_routine_command`] (still used by the in-process manual-trigger path).
+fn write_routine_script(routine: &Routine) -> io::Result<std::path::PathBuf> {
     let path = routine_script_path(&slugify(&routine.title));
     std::fs::create_dir_all(path.parent().expect("routine script path has a parent dir"))?;
-    let command = build_routine_command(routine, agent);
+    let exe = std::env::current_exe()?;
+    let command = format!(
+        "exec {} schedule trigger {}",
+        shell_quote(&exe.to_string_lossy()),
+        shell_quote(&routine.id),
+    );
     std::fs::write(&path, format!("#!/bin/sh\n{command}\n"))?;
     std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))?;
     Ok(path)
@@ -55,13 +62,12 @@ fn write_routine_script(routine: &Routine, agent: &AgentCommand) -> io::Result<s
 /// Format a single routine as a crontab line that invokes its `run.sh`:
 /// `<schedule> /bin/sh -l '<run.sh>' # moadim-routine:<id>`.
 ///
-/// The `-l` runs the script under a login shell so it sources the user's `~/.profile`, letting the
-/// agent inherit their environment variables (`GH_TOKEN`, API keys, …) rather than cron's minimal
-/// one.
+/// The `-l` runs the wrapper under a login shell so it sources the user's `~/.profile` (retained
+/// defensively; the agent's own environment is set up later by the daemon's `sh -lc` spawn).
 ///
 /// Returns `None` (after a warning) if the script cannot be written.
-pub(crate) fn format_routine_line(routine: &Routine, agent: &AgentCommand) -> Option<String> {
-    let script = match write_routine_script(routine, agent) {
+pub(crate) fn format_routine_line(routine: &Routine) -> Option<String> {
+    let script = match write_routine_script(routine) {
         Ok(path) => path,
         Err(err) => {
             log::warn!(
@@ -96,7 +102,9 @@ fn build_block(store: &RoutineStore) -> String {
     let lines: Vec<String> = routines
         .iter()
         .filter_map(|routine| match load_agent_command(&routine.agent) {
-            Ok(agent) => format_routine_line(routine, &agent),
+            // Validate the agent config at sync time so a broken routine is skipped here rather than
+            // failing at fire time; the wrapper script itself no longer embeds the agent command.
+            Ok(_) => format_routine_line(routine),
             Err(err) => {
                 log::warn!(
                     "routine sync: cannot load agent {:?} ({}) for routine {:?}; skipping",

--- a/src/sync/routines.rs
+++ b/src/sync/routines.rs
@@ -5,31 +5,25 @@
 //! ```text
 //! # BEGIN MOADIM-ROUTINES
 //! # Managed by moadim — routines (agent tmux sessions)
-//! * * * * * /bin/sh -l '/…/routines/<slug>/run.sh' # moadim-routine:<id>
+//! * * * * * /…/moadim schedule trigger '<id>' # moadim-routine:<id>
 //! # END MOADIM-ROUTINES
 //! ```
 //!
-//! Each routine's `run.sh` is a thin wrapper that re-invokes the `moadim` binary to trigger the
-//! routine by ID (`moadim schedule trigger <id>`); the crontab line is just
-//! `<schedule> /bin/sh -l '<run.sh>' # moadim-routine:<id>`. The wrapper hands off to the running
-//! daemon, which is the single source of truth for launch logic
-//! ([`crate::routines::build_routine_command`] + spawn). This means **scheduled routines require the
-//! daemon to be running** — it is installed as an OS service (launchd / systemd user) for exactly
-//! this reason. The earlier design inlined the whole launch command into `run.sh`, which both
-//! duplicated the build logic and pushed lines past cron's ~1000-char per-line limit.
+//! Each crontab line invokes the `moadim` binary directly to trigger the routine by ID
+//! (`moadim schedule trigger <id>`). No per-routine `run.sh` script is generated: the command is
+//! short enough to inline (well under cron's ~1000-char per-line limit), and the running daemon is
+//! the single source of truth for launch logic ([`crate::routines::build_routine_command`] + spawn).
+//! This means **scheduled routines require the daemon to be running** — it is installed as an OS
+//! service (launchd / systemd user) for exactly this reason.
 //!
-//! The agent still inherits the user's login environment (`GH_TOKEN`, API keys, …): the daemon's
-//! trigger path spawns the agent under `sh -lc`, which sources `~/.profile`. The crontab line's `-l`
-//! is retained defensively so the wrapper itself runs under a login shell. Reverse sync is not
-//! implemented — routines are managed only through the API.
+//! The binary is referenced by absolute path ([`std::env::current_exe`]) so resolution does not
+//! depend on cron's minimal `PATH`. The agent still inherits the user's login environment (`GH_TOKEN`,
+//! API keys, …): the daemon's trigger path spawns the agent under `sh -lc`, which sources
+//! `~/.profile`. Reverse sync is not implemented — routines are managed only through the API.
 
-use crate::utils::lock::LockRecover;
-use std::io;
-use std::os::unix::fs::PermissionsExt;
-
-use crate::paths::routine_script_path;
-use crate::routines::{load_agent_command, shell_quote, slugify, Routine, RoutineStore};
+use crate::routines::{load_agent_command, shell_quote, Routine, RoutineStore};
 use crate::sync::{read_crontab, replace_block_with, to_os_schedule, write_crontab, SyncError};
+use crate::utils::lock::LockRecover;
 
 /// Delimiter marking the start of the moadim routines crontab block.
 const BLOCK_BEGIN: &str = "# BEGIN MOADIM-ROUTINES";
@@ -38,52 +32,25 @@ const BLOCK_END: &str = "# END MOADIM-ROUTINES";
 /// Human-readable header comment written inside the block.
 const BLOCK_HEADER: &str = "# Managed by moadim — routines (agent tmux sessions)";
 
-/// Write the routine's `run.sh` wrapper and return its path.
+/// Format a single routine as a crontab line that triggers it via the `moadim` binary:
+/// `<schedule> '<moadim>' schedule trigger '<id>' # moadim-routine:<id>`.
 ///
-/// The script is a thin wrapper that re-invokes the `moadim` binary to trigger this routine by ID
-/// (`moadim schedule trigger <id>`), so the daemon owns the launch logic. It calls the daemon's own
-/// executable by absolute path ([`std::env::current_exe`]) so resolution does not depend on cron's
-/// `PATH`. The previous design inlined the whole launch command here, duplicating
-/// [`crate::routines::build_routine_command`] (still used by the in-process manual-trigger path).
-fn write_routine_script(routine: &Routine) -> io::Result<std::path::PathBuf> {
-    let path = routine_script_path(&slugify(&routine.title));
-    std::fs::create_dir_all(path.parent().expect("routine script path has a parent dir"))?;
-    let exe = std::env::current_exe()?;
-    let command = format!(
-        "exec {} schedule trigger {}",
+/// The binary is referenced by absolute path ([`std::env::current_exe`]) so cron's minimal `PATH`
+/// cannot break resolution; both the path and the routine ID are shell-quoted. The launch command
+/// itself ([`crate::routines::build_routine_command`]) is built and spawned by the daemon when the
+/// `schedule trigger` request arrives, so it is not duplicated into the crontab line.
+pub(crate) fn format_routine_line(routine: &Routine) -> String {
+    // The daemon is already running from this binary, so resolving its own path cannot realistically
+    // fail; a failure here means the process has no executable path at all, which is unrecoverable.
+    let exe = std::env::current_exe().expect("daemon executable path is resolvable");
+    let schedule = to_os_schedule(&routine.schedule);
+    format!(
+        "{} {} schedule trigger {} # moadim-routine:{}",
+        schedule,
         shell_quote(&exe.to_string_lossy()),
         shell_quote(&routine.id),
-    );
-    std::fs::write(&path, format!("#!/bin/sh\n{command}\n"))?;
-    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))?;
-    Ok(path)
-}
-
-/// Format a single routine as a crontab line that invokes its `run.sh`:
-/// `<schedule> /bin/sh -l '<run.sh>' # moadim-routine:<id>`.
-///
-/// The `-l` runs the wrapper under a login shell so it sources the user's `~/.profile` (retained
-/// defensively; the agent's own environment is set up later by the daemon's `sh -lc` spawn).
-///
-/// Returns `None` (after a warning) if the script cannot be written.
-pub(crate) fn format_routine_line(routine: &Routine) -> Option<String> {
-    let script = match write_routine_script(routine) {
-        Ok(path) => path,
-        Err(err) => {
-            log::warn!(
-                "routine sync: failed to write run.sh for routine {:?}: {err}; skipping",
-                routine.id
-            );
-            return None;
-        }
-    };
-    let schedule = to_os_schedule(&routine.schedule);
-    Some(format!(
-        "{} /bin/sh -l {} # moadim-routine:{}",
-        schedule,
-        shell_quote(&script.to_string_lossy()),
         routine.id
-    ))
+    )
 }
 
 /// Build the full routines block from the enabled managed routines in `store`.
@@ -103,8 +70,8 @@ fn build_block(store: &RoutineStore) -> String {
         .iter()
         .filter_map(|routine| match load_agent_command(&routine.agent) {
             // Validate the agent config at sync time so a broken routine is skipped here rather than
-            // failing at fire time; the wrapper script itself no longer embeds the agent command.
-            Ok(_) => format_routine_line(routine),
+            // failing at fire time; the crontab line itself no longer embeds the agent command.
+            Ok(_) => Some(format_routine_line(routine)),
             Err(err) => {
                 log::warn!(
                     "routine sync: cannot load agent {:?} ({}) for routine {:?}; skipping",

--- a/src/sync/routines_sync_tests.rs
+++ b/src/sync/routines_sync_tests.rs
@@ -23,94 +23,33 @@ fn make_routine(id: &str, title: &str, agent: &str) -> Routine {
 }
 
 #[test]
-fn format_routine_line_invokes_script_with_schedule_and_tag() {
+fn format_routine_line_inlines_schedule_trigger_and_tag() {
     let title = "Fid Sync Routine";
     let slug = slugify(title);
     let routine = make_routine("fid", title, "claude");
-    let line = format_routine_line(&routine).unwrap();
+    let line = format_routine_line(&routine);
     assert!(line.starts_with("30 9 * * 1-5 "));
-    // crontab line just runs the generated script — keeps it well under cron's length limit
-    assert!(line.contains("/bin/sh "));
-    // `-l` runs the wrapper under a login shell (retained defensively).
-    assert!(line.contains("/bin/sh -l "));
-    assert!(line.contains(&format!("/{slug}/run.sh")));
+    // The crontab line invokes the binary directly with the shell-quoted routine ID — no run.sh.
+    assert!(line.contains("schedule trigger 'fid'"));
     assert!(line.ends_with("# moadim-routine:fid"));
     assert!(!line.contains('\n'));
-    // The script is a thin wrapper that re-invokes the binary to trigger the routine by ID; the
-    // launch logic now lives in the daemon, not the script.
-    let script = std::fs::read_to_string(crate::paths::routine_script_path(&slug)).unwrap();
-    assert!(script.starts_with("#!/bin/sh\n"));
-    assert!(script.contains("schedule trigger 'fid'"));
-    assert!(!script.contains("tmux new-session"));
+    // No per-routine launch script is written any more.
+    assert!(!crate::paths::routine_script_path(&slug).exists());
     let _ = std::fs::remove_dir_all(crate::paths::routine_dir(&slug));
 }
 
 #[test]
-fn format_routine_line_creates_missing_parent_dir() {
-    // Covers write_routine_script's create_dir_all(parent) branch: the routine's
-    // directory does not exist yet, so the script write must create it first.
-    let title = "Parent Create Sync Routine";
-    let slug = slugify(title);
-    // Ensure a clean slate so create_dir_all actually has work to do.
-    let _ = std::fs::remove_dir_all(crate::paths::routine_dir(&slug));
-    assert!(!crate::paths::routine_dir(&slug).exists());
-
-    let routine = make_routine("parent-create", title, "claude");
-    let line = format_routine_line(&routine).unwrap();
-    assert!(line.ends_with("# moadim-routine:parent-create"));
-    assert!(crate::paths::routine_script_path(&slug).exists());
-
-    let _ = std::fs::remove_dir_all(crate::paths::routine_dir(&slug));
-}
-
-#[test]
-fn format_routine_line_returns_none_when_script_write_fails() {
-    // Covers the Err(err) arm of format_routine_line: write_routine_script fails
-    // because the routine directory path is occupied by a regular file, so
-    // create_dir_all on it errors and the line is skipped (returns None).
-    let title = "Write Fail Sync Routine";
-    let slug = slugify(title);
-    let routine_dir = crate::paths::routine_dir(&slug);
-    let _ = std::fs::remove_dir_all(&routine_dir);
-    if let Some(parent) = routine_dir.parent() {
-        std::fs::create_dir_all(parent).unwrap();
-    }
-    // Occupy the routine directory path with a regular file so that
-    // create_dir_all(<routine_dir>) inside write_routine_script fails.
-    std::fs::write(&routine_dir, "blocker").unwrap();
-
-    let routine = make_routine("write-fail", title, "claude");
-    let result = format_routine_line(&routine);
-    assert!(result.is_none(), "expected None on script write failure");
-
-    let _ = std::fs::remove_file(&routine_dir);
-}
-
-#[test]
-fn format_routine_line_when_parent_dir_already_exists() {
-    // Covers write_routine_script's path where the routine directory (the script's parent) already
-    // exists, so create_dir_all is a no-op success and execution proceeds to build + write the
-    // script and format the line. Uses a keyword schedule and repositories to run the full body.
-    let title = "Existing Parent Sync Routine";
-    let slug = slugify(title);
-    let routine_dir = crate::paths::routine_dir(&slug);
-    // Pre-create the routine (parent) directory so create_dir_all has nothing to do.
-    std::fs::create_dir_all(&routine_dir).unwrap();
-    assert!(routine_dir.exists());
-
-    let mut routine = make_routine("existing-parent", title, "claude");
-    routine.schedule = "@daily".to_string();
-    routine.repositories = vec![crate::routines::Repository {
-        repository: "https://example.com/ctx.git".to_string(),
-        branch: Some("main".to_string()),
-    }];
-
-    let line = format_routine_line(&routine).unwrap();
+fn format_routine_line_honors_keyword_schedule() {
+    // A `@`-keyword schedule is passed through `to_os_schedule` and prefixes the line.
+    let routine = {
+        let mut routine = make_routine("kw-id", "Keyword Sync Routine", "claude");
+        routine.schedule = "@daily".to_string();
+        routine
+    };
+    let line = format_routine_line(&routine);
     assert!(line.starts_with("@daily "), "wrong schedule: {line}");
-    assert!(line.ends_with("# moadim-routine:existing-parent"));
-    assert!(crate::paths::routine_script_path(&slug).exists());
-
-    let _ = std::fs::remove_dir_all(&routine_dir);
+    assert!(line.contains("schedule trigger 'kw-id'"));
+    assert!(line.ends_with("# moadim-routine:kw-id"));
 }
 
 #[test]
@@ -291,7 +230,7 @@ fn build_block_includes_routine_with_agent_config() {
         .insert("inc".into(), make_routine("inc", title, agent_name));
     let block = build_block(&store);
     assert!(block.contains("# moadim-routine:inc"));
-    assert!(block.contains(&format!("/{slug}/run.sh")));
+    assert!(block.contains("schedule trigger 'inc'"));
 
     std::fs::remove_file(&cfg).unwrap();
     let _ = std::fs::remove_dir_all(crate::paths::routine_dir(&slug));

--- a/src/sync/routines_sync_tests.rs
+++ b/src/sync/routines_sync_tests.rs
@@ -27,25 +27,21 @@ fn format_routine_line_invokes_script_with_schedule_and_tag() {
     let title = "Fid Sync Routine";
     let slug = slugify(title);
     let routine = make_routine("fid", title, "claude");
-    let agent = AgentCommand {
-        command: "claude".to_string(),
-        args: vec![],
-        setup: None,
-    };
-    let line = format_routine_line(&routine, &agent).unwrap();
+    let line = format_routine_line(&routine).unwrap();
     assert!(line.starts_with("30 9 * * 1-5 "));
     // crontab line just runs the generated script — keeps it well under cron's length limit
     assert!(line.contains("/bin/sh "));
-    // `-l` runs the script under a login shell so it sources the user's profile and the agent
-    // inherits their environment (PATH, GH_TOKEN, …) instead of cron's minimal one.
+    // `-l` runs the wrapper under a login shell (retained defensively).
     assert!(line.contains("/bin/sh -l "));
     assert!(line.contains(&format!("/{slug}/run.sh")));
     assert!(line.ends_with("# moadim-routine:fid"));
     assert!(!line.contains('\n'));
-    // the long launch command lives in the script, not the crontab line
+    // The script is a thin wrapper that re-invokes the binary to trigger the routine by ID; the
+    // launch logic now lives in the daemon, not the script.
     let script = std::fs::read_to_string(crate::paths::routine_script_path(&slug)).unwrap();
     assert!(script.starts_with("#!/bin/sh\n"));
-    assert!(script.contains("tmux new-session"));
+    assert!(script.contains("schedule trigger 'fid'"));
+    assert!(!script.contains("tmux new-session"));
     let _ = std::fs::remove_dir_all(crate::paths::routine_dir(&slug));
 }
 
@@ -60,12 +56,7 @@ fn format_routine_line_creates_missing_parent_dir() {
     assert!(!crate::paths::routine_dir(&slug).exists());
 
     let routine = make_routine("parent-create", title, "claude");
-    let agent = AgentCommand {
-        command: "claude".to_string(),
-        args: vec![],
-        setup: None,
-    };
-    let line = format_routine_line(&routine, &agent).unwrap();
+    let line = format_routine_line(&routine).unwrap();
     assert!(line.ends_with("# moadim-routine:parent-create"));
     assert!(crate::paths::routine_script_path(&slug).exists());
 
@@ -89,12 +80,7 @@ fn format_routine_line_returns_none_when_script_write_fails() {
     std::fs::write(&routine_dir, "blocker").unwrap();
 
     let routine = make_routine("write-fail", title, "claude");
-    let agent = AgentCommand {
-        command: "claude".to_string(),
-        args: vec![],
-        setup: None,
-    };
-    let result = format_routine_line(&routine, &agent);
+    let result = format_routine_line(&routine);
     assert!(result.is_none(), "expected None on script write failure");
 
     let _ = std::fs::remove_file(&routine_dir);
@@ -118,13 +104,8 @@ fn format_routine_line_when_parent_dir_already_exists() {
         repository: "https://example.com/ctx.git".to_string(),
         branch: Some("main".to_string()),
     }];
-    let agent = AgentCommand {
-        command: "claude".to_string(),
-        args: vec![],
-        setup: None,
-    };
 
-    let line = format_routine_line(&routine, &agent).unwrap();
+    let line = format_routine_line(&routine).unwrap();
     assert!(line.starts_with("@daily "), "wrong schedule: {line}");
     assert!(line.ends_with("# moadim-routine:existing-parent"));
     assert!(crate::paths::routine_script_path(&slug).exists());


### PR DESCRIPTION
## What

Removes the per-routine `run.sh` launch script entirely. The crontab line now invokes the `moadim` binary directly to trigger the routine by ID:

```
<schedule> '<moadim>' schedule trigger '<id>' # moadim-routine:<id>
```

The command is short enough to inline (no `run.sh` file, no risk of cron's ~1000-char per-line limit), and the running daemon stays the single source of truth for launch logic (`build_routine_command` + spawn). Stale `run.sh` files from older daemons are removed on the next persist (startup re-persists every routine).

## Scheduled vs manual trigger

A scheduled fire must record `last_scheduled_trigger_at`, **not** `last_manual_trigger_at` (the distinction added in 0.12). So `schedule trigger` gets its own path rather than reusing the manual trigger:

- **`svc_trigger_scheduled()`** spawns the launch command *without* stamping the manual timestamp. The spawned command writes `scheduled.local.toml` itself (its `printf` step, unchanged), which the daemon reads back on load.
- **New `POST /api/v1/routines/{id}/scheduled-trigger`** route + handler, registered in the OpenAPI spec.
- **`moadim schedule trigger <id>`** posts to it. (The earlier cron-job fallback is dropped — cron jobs run their handler scripts directly via crontab and never use this path.)
- Common spawn logic factored into `spawn_routine_command()`, shared by manual and scheduled paths. `build_routine_command` and the manual trigger are otherwise unchanged.

## Behavior change / tradeoff

**Scheduled routines now require the daemon to be running** (the fat self-contained script is gone). The daemon is installed as an OS service for this reason.

Env parity holds: the daemon spawns the agent under `sh -lc`, sourcing `~/.profile` (`GH_TOKEN`, API keys, …). The binary is referenced by absolute path (`current_exe`) so cron's minimal `PATH` cannot break resolution.

## Tests

- `routines_sync_tests`: assert the inline crontab line (`schedule trigger '<id>'`, no `run.sh` file written); dropped the obsolete script-write tests.
- `service_tests`: `svc_trigger_scheduled` not-found + spawns-without-recording-manual-trigger.
- `http_tests`: scheduled-trigger added to the routine lifecycle and the not-found route matrix.
- `commands_tests`: `schedule trigger` posts to the scheduled-trigger route.
- `cargo clippy --all-targets -- -D warnings` clean; full suite (510 tests) green; line coverage 100%; OpenAPI spec regenerated and committed.

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)
