### PR TITLE
fix(ical): mark routine VEVENTs TRANSPARENT so subscribers aren't shown BUSY (#461)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Fixed
 
+- Routine iCal feed events are now `TRANSP:TRANSPARENT` instead of the default
+  OPAQUE, so subscribing to the `.ics` feed no longer marks the operator BUSY at
+  every scheduled fire time. A fire is a momentary trigger, not reserved time. (#461)
 - Routine `update` now rejects a `ttl_secs` / `max_runtime_secs` that exceeds the
   cron-derived ceiling for the *effective* schedule (the new schedule if supplied,
   otherwise the routine's current one). The check runs before any mutation, so a

--- a/src/routines/ical.rs
+++ b/src/routines/ical.rs
@@ -112,6 +112,10 @@ pub fn build_ical(routines: &[Routine], now: DateTime<Local>) -> String {
             lines.push(format!("DTSTART:{stamp}"));
             lines.push(format!("SUMMARY:{summary}"));
             lines.push(format!("DESCRIPTION:{description}"));
+            // A fire time is a momentary trigger, not a block of busy time. Mark
+            // the event TRANSPARENT (RFC 5545 §3.8.2.7) so subscribing to the feed
+            // does not show the operator as BUSY at every scheduled run.
+            lines.push("TRANSP:TRANSPARENT".to_string());
             lines.push("END:VEVENT".to_string());
         }
     }

--- a/src/routines/ical_tests.rs
+++ b/src/routines/ical_tests.rs
@@ -54,6 +54,10 @@ fn enabled_daily_routine_yields_events_within_horizon() {
     assert!(ics.contains("@moadim\r\n"));
     assert!(ics.contains("DTSTART:"));
     assert!(ics.contains("DTSTAMP:"));
+    // Fire times are momentary triggers, not busy blocks: every event is
+    // TRANSPARENT so subscribers aren't marked BUSY (one per VEVENT).
+    assert!(ics.contains("TRANSP:TRANSPARENT\r\n"));
+    assert_eq!(count(&ics, "TRANSP:TRANSPARENT"), events);
 }
 
 #[test]


### PR DESCRIPTION
## Why

The routines iCalendar feed (`src/routines/ical.rs`) emitted each fire time as a default **OPAQUE** `VEVENT`. Per RFC 5545 §3.8.2.7, an OPAQUE event consumes time in the subscriber's free/busy lookup — so anyone subscribing to the feed is marked **BUSY** at every scheduled fire. A fire time is a momentary trigger, not a block of reserved time, so this is wrong: subscribing to "when do my routines run" should not blank out the operator's calendar availability.

## What

- Emit `TRANSP:TRANSPARENT` on every generated `VEVENT`.
- Extend the existing event-shape test to assert one `TRANSP:TRANSPARENT` line per event.

## Verification

- `cargo fmt --check` ✓
- `cargo clippy --all-targets -- -D warnings` ✓
- `cargo test --bin moadim routines::ical` → 12 passed ✓

Closes #461.

---
This pull request was opened by the **Daemon + Landing auto-improve PRs** routine of moadim.