### PR TITLE
chore(release): 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-06-21
+
 ### Added
 
 - **Day calendar view.** Routines and cron jobs gain a scrollable single-day
@@ -626,7 +628,8 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 - Ship the prebuilt UI in the published crate.
 - Rename the binary to `moadim` and add install docs.
 
-[Unreleased]: https://github.com/moadim-io/daemon/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/moadim-io/daemon/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/moadim-io/daemon/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/moadim-io/daemon/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/moadim-io/daemon/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/moadim-io/daemon/compare/v0.11.2...v0.12.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ opt-level = "z"
 
 [package]
 name = "moadim"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "Moadim.io MCP/REST server for managing cron jobs"
 license = "MIT"


### PR DESCRIPTION
## Release 0.15.0

Bumps `Cargo.toml` (+ `Cargo.lock`) from 0.14.0 → **0.15.0** and rolls the CHANGELOG `Unreleased` section into a dated `0.15.0` entry.

Minor bump: 12 commits since v0.14.0, including feats (day calendar view, machine picker UI, machine targeting from web UI).

Merging to `main` triggers `auto-release.yml`: pushes the `v0.15.0` tag and runs the crates.io publish + GitHub Release workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)