### PR TITLE
fix(ui): promote header logo to an <h1> for heading-landmark a11y (#589)

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -83,6 +83,7 @@
       align-items: baseline;
       gap: 10px;
       font-size: 17px;
+      font-weight: 400;
       letter-spacing: 0.3em;
       color: var(--accent);
     }

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -330,11 +330,11 @@ pub fn header(props: &HeaderProps) -> Html {
 
     html! {
         <header>
-            <div class="logo">
+            <h1 class="logo">
                 {"MOADIM"}
                 <span class="logo-sub">{"/ CONTROL"}</span>
                 <span class="logo-version">{version}</span>
-            </div>
+            </h1>
             <div class="header-right">
                 <div class="health">
                     <div class={dot_class}></div>


### PR DESCRIPTION
Closes #589.

## What
The Yew dashboard rendered **zero heading elements** (`grep -rno '<h[1-6]' ui/src` → empty). Screen-reader users had no `<h1>` and could not navigate by heading structure.

Promote the persistent header brand to `<h1 class="logo">` — the natural, always-present page title.

## Visual parity
A bare `<h1>` defaults to bold, so `.logo { font-weight: 400 }` is pinned in `ui/index.html`. The universal reset already zeroes `<h1>` margin and `.logo` already sets the font-size, so the rendered header is byte-identical.

## Scope
- UI-only: `ui/src/main.rs` + `ui/index.html` exclusively.
- Pure semantics + accessibility. No behavior, layout, copy, or product change.
- `prebuilt.html` intentionally not committed (generated by `cargo build`).

## Verified locally
- `cargo clippy -p ui --target wasm32-unknown-unknown` — clean (`all = "deny"`).
- `cargo build` — succeeds.

---
_This pull request was opened by the **UI segment auto-improve (issue → PR → merge)** routine of moadim._