### PR TITLE
fix(ui): add consistent :focus-visible keyboard focus indicators (#574)

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -849,6 +849,24 @@
       }
     }
 
+    /* ── Keyboard focus ── */
+    /* Give every interactive control a clear, consistent focus ring for
+       keyboard users. :focus-visible only fires for keyboard/programmatic
+       focus, so mouse users see no change. Mirrors the accent ring already
+       used by .row-check. */
+    .btn:focus-visible,
+    .btn-refresh:focus-visible,
+    .btn-stop:focus-visible,
+    .tab-btn:focus-visible,
+    .act-btn:focus-visible,
+    .view-btn:focus-visible,
+    .preset-btn:focus-visible,
+    .modal-x:focus-visible,
+    .toggle input:focus-visible + .toggle-track {
+      outline: 1px solid var(--accent);
+      outline-offset: 1px;
+    }
+
     /* ── Scrollbar ── */
     ::-webkit-scrollbar       { width: 5px; }
     ::-webkit-scrollbar-track { background: var(--bg); }


### PR DESCRIPTION
Closes #574.

## What
Adds a consistent accent `:focus-visible` outline to interactive controls that previously lacked one (`.btn`, `.tab-btn`, `.act-btn`, `.view-btn`, `.preset-btn`, `.btn-refresh`, `.btn-stop`, `.modal-x`, `.toggle`). Only `.row-check` had a visible focus ring before.

## Why
Keyboard-only users got a faint/inconsistent default focus indicator against the dark CRT theme. `:focus-visible` only fires for keyboard/programmatic focus, so mouse users see no change.

## Scope
- CSS-only, single file: `ui/index.html`.
- No behavior, layout, component, or product change. Nothing outside `ui/`.
- `cargo clippy -p ui --target wasm32-unknown-unknown` clean; no Rust changed so coverage is unaffected.

---
_This pull request was opened by the "UI segment auto-improve (issue → PR → merge)" routine of moadim._