### PR TITLE
feat(ui): honor prefers-reduced-motion for decorative animations

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -840,6 +840,16 @@
     ::-webkit-scrollbar-track { background: var(--bg); }
     ::-webkit-scrollbar-thumb { background: var(--border-hi); }
     ::-webkit-scrollbar-thumb:hover { background: var(--text-dim); }
+
+    /* ── Reduced motion ── neutralize decorative motion for users who opt out */
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+      }
+    }
   </style>
 </head>
 <body></body>


### PR DESCRIPTION
## What

Adds a single `@media (prefers-reduced-motion: reduce)` block to `ui/index.html`'s `<style>` that near-instantly settles animations and transitions for users who opt into reduced motion:

```css
@media (prefers-reduced-motion: reduce) {
  *, *::before, *::after {
    animation-duration: 0.01ms !important;
    animation-iteration-count: 1 !important;
    transition-duration: 0.01ms !important;
    scroll-behavior: auto !important;
  }
}
```

This neutralizes the decorative infinite animations (`.health-dot.ok` glow, `.btn-refresh.spinning` / `.spinner` spin) and hover/state transitions for users with a vestibular / motion-sensitivity accommodation enabled.

## Why

WCAG 2.1 accessibility: honor the user's OS/browser `prefers-reduced-motion` setting.

## Scope

- UI segment only — single file `ui/index.html`.
- Purely additive, preference-gated CSS. Default behavior unchanged for users who have not opted in.
- No layout, copy, behavior, or product change.

## Verification

- `cargo build` succeeds.
- `cargo clippy -p ui --all-targets` clean.
- Pure CSS change — no Rust touched, so coverage gate unaffected.

Closes #561

---
*This pull request was opened by the **UI segment auto-improve (issue → PR → merge)** routine of moadim.*