### PR TITLE
fix(ui): add aria-label to icon-only buttons for screen readers (#558)

### DIFF
--- a/ui/src/cron_jobs.rs
+++ b/ui/src/cron_jobs.rs
@@ -900,10 +900,10 @@ pub fn job_row(props: &JobRowProps) -> Html {
             </td>
             <td>
                 <div class="row-actions">
-                    <button class="act-btn run" title="Run now" onclick={on_trigger}>{"▶"}</button>
+                    <button class="act-btn run" title="Run now" aria-label="Run now" onclick={on_trigger}>{"▶"}</button>
                     <button class="act-btn logs" onclick={on_logs}>{"LOGS"}</button>
                     <button class="act-btn edit" onclick={on_edit}>{"EDIT"}</button>
-                    <button class="act-btn del" onclick={on_delete}>{"✕"}</button>
+                    <button class="act-btn del" title="Delete job" aria-label="Delete job" onclick={on_delete}>{"✕"}</button>
                 </div>
             </td>
         </tr>
@@ -1245,7 +1245,7 @@ pub fn job_modal(props: &JobModalProps) -> Html {
             <div class="modal">
                 <div class="modal-hd">
                     <div class="modal-title">{"EDIT JOB"}</div>
-                    <button class="modal-x" onclick={on_close_click.clone()}>{"✕"}</button>
+                    <button class="modal-x" title="Close" aria-label="Close" onclick={on_close_click.clone()}>{"✕"}</button>
                 </div>
                 <div class="modal-body">
                     <div class="form-group">
@@ -1527,7 +1527,7 @@ pub fn logs_page(props: &LogsPageProps) -> Html {
             <div class="page-hd">
                 <button class="btn btn-ghost btn-sm" onclick={on_back}>{"← BACK"}</button>
                 <div class="page-title">{format!("LOGS / {}", props.handler)}</div>
-                <button class="btn-refresh" title="Refresh" onclick={on_refresh}>{"↻"}</button>
+                <button class="btn-refresh" title="Refresh" aria-label="Refresh" onclick={on_refresh}>{"↻"}</button>
             </div>
             <div class="logs-wrap">
                 {body}

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -340,7 +340,7 @@ pub fn header(props: &HeaderProps) -> Html {
                     <span class="health-status">{status}</span>
                     <span class="health-uptime">{uptime}</span>
                 </div>
-                <button class="btn-refresh" title="Refresh" onclick={props.on_refresh.clone()}>{"↻"}</button>
+                <button class="btn-refresh" title="Refresh" aria-label="Refresh" onclick={props.on_refresh.clone()}>{"↻"}</button>
                 <button class="btn-stop" title="Stop the server" disabled={!props.ok} onclick={props.on_stop.clone()}>{"⏻ STOP"}</button>
             </div>
         </header>

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -801,7 +801,7 @@ pub fn filter_sort_bar(props: &FilterSortBarProps) -> Html {
                     } else {
                         html! {
                             <button class="btn btn-ghost btn-sm" onclick={on_clear}
-                                title="Clear repository filter">{"✕"}</button>
+                                title="Clear repository filter" aria-label="Clear repository filter">{"✕"}</button>
                         }
                     }
                 }
@@ -975,9 +975,9 @@ pub fn routine_calendar(props: &CalendarProps) -> Html {
     html! {
         <div class="cal-wrap">
             <div class="cal-nav">
-                <button class="btn-refresh" title="Previous month" onclick={on_prev}>{"‹"}</button>
+                <button class="btn-refresh" title="Previous month" aria-label="Previous month" onclick={on_prev}>{"‹"}</button>
                 <div class="cal-month">{month_label}</div>
-                <button class="btn-refresh" title="Next month" onclick={on_next}>{"›"}</button>
+                <button class="btn-refresh" title="Next month" aria-label="Next month" onclick={on_next}>{"›"}</button>
                 <button class="btn btn-ghost btn-sm" onclick={on_today}>{"TODAY"}</button>
             </div>
             {body}
@@ -1142,10 +1142,10 @@ pub fn routine_row(props: &RowProps) -> Html {
             </td>
             <td>
                 <div class="row-actions">
-                    <button class="act-btn run" title="Run now" onclick={on_trigger}>{"▶"}</button>
+                    <button class="act-btn run" title="Run now" aria-label="Run now" onclick={on_trigger}>{"▶"}</button>
                     <button class="act-btn logs" onclick={on_logs}>{"LOGS"}</button>
                     <button class="act-btn edit" onclick={on_edit}>{"EDIT"}</button>
-                    <button class="act-btn del" onclick={on_delete}>{"✕"}</button>
+                    <button class="act-btn del" title="Delete routine" aria-label="Delete routine" onclick={on_delete}>{"✕"}</button>
                 </div>
             </td>
         </tr>
@@ -1465,7 +1465,7 @@ pub fn routine_form(props: &FormProps) -> Html {
                 <div class="modal">
                     <div class="modal-hd">
                         <div class="modal-title">{"EDIT ROUTINE"}</div>
-                        <button class="modal-x" onclick={on_cancel_click}>{"✕"}</button>
+                        <button class="modal-x" title="Close" aria-label="Close" onclick={on_cancel_click}>{"✕"}</button>
                     </div>
                     {body}
                     {footer}
@@ -1600,7 +1600,7 @@ pub fn routine_logs(props: &LogsProps) -> Html {
             <div class="page-hd">
                 <button class="btn btn-ghost btn-sm" onclick={on_back}>{"← BACK"}</button>
                 <div class="page-title">{format!("LOGS / {}", props.title)}</div>
-                <button class="btn-refresh" title="Refresh" onclick={on_refresh}>{"↻"}</button>
+                <button class="btn-refresh" title="Refresh" aria-label="Refresh" onclick={on_refresh}>{"↻"}</button>
             </div>
             <div class="logs-wrap">
                 {body}


### PR DESCRIPTION
Closes #558.

## What

Add an `aria-label` to every **icon-only button** in the UI so screen readers announce a meaningful name instead of the raw glyph.

For a `<button>`, `aria-label` takes precedence over the glyph content in the accessible-name computation; a `title` does **not** override visible content. So the existing `title` tooltips helped sighted mouse users but the buttons were still announced as their glyph — e.g. the close/delete `✕` as "multiplication x". Two `✕` buttons (row delete, modal close) had neither `title` nor `aria-label`.

## Buttons labeled

| File | Button |
|------|--------|
| `ui/src/main.rs` | header refresh `↻` |
| `ui/src/cron_jobs.rs` | row run `▶`, row delete `✕`, edit-modal close `✕`, logs-page refresh `↻` |
| `ui/src/routines.rs` | repo-filter clear `✕`, calendar prev `‹` / next `›`, row run `▶`, row delete `✕`, edit-modal close `✕`, logs-page refresh `↻` |

## Scope / safety

- **UI-only**: diff touches `ui/src/*.rs` exclusively.
- **Non-product**: purely additive static attributes — no behavior, layout, styling, or data change.
- `cargo clippy -p ui --all-targets -- -D warnings` is clean.
- Matches the established pattern already used for the table checkboxes (`aria-label="Select job"`).

---
*This pull request was opened by the **UI segment auto-improve (issue → PR → merge)** routine of moadim.*
