### PR TITLE
docs(readme): warn that a non-loopback bind exposes the unauthenticated API (#253)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+### Documentation
+
+- The README's **Bind address** section now warns that the REST API and MCP
+  endpoint are unauthenticated, so `MOADIM_BIND_ADDR` should stay on a loopback
+  address: binding to a routable interface (a LAN IP or `0.0.0.0`) exposes
+  unauthenticated routine create/trigger — effectively remote code execution — to
+  the network. Recommends an authenticating reverse proxy / firewall for remote
+  access instead. (#253)
+
 ### Fixed
 
 - Routine `update` now rejects a `ttl_secs` / `max_runtime_secs` that exceeds the

--- a/README.md
+++ b/README.md
@@ -427,12 +427,24 @@ The server binds to `127.0.0.1:5784` by default — the same address every clien
 variable, set identically for the server and any client you run against it:
 
 ```sh
-# Bind the server to a different port (or interface)…
+# Bind the server to a different port (still on loopback)…
 MOADIM_BIND_ADDR=127.0.0.1:7000 moadim
 
 # …and point client commands at the same address.
 MOADIM_BIND_ADDR=127.0.0.1:7000 moadim status
 ```
+
+> **⚠️ Keep the bind address on loopback.** The REST API and the MCP endpoint are
+> **unauthenticated** — there is no token, password, or per-client check. Anyone who
+> can reach the bind address can create, edit, and trigger routines, and a triggered
+> routine launches an agent on your machine with your credentials. Binding to a
+> routable interface therefore hands that control surface — effectively remote code
+> execution — to the network: a LAN address exposes it to everyone on the subnet, and
+> `0.0.0.0` exposes it to every interface, including the public internet if the host is
+> reachable. The default `127.0.0.1` keeps the daemon private to the local machine;
+> leave it there. If you genuinely need remote access, put the daemon behind an
+> authenticating reverse proxy (or a firewall / VPN / SSH tunnel) instead of widening
+> `MOADIM_BIND_ADDR`.
 
 Because the override changes both the bind and the probe target, a client started without it
 keeps looking at the default `127.0.0.1:5784` and will report the relocated server as not running.


### PR DESCRIPTION
## Why

The **Bind address** section of the README invited overriding `MOADIM_BIND_ADDR` to bind to "a different port (or interface)" — with no security caveat. But the daemon's REST API and MCP endpoint are **unauthenticated**: there is no token, password, or per-client check. The codebase itself acknowledges this — `src/middlewares/security_headers.rs` describes "an unauthenticated loopback API", and a grep for any auth/bearer/token middleware turns up nothing.

That's safe while the bind stays on `127.0.0.1`, but the docs nudged users toward binding to "an interface" without flagging the consequence: anyone who can reach the bind address can create, edit, and **trigger** routines, and a triggered routine launches an agent on the host with the operator's credentials. Binding to a routable interface therefore hands routine create/trigger — effectively **remote code execution** — to the network (a LAN IP exposes the subnet; `0.0.0.0` exposes every interface, including the public internet on a reachable host).

This documents the existing security posture so an operator can't widen the bind without understanding the risk. It does **not** add authentication (tracked separately in #253 / #266 / #504) — it's the cheap, immediate mitigation: tell people to keep it on loopback.

## What

- README **Bind address** section: add a warning that the API/MCP are unauthenticated, that `MOADIM_BIND_ADDR` should stay on a loopback address, and that remote access should go through an authenticating reverse proxy / firewall / VPN / SSH tunnel rather than a wider bind. Adjusted the example comment ("still on loopback") so it no longer suggests binding to an arbitrary interface unqualified.
- CHANGELOG: note the doc clarification under `[Unreleased] → Documentation`.

Documentation only — no code or behavior change. `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `typos` all pass locally (the change touches no Rust).

Refs #253.

---
This pull request was opened by the **Daemon + Landing auto-improve PRs** routine of moadim.