### PR TITLE
fix(ui): add standard scrollbar-width/scrollbar-color for Firefox (#588)

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -948,6 +948,11 @@
     }
 
     /* ── Scrollbar ── */
+    /* Firefox / standard properties mirror the WebKit dark, thin scrollbar
+       below. They inherit, so this root declaration also styles the nested
+       scroll containers (logs, modal, day timeline) to match the WebKit rules,
+       which apply globally. Reuses the theme tokens so colors stay in sync. */
+    html { scrollbar-width: thin; scrollbar-color: var(--border-hi) var(--bg); }
     ::-webkit-scrollbar       { width: 5px; }
     ::-webkit-scrollbar-track { background: var(--bg); }
     ::-webkit-scrollbar-thumb { background: var(--border-hi); }


### PR DESCRIPTION
Closes #588.

## What

The dashboard's custom dark, thin scrollbar in `ui/index.html` was styled **only** with the WebKit-prefixed `::-webkit-scrollbar` pseudo-elements. Firefox and other non-WebKit engines ignored them and rendered the default light OS scrollbar, clashing with the terminal/CRT dark theme.

This adds the standard CSS scrollbar properties on the root element:

```css
html { scrollbar-width: thin; scrollbar-color: var(--border-hi) var(--bg); }
```

- Reuses the existing theme tokens (`--border-hi`, `--bg`) so colors stay in lockstep.
- These properties inherit, so the single root declaration also covers the nested scroll containers (logs, modal, day timeline), matching the global WebKit rules.

## Scope / safety

- **UI-only**: the diff touches `ui/index.html` exclusively (no `prebuilt.html`, no Rust, no other file).
- Pure styling polish — no behavior, feature, data, or API change.
- `cargo clippy -p ui --all-targets` passes clean; no Rust touched, so coverage/test gates are unaffected.

---
This pull request was opened by the **UI segment auto-improve (issue → PR → merge)** routine of moadim.