### PR TITLE
fix(ui): add aria-label to icon-only buttons for screen readers (#558)

### DIFF
--- a/ui/src/cron_jobs.rs
+++ b/ui/src/cron_jobs.rs
@@ -900,10 +900,10 @@ pub fn job_row(props: &JobRowProps) -> Html {
             </td>
             <td>
                 <div class="row-actions">
-                    <button class="act-btn run" title="Run now" onclick={on_trigger}>{"▶"}</button>
+                    <button class="act-btn run" aria-label="Run now" title="Run now" onclick={on_trigger}>{"▶"}</button>
                     <button class="act-btn logs" onclick={on_logs}>{"LOGS"}</button>
                     <button class="act-btn edit" onclick={on_edit}>{"EDIT"}</button>
-                    <button class="act-btn del" onclick={on_delete}>{"✕"}</button>
+                    <button class="act-btn del" aria-label="Delete job" title="Delete job" onclick={on_delete}>{"✕"}</button>
                 </div>
             </td>
         </tr>
@@ -1245,7 +1245,7 @@ pub fn job_modal(props: &JobModalProps) -> Html {
             <div class="modal">
                 <div class="modal-hd">
                     <div class="modal-title">{"EDIT JOB"}</div>
-                    <button class="modal-x" onclick={on_close_click.clone()}>{"✕"}</button>
+                    <button class="modal-x" aria-label="Close" title="Close" onclick={on_close_click.clone()}>{"✕"}</button>
                 </div>
                 <div class="modal-body">
                     <div class="form-group">
@@ -1527,7 +1527,7 @@ pub fn logs_page(props: &LogsPageProps) -> Html {
             <div class="page-hd">
                 <button class="btn btn-ghost btn-sm" onclick={on_back}>{"← BACK"}</button>
                 <div class="page-title">{format!("LOGS / {}", props.handler)}</div>
-                <button class="btn-refresh" title="Refresh" onclick={on_refresh}>{"↻"}</button>
+                <button class="btn-refresh" aria-label="Refresh" title="Refresh" onclick={on_refresh}>{"↻"}</button>
             </div>
             <div class="logs-wrap">
                 {body}

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -340,7 +340,7 @@ pub fn header(props: &HeaderProps) -> Html {
                     <span class="health-status">{status}</span>
                     <span class="health-uptime">{uptime}</span>
                 </div>
-                <button class="btn-refresh" title="Refresh" onclick={props.on_refresh.clone()}>{"↻"}</button>
+                <button class="btn-refresh" aria-label="Refresh" title="Refresh" onclick={props.on_refresh.clone()}>{"↻"}</button>
                 <button class="btn-stop" title="Stop the server" disabled={!props.ok} onclick={props.on_stop.clone()}>{"⏻ STOP"}</button>
             </div>
         </header>

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -801,7 +801,7 @@ pub fn filter_sort_bar(props: &FilterSortBarProps) -> Html {
                     } else {
                         html! {
                             <button class="btn btn-ghost btn-sm" onclick={on_clear}
-                                title="Clear repository filter">{"✕"}</button>
+                                aria-label="Clear repository filter" title="Clear repository filter">{"✕"}</button>
                         }
                     }
                 }
@@ -975,9 +975,9 @@ pub fn routine_calendar(props: &CalendarProps) -> Html {
     html! {
         <div class="cal-wrap">
             <div class="cal-nav">
-                <button class="btn-refresh" title="Previous month" onclick={on_prev}>{"‹"}</button>
+                <button class="btn-refresh" aria-label="Previous month" title="Previous month" onclick={on_prev}>{"‹"}</button>
                 <div class="cal-month">{month_label}</div>
-                <button class="btn-refresh" title="Next month" onclick={on_next}>{"›"}</button>
+                <button class="btn-refresh" aria-label="Next month" title="Next month" onclick={on_next}>{"›"}</button>
                 <button class="btn btn-ghost btn-sm" onclick={on_today}>{"TODAY"}</button>
             </div>
             {body}
@@ -1142,10 +1142,10 @@ pub fn routine_row(props: &RowProps) -> Html {
             </td>
             <td>
                 <div class="row-actions">
-                    <button class="act-btn run" title="Run now" onclick={on_trigger}>{"▶"}</button>
+                    <button class="act-btn run" aria-label="Run now" title="Run now" onclick={on_trigger}>{"▶"}</button>
                     <button class="act-btn logs" onclick={on_logs}>{"LOGS"}</button>
                     <button class="act-btn edit" onclick={on_edit}>{"EDIT"}</button>
-                    <button class="act-btn del" onclick={on_delete}>{"✕"}</button>
+                    <button class="act-btn del" aria-label="Delete routine" title="Delete routine" onclick={on_delete}>{"✕"}</button>
                 </div>
             </td>
         </tr>
@@ -1465,7 +1465,7 @@ pub fn routine_form(props: &FormProps) -> Html {
                 <div class="modal">
                     <div class="modal-hd">
                         <div class="modal-title">{"EDIT ROUTINE"}</div>
-                        <button class="modal-x" onclick={on_cancel_click}>{"✕"}</button>
+                        <button class="modal-x" aria-label="Close" title="Close" onclick={on_cancel_click}>{"✕"}</button>
                     </div>
                     {body}
                     {footer}
@@ -1600,7 +1600,7 @@ pub fn routine_logs(props: &LogsProps) -> Html {
             <div class="page-hd">
                 <button class="btn btn-ghost btn-sm" onclick={on_back}>{"← BACK"}</button>
                 <div class="page-title">{format!("LOGS / {}", props.title)}</div>
-                <button class="btn-refresh" title="Refresh" onclick={on_refresh}>{"↻"}</button>
+                <button class="btn-refresh" aria-label="Refresh" title="Refresh" onclick={on_refresh}>{"↻"}</button>
             </div>
             <div class="logs-wrap">
                 {body}


### PR DESCRIPTION
Closes #558.

## What

Adds an `aria-label` to every icon-only button in the dashboard so assistive tech announces a meaningful name instead of the raw glyph.

| Button | Glyph | aria-label |
|---|---|---|
| header / logs refresh | `↻` | Refresh |
| row run | `▶` | Run now |
| row delete | `✕` | Delete job / Delete routine |
| modal close | `✕` | Close |
| repo-filter clear | `✕` | Clear repository filter |
| calendar prev / next | `‹` `›` | Previous month / Next month |

For a `<button>`, `aria-label` takes precedence over glyph content in the accessible-name computation, unlike `title` (which only helps sighted mouse users and was already partly present). Two `✕` buttons previously had neither.

## Scope

- UI-only: touches `ui/src/main.rs`, `ui/src/cron_jobs.rs`, `ui/src/routines.rs` exclusively.
- Purely additive attributes — no behavior, layout, or styling change. Not a product change.
- `skip-changelog` applied: no user-facing behavioral change to document.

## Verification

- `cargo build -p ui` ✓
- `cargo clippy -p ui --all-targets` clean ✓
- pre-push gates (fmt, full clippy `-D warnings`, 100% line coverage) passed ✓

---
*This pull request was opened by the **UI segment auto-improve (issue → PR → merge)** routine of moadim.*