### PR TITLE
ci: automate release on Cargo.toml version bump

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,86 @@
+name: Auto Release
+
+# Releasing is now automated by design: a release is whatever lands on `main`
+# with a bumped `Cargo.toml` version. The old manual "push the vX.Y.Z tag after
+# merging" step is gone — this workflow performs it.
+#
+# Flow on every push to `main` that touches `Cargo.toml`:
+#   1. detect  — read the package version; release only if no `v<version>` tag
+#                exists yet (idempotent: dependency-only edits don't release).
+#   2. tag     — create and push `v<version>`.
+#   3. publish — call publish.yml (crates.io) directly via `workflow_call`.
+#   4. release — call release.yml (GitHub Release) directly via `workflow_call`.
+#
+# Why call publish/release directly instead of letting the tag push trigger
+# their `on: push: tags` listeners: a tag pushed with the default GITHUB_TOKEN
+# does NOT trigger other workflows (GitHub's loop-guard), so we invoke them
+# here. Manual `v*` tag pushes (by a human) still trigger those workflows as an
+# escape hatch.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Cargo.toml'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: auto-release
+  cancel-in-progress: false
+
+jobs:
+  detect:
+    name: Detect version bump
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.v.outputs.release }}
+      tag: ${{ steps.v.outputs.tag }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0 # need all tags to check existence
+
+      - id: v
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          TAG="v$VERSION"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "Tag $TAG already exists — nothing to release."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "New version $VERSION — will tag and release."
+            echo "release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  tag:
+    name: Push tag
+    needs: detect
+    if: needs.detect.outputs.release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "${{ needs.detect.outputs.tag }}"
+          git push origin "${{ needs.detect.outputs.tag }}"
+
+  publish:
+    needs: [detect, tag]
+    if: needs.detect.outputs.release == 'true'
+    uses: ./.github/workflows/publish.yml
+    with:
+      tag: ${{ needs.detect.outputs.tag }}
+    secrets: inherit
+
+  release:
+    needs: [detect, tag]
+    if: needs.detect.outputs.release == 'true'
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.detect.outputs.tag }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,26 @@
 name: Publish to crates.io
 
+# Publish the crate. Triggered two ways:
+#   * `workflow_call` from auto-release.yml on a version bump (automated path).
+#   * a manual `v*` tag push (escape hatch for hotfixes cut by hand).
+
 on:
   push:
     tags:
       - 'v*'
+  workflow_call:
+    inputs:
+      tag:
+        description: Tag to publish (e.g. v0.14.0)
+        required: true
+        type: string
 
 jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    env:
+      TAG: ${{ inputs.tag || github.ref_name }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -52,7 +64,7 @@ jobs:
       - name: Verify tag matches Cargo.toml version
         run: |
           CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-          TAG_VERSION=${GITHUB_REF_NAME#v}
+          TAG_VERSION=${TAG#v}
           if [ "$CARGO_VERSION" != "$TAG_VERSION" ]; then
             echo "Version mismatch: Cargo.toml=$CARGO_VERSION, tag=$TAG_VERSION"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,23 @@
 name: GitHub Release
 
-# Cut a GitHub Release whenever a `v*` tag is pushed (same trigger that drives
-# the crates.io publish in publish.yml). Release notes are extracted from the
-# matching version section in CHANGELOG.md so the published notes stay in sync
-# with the changelog. Runs independently of publish.yml — neither blocks the
-# other.
+# Cut a GitHub Release for a version. Triggered two ways:
+#   * `workflow_call` from auto-release.yml, right after it pushes the tag on a
+#     version bump (the automated path — see auto-release.yml).
+#   * a manual `v*` tag push (escape hatch for hotfixes cut by hand).
+# Release notes are extracted from the matching version section in CHANGELOG.md
+# so the published notes stay in sync with the changelog. Runs independently of
+# publish.yml — neither blocks the other.
 
 on:
   push:
     tags:
       - 'v*'
+  workflow_call:
+    inputs:
+      tag:
+        description: Tag to release (e.g. v0.14.0)
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -18,13 +26,15 @@ jobs:
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    env:
+      TAG: ${{ inputs.tag || github.ref_name }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Extract changelog section for this tag
         id: notes
         run: |
-          VERSION=${GITHUB_REF_NAME#v}
+          VERSION=${TAG#v}
           # Pull lines between '## [VERSION]' and the next '## [' heading.
           awk -v ver="$VERSION" '
             $0 ~ "^## \\[" ver "\\]" { capture=1; next }
@@ -41,5 +51,6 @@ jobs:
       - name: Create release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
-          name: ${{ github.ref_name }}
+          tag_name: ${{ env.TAG }}
+          name: ${{ env.TAG }}
           body_path: release-notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   without dropping to the CLI or REST. Blank preserves today's behavior (empty list =
   runs nowhere). Closes #580.
 
+### Changed
+
+- **Releases are automated on version bump.** Merging a `Cargo.toml` version bump to
+  `main` now auto-pushes the matching `vx.y.z` tag and runs the crates.io publish and
+  GitHub Release workflows (new `auto-release.yml`). No more manual tag push; `publish.yml`
+  and `release.yml` are now reusable (`workflow_call`) and keep their `v*` tag-push
+  trigger as a hand-cut fallback.
+
 ## [0.14.0] - 2026-06-21
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,22 @@ cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'
    [`CHANGELOG.md`](CHANGELOG.md) (Keep a Changelog format).
 4. Open a PR against `main`; fill in what changed and why.
 
+## Releasing
+
+Releases are automated. To cut one, open a PR that bumps the package version:
+
+1. Bump `version` in `Cargo.toml` (and `Cargo.lock`).
+2. Promote the `## [Unreleased]` entries in [`CHANGELOG.md`](CHANGELOG.md) to a
+   `## [x.y.z] - YYYY-MM-DD` section and add the compare link.
+3. Merge to `main`.
+
+On merge, [`auto-release.yml`](.github/workflows/auto-release.yml) detects the
+new version, pushes the `vx.y.z` tag, then publishes to crates.io
+([`publish.yml`](.github/workflows/publish.yml)) and cuts the GitHub Release
+([`release.yml`](.github/workflows/release.yml)). No manual tag push. The tag
+must not already exist, and `Cargo.toml`'s version must match the topmost
+changelog heading. Pushing a `v*` tag by hand still works as a fallback.
+
 ## Code conventions
 
 - New REST routes go in `src/routes/http.rs`; register them in the router


### PR DESCRIPTION
## Why

v0.14.0 shipped to `main` but never got a tag or a published release until pushed by hand — the `git push origin vX.Y.Z` step lived only in the release-PR body (#575), pure human knowledge with no automation. See the gap: PR #575 merged the version bump, but the release sat un-cut.

## What

Make releasing **automated by design**: a release is whatever lands on `main` with a bumped `Cargo.toml`.

- **New `auto-release.yml`** — on push to `main` touching `Cargo.toml`: read the package version; if no `v<version>` tag exists, push the tag, then run publish + release.
- **`publish.yml` / `release.yml` are now reusable** (`workflow_call` with a `tag` input), invoked directly by the orchestrator. They keep their `v*` tag-push trigger as a hand-cut fallback.
- Idempotent: dependency-only `Cargo.toml` edits don't release (tag already absent check); re-runs are safe.

## Design note

The orchestrator calls publish/release **directly** rather than relying on the tag-push event, because a tag pushed with the default `GITHUB_TOKEN` does **not** trigger other workflows (GitHub's loop-guard). 

**Zero new secrets:** GitHub Release uses `GITHUB_TOKEN`; publish uses the existing `CARGO_REGISTRY_TOKEN`.

Docs: added a "Releasing" section to CONTRIBUTING so the flow lives in the repo, not in PR prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)