### PR TITLE
fix(ui): honor prefers-reduced-motion for decorative animations (#561)

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -835,6 +835,20 @@
       .cal-chip { font-size: 8px; }
     }
 
+    /* ── Reduced motion ── */
+    /* Honor the user's OS/browser "reduce motion" preference: settle the
+       decorative, continuous animations (glow pulse, refresh/loader spin) and
+       hover transitions near-instantly. Gated behind the user's own opt-in, so
+       default motion is unchanged for everyone else. */
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+      }
+    }
+
     /* ── Scrollbar ── */
     ::-webkit-scrollbar       { width: 5px; }
     ::-webkit-scrollbar-track { background: var(--bg); }


### PR DESCRIPTION
Closes #561.

## What

Adds a single `@media (prefers-reduced-motion: reduce)` block to `ui/index.html` that settles the dashboard's decorative, continuous animations and hover transitions near-instantly for users who opt into reduced motion:

```css
@media (prefers-reduced-motion: reduce) {
  *, *::before, *::after {
    animation-duration: 0.01ms !important;
    animation-iteration-count: 1 !important;
    transition-duration: 0.01ms !important;
    scroll-behavior: auto !important;
  }
}
```

Affected motion: the `.health-dot.ok` glow pulse, `.btn-refresh.spinning` / `.spinner` spins, and the various hover transitions.

## Scope

- UI-only: touches `ui/index.html` exclusively.
- Gated behind the user's own OS/browser preference — default motion is unchanged for everyone else. Accessibility improvement, not a product change.
- `skip-changelog` applied: no user-facing behavioral change for default users.

## Verification

- `cargo build -p ui` ✓ (trunk processes index.html)
- pre-push gates (fmt, full clippy `-D warnings`, 100% line coverage) passed ✓

---
*This pull request was opened by the **UI segment auto-improve (issue → PR → merge)** routine of moadim.*