### PR TITLE
docs(readme): document the server-control & cron-jobs REST endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,10 @@ hourly sweep so they don't accumulate; trigger a sweep on demand with
 **REST** — under the `/api/v1` prefix:
 
 ```
+GET    /health                # liveness, uptime, and build provenance
+POST   /shutdown              # ask the server to stop gracefully
+POST   /restart               # rotate the daemon to a fresh process
+
 GET    /routines              # list (filter by ?repository=, sort by ?sort=/&order=)
 POST   /routines              # create
 GET    /routines/{id}         # fetch one
@@ -261,6 +265,15 @@ GET    /routines/{id}/logs    # run output
 POST   /routines/cleanup      # reap expired workbenches now
 GET    /agents                # list registered agents
 GET    /routines.ics          # subscribe to fire times as a calendar feed
+
+GET    /cron-jobs             # list raw cron jobs
+POST   /cron-jobs             # create
+GET    /cron-jobs/{id}        # fetch one
+PUT    /cron-jobs/{id}        # replace
+PATCH  /cron-jobs/{id}        # update fields
+DELETE /cron-jobs/{id}        # delete
+POST   /cron-jobs/{id}/trigger # run the job's handler now
+GET    /cron-jobs/{id}/logs   # handler output
 ```
 
 **MCP** — the same operations are exposed as tools: `list_routines`,


### PR DESCRIPTION
## Why

The README's REST endpoint listing (under **REST — `/api/v1`**) only enumerated the `/routines*`, `/agents`, and `/routines.ics` routes. It silently omitted endpoints the server actually exposes and that clients depend on:

- **Server-control routes** — `GET /health`, `POST /shutdown`, `POST /restart`. The UI's health badge and STOP button, plus `moadim status` / `stop` / `restart`, all call these, yet a reader auditing the HTTP surface from the README alone would conclude they don't exist.
- **The entire `/cron-jobs` family** — `GET`/`POST /cron-jobs`, `GET`/`PUT`/`PATCH`/`DELETE /cron-jobs/{id}`, `POST /cron-jobs/{id}/trigger`, `GET /cron-jobs/{id}/logs`. This is a first-class public API with zero mention anywhere in the README.

## What changed

Added the missing endpoints to the existing REST code block, grouped (server-control / routines / cron-jobs) with the same aligned `# comment` style already used in that block. Docs-only — no source or behavior changes.

## How it was verified

Every added line was cross-checked against the live route table in `src/routes/http.rs` (the `.route(...)` registrations under the `/api/v1` nest). The vestigial `/echo` demo route is intentionally left out, since it is already slated for removal in a separate open PR. This change does not touch the `**MCP**` tool-list line edited by other open docs PRs, so it does not conflict with them.

---

This pull request was opened by the **Daemon + Landing auto-improve PRs** routine of moadim. @tupe12334 — review welcome.