### PR TITLE
feat(ui): let users set the machines targeting list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   hour, prev/next/`TODAY` navigation, and the current hour highlighted and
   scrolled into view. Available alongside the routines `LIST`/`CALENDAR` toggle
   and as a new `LIST`/`DAY` toggle on the previously table-only cron-jobs page.
+- **Set machines from the web UI.** The routine and cron-job create/edit forms now
+  expose a `MACHINES` input (comma-separated), so multi-machine targeting is settable
+  without dropping to the CLI or REST. Blank preserves today's behavior (empty list =
+  runs nowhere). Closes #580.
 
 ## [0.14.0] - 2026-06-21
 

--- a/ui/src/cron_jobs.rs
+++ b/ui/src/cron_jobs.rs
@@ -24,6 +24,9 @@ pub struct CronJob {
     pub schedule: String,
     pub handler: String,
     pub metadata: Json,
+    /// Machines this job runs on. An empty list runs nowhere (dormant until assigned).
+    #[serde(default)]
+    pub machines: Vec<String>,
     pub enabled: bool,
     pub created_at: u64,
     pub updated_at: u64,
@@ -39,6 +42,8 @@ pub struct CreateRequest {
     pub schedule: String,
     pub handler: String,
     pub metadata: Json,
+    /// Machines to run this job on (empty = runs nowhere until assigned).
+    pub machines: Vec<String>,
     pub enabled: bool,
 }
 
@@ -51,7 +56,23 @@ pub struct UpdateRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Json>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub machines: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
+}
+
+/// Render a machines list as a comma-separated string for the form input.
+fn machines_to_text(machines: &[String]) -> String {
+    machines.join(", ")
+}
+
+/// Parse a comma-separated machines input into a list, trimming blanks and dropping empties.
+fn text_to_machines(text: &str) -> Vec<String> {
+    text.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
 }
 
 // ─── API layer ────────────────────────────────────────────────────────────────
@@ -460,6 +481,7 @@ pub fn cron_jobs_page(props: &CronJobsPageProps) -> Html {
                         schedule: Some(req.schedule),
                         handler: Some(req.handler),
                         metadata: Some(req.metadata),
+                        machines: Some(req.machines),
                         enabled: Some(req.enabled),
                     };
                     match api_update(id, &upd).await {
@@ -992,6 +1014,7 @@ pub fn create_page(props: &CreatePageProps) -> Html {
     let schedule = use_state(String::new);
     let handler = use_state(String::new);
     let meta_raw = use_state(String::new);
+    let machines_raw = use_state(String::new);
     let enabled = use_state(|| true);
     let meta_err = use_state(String::new);
     let saving = use_state(|| false);
@@ -1028,6 +1051,13 @@ pub fn create_page(props: &CreatePageProps) -> Html {
             meta_raw.set(val);
         })
     };
+    let on_machines = {
+        let machines_raw = machines_raw.clone();
+        Callback::from(move |e: InputEvent| {
+            let input: HtmlInputElement = e.target_unchecked_into();
+            machines_raw.set(input.value());
+        })
+    };
     let on_enabled = {
         let enabled = enabled.clone();
         Callback::from(move |e: Event| {
@@ -1049,6 +1079,7 @@ pub fn create_page(props: &CreatePageProps) -> Html {
         let schedule = schedule.clone();
         let handler = handler.clone();
         let meta_raw = meta_raw.clone();
+        let machines_raw = machines_raw.clone();
         let meta_err = meta_err.clone();
         let enabled = enabled.clone();
         let saving = saving.clone();
@@ -1067,6 +1098,7 @@ pub fn create_page(props: &CreatePageProps) -> Html {
                 schedule: (*schedule).clone(),
                 handler: (*handler).clone(),
                 metadata,
+                machines: text_to_machines(&machines_raw),
                 enabled: *enabled,
             });
         })
@@ -1152,6 +1184,21 @@ pub fn create_page(props: &CreatePageProps) -> Html {
                             <div class="field-err">{(*meta_err).clone()}</div>
                         }
                     </div>
+                    <div class="form-group">
+                        <label class="form-label">
+                            {"MACHINES "}
+                            <span style="color:var(--text-ghost)">{"(comma-separated; blank = runs nowhere)"}</span>
+                        </label>
+                        <input
+                            class="form-input"
+                            type="text"
+                            placeholder="laptop, work, server"
+                            value={(*machines_raw).clone()}
+                            oninput={on_machines}
+                            autocomplete="off"
+                            spellcheck="false"
+                        />
+                    </div>
                     <div class="form-group" style="margin-bottom:0">
                         <div class="toggle-row">
                             <span class="toggle-row-label">{"ENABLED"}</span>
@@ -1215,6 +1262,13 @@ pub fn job_modal(props: &JobModalProps) -> Html {
             })
             .unwrap_or_default()
     });
+    let machines_raw = use_state(|| {
+        props
+            .editing
+            .as_ref()
+            .map(|j| machines_to_text(&j.machines))
+            .unwrap_or_default()
+    });
     let enabled = use_state(|| props.editing.as_ref().map(|j| j.enabled).unwrap_or(true));
     let meta_err = use_state(String::new);
     let saving = use_state(|| false);
@@ -1264,6 +1318,14 @@ pub fn job_modal(props: &JobModalProps) -> Html {
         Callback::from(move |_: MouseEvent| schedule.set(val.to_string()))
     };
 
+    let on_machines = {
+        let machines_raw = machines_raw.clone();
+        Callback::from(move |e: InputEvent| {
+            let input: HtmlInputElement = e.target_unchecked_into();
+            machines_raw.set(input.value());
+        })
+    };
+
     let on_close_click = {
         let cb = props.on_close.clone();
         Callback::from(move |_: MouseEvent| cb.emit(()))
@@ -1272,6 +1334,7 @@ pub fn job_modal(props: &JobModalProps) -> Html {
         let schedule = schedule.clone();
         let handler = handler.clone();
         let meta_raw = meta_raw.clone();
+        let machines_raw = machines_raw.clone();
         let meta_err = meta_err.clone();
         let enabled = enabled.clone();
         let saving = saving.clone();
@@ -1290,6 +1353,7 @@ pub fn job_modal(props: &JobModalProps) -> Html {
                 schedule: (*schedule).clone(),
                 handler: (*handler).clone(),
                 metadata,
+                machines: text_to_machines(&machines_raw),
                 enabled: *enabled,
             });
         })
@@ -1374,6 +1438,21 @@ pub fn job_modal(props: &JobModalProps) -> Html {
                         if !meta_err.is_empty() {
                             <div class="field-err">{(*meta_err).clone()}</div>
                         }
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">
+                            {"MACHINES "}
+                            <span style="color:var(--text-ghost)">{"(comma-separated; blank = runs nowhere)"}</span>
+                        </label>
+                        <input
+                            class="form-input"
+                            type="text"
+                            placeholder="laptop, work, server"
+                            value={(*machines_raw).clone()}
+                            oninput={on_machines}
+                            autocomplete="off"
+                            spellcheck="false"
+                        />
                     </div>
                     <div class="form-group" style="margin-bottom:0">
                         <div class="toggle-row">

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -39,6 +39,9 @@ pub struct Routine {
     pub prompt: String,
     #[serde(default)]
     pub repositories: Vec<Repository>,
+    /// Machines this routine runs on. An empty list runs nowhere (dormant until assigned).
+    #[serde(default)]
+    pub machines: Vec<String>,
     pub enabled: bool,
     #[serde(default)]
     pub source: String,
@@ -67,6 +70,8 @@ pub struct CreateRoutineRequest {
     pub agent: String,
     pub prompt: String,
     pub repositories: Vec<Repository>,
+    /// Machines to run this routine on (empty = runs nowhere until assigned).
+    pub machines: Vec<String>,
     pub enabled: bool,
     /// Workbench retention (seconds); `None` lets the server apply its default.
     pub ttl_secs: Option<u64>,
@@ -90,6 +95,8 @@ pub struct UpdateRoutineRequest {
     pub prompt: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repositories: Option<Vec<Repository>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub machines: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -515,6 +522,7 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
                         agent: Some(req.agent),
                         prompt: Some(req.prompt),
                         repositories: Some(req.repositories),
+                        machines: Some(req.machines),
                         enabled: Some(req.enabled),
                         ttl_secs: req.ttl_secs,
                     };
@@ -1195,6 +1203,20 @@ fn text_to_repos(text: &str) -> Vec<Repository> {
         .collect()
 }
 
+/// Render a machines list as a comma-separated string for the form input.
+fn machines_to_text(machines: &[String]) -> String {
+    machines.join(", ")
+}
+
+/// Parse a comma-separated machines input into a list, trimming blanks and dropping empties.
+fn text_to_machines(text: &str) -> Vec<String> {
+    text.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
 /// Parse a TTL textarea value into seconds. Blank/whitespace → `None` (use the server default);
 /// a valid non-negative integer → `Some(secs)`; anything else → `None`.
 fn parse_ttl(raw: &str) -> Option<u64> {
@@ -1275,6 +1297,12 @@ pub fn routine_form(props: &FormProps) -> Html {
             .map(|r| repos_to_text(&r.repositories))
             .unwrap_or_default()
     });
+    let machines_raw = use_state(|| {
+        editing
+            .as_ref()
+            .map(|r| machines_to_text(&r.machines))
+            .unwrap_or_default()
+    });
     let enabled = use_state(|| editing.as_ref().map(|r| r.enabled).unwrap_or(true));
     // Blank means "use the server default"; otherwise the workbench TTL in seconds.
     let ttl_raw = use_state(|| {
@@ -1323,6 +1351,13 @@ pub fn routine_form(props: &FormProps) -> Html {
             repos_raw.set(i.value());
         })
     };
+    let on_machines = {
+        let machines_raw = machines_raw.clone();
+        Callback::from(move |e: InputEvent| {
+            let i: HtmlInputElement = e.target_unchecked_into();
+            machines_raw.set(i.value());
+        })
+    };
     let on_enabled = {
         let enabled = enabled.clone();
         Callback::from(move |e: Event| {
@@ -1359,6 +1394,7 @@ pub fn routine_form(props: &FormProps) -> Html {
         let agent = agent.clone();
         let prompt = prompt.clone();
         let repos_raw = repos_raw.clone();
+        let machines_raw = machines_raw.clone();
         let enabled = enabled.clone();
         let ttl_raw = ttl_raw.clone();
         let saving = saving.clone();
@@ -1374,6 +1410,7 @@ pub fn routine_form(props: &FormProps) -> Html {
                 agent: (*agent).clone(),
                 prompt: (*prompt).clone(),
                 repositories: text_to_repos(&repos_raw),
+                machines: text_to_machines(&machines_raw),
                 enabled: *enabled,
                 ttl_secs: parse_ttl(&ttl_raw),
             });
@@ -1439,6 +1476,14 @@ pub fn routine_form(props: &FormProps) -> Html {
                 </label>
                 <textarea class="form-input" placeholder={"https://github.com/org/repo main"}
                     value={(*repos_raw).clone()} oninput={on_repos} />
+            </div>
+            <div class="form-group">
+                <label class="form-label">
+                    {"MACHINES "}
+                    <span style="color:var(--text-ghost)">{"(comma-separated; blank = runs nowhere)"}</span>
+                </label>
+                <input class="form-input" type="text" placeholder="laptop, work, server"
+                    value={(*machines_raw).clone()} oninput={on_machines} autocomplete="off" spellcheck="false" />
             </div>
             <div class="form-group">
                 <label class="form-label">


### PR DESCRIPTION
## What

Adds a `MACHINES` input to the routine and cron-job create/edit forms so the multi-machine targeting list (#573, v0.14.0) is settable from the web UI — previously only reachable via the CLI `--machines` flag, REST, or MCP tools.

Since an empty `machines` list runs **nowhere**, a UI-created routine/job was dormant on every machine until the user dropped to the CLI. This closes that gap.

## Changes

- `ui/src/routines.rs`: add `machines` to the UI `Routine`, `CreateRoutineRequest`, and `UpdateRoutineRequest` types; add a comma-separated `MACHINES` form input (pre-filled when editing); send the parsed list on create and update.
- `ui/src/cron_jobs.rs`: same for `CronJob` / `CreateRequest` / `UpdateRequest`, wired into both `CreatePage` and `JobModal`.
- Comma-separated parsing trims blanks and drops empties; blank input → empty list (unchanged behavior).

## Out of scope

- Picking from a discovered list of known machines (no endpoint enumerates them).
- Showing the current machine identity as a form hint.

Closes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)