### PR TITLE
chore(lint): enable clippy::manual_let_else and rewrite the violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 - Enabled the `clippy::semicolon_if_nothing_returned` lint and fixed the existing
   violations so statements that return `()` end with a trailing semicolon. No
   behavior change.
+- Enabled the `clippy::manual_let_else` lint and rewrote the `match` guards
+  whose only non-binding arm diverged (`return`/`continue`) as
+  `let ... else { ... }`, keeping the happy path unindented. No behavior change.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,7 @@ map_unwrap_or = "deny"
 # Require a trailing `;` on the last statement of a `()`-returning block so
 # statement-only blocks read consistently and intent stays explicit.
 semicolon_if_nothing_returned = "deny"
+# Prefer `let PATTERN = expr else { diverge }` over a `match` whose only
+# non-binding arm diverges (return/continue/break), keeping the happy path
+# unindented.
+manual_let_else = "deny"

--- a/src/middlewares/fs_location.rs
+++ b/src/middlewares/fs_location.rs
@@ -10,14 +10,12 @@ pub async fn fs_location(req: Request, next: Next) -> Response {
 
 /// Inject fields from a JSON object value as `x-*` response headers.
 fn inject_headers_from_value(mut res: Response, val: serde_json::Value) -> Response {
-    let map = match val {
-        serde_json::Value::Object(obj) => obj,
-        _ => return res,
+    let serde_json::Value::Object(map) = val else {
+        return res;
     };
     for (key, value) in map {
-        let str_value = match value {
-            serde_json::Value::String(string) => string,
-            _ => continue,
+        let serde_json::Value::String(str_value) = value else {
+            continue;
         };
         let name = format!("x-{}", key.replace('_', "-"));
         if let (Ok(header_name), Ok(header_value)) = (

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -231,9 +231,8 @@ pub fn migrate_prompt_files() {
 /// Extracted so tests can drive the migration against a controlled scratch directory, including the
 /// `read_dir` error-return branch and the per-entry rename-failure branch.
 pub(crate) fn migrate_prompt_files_from_dir(dir: &std::path::Path) {
-    let entries = match std::fs::read_dir(dir) {
-        Ok(entries) => entries,
-        Err(_) => return,
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
     };
     for entry in entries.flatten() {
         if !entry.file_type().is_ok_and(|ft| ft.is_dir()) {
@@ -270,9 +269,8 @@ pub fn migrate_routine_dirs() {
 /// `read_dir` error-return branch, the non-directory and unparsable-toml `continue` branches, and the
 /// `write_routine`/`remove_routine_dir` failure-log branches.
 pub(crate) fn migrate_routine_dirs_from_dir(dir: &std::path::Path) {
-    let entries = match std::fs::read_dir(dir) {
-        Ok(entries) => entries,
-        Err(_) => return,
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
     };
     for entry in entries.flatten() {
         if !entry.file_type().is_ok_and(|ft| ft.is_dir()) {


### PR DESCRIPTION
## Why

The codebase already denies a curated set of clippy lints (`map_unwrap_or`, `semicolon_if_nothing_returned`, `uninlined_format_args`, …). `clippy::manual_let_else` is a natural next addition: it flags a `match` whose only non-binding arm diverges (`return` / `continue` / `break`), a pattern that reads more directly as `let PATTERN = expr else { diverge };` and keeps the happy path unindented.

## What

- Enable `manual_let_else = "deny"` in `[lints.clippy]` (Cargo.toml), with a comment matching the existing style.
- Rewrite the four existing violations:
  - `src/middlewares/fs_location.rs` — the JSON object guard (`return res`) and the per-entry string guard (`continue`).
  - `src/routine_storage.rs` — the two `read_dir` error-return guards in the prompt-file and routine-dir migrations.

## Verification

- `cargo clippy --all-targets -- -D warnings` ✅ (clean)
- `cargo fmt --check` ✅
- `cargo test` ✅ — 536 passed, 0 failed

No behavior change: control flow is identical, the diverging arms become the `else` block.

---
This pull request was opened by the "Daemon + Landing auto-improve & auto-merge lint/docs PRs" routine of moadim.