### PR TITLE
fix(ui): remove duplicate prefers-reduced-motion CSS block (#568)

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -854,16 +854,6 @@
     ::-webkit-scrollbar-track { background: var(--bg); }
     ::-webkit-scrollbar-thumb { background: var(--border-hi); }
     ::-webkit-scrollbar-thumb:hover { background: var(--text-dim); }
-
-    /* ── Reduced motion ── neutralize decorative motion for users who opt out */
-    @media (prefers-reduced-motion: reduce) {
-      *, *::before, *::after {
-        animation-duration: 0.01ms !important;
-        animation-iteration-count: 1 !important;
-        transition-duration: 0.01ms !important;
-        scroll-behavior: auto !important;
-      }
-    }
   </style>
 </head>
 <body></body>


### PR DESCRIPTION
Closes #568.

`ui/index.html` contained the exact same `@media (prefers-reduced-motion: reduce)` rule **twice** — the first under the `── Reduced motion ──` heading, the second (now removed) after the scrollbar rules. The two were byte-identical.

### Change
- Remove the redundant second block.
- **No behavior change**: the surviving documented block applies the identical `animation-duration` / `animation-iteration-count` / `transition-duration` / `scroll-behavior` overrides, so reduced-motion handling is unchanged for every user.

### Scope
- **UI-only**: diff touches `ui/index.html` exclusively.
- **Not a product change**: pure CSS dedup, no feature/behavior/data/API impact.

`skip-changelog` applied — no user-facing change to document (identical CSS removed).

---
*This pull request was opened by the "UI segment auto-improve (issue → PR → merge)" routine of moadim.*