### PR TITLE
test: isolate routine tests behind MOADIM_HOME_OVERRIDE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,14 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   and `release.yml` are now reusable (`workflow_call`) and keep their `v*` tag-push
   trigger as a hand-cut fallback.
 
+### Fixed
+
+- **Test isolation.** The routine service and storage unit tests no longer write
+  into the developer's real `~/.config/moadim` home. They resolved paths through
+  `paths::home()`, which falls back to the real home when `MOADIM_HOME_OVERRIDE`
+  is unset, so tests leaked routine dirs (and the migration tests even scanned real
+  state). Every test now runs against an isolated temp home.
+
 ## [0.14.0] - 2026-06-21
 
 ### Added

--- a/src/routine_storage_tests.rs
+++ b/src/routine_storage_tests.rs
@@ -46,40 +46,43 @@ fn load_store_from_dir_inserts_written_routines() {
 
 #[test]
 fn write_then_load_round_trips() {
-    let id = "rs-roundtrip-id";
-    let title = "Rs Roundtrip Routine";
-    let slug = slugify(title);
-    let routine = make_routine(id, title);
-    write_routine(&routine).unwrap();
+    with_override_home(|_home| {
+        let id = "rs-roundtrip-id";
+        let title = "Rs Roundtrip Routine";
+        let slug = slugify(title);
+        let routine = make_routine(id, title);
+        write_routine(&routine).unwrap();
 
-    assert!(crate::paths::routine_toml_path(&slug).exists());
-    assert!(crate::paths::routine_prompt_path(&slug).exists());
-    assert!(crate::paths::routine_gitignore_path(&slug).exists());
+        assert!(crate::paths::routine_toml_path(&slug).exists());
+        assert!(crate::paths::routine_prompt_path(&slug).exists());
+        assert!(crate::paths::routine_gitignore_path(&slug).exists());
 
-    let loaded = load_routine_from_dir(&slug).unwrap();
-    assert_eq!(loaded.id, id);
-    assert_eq!(loaded.schedule, "@daily");
-    assert_eq!(loaded.title, title);
-    assert_eq!(loaded.agent, "claude");
-    assert_eq!(loaded.prompt, "task");
-    assert_eq!(loaded.repositories.len(), 1);
-    assert_eq!(loaded.repositories[0].branch.as_deref(), Some("main"));
-    assert!(loaded.enabled);
+        let loaded = load_routine_from_dir(&slug).unwrap();
+        assert_eq!(loaded.id, id);
+        assert_eq!(loaded.schedule, "@daily");
+        assert_eq!(loaded.title, title);
+        assert_eq!(loaded.agent, "claude");
+        assert_eq!(loaded.prompt, "task");
+        assert_eq!(loaded.repositories.len(), 1);
+        assert_eq!(loaded.repositories[0].branch.as_deref(), Some("main"));
+        assert!(loaded.enabled);
 
-    remove_routine_dir(&slug).unwrap();
-    assert!(!crate::paths::routine_dir(&slug).exists());
+        remove_routine_dir(&slug).unwrap();
+        assert!(!crate::paths::routine_dir(&slug).exists());
+    });
 }
 
 #[test]
 fn prompt_file_contains_composed_prompt() {
-    let title = "Rs Prompt Routine";
-    let slug = slugify(title);
-    write_routine(&make_routine("rs-prompt-id", title)).unwrap();
-    let prompt = std::fs::read_to_string(crate::paths::routine_prompt_path(&slug)).unwrap();
-    assert!(prompt.contains("# Workbench"));
-    assert!(prompt.contains("https://example.com/r.git (branch main)"));
-    assert!(prompt.contains("task"));
-    remove_routine_dir(&slug).unwrap();
+    with_override_home(|_home| {
+        let title = "Rs Prompt Routine";
+        let slug = slugify(title);
+        write_routine(&make_routine("rs-prompt-id", title)).unwrap();
+        let prompt = std::fs::read_to_string(crate::paths::routine_prompt_path(&slug)).unwrap();
+        assert!(prompt.contains("# Workbench"));
+        assert!(prompt.contains("https://example.com/r.git (branch main)"));
+        assert!(prompt.contains("task"));
+    });
 }
 
 #[test]
@@ -87,31 +90,31 @@ fn write_routine_persists_composed_prompt_sidecar_with_repos() {
     // Focused coverage for the `atomic_write(routine_prompt_path, compose_prompt(..))`
     // call in `write_routine`: a routine with a non-empty prompt AND repositories runs
     // `compose_prompt` fully, and the composed body lands in prompt.md on disk.
-    let id = "rs-prompt-sidecar-id";
-    let title = "Rs Prompt Sidecar Routine";
-    let slug = slugify(title);
-    let mut routine = make_routine(id, title);
-    routine.prompt = "line one\nline two".to_string();
-    routine.repositories = vec![
-        Repository {
-            repository: "https://example.com/a.git".to_string(),
-            branch: Some("dev".to_string()),
-        },
-        Repository {
-            repository: "https://example.com/b.git".to_string(),
-            branch: None,
-        },
-    ];
+    with_override_home(|_home| {
+        let id = "rs-prompt-sidecar-id";
+        let title = "Rs Prompt Sidecar Routine";
+        let slug = slugify(title);
+        let mut routine = make_routine(id, title);
+        routine.prompt = "line one\nline two".to_string();
+        routine.repositories = vec![
+            Repository {
+                repository: "https://example.com/a.git".to_string(),
+                branch: Some("dev".to_string()),
+            },
+            Repository {
+                repository: "https://example.com/b.git".to_string(),
+                branch: None,
+            },
+        ];
 
-    write_routine(&routine).unwrap();
+        write_routine(&routine).unwrap();
 
-    let written = std::fs::read_to_string(crate::paths::routine_prompt_path(&slug)).unwrap();
-    assert_eq!(written, compose_prompt(&routine));
-    assert!(written.contains("https://example.com/a.git (branch dev)"));
-    assert!(written.contains("https://example.com/b.git\n"));
-    assert!(written.contains("line one\nline two"));
-
-    remove_routine_dir(&slug).unwrap();
+        let written = std::fs::read_to_string(crate::paths::routine_prompt_path(&slug)).unwrap();
+        assert_eq!(written, compose_prompt(&routine));
+        assert!(written.contains("https://example.com/a.git (branch dev)"));
+        assert!(written.contains("https://example.com/b.git\n"));
+        assert!(written.contains("line one\nline two"));
+    });
 }
 
 #[test]
@@ -120,27 +123,27 @@ fn write_routine_errors_when_prompt_sidecar_write_fails() {
     // the routine dir, gitignore, and `routine.toml` all write successfully, but a
     // non-empty directory occupies the `prompt.md` path, so the atomic rename over it
     // fails and `write_routine` returns that error.
-    let id = "rs-prompt-write-fail-id";
-    let title = "Rs Prompt Write Fail Routine";
-    let slug = slugify(title);
-    let dir = crate::paths::routine_dir(&slug);
-    std::fs::create_dir_all(&dir).unwrap();
-    // Block prompt.md with a *non-empty* directory so the atomic rename over it fails.
-    let prompt_dir = crate::paths::routine_prompt_path(&slug);
-    std::fs::create_dir_all(&prompt_dir).unwrap();
-    std::fs::write(prompt_dir.join("occupant"), "keep me non-empty").unwrap();
+    with_override_home(|_home| {
+        let id = "rs-prompt-write-fail-id";
+        let title = "Rs Prompt Write Fail Routine";
+        let slug = slugify(title);
+        let dir = crate::paths::routine_dir(&slug);
+        std::fs::create_dir_all(&dir).unwrap();
+        // Block prompt.md with a *non-empty* directory so the atomic rename over it fails.
+        let prompt_dir = crate::paths::routine_prompt_path(&slug);
+        std::fs::create_dir_all(&prompt_dir).unwrap();
+        std::fs::write(prompt_dir.join("occupant"), "keep me non-empty").unwrap();
 
-    let err = write_routine(&make_routine(id, title)).unwrap_err();
-    let _ = err;
+        let err = write_routine(&make_routine(id, title)).unwrap_err();
+        let _ = err;
 
-    // routine.toml was written successfully before the prompt step failed.
-    assert!(crate::paths::routine_toml_path(&slug).exists());
-    assert!(
-        prompt_dir.is_dir(),
-        "the blocking prompt dir is left in place"
-    );
-
-    remove_routine_dir(&slug).unwrap();
+        // routine.toml was written successfully before the prompt step failed.
+        assert!(crate::paths::routine_toml_path(&slug).exists());
+        assert!(
+            prompt_dir.is_dir(),
+            "the blocking prompt dir is left in place"
+        );
+    });
 }
 
 #[test]
@@ -148,127 +151,129 @@ fn load_routine_from_dir_applies_defaults_for_absent_optional_fields() {
     // A minimal routine.toml that omits prompt, enabled, timestamps, and id exercises the
     // default-fallback arms in load_routine_from_dir: prompt -> "", enabled -> true,
     // created_at/updated_at -> 0, and id -> dir_name (legacy fallback).
-    let slug = "rs-defaults-routine";
-    let dir = crate::paths::routine_dir(slug);
-    std::fs::create_dir_all(&dir).unwrap();
-    std::fs::write(
-        crate::paths::routine_toml_path(slug),
-        "schedule = \"@daily\"\ntitle = \"Rs Defaults Routine\"\nagent = \"claude\"\n",
-    )
-    .unwrap();
+    with_override_home(|_home| {
+        let slug = "rs-defaults-routine";
+        let dir = crate::paths::routine_dir(slug);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            crate::paths::routine_toml_path(slug),
+            "schedule = \"@daily\"\ntitle = \"Rs Defaults Routine\"\nagent = \"claude\"\n",
+        )
+        .unwrap();
 
-    let loaded = load_routine_from_dir(slug).unwrap();
-    assert_eq!(loaded.id, slug, "absent id falls back to the dir name");
-    assert_eq!(loaded.prompt, "", "absent prompt defaults to empty");
-    assert!(loaded.enabled, "absent enabled defaults to true");
-    assert_eq!(loaded.created_at, 0);
-    assert_eq!(loaded.updated_at, 0);
-    assert!(loaded.repositories.is_empty());
-
-    remove_routine_dir(slug).unwrap();
+        let loaded = load_routine_from_dir(slug).unwrap();
+        assert_eq!(loaded.id, slug, "absent id falls back to the dir name");
+        assert_eq!(loaded.prompt, "", "absent prompt defaults to empty");
+        assert!(loaded.enabled, "absent enabled defaults to true");
+        assert_eq!(loaded.created_at, 0);
+        assert_eq!(loaded.updated_at, 0);
+        assert!(loaded.repositories.is_empty());
+    });
 }
 
 #[test]
 fn load_routine_from_dir_missing_returns_none() {
-    assert!(load_routine_from_dir("rs-does-not-exist-zzz").is_none());
+    with_override_home(|_home| {
+        assert!(load_routine_from_dir("rs-does-not-exist-zzz").is_none());
+    });
 }
 
 #[test]
 fn last_manual_trigger_at_persists_to_sidecar_not_routine_toml() {
     // Runtime trigger state is written to the gitignored `state.local.toml` sidecar and kept out
     // of the version-controlled `routine.toml`, then read back from the sidecar on load.
-    let title = "Rs Sidecar Routine";
-    let slug = slugify(title);
-    let mut routine = make_routine("rs-sidecar-id", title);
-    routine.last_manual_trigger_at = Some(12345);
-    write_routine(&routine).unwrap();
+    with_override_home(|_home| {
+        let title = "Rs Sidecar Routine";
+        let slug = slugify(title);
+        let mut routine = make_routine("rs-sidecar-id", title);
+        routine.last_manual_trigger_at = Some(12345);
+        write_routine(&routine).unwrap();
 
-    // The tracked config file does not carry the runtime timestamp...
-    let toml_text = std::fs::read_to_string(crate::paths::routine_toml_path(&slug)).unwrap();
-    assert!(
-        !toml_text.contains("last_manual_trigger_at"),
-        "routine.toml must not carry runtime trigger state: {toml_text}"
-    );
-    // ...the gitignored sidecar does, and it round-trips through load.
-    assert!(crate::paths::routine_state_path(&slug).exists());
-    let state_text = std::fs::read_to_string(crate::paths::routine_state_path(&slug)).unwrap();
-    assert!(state_text.contains("last_manual_trigger_at"));
-    assert_eq!(
-        load_routine_from_dir(&slug).unwrap().last_manual_trigger_at,
-        Some(12345)
-    );
-
-    remove_routine_dir(&slug).unwrap();
+        // The tracked config file does not carry the runtime timestamp...
+        let toml_text = std::fs::read_to_string(crate::paths::routine_toml_path(&slug)).unwrap();
+        assert!(
+            !toml_text.contains("last_manual_trigger_at"),
+            "routine.toml must not carry runtime trigger state: {toml_text}"
+        );
+        // ...the gitignored sidecar does, and it round-trips through load.
+        assert!(crate::paths::routine_state_path(&slug).exists());
+        let state_text = std::fs::read_to_string(crate::paths::routine_state_path(&slug)).unwrap();
+        assert!(state_text.contains("last_manual_trigger_at"));
+        assert_eq!(
+            load_routine_from_dir(&slug).unwrap().last_manual_trigger_at,
+            Some(12345)
+        );
+    });
 }
 
 #[test]
 fn write_routine_clears_stale_sidecar_when_untriggered() {
     // Re-writing a routine whose trigger state has been cleared removes the now-stale sidecar, so
     // the on-disk state mirrors the in-memory `None`.
-    let title = "Rs Clear Sidecar Routine";
-    let slug = slugify(title);
-    let mut routine = make_routine("rs-clear-id", title);
-    routine.last_manual_trigger_at = Some(999);
-    write_routine(&routine).unwrap();
-    assert!(crate::paths::routine_state_path(&slug).exists());
+    with_override_home(|_home| {
+        let title = "Rs Clear Sidecar Routine";
+        let slug = slugify(title);
+        let mut routine = make_routine("rs-clear-id", title);
+        routine.last_manual_trigger_at = Some(999);
+        write_routine(&routine).unwrap();
+        assert!(crate::paths::routine_state_path(&slug).exists());
 
-    routine.last_manual_trigger_at = None;
-    write_routine(&routine).unwrap();
-    assert!(
-        !crate::paths::routine_state_path(&slug).exists(),
-        "sidecar should be removed when there is no trigger state"
-    );
-    assert_eq!(
-        load_routine_from_dir(&slug).unwrap().last_manual_trigger_at,
-        None
-    );
-
-    remove_routine_dir(&slug).unwrap();
+        routine.last_manual_trigger_at = None;
+        write_routine(&routine).unwrap();
+        assert!(
+            !crate::paths::routine_state_path(&slug).exists(),
+            "sidecar should be removed when there is no trigger state"
+        );
+        assert_eq!(
+            load_routine_from_dir(&slug).unwrap().last_manual_trigger_at,
+            None
+        );
+    });
 }
 
 #[test]
 fn load_routine_falls_back_to_legacy_last_triggered_in_routine_toml() {
     // A routine written by an older daemon stored `last_triggered_at` inside `routine.toml` and
     // has no sidecar. Load still surfaces the timestamp via the legacy-field fallback.
-    let slug = "rs-legacy-trigger-routine";
-    let dir = crate::paths::routine_dir(slug);
-    std::fs::create_dir_all(&dir).unwrap();
-    std::fs::write(
-        crate::paths::routine_toml_path(slug),
-        "schedule = \"@daily\"\ntitle = \"Rs Legacy Trigger\"\nagent = \"claude\"\nlast_triggered_at = 777\n",
-    )
-    .unwrap();
-    // No sidecar exists yet.
-    assert!(!crate::paths::routine_state_path(slug).exists());
+    with_override_home(|_home| {
+        let slug = "rs-legacy-trigger-routine";
+        let dir = crate::paths::routine_dir(slug);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            crate::paths::routine_toml_path(slug),
+            "schedule = \"@daily\"\ntitle = \"Rs Legacy Trigger\"\nagent = \"claude\"\nlast_triggered_at = 777\n",
+        )
+        .unwrap();
+        // No sidecar exists yet.
+        assert!(!crate::paths::routine_state_path(slug).exists());
 
-    assert_eq!(
-        load_routine_from_dir(slug).unwrap().last_manual_trigger_at,
-        Some(777)
-    );
-
-    remove_routine_dir(slug).unwrap();
+        assert_eq!(
+            load_routine_from_dir(slug).unwrap().last_manual_trigger_at,
+            Some(777)
+        );
+    });
 }
 
 #[test]
 fn load_routine_ignores_unparsable_sidecar() {
     // A malformed `state.local.toml` parses to `None` (rather than crashing the load), and with no
     // legacy field in `routine.toml` the routine loads with no trigger timestamp.
-    let slug = "rs-bad-sidecar-routine";
-    let dir = crate::paths::routine_dir(slug);
-    std::fs::create_dir_all(&dir).unwrap();
-    std::fs::write(
-        crate::paths::routine_toml_path(slug),
-        "schedule = \"@daily\"\ntitle = \"Rs Bad Sidecar\"\nagent = \"claude\"\n",
-    )
-    .unwrap();
-    std::fs::write(crate::paths::routine_state_path(slug), "= not valid toml =").unwrap();
+    with_override_home(|_home| {
+        let slug = "rs-bad-sidecar-routine";
+        let dir = crate::paths::routine_dir(slug);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            crate::paths::routine_toml_path(slug),
+            "schedule = \"@daily\"\ntitle = \"Rs Bad Sidecar\"\nagent = \"claude\"\n",
+        )
+        .unwrap();
+        std::fs::write(crate::paths::routine_state_path(slug), "= not valid toml =").unwrap();
 
-    assert_eq!(
-        load_routine_from_dir(slug).unwrap().last_manual_trigger_at,
-        None
-    );
-
-    remove_routine_dir(slug).unwrap();
+        assert_eq!(
+            load_routine_from_dir(slug).unwrap().last_manual_trigger_at,
+            None
+        );
+    });
 }
 
 #[test]
@@ -276,48 +281,48 @@ fn load_routine_reads_scheduled_trigger_from_sidecar() {
     // `last_scheduled_trigger_at` lives in its own gitignored `scheduled.local.toml` sidecar,
     // written by the routine's `run.sh` at cron fire time, and is read back on load — independently
     // of the manual-trigger sidecar.
-    let title = "Rs Scheduled Sidecar Routine";
-    let slug = slugify(title);
-    write_routine(&make_routine("rs-scheduled-id", title)).unwrap();
-    std::fs::write(
-        crate::paths::routine_scheduled_state_path(&slug),
-        "last_scheduled_trigger_at = 4242\n",
-    )
-    .unwrap();
+    with_override_home(|_home| {
+        let title = "Rs Scheduled Sidecar Routine";
+        let slug = slugify(title);
+        write_routine(&make_routine("rs-scheduled-id", title)).unwrap();
+        std::fs::write(
+            crate::paths::routine_scheduled_state_path(&slug),
+            "last_scheduled_trigger_at = 4242\n",
+        )
+        .unwrap();
 
-    let loaded = load_routine_from_dir(&slug).unwrap();
-    assert_eq!(loaded.last_scheduled_trigger_at, Some(4242));
-    // The scheduled timestamp is distinct from the (unset) manual one.
-    assert_eq!(loaded.last_manual_trigger_at, None);
-
-    remove_routine_dir(&slug).unwrap();
+        let loaded = load_routine_from_dir(&slug).unwrap();
+        assert_eq!(loaded.last_scheduled_trigger_at, Some(4242));
+        // The scheduled timestamp is distinct from the (unset) manual one.
+        assert_eq!(loaded.last_manual_trigger_at, None);
+    });
 }
 
 #[test]
 fn load_routine_ignores_unparsable_scheduled_sidecar() {
     // A malformed `scheduled.local.toml` parses to `None` rather than crashing the load.
-    let slug = "rs-bad-scheduled-sidecar-routine";
-    let dir = crate::paths::routine_dir(slug);
-    std::fs::create_dir_all(&dir).unwrap();
-    std::fs::write(
-        crate::paths::routine_toml_path(slug),
-        "schedule = \"@daily\"\ntitle = \"Rs Bad Scheduled Sidecar\"\nagent = \"claude\"\n",
-    )
-    .unwrap();
-    std::fs::write(
-        crate::paths::routine_scheduled_state_path(slug),
-        "= not valid toml =",
-    )
-    .unwrap();
+    with_override_home(|_home| {
+        let slug = "rs-bad-scheduled-sidecar-routine";
+        let dir = crate::paths::routine_dir(slug);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            crate::paths::routine_toml_path(slug),
+            "schedule = \"@daily\"\ntitle = \"Rs Bad Scheduled Sidecar\"\nagent = \"claude\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            crate::paths::routine_scheduled_state_path(slug),
+            "= not valid toml =",
+        )
+        .unwrap();
 
-    assert_eq!(
-        load_routine_from_dir(slug)
-            .unwrap()
-            .last_scheduled_trigger_at,
-        None
-    );
-
-    remove_routine_dir(slug).unwrap();
+        assert_eq!(
+            load_routine_from_dir(slug)
+                .unwrap()
+                .last_scheduled_trigger_at,
+            None
+        );
+    });
 }
 
 #[test]
@@ -325,69 +330,71 @@ fn write_routine_preserves_scheduler_written_scheduled_sidecar() {
     // The daemon never writes the scheduled sidecar, so re-persisting a routine (e.g. on startup or
     // an update) must leave the scheduler-stamped `scheduled.local.toml` untouched — the bug this
     // separate-file design exists to prevent.
-    let title = "Rs Preserve Scheduled Routine";
-    let slug = slugify(title);
-    let mut routine = make_routine("rs-preserve-scheduled-id", title);
-    write_routine(&routine).unwrap();
+    with_override_home(|_home| {
+        let title = "Rs Preserve Scheduled Routine";
+        let slug = slugify(title);
+        let mut routine = make_routine("rs-preserve-scheduled-id", title);
+        write_routine(&routine).unwrap();
 
-    // Simulate a scheduled cron firing stamping the sidecar.
-    std::fs::write(
-        crate::paths::routine_scheduled_state_path(&slug),
-        "last_scheduled_trigger_at = 55\n",
-    )
-    .unwrap();
+        // Simulate a scheduled cron firing stamping the sidecar.
+        std::fs::write(
+            crate::paths::routine_scheduled_state_path(&slug),
+            "last_scheduled_trigger_at = 55\n",
+        )
+        .unwrap();
 
-    // A subsequent daemon-side write (manual trigger recorded, routine updated, repersist, …).
-    routine.last_manual_trigger_at = Some(7);
-    write_routine(&routine).unwrap();
+        // A subsequent daemon-side write (manual trigger recorded, routine updated, repersist, …).
+        routine.last_manual_trigger_at = Some(7);
+        write_routine(&routine).unwrap();
 
-    assert!(
-        crate::paths::routine_scheduled_state_path(&slug).exists(),
-        "daemon write must not remove the scheduler-owned sidecar"
-    );
-    let loaded = load_routine_from_dir(&slug).unwrap();
-    assert_eq!(loaded.last_scheduled_trigger_at, Some(55));
-    assert_eq!(loaded.last_manual_trigger_at, Some(7));
-
-    remove_routine_dir(&slug).unwrap();
+        assert!(
+            crate::paths::routine_scheduled_state_path(&slug).exists(),
+            "daemon write must not remove the scheduler-owned sidecar"
+        );
+        let loaded = load_routine_from_dir(&slug).unwrap();
+        assert_eq!(loaded.last_scheduled_trigger_at, Some(55));
+        assert_eq!(loaded.last_manual_trigger_at, Some(7));
+    });
 }
 
 #[test]
 fn torn_routine_toml_loads_as_none() {
     // A truncated/garbage routine.toml (e.g. left by a crash mid-write) must not panic or load a
     // half-baked routine; the loader returns None and the routine is simply absent.
-    let slug = "rs-torn-toml-routine";
-    let dir = crate::paths::routine_dir(slug);
-    std::fs::create_dir_all(&dir).unwrap();
-    std::fs::write(crate::paths::routine_toml_path(slug), "id = \"x\"\nschedu").unwrap();
-    assert!(load_routine_from_dir(slug).is_none());
-    remove_routine_dir(slug).unwrap();
+    with_override_home(|_home| {
+        let slug = "rs-torn-toml-routine";
+        let dir = crate::paths::routine_dir(slug);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(crate::paths::routine_toml_path(slug), "id = \"x\"\nschedu").unwrap();
+        assert!(load_routine_from_dir(slug).is_none());
+    });
 }
 
 #[test]
 fn write_routine_leaves_no_tmp_residue() {
-    let id = "rs-no-residue-id";
-    let title = "Rs No Residue Routine";
-    let slug = slugify(title);
-    write_routine(&make_routine(id, title)).unwrap();
-    let residue = std::fs::read_dir(crate::paths::routine_dir(&slug))
-        .unwrap()
-        .filter_map(|entry| entry.ok())
-        .filter(|entry| entry.file_name().to_string_lossy().contains(".tmp"))
-        .count();
-    assert_eq!(residue, 0, "atomic_write must leave no .tmp files behind");
-    remove_routine_dir(&slug).unwrap();
+    with_override_home(|_home| {
+        let id = "rs-no-residue-id";
+        let title = "Rs No Residue Routine";
+        let slug = slugify(title);
+        write_routine(&make_routine(id, title)).unwrap();
+        let residue = std::fs::read_dir(crate::paths::routine_dir(&slug))
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.file_name().to_string_lossy().contains(".tmp"))
+            .count();
+        assert_eq!(residue, 0, "atomic_write must leave no .tmp files behind");
+    });
 }
 
 #[test]
 fn load_store_includes_written_routine() {
-    let id = "rs-loadstore-id";
-    let title = "Rs Loadstore Routine";
-    let slug = slugify(title);
-    write_routine(&make_routine(id, title)).unwrap();
-    let store = load_store();
-    assert!(store.lock().unwrap().contains_key(id));
-    remove_routine_dir(&slug).unwrap();
+    with_override_home(|_home| {
+        let id = "rs-loadstore-id";
+        let title = "Rs Loadstore Routine";
+        write_routine(&make_routine(id, title)).unwrap();
+        let store = load_store();
+        assert!(store.lock().unwrap().contains_key(id));
+    });
 }
 
 #[test]
@@ -398,55 +405,58 @@ fn load_store_from_dir_missing_dir_empty() {
 
 #[test]
 fn remove_routine_dir_noop_when_absent() {
-    remove_routine_dir("rs-never-created-zzz").unwrap();
+    with_override_home(|_home| {
+        remove_routine_dir("rs-never-created-zzz").unwrap();
+    });
 }
 
 #[test]
 fn migrate_routine_dirs_moves_legacy_uuid_dir_to_slug() {
-    let id = "rs-legacy-uuid-1234";
-    let title = "Rs Legacy Migrate Routine";
-    let slug = slugify(title);
-    let legacy_dir = crate::paths::routine_dir(id);
-    std::fs::create_dir_all(&legacy_dir).unwrap();
-    // Legacy layout: routine.toml + prompt.md live under the UUID-named dir.
-    let toml = format!(
-        "id = \"{id}\"\nschedule = \"@daily\"\ntitle = \"{title}\"\nagent = \"claude\"\nprompt = \"task\"\nenabled = true\n"
-    );
-    std::fs::write(legacy_dir.join("routine.toml"), toml).unwrap();
-    std::fs::write(legacy_dir.join("prompt.md"), "legacy prompt").unwrap();
+    with_override_home(|_home| {
+        let id = "rs-legacy-uuid-1234";
+        let title = "Rs Legacy Migrate Routine";
+        let slug = slugify(title);
+        let legacy_dir = crate::paths::routine_dir(id);
+        std::fs::create_dir_all(&legacy_dir).unwrap();
+        // Legacy layout: routine.toml + prompt.md live under the UUID-named dir.
+        let toml = format!(
+            "id = \"{id}\"\nschedule = \"@daily\"\ntitle = \"{title}\"\nagent = \"claude\"\nprompt = \"task\"\nenabled = true\n"
+        );
+        std::fs::write(legacy_dir.join("routine.toml"), toml).unwrap();
+        std::fs::write(legacy_dir.join("prompt.md"), "legacy prompt").unwrap();
 
-    migrate_routine_dirs();
+        migrate_routine_dirs();
 
-    // Legacy dir removed; canonical slug dir now holds toml + prompt.
-    assert!(!legacy_dir.exists(), "legacy UUID dir should be removed");
-    assert!(crate::paths::routine_toml_path(&slug).exists());
-    assert!(crate::paths::routine_prompt_path(&slug).exists());
-    let loaded = load_routine_from_dir(&slug).unwrap();
-    assert_eq!(loaded.id, id, "UUID id preserved across the dir migration");
-
-    remove_routine_dir(&slug).unwrap();
+        // Legacy dir removed; canonical slug dir now holds toml + prompt.
+        assert!(!legacy_dir.exists(), "legacy UUID dir should be removed");
+        assert!(crate::paths::routine_toml_path(&slug).exists());
+        assert!(crate::paths::routine_prompt_path(&slug).exists());
+        let loaded = load_routine_from_dir(&slug).unwrap();
+        assert_eq!(loaded.id, id, "UUID id preserved across the dir migration");
+    });
 }
 
 #[test]
 fn repersist_routines_recreates_missing_prompt_sidecar() {
-    let id = "rs-repersist-id";
-    let title = "Rs Repersist Routine";
-    let slug = slugify(title);
-    write_routine(&make_routine(id, title)).unwrap();
-    // Simulate the sync-only state: prompt.md gone, only run.sh-style dir remains.
-    std::fs::remove_file(crate::paths::routine_prompt_path(&slug)).unwrap();
-    assert!(!crate::paths::routine_prompt_path(&slug).exists());
+    with_override_home(|_home| {
+        let id = "rs-repersist-id";
+        let title = "Rs Repersist Routine";
+        let slug = slugify(title);
+        write_routine(&make_routine(id, title)).unwrap();
+        // Simulate the sync-only state: prompt.md gone, only run.sh-style dir remains.
+        std::fs::remove_file(crate::paths::routine_prompt_path(&slug)).unwrap();
+        assert!(!crate::paths::routine_prompt_path(&slug).exists());
 
-    let mut map = HashMap::new();
-    map.insert(id.to_string(), make_routine(id, title));
-    let store = Arc::new(Mutex::new(map));
-    repersist_routines(&store);
+        let mut map = HashMap::new();
+        map.insert(id.to_string(), make_routine(id, title));
+        let store = Arc::new(Mutex::new(map));
+        repersist_routines(&store);
 
-    assert!(
-        crate::paths::routine_prompt_path(&slug).exists(),
-        "repersist should recreate the prompt sidecar"
-    );
-    remove_routine_dir(&slug).unwrap();
+        assert!(
+            crate::paths::routine_prompt_path(&slug).exists(),
+            "repersist should recreate the prompt sidecar"
+        );
+    });
 }
 
 /// A unique, not-yet-created scratch directory under the system temp dir.
@@ -581,6 +591,29 @@ fn migrate_routine_dirs_from_dir_skips_non_dir_and_unparsable() {
         // Neither entry was migrated away; both are left exactly as they were.
         assert!(routines.join("stray.txt").exists());
         assert!(garbage.join("routine.toml").exists());
+    });
+}
+
+#[test]
+fn migrate_routine_dirs_from_dir_skips_already_canonical_dir() {
+    // A routine dir whose name already equals its slug needs no migration: the
+    // `slug == dir_name` guard short-circuits with `continue`, leaving the dir untouched.
+    with_override_home(|_home| {
+        let routines = crate::paths::routines_dir();
+        std::fs::create_dir_all(&routines).unwrap();
+
+        // write_routine lays the routine down under its canonical slug-named dir.
+        let title = "Rs Canonical Routine";
+        let slug = slugify(title);
+        write_routine(&make_routine("rs-canonical-id", title)).unwrap();
+        // The on-disk dir name already equals the slug, so the scan hits the no-op guard.
+        assert!(routines.join(&slug).is_dir());
+
+        migrate_routine_dirs_from_dir(&routines);
+
+        // Already canonical, so the dir stays exactly where it was.
+        assert!(crate::paths::routine_toml_path(&slug).exists());
+        assert_eq!(load_routine_from_dir(&slug).unwrap().id, "rs-canonical-id");
     });
 }
 

--- a/src/routines/service_tests.rs
+++ b/src/routines/service_tests.rs
@@ -6,6 +6,35 @@ use crate::routines::{new_store, slugify, Repository};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
+/// Point `MOADIM_HOME_OVERRIDE` at a fresh, empty temp home for the duration of a test, removing the
+/// env var and the temp dir on drop. This keeps `svc_create`/`svc_update`/`write_routine` and the
+/// other disk-touching paths off the developer's real `~/.moadim`, so a panicking assertion can never
+/// leak test routines into the real home. Tests in this crate run single-threaded
+/// (`RUST_TEST_THREADS=1`), so the global env mutation is safe.
+struct TempHome(std::path::PathBuf);
+
+impl TempHome {
+    fn set() -> TempHome {
+        let dir = std::env::temp_dir().join(format!("moadim-svctest-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).expect("create temp home");
+        // SAFETY: single-threaded test execution.
+        unsafe {
+            std::env::set_var("MOADIM_HOME_OVERRIDE", &dir);
+        }
+        TempHome(dir)
+    }
+}
+
+impl Drop for TempHome {
+    fn drop(&mut self) {
+        // SAFETY: single-threaded test execution.
+        unsafe {
+            std::env::remove_var("MOADIM_HOME_OVERRIDE");
+        }
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
 /// Build a routine with overridable identity, title, timestamps, and repository URL.
 fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Routine {
     Routine {
@@ -38,6 +67,7 @@ fn store_with(routines: Vec<Routine>) -> RoutineStore {
 
 #[test]
 fn svc_list_sorts_by_updated_at() {
+    let _home = TempHome::set();
     // Covers the `RoutineSort::Updated` arm: sort by `updated_at` ascending.
     let store = store_with(vec![
         make_routine("late", "Zeta", 100, 300),
@@ -56,6 +86,7 @@ fn svc_list_sorts_by_updated_at() {
 
 #[test]
 fn svc_list_sorts_by_title_case_insensitively() {
+    let _home = TempHome::set();
     // Covers the `RoutineSort::Title` arm: sort by lowercased title.
     let store = store_with(vec![
         make_routine("banana", "banana", 0, 0),
@@ -104,6 +135,7 @@ fn empty_update_request() -> UpdateRoutineRequest {
 
 #[test]
 fn svc_create_rejects_blank_title() {
+    let _home = TempHome::set();
     // Covers the `reject_blank("title", ..)` error arm in `svc_create`: a
     // whitespace-only title is refused before any slug/disk work (#226).
     let store = new_store();
@@ -119,6 +151,7 @@ fn svc_create_rejects_blank_title() {
 
 #[test]
 fn svc_create_rejects_blank_prompt() {
+    let _home = TempHome::set();
     // Covers the `reject_blank("prompt", ..)` error arm in `svc_create`: an empty
     // prompt would make the routine fire forever with no task (#224).
     let store = new_store();
@@ -134,6 +167,7 @@ fn svc_create_rejects_blank_prompt() {
 
 #[test]
 fn svc_create_rejects_zero_ttl_secs() {
+    let _home = TempHome::set();
     // Covers the `reject_zero_secs("ttl_secs", ..)` error arm in `svc_create`:
     // a zero TTL reaps finished-run logs instantly (#233).
     let store = new_store();
@@ -149,6 +183,7 @@ fn svc_create_rejects_zero_ttl_secs() {
 
 #[test]
 fn svc_create_rejects_zero_max_runtime_secs() {
+    let _home = TempHome::set();
     // Covers the `reject_zero_secs("max_runtime_secs", ..)` error arm in
     // `svc_create`: a zero cap self-kills the run immediately (#233).
     let store = new_store();
@@ -164,6 +199,7 @@ fn svc_create_rejects_zero_max_runtime_secs() {
 
 #[test]
 fn svc_create_persists_machines() {
+    let _home = TempHome::set();
     // Covers the `machines: req.machines` assignment in `svc_create`.
     let store = new_store();
     let resp = svc_create(
@@ -179,6 +215,7 @@ fn svc_create_persists_machines() {
 
 #[test]
 fn svc_update_sets_machines() {
+    let _home = TempHome::set();
     // Covers the `if let Some(machines) = req.machines` branch in `svc_update`.
     let store = store_with(vec![make_routine("upd-machines", "Keep", 1, 1)]);
     let resp = svc_update(
@@ -195,6 +232,7 @@ fn svc_update_sets_machines() {
 
 #[test]
 fn svc_update_rejects_blank_title() {
+    let _home = TempHome::set();
     // Covers the `reject_blank("title", ..)` error arm in `svc_update`.
     let store = store_with(vec![make_routine("upd-blank-title", "Keep", 1, 1)]);
     let result = svc_update(
@@ -210,6 +248,7 @@ fn svc_update_rejects_blank_title() {
 
 #[test]
 fn svc_update_rejects_blank_prompt() {
+    let _home = TempHome::set();
     // Covers the `reject_blank("prompt", ..)` error arm in `svc_update`.
     let store = store_with(vec![make_routine("upd-blank-prompt", "Keep", 1, 1)]);
     let result = svc_update(
@@ -225,6 +264,7 @@ fn svc_update_rejects_blank_prompt() {
 
 #[test]
 fn svc_update_rejects_zero_durations() {
+    let _home = TempHome::set();
     // Covers both `reject_zero_secs` error arms on the update path.
     let store = store_with(vec![make_routine("upd-zero-secs", "Keep", 1, 1)]);
     let ttl = svc_update(
@@ -249,6 +289,7 @@ fn svc_update_rejects_zero_durations() {
 
 #[test]
 fn svc_create_rejects_ttl_above_cron_ceiling() {
+    let _home = TempHome::set();
     // A `*/5 * * * *` routine has a ttl ceiling of min(3600, 300) = 300s. An explicit 1800 would be
     // silently clamped to 300, so it is rejected with `BadRequest` up front (#468).
     let store = new_store();
@@ -265,6 +306,7 @@ fn svc_create_rejects_ttl_above_cron_ceiling() {
 
 #[test]
 fn svc_create_rejects_max_runtime_above_cron_ceiling() {
+    let _home = TempHome::set();
     // Mirror of the ttl ceiling for the watchdog bound (#468).
     let store = new_store();
     let result = svc_create(
@@ -280,6 +322,7 @@ fn svc_create_rejects_max_runtime_above_cron_ceiling() {
 
 #[test]
 fn svc_create_accepts_secs_at_cron_ceiling() {
+    let _home = TempHome::set();
     // A value equal to the cron-derived ceiling (`*/5` -> 300s) is in force, not clamped, so it
     // passes `reject_over_ceiling` (covering the `secs <= ceiling` arm for both fields). A
     // duplicate-slug routine pre-seeded in the store makes the create fail *after* that check with a
@@ -307,6 +350,7 @@ fn svc_create_accepts_secs_at_cron_ceiling() {
 
 #[test]
 fn svc_update_rejects_ttl_above_current_schedule_ceiling() {
+    let _home = TempHome::set();
     // No schedule supplied: the ceiling derives from the routine's *current* `*/5` schedule, so a
     // 1800s ttl exceeds the 300s ceiling and is rejected without mutating the store (#468).
     let store = store_with(vec![Routine {
@@ -336,6 +380,7 @@ fn svc_update_rejects_ttl_above_current_schedule_ceiling() {
 
 #[test]
 fn svc_update_rejects_secs_above_new_schedule_ceiling() {
+    let _home = TempHome::set();
     // A supplied schedule is the *effective* schedule for the ceiling: tightening a `@daily` routine
     // to `*/5` while setting max_runtime 1800 exceeds the new 300s ceiling and is rejected (#468).
     let store = store_with(vec![make_routine("upd-new-sched", "Keep New Sched", 1, 1)]);
@@ -353,6 +398,7 @@ fn svc_update_rejects_secs_above_new_schedule_ceiling() {
 
 #[test]
 fn svc_create_rejects_duplicate_slug() {
+    let _home = TempHome::set();
     // Covers the slug-conflict branch in `svc_create`: an existing routine whose
     // title slugifies to the same value forces a `Conflict`.
     let title = "Svc Create Dup ZZZ";
@@ -395,11 +441,11 @@ fn svc_create_rejects_duplicate_slug() {
 
         svc_delete(&store, &first.routine.id).unwrap();
     });
-    let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
 }
 
 #[test]
 fn svc_create_rejects_malformed_agent_config() {
+    let _home = TempHome::set();
     // A referenced agent whose `<name>.toml` is present but unparseable is rejected at create time
     // with `BadRequest` quoting the parse error — not silently skipped at fire time.
     let agent_name = "svc-create-malformed-agent-zzz";
@@ -426,12 +472,11 @@ fn svc_create_rejects_malformed_agent_config() {
         Err(AppError::BadRequest(msg)) => assert!(msg.contains("malformed config")),
         other => panic!("expected BadRequest, got {other:?}"),
     }
-
-    std::fs::remove_file(&cfg).unwrap();
 }
 
 #[test]
 fn svc_update_rejects_malformed_agent_config() {
+    let _home = TempHome::set();
     // The same rejection applies when an update switches a routine to a malformed agent.
     let agent_name = "svc-update-malformed-agent-zzz";
     std::fs::create_dir_all(crate::paths::agents_dir()).unwrap();
@@ -463,13 +508,11 @@ fn svc_update_rejects_malformed_agent_config() {
         Err(AppError::BadRequest(msg)) => assert!(msg.contains("malformed config")),
         other => panic!("expected BadRequest, got {other:?}"),
     }
-
-    let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
-    std::fs::remove_file(&cfg).unwrap();
 }
 
 #[test]
 fn svc_update_rejects_renaming_into_existing_slug() {
+    let _home = TempHome::set();
     // Covers the slug-conflict branch in `svc_update`: renaming one routine to a
     // title that another routine already owns yields a `Conflict`.
     let title_keep = "Svc Update Keep ZZZ";
@@ -507,13 +550,11 @@ fn svc_update_rejects_renaming_into_existing_slug() {
         );
         assert!(matches!(conflict, Err(AppError::Conflict(_))));
     });
-
-    let _ = crate::routine_storage::remove_routine_dir(&slugify(title_keep));
-    let _ = crate::routine_storage::remove_routine_dir(&slugify(title_other));
 }
 
 #[test]
 fn svc_update_sets_ttl_secs() {
+    let _home = TempHome::set();
     // Covers the `req.ttl_secs` apply branch in `svc_update`.
     let title = "Svc Update Ttl ZZZ";
     let store = new_store();
@@ -544,12 +585,11 @@ fn svc_update_sets_ttl_secs() {
         .unwrap();
         assert_eq!(updated.routine.ttl_secs, Some(1800));
     });
-
-    let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
 }
 
 #[test]
 fn svc_update_sets_max_runtime_secs() {
+    let _home = TempHome::set();
     // Covers the `req.max_runtime_secs` apply branch in `svc_update`.
     let title = "Svc Update Max Runtime ZZZ";
     let store = new_store();
@@ -581,12 +621,11 @@ fn svc_update_sets_max_runtime_secs() {
         .unwrap();
         assert_eq!(updated.routine.max_runtime_secs, Some(1234));
     });
-
-    let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
 }
 
 #[test]
 fn svc_logs_returns_newest_workbench_log() {
+    let _home = TempHome::set();
     // Covers the newest-workbench selection inside `svc_logs`: with two valid
     // `{slug}-{ts}` workbench directories, the higher timestamp wins and its
     // `agent.log` contents are returned.
@@ -611,13 +650,11 @@ fn svc_logs_returns_newest_workbench_log() {
 
     let logs = svc_logs(&store, "logs-id").unwrap();
     assert_eq!(logs, "new log contents");
-
-    let _ = std::fs::remove_dir_all(&older);
-    let _ = std::fs::remove_dir_all(&newer);
 }
 
 #[test]
 fn svc_logs_skips_foreign_and_unparseable_workbenches() {
+    let _home = TempHome::set();
     // Exercises the read_dir loop body across every arm: a workbench whose name
     // does not parse as `{slug}-{ts}` (parser returns None → skipped), a workbench
     // that parses but belongs to a different routine (`dir_slug != slug` → skipped),
@@ -651,18 +688,14 @@ fn svc_logs_skips_foreign_and_unparseable_workbenches() {
 
     let logs = svc_logs(&store, "logs-mixed-id").unwrap();
     assert_eq!(logs, "mine log contents");
-
-    let _ = std::fs::remove_dir_all(&unparseable);
-    let _ = std::fs::remove_dir_all(&foreign);
-    let _ = std::fs::remove_dir_all(&mine);
 }
 
 #[test]
 fn svc_logs_empty_when_workbenches_dir_absent() {
-    // Covers the `read_dir` error path in `svc_logs`: with `HOME` redirected to a fresh
-    // temp dir, `workbenches_dir()` does not exist, so `std::fs::read_dir` returns Err and
-    // the loop is skipped entirely. With no workbench found, the function returns an empty
-    // string.
+    let _home = TempHome::set();
+    // Covers the `read_dir` error path in `svc_logs`: the fresh temp home has no `workbenches`
+    // subdirectory, so `std::fs::read_dir` returns Err and the loop is skipped entirely. With no
+    // workbench found, the function returns an empty string.
     let title = "Svc Logs No Workbenches ZZQ";
     let store = new_store();
     store.lock().unwrap().insert(
@@ -670,29 +703,15 @@ fn svc_logs_empty_when_workbenches_dir_absent() {
         make_routine("logs-empty-id", title, 1, 1),
     );
 
-    let fresh_home = std::env::temp_dir().join(format!("moadim-no-wb-{}", uuid::Uuid::new_v4()));
-    std::fs::create_dir_all(&fresh_home).unwrap();
-    let saved = std::env::var_os("HOME");
-    // SAFETY: single-threaded test harness (RUST_TEST_THREADS=1); restored immediately after.
-    unsafe {
-        std::env::set_var("HOME", &fresh_home);
-    }
     assert!(!crate::paths::workbenches_dir().exists());
 
     let logs = svc_logs(&store, "logs-empty-id").unwrap();
-
-    unsafe {
-        match saved {
-            Some(value) => std::env::set_var("HOME", value),
-            None => std::env::remove_var("HOME"),
-        }
-    }
     assert_eq!(logs, "");
-    let _ = std::fs::remove_dir_all(&fresh_home);
 }
 
 #[test]
 fn svc_logs_missing_routine_not_found() {
+    let _home = TempHome::set();
     assert!(matches!(
         svc_logs(&new_store(), "nope"),
         Err(AppError::NotFound)
@@ -723,6 +742,7 @@ fn with_empty_path(body: impl FnOnce()) {
 
 #[test]
 fn svc_create_warns_when_crontab_sync_fails() {
+    let _home = TempHome::set();
     // With `PATH` cleared the `crontab` binary cannot be spawned, so
     // `sync_routines_to_crontab` errors and `svc_create` logs the warning but
     // still returns the created routine.
@@ -746,11 +766,11 @@ fn svc_create_warns_when_crontab_sync_fails() {
         .unwrap();
         assert_eq!(created.routine.title, title);
     });
-    let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
 }
 
 #[test]
 fn svc_update_warns_when_crontab_sync_fails() {
+    let _home = TempHome::set();
     // Same crontab-spawn failure as above, on the update path.
     let title = "Svc Update Sync Fail ZZZ";
     let store = new_store();
@@ -776,11 +796,11 @@ fn svc_update_warns_when_crontab_sync_fails() {
         .unwrap();
         assert_eq!(updated.routine.prompt, "changed");
     });
-    let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
 }
 
 #[test]
 fn svc_delete_warns_when_crontab_sync_fails() {
+    let _home = TempHome::set();
     // Same crontab-spawn failure, on the delete path.
     let title = "Svc Delete Sync Fail ZZZ";
     let store = new_store();
@@ -791,7 +811,6 @@ fn svc_delete_warns_when_crontab_sync_fails() {
         let deleted = svc_delete(&store, "del-sync-id").unwrap();
         assert_eq!(deleted.routine.title, title);
     });
-    let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
 }
 
 /// Run `body` with `MOADIM_CRONTAB_BIN` pointed at a shim that succeeds (`crontab -l` prints an
@@ -829,6 +848,7 @@ fn with_working_crontab(body: impl FnOnce()) {
 
 #[test]
 fn svc_create_syncs_crontab_on_success() {
+    let _home = TempHome::set();
     // A working crontab shim makes the post-create sync return `Ok`, covering the
     // non-error branch of the sync guard in `svc_create`.
     let title = "Svc Create Sync OK ZZZ";
@@ -851,11 +871,11 @@ fn svc_create_syncs_crontab_on_success() {
         .unwrap();
         assert_eq!(created.routine.title, title);
     });
-    let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
 }
 
 #[test]
 fn svc_update_syncs_crontab_on_success() {
+    let _home = TempHome::set();
     let title = "Svc Update Sync OK ZZZ";
     let store = new_store();
     let routine = make_routine("upd-sync-ok-id", title, 1, 1);
@@ -883,11 +903,11 @@ fn svc_update_syncs_crontab_on_success() {
         .unwrap();
         assert_eq!(updated.routine.prompt, "changed");
     });
-    let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
 }
 
 #[test]
 fn svc_delete_syncs_crontab_on_success() {
+    let _home = TempHome::set();
     let title = "Svc Delete Sync OK ZZZ";
     let store = new_store();
     let routine = make_routine("del-sync-ok-id", title, 1, 1);
@@ -900,11 +920,11 @@ fn svc_delete_syncs_crontab_on_success() {
         let deleted = svc_delete(&store, "del-sync-ok-id").unwrap();
         assert_eq!(deleted.routine.title, title);
     });
-    let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
 }
 
 #[test]
 fn svc_trigger_warns_when_spawn_fails() {
+    let _home = TempHome::set();
     // With `PATH` cleared and an agent config present, `build_routine_command`
     // produces a command that `sh -c` cannot run because `sh` itself is not on
     // `PATH`, so the spawn fails and the warning branch runs. The trigger still
@@ -928,13 +948,11 @@ fn svc_trigger_warns_when_spawn_fails() {
         let triggered = svc_trigger(&store, "trig-spawn-id").unwrap();
         assert!(triggered.last_manual_trigger_at.is_some());
     });
-
-    let _ = std::fs::remove_file(&cfg);
-    let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
 }
 
 #[test]
 fn svc_trigger_scheduled_missing_routine_not_found() {
+    let _home = TempHome::set();
     assert!(matches!(
         svc_trigger_scheduled(&new_store(), "nope"),
         Err(AppError::NotFound)
@@ -943,6 +961,7 @@ fn svc_trigger_scheduled_missing_routine_not_found() {
 
 #[test]
 fn svc_trigger_scheduled_spawns_without_recording_manual_trigger() {
+    let _home = TempHome::set();
     // The scheduled path must leave `last_manual_trigger_at` untouched (it is for *manual* triggers
     // only); `with_empty_path` makes the spawn fail so the test never launches a real session, while
     // still exercising the spawn branch.
@@ -965,9 +984,6 @@ fn svc_trigger_scheduled_spawns_without_recording_manual_trigger() {
         let triggered = svc_trigger_scheduled(&store, "trig-sched-id").unwrap();
         assert!(triggered.last_manual_trigger_at.is_none());
     });
-
-    let _ = std::fs::remove_file(&cfg);
-    let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
 }
 
 /// Build a create request with the given title and an otherwise-valid body.
@@ -987,6 +1003,7 @@ fn create_req_with_title(title: &str) -> CreateRoutineRequest {
 
 #[test]
 fn svc_create_rejects_blank_and_punctuation_titles() {
+    let _home = TempHome::set();
     // Covers `validate_title`'s alphanumeric-required reject branch via `svc_create`:
     // empty, whitespace-only, and punctuation-only titles all 400 before any
     // persistence or crontab sync, leaving the store empty (issue #226).
@@ -1003,6 +1020,7 @@ fn svc_create_rejects_blank_and_punctuation_titles() {
 
 #[test]
 fn svc_create_rejects_overlong_title() {
+    let _home = TempHome::set();
     // Covers `validate_title`'s max-length reject branch: a title past
     // `MAX_TITLE_LEN` characters 400s even though it has alphanumerics.
     let store = new_store();
@@ -1014,6 +1032,7 @@ fn svc_create_rejects_overlong_title() {
 
 #[test]
 fn svc_create_rejects_unknown_agent() {
+    let _home = TempHome::set();
     // Covers the agent-validation branch in `svc_create`: an agent name that is
     // not in the registry must fail loud with `BadRequest` instead of being
     // persisted and silently skipped at fire time (#139).
@@ -1039,6 +1058,7 @@ fn svc_create_rejects_unknown_agent() {
 
 #[test]
 fn svc_update_rejects_blank_and_punctuation_titles() {
+    let _home = TempHome::set();
     // Covers the `req.title` validation branch in `svc_update`: renaming an
     // existing routine to an empty, whitespace-only, or punctuation-only title
     // 400s and leaves the stored title untouched (issue #226).
@@ -1076,11 +1096,11 @@ fn svc_update_rejects_blank_and_punctuation_titles() {
             original
         );
     }
-    let _ = crate::routine_storage::remove_routine_dir(&slugify(original));
 }
 
 #[test]
 fn svc_create_accepts_builtin_agent() {
+    let _home = TempHome::set();
     // Covers the success path of agent validation: a built-in agent
     // (`ensure_default_agents` seeds `claude`/`codex`) is accepted.
     crate::routines::ensure_default_agents();
@@ -1104,11 +1124,11 @@ fn svc_create_accepts_builtin_agent() {
     assert_eq!(created.routine.agent, "claude");
 
     svc_delete(&store, &created.routine.id).unwrap();
-    let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
 }
 
 #[test]
 fn svc_update_rejects_unknown_agent() {
+    let _home = TempHome::set();
     // Covers the agent-validation branch in `svc_update`: updating a routine's
     // agent to an unknown name must fail with `BadRequest` before persisting.
     let title = "Svc Update Unknown Agent ZZZ";
@@ -1138,12 +1158,11 @@ fn svc_update_rejects_unknown_agent() {
         store.lock().unwrap().get("upd-agent-id").unwrap().agent,
         "claude"
     );
-
-    let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
 }
 
 #[test]
 fn svc_create_rejects_blank_repository_url() {
+    let _home = TempHome::set();
     // Covers the repositories-validation branch in `svc_create` (#241): an entry
     // whose URL is empty or whitespace-only must fail loud with `BadRequest`
     // instead of being stored and rendered as a broken `- ` clone bullet.
@@ -1174,6 +1193,7 @@ fn svc_create_rejects_blank_repository_url() {
 
 #[test]
 fn svc_create_rejects_blank_repository_branch() {
+    let _home = TempHome::set();
     // Covers the optional-branch guard: a `Some` branch that is empty/whitespace
     // must be rejected so `compose_prompt` cannot emit `- url (branch )`.
     let store = new_store();
@@ -1200,6 +1220,7 @@ fn svc_create_rejects_blank_repository_branch() {
 
 #[test]
 fn svc_create_trims_repository_entries() {
+    let _home = TempHome::set();
     // Covers the normalization path: surrounding whitespace on a valid URL/branch
     // is trimmed before storing, so the rendered preamble bullet is clean.
     crate::routines::ensure_default_agents();
@@ -1228,11 +1249,11 @@ fn svc_create_trims_repository_entries() {
     assert_eq!(repo.branch.as_deref(), Some("main"));
 
     svc_delete(&store, &created.routine.id).unwrap();
-    let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
 }
 
 #[test]
 fn svc_update_rejects_blank_repository_url() {
+    let _home = TempHome::set();
     // Covers the repositories-validation branch in `svc_update`: replacing the
     // list with a blank-URL entry must fail with `BadRequest` before persisting.
     let title = "Svc Update Blank Repo ZZZ";
@@ -1268,6 +1289,4 @@ fn svc_update_rejects_blank_repository_url() {
         .unwrap()
         .repositories
         .is_empty());
-
-    let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
 }


### PR DESCRIPTION
## What

Make the routine **service** and **storage** unit tests hermetic so they stop writing into the developer's real `~/.config/moadim` home.

Fixes #585.

## Why

`crate::paths::home()` honors the `MOADIM_HOME_OVERRIDE` test seam but falls back to the **real** home when it's unset. Tests calling `write_routine` / `svc_create` / `svc_update` / `migrate_routine_dirs` without the override therefore resolved `routine_dir(...)` under the real `~/.config/moadim`:

- **`service_tests.rs`** — none of the 45 tests set the override. Success-path tests leaked slugs like `valid-title` (from `valid_create_request`) and `keep` (title `"Keep"`).
- **`routine_storage_tests.rs`** — a `with_override_home` helper existed and isolated the later tests, but ~18 earlier tests called `write_routine` / `routine_dir` raw. Worst case: `migrate_routine_dirs_moves_legacy_uuid_dir_to_slug` invoked the public `migrate_routine_dirs()`, which **scans and rewrites the real routines directory**.

Cleanup was post-body (`remove_routine_dir(...)` at the end), so a failing assertion leaked the dir; tests racing the shared real home were also non-hermetic.

Evidence — leftover dirs found in real home, all matching test fixtures (not user routines): `keep`, `valid-title`, `rs-inner-legacy-routine`, `rs-remove-fail-routine`, `rs-write-fail-uuid`.

## How

- **`service_tests.rs`**: added a `TempHome` RAII guard (mirrors the one in `routes/http_tests.rs`) — points `MOADIM_HOME_OVERRIDE` at a fresh temp dir, removes it and the env var on `Drop`. Instantiated at the top of every test; dropped now-redundant real-home teardown.
- **`routine_storage_tests.rs`**: routed the remaining raw tests through the existing `with_override_home` seam; dropped redundant teardown.
- Added `migrate_routine_dirs_from_dir_skips_already_canonical_dir` to restore coverage of the `slug == dir_name` no-op guard, which was previously covered only *incidentally* by the migration test scanning the real home (the very bug being fixed).

RAII / closure teardown also fixes the panic-leak, since cleanup no longer depends on the test body completing.

## Verification

- `cargo test --bin moadim` → **565 passed, 0 failed**.
- `cargo clippy --bin moadim --all-targets` → clean.
- Coverage gate: `routine_storage.rs` back to **100% line coverage**.
- Hermeticity check: a full `cargo test` run creates **zero** new dirs in the real `~/.config/moadim/routines/` (verified before/after diff).

## Note

Pre-existing leaked dirs in the maintainer's real home (from before this fix) are not touched by this PR; they can be removed manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
