### PR TITLE
docs(readme): correct & complete the routines MCP tool list

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ GET    /routines.ics          # subscribe to fire times as a calendar feed
 
 **MCP** — the same operations are exposed as tools: `list_routines`,
 `get_routine`, `create_routine`, `update_routine`, `delete_routine`,
-`trigger_routine`, and `cleanup_routines`.
+`trigger_routine`, `routine_logs`, `list_agents`, and `cleanup_workbenches`.
 
 **Agents:** the `agent` field resolves to a config at
 `~/.config/moadim/agents/<agent>.toml`. API responses include


### PR DESCRIPTION
## Why

The **Routines → MCP** summary in `README.md` listed the cleanup tool as `cleanup_routines`:

> the same operations are exposed as tools: `list_routines`, `get_routine`, `create_routine`, `update_routine`, `delete_routine`, `trigger_routine`, and `cleanup_routines`.

No tool named `cleanup_routines` exists. The actual `#[tool]` method in `src/routes/mcp.rs` is **`cleanup_workbenches`** (and the test `cleanup_workbenches_tool_returns_removed_count` confirms it). An agent reading the README and calling `cleanup_routines` over MCP would get an unknown-tool error.

The list also omitted two routine-scope tools that exist in `mcp.rs` and mirror REST endpoints documented just above it.

## What

- `cleanup_routines` → **`cleanup_workbenches`** (the real tool name).
- Added **`routine_logs`** (mirrors `GET /routines/{id}/logs`) and **`list_agents`** (mirrors `GET /agents`).

All names verified against the `#[tool]` methods in `src/routes/mcp.rs`. Docs only — no code change.

---

This pull request was opened by the "Daemon + Landing auto-improve PRs" routine of moadim. @tupe12334