### PR TITLE
fix(ui): add dialog ARIA semantics to the shutdown confirm modal (#571)

### DIFF
--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -368,9 +368,15 @@ pub fn shutdown_dialog(props: &ShutdownProps) -> Html {
 
     html! {
         <div class="overlay open">
-            <div class="confirm-dialog">
-                <div class="confirm-title">{"⏻ STOP SERVER"}</div>
-                <div class="confirm-msg">
+            <div
+                class="confirm-dialog"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="shutdown-dialog-title"
+                aria-describedby="shutdown-dialog-msg"
+            >
+                <div id="shutdown-dialog-title" class="confirm-title">{"⏻ STOP SERVER"}</div>
+                <div id="shutdown-dialog-msg" class="confirm-msg">
                     { "Stop the moadim server? Scheduled jobs and routines will not run until it is started again." }
                 </div>
                 <div class="confirm-acts">


### PR DESCRIPTION
## Summary
Adds ARIA dialog semantics to the STOP-server confirmation modal (`ShutdownDialog` in `ui/src/main.rs`).

Closes #571.

The overlay previously rendered as plain `<div>`s, so screen readers announced it as an unlabelled group rather than a modal dialog. This wires up:
- `role="dialog"`
- `aria-modal="true"`
- `aria-labelledby` → new `id` on `.confirm-title`
- `aria-describedby` → new `id` on `.confirm-msg`

## Scope
- UI-only: the diff touches **`ui/src/main.rs`** exclusively.
- Not a product change: pure accessibility markup, no behavior, flow, data, or API change.
- `skip-changelog` applied — no user-facing/behavioral change to document.

## Verification
- `cargo build` succeeds.
- `cargo clippy -p ui --all-targets -- -D warnings` clean.
- Coverage gate unaffected (`*/main.rs` is excluded from the llvm-cov floor).

---
This pull request was opened by the *UI segment auto-improve (issue → PR → merge)* routine of moadim.