### PR TITLE
feat(ui): flexible day view with zoom into the hour (#591)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   hour, prev/next/`TODAY` navigation, and the current hour highlighted and
   scrolled into view. Available alongside the routines `LIST`/`CALENDAR` toggle
   and as a new `LIST`/`DAY` toggle on the previously table-only cron-jobs page.
+- **Zoom into the day view.** The single-day timeline gains a `−`/`+` zoom
+  control with four per-hour heights. The compact level keeps the wrapped-chip
+  layout; deeper levels switch each hour into a minute-positioned timeline where
+  fire times float at their exact minute against quarter-hour guide lines and a
+  `:00/:15/:30/:45` ruler, so sub-hour timing is readable at a glance. Closes #591.
 - **Set machines from the web UI.** The routine and cron-job create/edit forms now
   expose a `MACHINES` input (comma-separated), so multi-machine targeting is settable
   without dropping to the CLI or REST. Blank preserves today's behavior (empty list =

--- a/ui/index.html
+++ b/ui/index.html
@@ -857,15 +857,26 @@
       text-align: center;
     }
     .day-nav .btn-ghost { margin-left: auto; }
+    .day-zoom { display: flex; align-items: center; gap: 4px; }
+    .day-zoom .btn-refresh { padding: 2px 8px; }
+    .day-zoom-level {
+      font-size: 10px;
+      letter-spacing: 0.06em;
+      color: var(--text-ghost);
+      min-width: 22px;
+      text-align: center;
+      font-variant-numeric: tabular-nums;
+    }
 
     .day-scroll {
+      --dh: 40px;
       max-height: 60vh;
       overflow-y: auto;
     }
     .day-hour {
       display: grid;
       grid-template-columns: 64px 1fr;
-      min-height: 38px;
+      min-height: var(--dh);
       border-bottom: 1px solid var(--border);
     }
     .day-scroll > .day-hour:last-child { border-bottom: none; }
@@ -888,6 +899,47 @@
       gap: 4px;
       padding: 6px 8px;
     }
+
+    /* ── Detail (zoomed) mode: minute-positioned timeline ── */
+    /* Hour label becomes a quarter-hour ruler spanning the tall row. */
+    .day-scroll.detail .day-hour-label {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      padding: 0 10px;
+      text-align: right;
+    }
+    .day-scroll.detail .day-hour-label .qt { font-size: 9px; opacity: 0.45; }
+    .day-scroll.detail .day-hour-label .qt-end { height: 0; }
+    /* Slot is a positioning context with quarter-hour guide lines. */
+    .day-scroll.detail .day-hour-slot {
+      position: relative;
+      display: block;
+      padding: 0;
+    }
+    .day-scroll.detail .day-hour-slot::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      background: repeating-linear-gradient(
+        to bottom,
+        var(--border) 0,
+        var(--border) 1px,
+        transparent 1px,
+        transparent calc(var(--dh) / 4)
+      );
+      opacity: 0.5;
+    }
+    /* Each fire chip floats at its exact minute via inline top:%. */
+    .day-scroll.detail .day-chip {
+      position: absolute;
+      left: 8px;
+      max-width: calc(100% - 16px);
+      transform: translateY(-50%);
+      z-index: 1;
+    }
+    .day-scroll.detail .day-chip:hover { z-index: 2; }
     .day-chip {
       display: inline-flex;
       align-items: baseline;

--- a/ui/src/day_timeline.rs
+++ b/ui/src/day_timeline.rs
@@ -20,6 +20,12 @@ const MONTHS: [&str; 12] = [
     "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC",
 ];
 
+/// Zoom levels: pixel height of one hour row. The first level keeps the original
+/// compact, chip-wrapping layout; the rest grow the hour tall enough to lay fire
+/// times out by their exact minute against quarter-hour guide lines, so you can
+/// read sub-hour timing instead of a single wrapped bucket.
+const ZOOM_LEVELS: [i32; 4] = [40, 140, 300, 600];
+
 /// One schedulable thing on the timeline: a display label and its cron schedule.
 #[derive(Clone, PartialEq)]
 pub struct TimelineItem {
@@ -67,6 +73,8 @@ pub struct DayTimelineProps {
 pub fn day_timeline(props: &DayTimelineProps) -> Html {
     // Day offset from today; negative = past, positive = future.
     let offset = use_state(|| 0i64);
+    // Zoom level index into ZOOM_LEVELS; 0 = compact, higher = deeper into the hour.
+    let zoom = use_state(|| 0usize);
     // Ref on the "now" hour row so we can scroll it into view when viewing today.
     let now_ref = use_node_ref();
 
@@ -82,11 +90,19 @@ pub fn day_timeline(props: &DayTimelineProps) -> Html {
         let offset = offset.clone();
         Callback::from(move |_: MouseEvent| offset.set(0))
     };
+    let on_zoom_in = {
+        let zoom = zoom.clone();
+        Callback::from(move |_: MouseEvent| zoom.set((*zoom + 1).min(ZOOM_LEVELS.len() - 1)))
+    };
+    let on_zoom_out = {
+        let zoom = zoom.clone();
+        Callback::from(move |_: MouseEvent| zoom.set(zoom.saturating_sub(1)))
+    };
 
     // Scroll the current hour into view whenever we land on today.
     {
         let now_ref = now_ref.clone();
-        use_effect_with(*offset, move |_| {
+        use_effect_with((*offset, *zoom), move |_| {
             if let Some(el) = now_ref.cast::<Element>() {
                 el.scroll_into_view_with_bool(true);
             }
@@ -138,8 +154,17 @@ pub fn day_timeline(props: &DayTimelineProps) -> Html {
             </div>
         }
     } else {
+        // Level 0 keeps the compact wrap layout; deeper levels switch to a
+        // minute-positioned timeline with quarter-hour guide lines.
+        let detailed = *zoom > 0;
+        let hour_px = ZOOM_LEVELS[*zoom];
+        let scroll_cls = if detailed {
+            "day-scroll detail"
+        } else {
+            "day-scroll"
+        };
         html! {
-            <div class="day-scroll">
+            <div class={scroll_cls} style={format!("--dh:{hour_px}px")}>
                 { for (0..24usize).map(|h| {
                     let slot = &buckets[h];
                     let mut cls = String::from("day-hour");
@@ -147,15 +172,36 @@ pub fn day_timeline(props: &DayTimelineProps) -> Html {
                         cls.push_str(" now");
                     }
                     let row_ref = if h == now_hour { now_ref.clone() } else { NodeRef::default() };
+                    let label = if detailed {
+                        html! {
+                            <div class="day-hour-label">
+                                <span>{format!("{h:02}:00")}</span>
+                                <span class="qt">{format!("{h:02}:15")}</span>
+                                <span class="qt">{format!("{h:02}:30")}</span>
+                                <span class="qt">{format!("{h:02}:45")}</span>
+                                <span class="qt-end"></span>
+                            </div>
+                        }
+                    } else {
+                        html! { <div class="day-hour-label">{format!("{h:02}:00")}</div> }
+                    };
                     html! {
                         <div class={cls} ref={row_ref}>
-                            <div class="day-hour-label">{format!("{h:02}:00")}</div>
+                            {label}
                             <div class="day-hour-slot">
-                                { for slot.iter().map(|(t, label)| html! {
-                                    <div class="day-chip" title={label.clone()}>
-                                        <span class="day-chip-time">{format!("{:02}:{:02}", t.hour(), t.minute())}</span>
-                                        <span class="day-chip-label">{label.clone()}</span>
-                                    </div>
+                                { for slot.iter().map(|(t, lbl)| {
+                                    let frac = (t.minute() as f32 + t.second() as f32 / 60.0) / 60.0;
+                                    let style = if detailed {
+                                        Some(format!("top:{:.3}%", frac * 100.0))
+                                    } else {
+                                        None
+                                    };
+                                    html! {
+                                        <div class="day-chip" style={style} title={lbl.clone()}>
+                                            <span class="day-chip-time">{format!("{:02}:{:02}", t.hour(), t.minute())}</span>
+                                            <span class="day-chip-label">{lbl.clone()}</span>
+                                        </div>
+                                    }
                                 }) }
                             </div>
                         </div>
@@ -171,6 +217,13 @@ pub fn day_timeline(props: &DayTimelineProps) -> Html {
                 <button class="btn-refresh" title="Previous day" aria-label="Previous day" onclick={on_prev}>{"‹"}</button>
                 <div class="day-date">{date_label}</div>
                 <button class="btn-refresh" title="Next day" aria-label="Next day" onclick={on_next}>{"›"}</button>
+                <div class="day-zoom">
+                    <button class="btn-refresh" title="Zoom out" aria-label="Zoom out"
+                        disabled={*zoom == 0} onclick={on_zoom_out}>{"−"}</button>
+                    <span class="day-zoom-level">{format!("{}×", *zoom + 1)}</span>
+                    <button class="btn-refresh" title="Zoom into the hour" aria-label="Zoom in"
+                        disabled={*zoom == ZOOM_LEVELS.len() - 1} onclick={on_zoom_in}>{"+"}</button>
+                </div>
                 <button class="btn btn-ghost btn-sm" onclick={on_today}>{"TODAY"}</button>
             </div>
             {body}


### PR DESCRIPTION
## What

Adds a zoom control to the single-day timeline so you can see deeper into each hour instead of only which hour a job fires in.

- `−` / `level` / `+` zoom control in the day nav, four per-hour heights (40/140/300/600px).
- Level 1 keeps the original compact, chip-wrapping layout.
- Levels 2–4 switch each hour into a **minute-positioned timeline**: every fire chip floats at its exact minute (down to the second) against quarter-hour guide lines, with a `:00/:15/:30/:45` ruler in the time column.
- "now" highlight and auto-scroll-to-current-hour preserved; the scroll effect re-fires on zoom change since row heights shift.

Shared `DayTimeline` component, so it applies to both the routines and cron-jobs day views.

## Verification

- `cargo check` + `cargo clippy` (deny=all) clean on the `wasm32-unknown-unknown` target.
- `cargo fmt` clean.
- Layout verified in-browser: chips land at their exact minute, guide lines + ruler render, "now" hour highlight spans the full hour.

Closes #591.

🤖 Generated with [Claude Code](https://claude.com/claude-code)