### PR TITLE
docs(man): sync moadim.1 with the 0.14.0 CLI surface (#556)

### DIFF
--- a/docs/moadim.1
+++ b/docs/moadim.1
@@ -1,7 +1,7 @@
 .\" Man page for moadim.
 .\" Mirrors the built-in `moadim --help` output (src/cli.rs::print_help).
 .\" View with:  man ./docs/moadim.1   or install into share/man/man1/.
-.TH MOADIM 1 "2026-06-21" "moadim 0.13.0" "Moadim Manual"
+.TH MOADIM 1 "2026-06-21" "moadim 0.14.0" "Moadim Manual"
 .SH NAME
 moadim \- cron/MCP/REST server with a web control panel
 .SH SYNOPSIS
@@ -55,6 +55,10 @@ Register moadim as an OS service (launchd / systemd user).
 .B uninstall
 Remove the OS service registration.
 .TP
+.B machine <show|set|list>
+Show or set this machine's identity, or list the machines referenced by
+routines and cron jobs.
+.TP
 .BR "help" ", " \-h ", " \-\-help
 Show usage help.
 .TP
@@ -74,6 +78,11 @@ Manage cron jobs (alias:
 .B routines <create|list|get|update|replace|delete|trigger|logs|ical> ...
 Manage routines (alias:
 .BR routine ).
+.TP
+.B schedule trigger <id>
+Trigger a routine or cron job by ID (used by the generated
+.B run.sh
+wrappers).
 .TP
 .B agents
 List available agent keys.


### PR DESCRIPTION
## Why

The committed man page (`docs/moadim.1`) mirrors `moadim --help` (`src/cli.rs::print_help`) by hand, with no sync test — so it drifts silently (issue #556). The 0.14.0 multi-machine release left it stale on three counts:

- **Version stamp** — the `.TH` line still read `moadim 0.13.0`; `Cargo.toml` and the latest `CHANGELOG` release are `0.14.0`.
- **`machine <show|set|list>`** — added with multi-machine targeting, present in `--help`, absent from the man page `COMMANDS`.
- **`schedule trigger <id>`** — the `run.sh` wrapper entry point, present in `--help`, absent from the man page `DATA COMMANDS`.

## What

Brings all three back in line with `print_help`, matching the surrounding roff style and command ordering.

## Notes

- Docs-only — touches neither `src/` nor `ui/`, so the `unreleased-entry` gate is exempt.
- Verified with `mandoc -Tlint docs/moadim.1` (clean) and `man ./docs/moadim.1` (renders, footer now reads `moadim 0.14.0`).
- This is the manual-sync half of #556; the automated drift-guard test it asks for is a worthwhile follow-up and intentionally out of scope here.

This pull request was opened by the "Daemon + Landing auto-improve & auto-merge lint/docs PRs" routine of moadim.