### PR TITLE
fix(ui): promote header brand to an <h1> heading landmark (#589)

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -82,6 +82,7 @@
       display: flex;
       align-items: baseline;
       gap: 10px;
+      font-weight: 400;
       font-size: 17px;
       letter-spacing: 0.3em;
       color: var(--accent);

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -330,11 +330,11 @@ pub fn header(props: &HeaderProps) -> Html {
 
     html! {
         <header>
-            <div class="logo">
+            <h1 class="logo">
                 {"MOADIM"}
                 <span class="logo-sub">{"/ CONTROL"}</span>
                 <span class="logo-version">{version}</span>
-            </div>
+            </h1>
             <div class="header-right">
                 <div class="health">
                     <div class={dot_class}></div>


### PR DESCRIPTION
Closes #589.

## What
The Yew dashboard (`ui/`) rendered **zero heading elements**, so screen-reader users had no `<h1>` and could not navigate the page by heading structure. This promotes the always-present header brand from `<div class="logo">` to `<h1 class="logo">`, giving the document exactly one top-level heading.

## Visual parity
A bare `<h1>` defaults to bold; `.logo` now pins `font-weight: 400` so the rendered weight is unchanged. Margin is already zeroed by the universal reset and `font-size` is already set on `.logo`, so the render stays byte-identical.

## Scope
- UI-only: touches `ui/src/main.rs` and `ui/index.html` exclusively.
- Pure semantics + a11y — no behavior, layout, copy, or product change.

## Verification
- `trunk build ui/index.html` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- Pre-push gates (fmt, clippy, 100% line coverage) ✅

`skip-changelog` label applied: the UI-only mandate restricts edits to files under `ui/`, so `CHANGELOG.md` is intentionally untouched.

---
This pull request was opened by the **UI segment auto-improve (issue → PR → merge)** routine of moadim.