### PR TITLE
fix(ui): remove duplicate prefers-reduced-motion CSS block

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -854,16 +854,6 @@
     ::-webkit-scrollbar-track { background: var(--bg); }
     ::-webkit-scrollbar-thumb { background: var(--border-hi); }
     ::-webkit-scrollbar-thumb:hover { background: var(--text-dim); }
-
-    /* ── Reduced motion ── neutralize decorative motion for users who opt out */
-    @media (prefers-reduced-motion: reduce) {
-      *, *::before, *::after {
-        animation-duration: 0.01ms !important;
-        animation-iteration-count: 1 !important;
-        transition-duration: 0.01ms !important;
-        scroll-behavior: auto !important;
-      }
-    }
   </style>
 </head>
 <body></body>


### PR DESCRIPTION
Closes #568.

## What
`ui/index.html` declared the same `@media (prefers-reduced-motion: reduce)` rule **twice** — once under the `── Reduced motion ──` heading and again right after the scrollbar rules. The two blocks were byte-identical (verified with `diff`), so the second was dead, redundant CSS.

This PR removes the duplicate block. The surviving block applies the identical `animation-duration` / `animation-iteration-count` / `transition-duration` / `scroll-behavior` overrides, so **reduced-motion behavior is unchanged** for every user.

## Scope
- **UI-only:** diff touches `ui/index.html` exclusively.
- **Not a product change:** pure CSS dedup — no feature/behavior/data/API impact.
- `cargo build` succeeds locally; no `prebuilt.html` regenerated/committed.

`skip-changelog` applied: this is a no-op cleanup with no user-facing change to document.

---
*This pull request was opened by the "UI segment auto-improve (issue → PR → merge)" routine of moadim.*