### PR TITLE
fix(ui): announce toasts to screen readers via aria-live region (#564)

### DIFF
--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -392,7 +392,7 @@ pub struct ToastStackProps {
 #[function_component(ToastStack)]
 pub fn toast_stack(props: &ToastStackProps) -> Html {
     html! {
-        <div class="toast-wrap">
+        <div class="toast-wrap" role="status" aria-live="polite" aria-atomic="false">
             { for props.toasts.iter().map(|t| {
                 let cls = match t.kind { ToastKind::Ok => "toast ok", ToastKind::Err => "toast err" };
                 html! {


### PR DESCRIPTION
Closes #564.

## Problem
`ToastStack` (`ui/src/main.rs`) renders a plain `<div class="toast-wrap">` with no ARIA live-region semantics, so assistive technology never announces toasts. Screen-reader users miss the success/error feedback sighted users see.

## Change
Mark the always-present toast container as a polite live region:
- `role="status"`
- `aria-live="polite"`
- `aria-atomic="false"` (announce only the newly added toast, not the whole stack)

The container is always in the DOM, so it qualifies as a valid live region — newly appended toasts get announced automatically.

## Scope
- Single-attribute addition confined to `ui/src/main.rs`. `git diff --name-only origin/main...HEAD` lists only `ui/` paths.
- Pure accessibility enhancement: no behavior, feature, data, or API change.
- `skip-changelog` applied: the routine is restricted to files under `ui/` and may not edit the root `CHANGELOG.md`.

## Verification
- `cargo build -p ui` succeeds.
- `cargo clippy -p ui --all-targets -- -D warnings` clean.
- Pre-push gate (clippy + 100% line coverage + `cargo test`) passed locally.

---
This pull request was opened by the *UI segment auto-improve (issue → PR → merge)* routine of moadim.