### PR TITLE
fix(routines): trim the routine title before persisting it

### DIFF
--- a/.changeset/routines-trim-title.md
+++ b/.changeset/routines-trim-title.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Trim a routine's title before persisting it, so padded input no longer leaks surrounding whitespace into `routine.toml`, workbench `CLAUDE.md` disclosures, and the UI.

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -231,7 +231,11 @@ pub fn svc_create(
     let routine = Routine {
         id: Uuid::new_v4().to_string(),
         schedule: normalize_schedule(&req.schedule),
-        title: req.title,
+        // Trim before persisting so a padded title (`"  Deploy  "`) is not rendered
+        // verbatim into the workbench `CLAUDE.md` disclosure, the iCal `SUMMARY`, and
+        // the UI rows. Mirrors `validate_repositories`, which already normalizes the
+        // repository fields, and `validate_title`, which length-checks the trimmed value.
+        title: req.title.trim().to_string(),
         agent: req.agent,
         prompt: req.prompt,
         repositories,
@@ -299,7 +303,8 @@ pub fn svc_update(
         routine.schedule = normalize_schedule(&schedule);
     }
     if let Some(title) = req.title {
-        routine.title = title;
+        // Trim on rename for the same reason as `svc_create` above.
+        routine.title = title.trim().to_string();
     }
     if let Some(agent) = req.agent {
         routine.agent = agent;

--- a/src/routines/service_tests.rs
+++ b/src/routines/service_tests.rs
@@ -259,6 +259,28 @@ fn svc_create_rejects_duplicate_slug() {
 }
 
 #[test]
+fn svc_create_trims_title_before_persisting() {
+    // Covers the title `.trim()` on the `svc_create` store path: a padded title is
+    // length-checked trimmed but must also be *stored* trimmed, so the disclosure /
+    // iCal SUMMARY / UI rows never render the surrounding whitespace.
+    let title = "Svc Create Trim ZZZ";
+    let store = new_store();
+    with_empty_path(|| {
+        let created = svc_create(
+            &store,
+            CreateRoutineRequest {
+                title: "   Svc Create Trim ZZZ   ".into(),
+                ..valid_create_request()
+            },
+        )
+        .unwrap();
+        assert_eq!(created.routine.title, title);
+        svc_delete(&store, &created.routine.id).unwrap();
+    });
+    let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
+}
+
+#[test]
 fn svc_create_rejects_malformed_agent_config() {
     // A referenced agent whose `<name>.toml` is present but unparseable is rejected at create time
     // with `BadRequest` quoting the parse error — not silently skipped at fire time.
@@ -433,6 +455,33 @@ fn svc_update_sets_max_runtime_secs() {
         )
         .unwrap();
         assert_eq!(updated.routine.max_runtime_secs, Some(1234));
+    });
+
+    let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
+}
+
+#[test]
+fn svc_update_trims_title_before_persisting() {
+    // Covers the title `.trim()` on the `svc_update` apply path. Renaming with the
+    // same slug but different spacing/case must store the trimmed title.
+    let title = "Svc Update Trim ZZZ";
+    let store = new_store();
+    let routine = make_routine("trim-id", title, 1, 1);
+    crate::routine_storage::write_routine(&routine).unwrap();
+    store.lock().unwrap().insert("trim-id".into(), routine);
+
+    with_empty_path(|| {
+        let updated = svc_update(
+            &store,
+            "trim-id",
+            UpdateRoutineRequest {
+                // Same slug, padded: applies the rename branch without a conflict.
+                title: Some("  Svc Update Trim ZZZ  ".into()),
+                ..empty_update_request()
+            },
+        )
+        .unwrap();
+        assert_eq!(updated.routine.title, title);
     });
 
     let _ = crate::routine_storage::remove_routine_dir(&slugify(title));


### PR DESCRIPTION
## Why

`svc_create` and `svc_update` stored `req.title` verbatim, so a padded title like `"  Deploy bot  "` was persisted into `routine.toml` and then rendered **with its surrounding whitespace** into:

- every workbench `CLAUDE.md` routine-origin disclosure (`Routine name:   Deploy bot  `),
- the iCal `SUMMARY` on `/routines.ics`,
- the UI routine rows.

This contradicts two deliberate decisions already in the code:

1. `validate_repositories` already **trims and normalizes** every repository URL/branch before storing (#241).
2. `validate_title` already length-checks the **trimmed** title (`title.trim().chars().count()`) — so a title was length-checked trimmed but stored padded.

Trimming on store closes that gap and makes title handling consistent with the repository fields.

## What

- Trim the title at both store sites (`svc_create` assignment and `svc_update` rename branch).
- Slug computation is unaffected: `slugify` already ignores leading/trailing non-alphanumerics, so `slugify(padded) == slugify(trimmed)` — no conflict-detection or routing change.
- Add two focused tests (`svc_create_trims_title_before_persisting`, `svc_update_trims_title_before_persisting`) asserting the stored title is trimmed.

## Verification

- `cargo test --bin moadim routines::service` → 38 passed, 0 failed (incl. the 2 new tests).
- `cargo clippy --all-targets -- -D warnings` → clean.
- `cargo fmt --check` → clean.

Scope is intentionally title-only; the multi-line free-text `prompt` is left untouched since leading/trailing blank lines there are harmless.

---
This pull request was opened by the **Daemon + Landing auto-improve PRs** routine of moadim.