### PR TITLE
fix(ui): announce toast notifications to screen readers via aria-live region (#564)

### DIFF
--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -392,7 +392,7 @@ pub struct ToastStackProps {
 #[function_component(ToastStack)]
 pub fn toast_stack(props: &ToastStackProps) -> Html {
     html! {
-        <div class="toast-wrap">
+        <div class="toast-wrap" role="status" aria-live="polite" aria-atomic="false">
             { for props.toasts.iter().map(|t| {
                 let cls = match t.kind { ToastKind::Ok => "toast ok", ToastKind::Err => "toast err" };
                 html! {


### PR DESCRIPTION
Closes #564.

## UI improvement (accessibility, UI-only)

### Problem
The toast notification stack rendered by `ToastStack` (`ui/src/main.rs`) was a plain `<div class="toast-wrap">` with no ARIA live-region semantics, so assistive technology never announced toasts. Sighted users see success/error feedback (e.g. "Server stopping…", "Stop failed: …") that screen-reader users miss entirely.

### Change
Mark the always-present toast container as a polite live region:
- `role="status"`
- `aria-live="polite"`
- `aria-atomic="false"` (announce only the newly added toast, not the whole stack)

The container is always in the DOM (rendered even when empty), so it qualifies as a valid live region — newly appended toasts get announced automatically.

### Scope
- Single-attribute addition confined to `ui/src/main.rs`. `git diff --name-only origin/main...HEAD` lists only `ui/...`.
- Pure accessibility enhancement: no behavior, feature, data, or API change → not a product change.
- `cargo clippy -p ui --all-targets -- -D warnings` clean; `cargo fmt -p ui --check` clean. The change lives in `main.rs`, which the 100% line-coverage gate excludes, so coverage is unaffected.

### Changelog
`skip-changelog` label applied: per the UI-segment auto-improve routine's scope, edits are restricted to files under `ui/`, so `CHANGELOG.md` (repo root) is intentionally not touched.

---
This pull request was opened by the *UI segment auto-improve (issue → PR → merge)* routine of moadim.