### PR TITLE
chore(lint): enable clippy::map_unwrap_or (#524)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   `null` when no server answers or its `/health` body cannot be parsed; exit codes
   and the human-readable `status` output are unchanged (#284).
 
+### Changed
+
+- Enabled the `clippy::map_unwrap_or` lint and fixed the violations, replacing
+  `map(...).unwrap_or(...)` / `map(...).unwrap_or_else(...)` chains with the more
+  direct `map_or` / `map_or_else`. No behavior change. (#524)
+
 ### Fixed
 
 - 6-field cron schedules (`sec min hour dom month dow`, accepted by `croner`)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,5 @@ min_ident_chars = "deny"
 uninlined_format_args = "deny"
 # Reject leftover `dbg!` debugging macros so they never ship to production.
 dbg_macro = "deny"
+# Prefer `map_or`/`map_or_else`/`is_ok_and` over `.map(f).unwrap_or(_)`.
+map_unwrap_or = "deny"

--- a/src/routes/mcp.rs
+++ b/src/routes/mcp.rs
@@ -377,11 +377,9 @@ impl MoadimMcp {
     )]
     fn restart(&self) -> Result<CallToolResult, rmcp::ErrorData> {
         log::info!("restart requested via MCP");
-        Ok(crate::cli::spawn_restart()
-            .map(|helper_pid| {
-                ok(serde_json::json!({ "status": "restarting", "helper_pid": helper_pid }))
-            })
-            .unwrap_or_else(err))
+        Ok(crate::cli::spawn_restart().map_or_else(err, |helper_pid| {
+            ok(serde_json::json!({ "status": "restarting", "helper_pid": helper_pid }))
+        }))
     }
 }
 

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -230,7 +230,7 @@ pub(crate) fn migrate_prompt_files_from_dir(dir: &std::path::Path) {
         Err(_) => return,
     };
     for entry in entries.flatten() {
-        if !entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+        if !entry.file_type().is_ok_and(|ft| ft.is_dir()) {
             continue;
         }
         let old = entry.path().join("prompt.txt");
@@ -269,7 +269,7 @@ pub(crate) fn migrate_routine_dirs_from_dir(dir: &std::path::Path) {
         Err(_) => return,
     };
     for entry in entries.flatten() {
-        if !entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+        if !entry.file_type().is_ok_and(|ft| ft.is_dir()) {
             continue;
         }
         let dir_name = entry.file_name().to_string_lossy().to_string();
@@ -321,7 +321,7 @@ pub(crate) fn load_store_from_dir(dir: &std::path::Path) -> RoutineStore {
     let mut routines = HashMap::new();
     if let Ok(entries) = std::fs::read_dir(dir) {
         for entry in entries.flatten() {
-            if entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+            if entry.file_type().is_ok_and(|ft| ft.is_dir()) {
                 let dir_name = entry.file_name().to_string_lossy().to_string();
                 if let Some(routine) = load_routine_from_dir(&dir_name) {
                     routines.insert(routine.id.clone(), routine);

--- a/src/routines/cleanup/mod.rs
+++ b/src/routines/cleanup/mod.rs
@@ -75,7 +75,7 @@ fn reap_dir(
     };
     let mut removed = 0;
     for entry in entries.flatten() {
-        if !entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+        if !entry.file_type().is_ok_and(|ft| ft.is_dir()) {
             continue;
         }
         let name = entry.file_name().to_string_lossy().into_owned();

--- a/src/routines/cleanup/session.rs
+++ b/src/routines/cleanup/session.rs
@@ -33,8 +33,7 @@ pub(super) fn tmux_session_alive(session: &str) -> bool {
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .status()
-        .map(|status| status.success())
-        .unwrap_or(false)
+        .is_ok_and(|status| status.success())
 }
 
 /// Force-kill the tmux session named `session` (best-effort).

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -152,11 +152,7 @@ pub(crate) fn load_store_from_dir(dir: &std::path::Path) -> CronStore {
     let mut jobs = HashMap::new();
     if let Ok(entries) = std::fs::read_dir(dir) {
         for entry in entries.flatten() {
-            if entry
-                .file_type()
-                .map(|file_type| file_type.is_dir())
-                .unwrap_or(false)
-            {
+            if entry.file_type().is_ok_and(|file_type| file_type.is_dir()) {
                 let id = entry.file_name().to_string_lossy().to_string();
                 if let Some(job) = load_job_from_dir(&id) {
                     jobs.insert(id, job);

--- a/src/utils/time.rs
+++ b/src/utils/time.rs
@@ -14,8 +14,7 @@ pub fn now_secs() -> u64 {
 fn secs_since_epoch(moment: SystemTime) -> u64 {
     moment
         .duration_since(SystemTime::UNIX_EPOCH)
-        .map(|elapsed| elapsed.as_secs())
-        .unwrap_or(0)
+        .map_or(0, |elapsed| elapsed.as_secs())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

Enables the [`clippy::map_unwrap_or`](https://rust-lang.github.io/rust-clippy/master/index.html#map_unwrap_or) pedantic lint at `deny` in `[lints.clippy]` and rewrites the 8 flagged sites to the clearer single-combinator forms.

All rewrites are behavior-preserving (applied via `cargo clippy --fix`):

| Before | After |
| --- | --- |
| `.map(f).unwrap_or(false)` on a `Result` | `.is_ok_and(f)` |
| `.map(f).unwrap_or(d)` | `.map_or(d, f)` |
| `.map(f).unwrap_or_else(g)` | `.map_or_else(g, f)` |

Sites touched: `src/storage.rs`, `src/utils/time.rs`, `src/routine_storage.rs` (×3), `src/routines/cleanup/mod.rs`, `src/routines/cleanup/session.rs`, `src/routes/mcp.rs`.

## Checks

- `cargo fmt --check` ✅
- `cargo clippy --all-targets` ✅ (clean with the new `deny`)
- `cargo test` ✅ 532 passed

The generated `prebuilt.html` artifact was intentionally left out of this change.

Closes #524

---
🤖 This pull request was opened by the **Open issues → fix PRs (owned repos + my orgs)** routine of moadim.