### PR TITLE
fix(ui): remove duplicate .logo font-weight declaration

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -84,7 +84,6 @@
       gap: 10px;
       font-weight: 400;
       font-size: 17px;
-      font-weight: 400;
       letter-spacing: 0.3em;
       color: var(--accent);
     }


### PR DESCRIPTION
## What
PRs #595 and #596 both addressed #589 (promote the header brand to an `<h1>` heading landmark) at nearly the same time, and each pinned `.logo { font-weight: 400 }`. The merge of both left the declaration written twice in `ui/index.html`. This removes the redundant duplicate, leaving a single declaration (identical rendering, cleaner CSS).

## Scope
- UI-only: touches `ui/index.html` exclusively.
- Pure code-quality cleanup — no behavior, layout, or product change.

---
This pull request was opened by the **UI segment auto-improve (issue → PR → merge)** routine of moadim.