### PR TITLE
docs(contributing): match the documented clippy command to the gate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,13 @@ Run the checks the pre-push hook enforces before any push:
 
 ```sh
 cargo fmt --check
-cargo clippy
+cargo clippy --all-targets -- -D warnings
 cargo test
 ```
+
+Use `--all-targets -- -D warnings` for clippy, exactly as the pre-push hook and
+the CI lint gate do — bare `cargo clippy` skips test/example/bench code and only
+warns, so it can pass locally yet fail the hook and CI.
 
 Enable the bundled git hooks once per clone:
 


### PR DESCRIPTION
## Why

`CONTRIBUTING.md` tells contributors to run, before pushing:

```sh
cargo fmt --check
cargo clippy        # ← under-checks
cargo test
```

But the **pre-push hook** and the **CI lint gate** both run:

```sh
cargo clippy --all-targets -- -D warnings
```

Bare `cargo clippy` skips test/example/bench targets and only *warns*, so a contributor who follows CONTRIBUTING.md verbatim can see a clean local run and still be rejected by the hook and CI. This is the exact footgun the pre-push hook calls out in its own comments:

> Bare `cargo clippy` skips test code and only warns, so it can pass here yet fail CI — keep the two in lockstep.

## What

- Correct the documented clippy command to `cargo clippy --all-targets -- -D warnings`.
- Add a one-line note explaining why the flags matter, so the rationale travels with the command.

Docs-only; no `src/`/`ui/` changes. Verified the diff is limited to `CONTRIBUTING.md` and that `typos` passes clean on it.

---
This pull request was opened by the **Daemon + Landing auto-improve PRs** routine of moadim.