### PR TITLE
chore(release): v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-06-21
+
 ### Added
 
 - **Multi-machine targeting.** Routines and cron jobs now carry a `machines` list,
@@ -586,7 +588,8 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 - Ship the prebuilt UI in the published crate.
 - Rename the binary to `moadim` and add install docs.
 
-[Unreleased]: https://github.com/moadim-io/daemon/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/moadim-io/daemon/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/moadim-io/daemon/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/moadim-io/daemon/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/moadim-io/daemon/compare/v0.11.2...v0.12.0
 [0.11.2]: https://github.com/moadim-io/daemon/compare/v0.11.1...v0.11.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ opt-level = "z"
 
 [package]
 name = "moadim"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Moadim.io MCP/REST server for managing cron jobs"
 license = "MIT"


### PR DESCRIPTION
Release v0.14.0.

- Bump `Cargo.toml` / `Cargo.lock` to `0.14.0`
- Promote `## [Unreleased]` changelog entries to `## [0.14.0] - 2026-06-21`
- Add `v0.13.0...v0.14.0` compare link

Merge, then push the `v0.14.0` tag to trigger the GitHub Release + crates.io publish workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)