### PR TITLE
chore(lint): enable clippy::redundant_closure_for_method_calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+### Changed
+
+- Enabled the `clippy::redundant_closure_for_method_calls` lint and fixed the
+  violations, replacing closures that only forward their receiver to a method
+  (`|e| e.ok()`, `|s| s.to_string()`, `|p| p.into_inner()`) with the method
+  path itself (`Result::ok`, `ToString::to_string`,
+  `std::sync::PoisonError::into_inner`). No behavior change.
+
 ## [0.15.0] - 2026-06-21
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,3 +70,7 @@ semicolon_if_nothing_returned = "deny"
 # non-binding arm diverges (return/continue/break), keeping the happy path
 # unindented.
 manual_let_else = "deny"
+# Prefer naming the method directly (`Result::ok`, `ToString::to_string`) over
+# wrapping it in a closure that only forwards the receiver
+# (`|e| e.ok()`, `|s| s.to_string()`).
+redundant_closure_for_method_calls = "deny"

--- a/src/cli_tests.rs
+++ b/src/cli_tests.rs
@@ -4,7 +4,7 @@ use super::*;
 
 /// Build a `Vec<String>` from string literals for [`parse`].
 fn argv(args: &[&str]) -> Vec<String> {
-    args.iter().map(|arg| arg.to_string()).collect()
+    args.iter().map(ToString::to_string).collect()
 }
 
 #[test]

--- a/src/commands_tests.rs
+++ b/src/commands_tests.rs
@@ -19,7 +19,7 @@ const UNREACHABLE_ADDR: &str = "127.0.0.1:1";
 
 /// Build a `Vec<String>` argv from string literals.
 fn argv(args: &[&str]) -> Vec<String> {
-    args.iter().map(|arg| arg.to_string()).collect()
+    args.iter().map(ToString::to_string).collect()
 }
 
 /// Save an env var's prior value and restore it on drop so a test's override never leaks.

--- a/src/machine/mod_tests.rs
+++ b/src/machine/mod_tests.rs
@@ -217,7 +217,7 @@ fn referenced_machines_unions_routines_and_jobs() {
     let names = referenced_machines();
     let expected: std::collections::BTreeSet<String> = ["laptop", "server", "work"]
         .iter()
-        .map(|name| name.to_string())
+        .map(ToString::to_string)
         .collect();
     assert_eq!(names, expected);
     let _ = std::fs::remove_dir_all(&home);

--- a/src/routine_storage_tests.rs
+++ b/src/routine_storage_tests.rs
@@ -379,7 +379,7 @@ fn write_routine_leaves_no_tmp_residue() {
         write_routine(&make_routine(id, title)).unwrap();
         let residue = std::fs::read_dir(crate::paths::routine_dir(&slug))
             .unwrap()
-            .filter_map(|entry| entry.ok())
+            .filter_map(Result::ok)
             .filter(|entry| entry.file_name().to_string_lossy().contains(".tmp"))
             .count();
         assert_eq!(residue, 0, "atomic_write must leave no .tmp files behind");

--- a/src/routines/agents/mod.rs
+++ b/src/routines/agents/mod.rs
@@ -94,7 +94,7 @@ pub(crate) fn available_agents_in(dir: &Path) -> Vec<String> {
         return builtin_agent_names();
     };
     let mut names: Vec<String> = entries
-        .filter_map(|entry| entry.ok())
+        .filter_map(Result::ok)
         .filter_map(|entry| {
             let path = entry.path();
             (path.extension()? == "toml")

--- a/src/routines/service_tests.rs
+++ b/src/routines/service_tests.rs
@@ -729,7 +729,7 @@ static PATH_GUARD: Mutex<()> = Mutex::new(());
 fn with_empty_path(body: impl FnOnce()) {
     let guard = PATH_GUARD
         .lock()
-        .unwrap_or_else(|poison| poison.into_inner());
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let saved = std::env::var_os("PATH");
     std::env::set_var("PATH", "");
     body();
@@ -823,7 +823,7 @@ fn with_working_crontab(body: impl FnOnce()) {
 
     let guard = PATH_GUARD
         .lock()
-        .unwrap_or_else(|poison| poison.into_inner());
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let base = std::env::temp_dir().join(format!("moadim-routcronok-{}", uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&base).unwrap();
     let script = base.join("crontab-ok.sh");

--- a/src/utils/atomic_tests.rs
+++ b/src/utils/atomic_tests.rs
@@ -13,7 +13,7 @@ fn scratch_dir() -> PathBuf {
 fn tmp_residue(dir: &Path) -> usize {
     std::fs::read_dir(dir)
         .unwrap()
-        .filter_map(|entry| entry.ok())
+        .filter_map(Result::ok)
         .filter(|entry| entry.file_name().to_string_lossy().contains(".tmp"))
         .count()
 }

--- a/src/utils/lock.rs
+++ b/src/utils/lock.rs
@@ -15,7 +15,8 @@ pub trait LockRecover<Inner> {
 
 impl<Inner> LockRecover<Inner> for Mutex<Inner> {
     fn lock_recover(&self) -> MutexGuard<'_, Inner> {
-        self.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+        self.lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 }
 


### PR DESCRIPTION
## Why

This repo hardens incrementally by enabling one focused clippy lint at a time and fixing the existing violations (see the `0.14.0` entries for `map_unwrap_or`, `semicolon_if_nothing_returned`, and `manual_let_else`). `clippy::redundant_closure_for_method_calls` is the next in that line.

The lint flags closures that exist only to forward their receiver to a method — `|e| e.ok()`, `|s| s.to_string()`, `|p| p.into_inner()` — where the method path can be passed directly. Naming the method is shorter, drops a binding, and reads as "this is just `Result::ok`" rather than an arbitrary closure.

## What

- Enables `redundant_closure_for_method_calls = "deny"` in `[lints.clippy]`, with a comment matching the existing entries.
- Fixes the 9 current violations across production and test code:
  - `src/utils/lock.rs`, `src/routines/service_tests.rs` (×2): `|p| p.into_inner()` → `std::sync::PoisonError::into_inner`
  - `src/routines/agents/mod.rs`, `src/routine_storage_tests.rs`, `src/utils/atomic_tests.rs`: `|e| e.ok()` → `Result::ok`
  - `src/cli_tests.rs`, `src/commands_tests.rs`, `src/machine/mod_tests.rs`: `|x| x.to_string()` → `ToString::to_string`

No behavior change — every rewrite is a clippy-suggested, semantically identical substitution.

## Verification

- `cargo fmt --check` — clean.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test` — 567 passed, 0 failed.

---
This pull request was opened by the **Daemon + Landing auto-improve & auto-merge lint/docs PRs** routine of moadim.