### PR TITLE
feat: machine picker UI backed by GET /api/v1/machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   expose a `MACHINES` input (comma-separated), so multi-machine targeting is settable
   without dropping to the CLI or REST. Blank preserves today's behavior (empty list =
   runs nowhere). Closes #580.
+- **Machine picker.** The `MACHINES` field in the routine and cron-job forms is now a
+  picker: it fetches the daemon's known machine names from the new `GET /api/v1/machines`
+  endpoint (every name referenced by a routine or cron job, plus this machine's own
+  identity) and renders them as toggleable chips, while still allowing a brand-new name
+  to be typed and added. Closes #586.
 
 ### Changed
 

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -374,6 +374,31 @@
         }
       }
     },
+    "/machines": {
+      "get": {
+        "tags": [
+          "crate::routes::http"
+        ],
+        "summary": "`GET /machines` — distinct machine names this daemon knows about.",
+        "description": "There is no central machine registry, so the \"known\" set is the union of every `machines`\ntargeting list declared by a routine or cron job, plus this machine's own resolved identity\n([`crate::machine::current_machine`]) so the local machine is always pickable even before\nanything targets it. Sorted and de-duplicated. Backs the UI machine picker; mirrors the\n`moadim machine list` CLI but reads the live in-memory stores instead of disk.",
+        "operationId": "list_machines",
+        "responses": {
+          "200": {
+            "description": "Known machine names, sorted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/restart": {
       "post": {
         "tags": [

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -12,6 +12,7 @@
         crate::routes::http::shutdown,
         crate::routes::http::restart,
         crate::routes::http::echo,
+        crate::routes::http::list_machines,
         crate::cron_jobs::list,
         crate::cron_jobs::create,
         crate::cron_jobs::get,

--- a/src/routes/http.rs
+++ b/src/routes/http.rs
@@ -142,6 +142,28 @@ pub async fn echo(body: axum::body::Bytes) -> Result<Json<EchoResponse>, axum::h
     }))
 }
 
+/// `GET /machines` — distinct machine names this daemon knows about.
+///
+/// There is no central machine registry, so the "known" set is the union of every `machines`
+/// targeting list declared by a routine or cron job, plus this machine's own resolved identity
+/// ([`crate::machine::current_machine`]) so the local machine is always pickable even before
+/// anything targets it. Sorted and de-duplicated. Backs the UI machine picker; mirrors the
+/// `moadim machine list` CLI but reads the live in-memory stores instead of disk.
+#[utoipa::path(get, path = "/machines",
+    responses((status = 200, body = Vec<String>, description = "Known machine names, sorted")))]
+pub async fn list_machines(State(state): State<AppState>) -> Json<Vec<String>> {
+    use crate::utils::lock::LockRecover;
+    let mut names = std::collections::BTreeSet::new();
+    names.insert(crate::machine::current_machine());
+    for routine in state.routines.lock_recover().values() {
+        names.extend(routine.machines.iter().cloned());
+    }
+    for job in state.store.lock_recover().values() {
+        names.extend(job.machines.iter().cloned());
+    }
+    Json(names.into_iter().collect())
+}
+
 /// Build the Axum router with all routes, middleware, and state wired up.
 ///
 /// The shutdown signal is created internally; callers that need to trigger shutdown out of band
@@ -195,6 +217,7 @@ pub(crate) fn build_app_with_shutdown(
         .route("/shutdown", post(shutdown))
         .route("/restart", post(restart))
         .route("/echo", post(echo))
+        .route("/machines", get(list_machines))
         .route("/cron-jobs", get(cron_jobs::list).post(cron_jobs::create))
         .route(
             "/cron-jobs/{id}",

--- a/src/routes/http_tests.rs
+++ b/src/routes/http_tests.rs
@@ -127,6 +127,73 @@ async fn build_app_serves_agents() {
 }
 
 #[tokio::test]
+async fn build_app_serves_machines() {
+    // Seed a cron job and a routine whose targeting lists overlap (`shared`) so the response
+    // exercises de-duplication across both stores, plus the implicit local-identity entry.
+    let store = new_store();
+    store.lock().unwrap().insert(
+        "j1".to_string(),
+        crate::cron_jobs::CronJob {
+            id: "j1".to_string(),
+            schedule: "@daily".to_string(),
+            handler: "h".to_string(),
+            metadata: serde_json::Value::Null,
+            machines: vec!["zeta-box".to_string(), "shared".to_string()],
+            enabled: true,
+            source: "managed".to_string(),
+            created_at: 0,
+            updated_at: 0,
+            last_manual_trigger_at: None,
+        },
+    );
+    let routines = crate::routines::new_store();
+    routines.lock().unwrap().insert(
+        "r1".to_string(),
+        crate::routines::Routine {
+            id: "r1".to_string(),
+            schedule: "@daily".to_string(),
+            title: "R".to_string(),
+            agent: "claude".to_string(),
+            prompt: "p".to_string(),
+            repositories: vec![],
+            machines: vec!["alpha-box".to_string(), "shared".to_string()],
+            enabled: true,
+            source: "managed".to_string(),
+            created_at: 0,
+            updated_at: 0,
+            last_manual_trigger_at: None,
+            last_scheduled_trigger_at: None,
+            ttl_secs: None,
+            max_runtime_secs: None,
+        },
+    );
+    let resp = build_app(store, routines)
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/machines")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let machines: Vec<String> = serde_json::from_slice(&bytes).unwrap();
+
+    let mut expected = vec![
+        crate::machine::current_machine(),
+        "alpha-box".to_string(),
+        "shared".to_string(),
+        "zeta-box".to_string(),
+    ];
+    expected.sort();
+    expected.dedup();
+    assert_eq!(machines, expected);
+}
+
+#[tokio::test]
 async fn build_app_serves_health() {
     let app = build_app(new_store(), crate::routines::new_store());
     let resp = app

--- a/ui/index.html
+++ b/ui/index.html
@@ -523,6 +523,29 @@
     }
     .preset-btn:hover { border-color: var(--accent); color: var(--accent); }
 
+    /* machines picker */
+    .machine-chips { display: flex; flex-wrap: wrap; gap: 5px; margin-bottom: 6px; }
+    .machine-chip {
+      font-family: var(--mono);
+      font-size: 10px;
+      padding: 3px 9px;
+      border: 1px solid var(--border);
+      color: var(--text-dim);
+      cursor: pointer;
+      background: transparent;
+      transition: all 0.1s;
+      letter-spacing: 0.04em;
+    }
+    .machine-chip:hover { border-color: var(--accent); color: var(--accent); }
+    .machine-chip.on {
+      border-color: var(--accent);
+      color: var(--bg-1);
+      background: var(--accent);
+    }
+    .machine-empty { font-size: 10px; color: var(--text-ghost); margin-bottom: 6px; }
+    .machine-add { display: flex; gap: 6px; align-items: stretch; }
+    .machine-add .form-input { flex: 1; }
+
     /* cron preview */
     .cron-preview {
       margin-top: 6px;

--- a/ui/src/cron_jobs.rs
+++ b/ui/src/cron_jobs.rs
@@ -14,6 +14,7 @@ use web_sys::HtmlInputElement;
 use yew::prelude::*;
 
 use crate::day_timeline::{DayTimeline, TimelineItem};
+use crate::machines::MachinesPicker;
 use crate::{describe_cron_live, reltime, ToastKind};
 
 // ─── Types (mirror server API exactly) ────────────────────────────────────────
@@ -59,20 +60,6 @@ pub struct UpdateRequest {
     pub machines: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
-}
-
-/// Render a machines list as a comma-separated string for the form input.
-fn machines_to_text(machines: &[String]) -> String {
-    machines.join(", ")
-}
-
-/// Parse a comma-separated machines input into a list, trimming blanks and dropping empties.
-fn text_to_machines(text: &str) -> Vec<String> {
-    text.split(',')
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string)
-        .collect()
 }
 
 // ─── API layer ────────────────────────────────────────────────────────────────
@@ -1014,7 +1001,7 @@ pub fn create_page(props: &CreatePageProps) -> Html {
     let schedule = use_state(String::new);
     let handler = use_state(String::new);
     let meta_raw = use_state(String::new);
-    let machines_raw = use_state(String::new);
+    let machines = use_state(Vec::<String>::new);
     let enabled = use_state(|| true);
     let meta_err = use_state(String::new);
     let saving = use_state(|| false);
@@ -1052,11 +1039,8 @@ pub fn create_page(props: &CreatePageProps) -> Html {
         })
     };
     let on_machines = {
-        let machines_raw = machines_raw.clone();
-        Callback::from(move |e: InputEvent| {
-            let input: HtmlInputElement = e.target_unchecked_into();
-            machines_raw.set(input.value());
-        })
+        let machines = machines.clone();
+        Callback::from(move |next: Vec<String>| machines.set(next))
     };
     let on_enabled = {
         let enabled = enabled.clone();
@@ -1079,7 +1063,7 @@ pub fn create_page(props: &CreatePageProps) -> Html {
         let schedule = schedule.clone();
         let handler = handler.clone();
         let meta_raw = meta_raw.clone();
-        let machines_raw = machines_raw.clone();
+        let machines = machines.clone();
         let meta_err = meta_err.clone();
         let enabled = enabled.clone();
         let saving = saving.clone();
@@ -1098,7 +1082,7 @@ pub fn create_page(props: &CreatePageProps) -> Html {
                 schedule: (*schedule).clone(),
                 handler: (*handler).clone(),
                 metadata,
-                machines: text_to_machines(&machines_raw),
+                machines: (*machines).clone(),
                 enabled: *enabled,
             });
         })
@@ -1184,21 +1168,7 @@ pub fn create_page(props: &CreatePageProps) -> Html {
                             <div class="field-err">{(*meta_err).clone()}</div>
                         }
                     </div>
-                    <div class="form-group">
-                        <label class="form-label">
-                            {"MACHINES "}
-                            <span style="color:var(--text-ghost)">{"(comma-separated; blank = runs nowhere)"}</span>
-                        </label>
-                        <input
-                            class="form-input"
-                            type="text"
-                            placeholder="laptop, work, server"
-                            value={(*machines_raw).clone()}
-                            oninput={on_machines}
-                            autocomplete="off"
-                            spellcheck="false"
-                        />
-                    </div>
+                    <MachinesPicker value={(*machines).clone()} on_change={on_machines} />
                     <div class="form-group" style="margin-bottom:0">
                         <div class="toggle-row">
                             <span class="toggle-row-label">{"ENABLED"}</span>
@@ -1262,11 +1232,11 @@ pub fn job_modal(props: &JobModalProps) -> Html {
             })
             .unwrap_or_default()
     });
-    let machines_raw = use_state(|| {
+    let machines = use_state(|| {
         props
             .editing
             .as_ref()
-            .map(|j| machines_to_text(&j.machines))
+            .map(|j| j.machines.clone())
             .unwrap_or_default()
     });
     let enabled = use_state(|| props.editing.as_ref().map(|j| j.enabled).unwrap_or(true));
@@ -1319,11 +1289,8 @@ pub fn job_modal(props: &JobModalProps) -> Html {
     };
 
     let on_machines = {
-        let machines_raw = machines_raw.clone();
-        Callback::from(move |e: InputEvent| {
-            let input: HtmlInputElement = e.target_unchecked_into();
-            machines_raw.set(input.value());
-        })
+        let machines = machines.clone();
+        Callback::from(move |next: Vec<String>| machines.set(next))
     };
 
     let on_close_click = {
@@ -1334,7 +1301,7 @@ pub fn job_modal(props: &JobModalProps) -> Html {
         let schedule = schedule.clone();
         let handler = handler.clone();
         let meta_raw = meta_raw.clone();
-        let machines_raw = machines_raw.clone();
+        let machines = machines.clone();
         let meta_err = meta_err.clone();
         let enabled = enabled.clone();
         let saving = saving.clone();
@@ -1353,7 +1320,7 @@ pub fn job_modal(props: &JobModalProps) -> Html {
                 schedule: (*schedule).clone(),
                 handler: (*handler).clone(),
                 metadata,
-                machines: text_to_machines(&machines_raw),
+                machines: (*machines).clone(),
                 enabled: *enabled,
             });
         })
@@ -1439,21 +1406,7 @@ pub fn job_modal(props: &JobModalProps) -> Html {
                             <div class="field-err">{(*meta_err).clone()}</div>
                         }
                     </div>
-                    <div class="form-group">
-                        <label class="form-label">
-                            {"MACHINES "}
-                            <span style="color:var(--text-ghost)">{"(comma-separated; blank = runs nowhere)"}</span>
-                        </label>
-                        <input
-                            class="form-input"
-                            type="text"
-                            placeholder="laptop, work, server"
-                            value={(*machines_raw).clone()}
-                            oninput={on_machines}
-                            autocomplete="off"
-                            spellcheck="false"
-                        />
-                    </div>
+                    <MachinesPicker value={(*machines).clone()} on_change={on_machines} />
                     <div class="form-group" style="margin-bottom:0">
                         <div class="toggle-row">
                             <span class="toggle-row-label">{"ENABLED"}</span>

--- a/ui/src/machines.rs
+++ b/ui/src/machines.rs
@@ -1,0 +1,130 @@
+//! Reusable machine-targeting picker shared by the routine and cron-job forms.
+//!
+//! Fetches the daemon's known machine names (`GET /api/v1/machines` — every name referenced by a
+//! routine or cron job, plus this machine's own identity) and renders them as toggleable chips.
+//! The selection stays open-ended: a brand-new name can be added even if no entry references it
+//! yet, so the picker never blocks assigning a machine the daemon hasn't seen.
+
+use gloo_net::http::Request;
+use wasm_bindgen_futures::spawn_local;
+use web_sys::HtmlInputElement;
+use yew::prelude::*;
+
+async fn api_machines() -> Result<Vec<String>, String> {
+    Request::get("/api/v1/machines")
+        .send()
+        .await
+        .map_err(|e| e.to_string())?
+        .json::<Vec<String>>()
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[derive(Properties, PartialEq)]
+pub struct MachinesPickerProps {
+    /// Currently selected machine names.
+    pub value: Vec<String>,
+    /// Emits the new (sorted, de-duplicated) selection whenever it changes.
+    pub on_change: Callback<Vec<String>>,
+}
+
+#[function_component(MachinesPicker)]
+pub fn machines_picker(props: &MachinesPickerProps) -> Html {
+    // Known machines fetched from the daemon. Merged with the current selection below so a machine
+    // that is assigned but not yet referenced elsewhere still renders as a chip.
+    let known = use_state(Vec::<String>::new);
+    {
+        let known = known.clone();
+        use_effect_with((), move |_| {
+            spawn_local(async move {
+                if let Ok(list) = api_machines().await {
+                    known.set(list);
+                }
+            });
+            || ()
+        });
+    }
+    let new_name = use_state(String::new);
+
+    // Candidate chips: union of known + selected, sorted and de-duplicated.
+    let mut candidates: Vec<String> = known
+        .iter()
+        .cloned()
+        .chain(props.value.iter().cloned())
+        .collect();
+    candidates.sort();
+    candidates.dedup();
+
+    let toggle = {
+        let on_change = props.on_change.clone();
+        let value = props.value.clone();
+        Callback::from(move |name: String| {
+            let mut next = value.clone();
+            if let Some(pos) = next.iter().position(|m| m == &name) {
+                next.remove(pos);
+            } else {
+                next.push(name);
+                next.sort();
+            }
+            on_change.emit(next);
+        })
+    };
+
+    let on_new_input = {
+        let new_name = new_name.clone();
+        Callback::from(move |e: InputEvent| {
+            let i: HtmlInputElement = e.target_unchecked_into();
+            new_name.set(i.value());
+        })
+    };
+
+    let add_new = {
+        let on_change = props.on_change.clone();
+        let value = props.value.clone();
+        let new_name = new_name.clone();
+        Callback::from(move |_: MouseEvent| {
+            let name = new_name.trim().to_string();
+            // Ignore blanks and names already selected; either way clear the input.
+            if !name.is_empty() && !value.contains(&name) {
+                let mut next = value.clone();
+                next.push(name);
+                next.sort();
+                on_change.emit(next);
+            }
+            new_name.set(String::new());
+        })
+    };
+
+    html! {
+        <div class="form-group">
+            <label class="form-label">
+                {"MACHINES "}
+                <span style="color:var(--text-ghost)">{"(pick targets; none = runs nowhere)"}</span>
+            </label>
+            if candidates.is_empty() {
+                <div class="machine-empty">{"No machines known yet — add one below."}</div>
+            } else {
+                <div class="machine-chips">
+                    { for candidates.iter().map(|name| {
+                        let on = props.value.contains(name);
+                        let cls = if on { "machine-chip on" } else { "machine-chip" };
+                        let toggle = toggle.clone();
+                        let n = name.clone();
+                        html! {
+                            <button type="button" class={cls}
+                                onclick={Callback::from(move |_: MouseEvent| toggle.emit(n.clone()))}>
+                                { name.clone() }
+                            </button>
+                        }
+                    }) }
+                </div>
+            }
+            <div class="machine-add">
+                <input class="form-input" type="text" placeholder="add a machine name"
+                    value={(*new_name).clone()} oninput={on_new_input}
+                    autocomplete="off" spellcheck="false" />
+                <button type="button" class="preset-btn" onclick={add_new}>{"ADD"}</button>
+            </div>
+        </div>
+    }
+}

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -8,6 +8,7 @@ use yew_router::prelude::*;
 
 mod cron_jobs;
 mod day_timeline;
+mod machines;
 mod routines;
 use cron_jobs::CronJobsPage;
 use routines::RoutinesPage;

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -13,6 +13,7 @@ use web_sys::{HtmlInputElement, HtmlSelectElement};
 use yew::prelude::*;
 
 use crate::day_timeline::{DayTimeline, TimelineItem};
+use crate::machines::MachinesPicker;
 use crate::{describe_cron_live, parse_cron, reltime, ToastKind};
 
 /// Agents the daemon ships built-in configs for (see `src/routines/agents`). Keep in sync with
@@ -1203,20 +1204,6 @@ fn text_to_repos(text: &str) -> Vec<Repository> {
         .collect()
 }
 
-/// Render a machines list as a comma-separated string for the form input.
-fn machines_to_text(machines: &[String]) -> String {
-    machines.join(", ")
-}
-
-/// Parse a comma-separated machines input into a list, trimming blanks and dropping empties.
-fn text_to_machines(text: &str) -> Vec<String> {
-    text.split(',')
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string)
-        .collect()
-}
-
 /// Parse a TTL textarea value into seconds. Blank/whitespace → `None` (use the server default);
 /// a valid non-negative integer → `Some(secs)`; anything else → `None`.
 fn parse_ttl(raw: &str) -> Option<u64> {
@@ -1297,10 +1284,10 @@ pub fn routine_form(props: &FormProps) -> Html {
             .map(|r| repos_to_text(&r.repositories))
             .unwrap_or_default()
     });
-    let machines_raw = use_state(|| {
+    let machines = use_state(|| {
         editing
             .as_ref()
-            .map(|r| machines_to_text(&r.machines))
+            .map(|r| r.machines.clone())
             .unwrap_or_default()
     });
     let enabled = use_state(|| editing.as_ref().map(|r| r.enabled).unwrap_or(true));
@@ -1352,11 +1339,8 @@ pub fn routine_form(props: &FormProps) -> Html {
         })
     };
     let on_machines = {
-        let machines_raw = machines_raw.clone();
-        Callback::from(move |e: InputEvent| {
-            let i: HtmlInputElement = e.target_unchecked_into();
-            machines_raw.set(i.value());
-        })
+        let machines = machines.clone();
+        Callback::from(move |next: Vec<String>| machines.set(next))
     };
     let on_enabled = {
         let enabled = enabled.clone();
@@ -1394,7 +1378,7 @@ pub fn routine_form(props: &FormProps) -> Html {
         let agent = agent.clone();
         let prompt = prompt.clone();
         let repos_raw = repos_raw.clone();
-        let machines_raw = machines_raw.clone();
+        let machines = machines.clone();
         let enabled = enabled.clone();
         let ttl_raw = ttl_raw.clone();
         let saving = saving.clone();
@@ -1410,7 +1394,7 @@ pub fn routine_form(props: &FormProps) -> Html {
                 agent: (*agent).clone(),
                 prompt: (*prompt).clone(),
                 repositories: text_to_repos(&repos_raw),
-                machines: text_to_machines(&machines_raw),
+                machines: (*machines).clone(),
                 enabled: *enabled,
                 ttl_secs: parse_ttl(&ttl_raw),
             });
@@ -1477,14 +1461,7 @@ pub fn routine_form(props: &FormProps) -> Html {
                 <textarea class="form-input" placeholder={"https://github.com/org/repo main"}
                     value={(*repos_raw).clone()} oninput={on_repos} />
             </div>
-            <div class="form-group">
-                <label class="form-label">
-                    {"MACHINES "}
-                    <span style="color:var(--text-ghost)">{"(comma-separated; blank = runs nowhere)"}</span>
-                </label>
-                <input class="form-input" type="text" placeholder="laptop, work, server"
-                    value={(*machines_raw).clone()} oninput={on_machines} autocomplete="off" spellcheck="false" />
-            </div>
+            <MachinesPicker value={(*machines).clone()} on_change={on_machines} />
             <div class="form-group">
                 <label class="form-label">
                     {"WORKBENCH TTL "}


### PR DESCRIPTION
## What

Turns the free-text `MACHINES` field (added in #582) into a **picker**. Closes #586.

## Backend

New `GET /api/v1/machines` returns the sorted, de-duplicated set of known machine names: every name referenced by any routine or cron job, plus this daemon's own resolved identity (`machine::current_machine()`) so the local machine is always pickable even before anything targets it. Mirrors `GET /agents` and the `moadim machine list` CLI, but reads the live in-memory stores. Registered in the OpenAPI spec (`apis/openapi.json` regenerated).

## UI

New reusable `MachinesPicker` component (`ui/src/machines.rs`), used by both the routine and cron-job create/edit forms:
- Fetches `/api/v1/machines` and renders known names as toggleable chips (selected chips highlighted).
- Merges in any already-selected machine not yet in the known set, so editing an entry always shows its current targets.
- Keeps a text input + `ADD` so a brand-new machine name can still be assigned — the field stays open-ended.

Replaces the comma-separated text input and its parse/format helpers in both forms.

## Tests

`build_app_serves_machines` seeds an overlapping routine + cron job and asserts the response is the sorted, de-duplicated union plus the local identity. Line coverage stays at 100%.

## Out of scope

- A persistent machine registry (known set stays derived).
- Exposing machines over MCP.

Closes #586

🤖 Generated with [Claude Code](https://claude.com/claude-code)