### PR TITLE
feat(ui): NEXT RUN time + countdown column and DUE SOON KPI tile (#597)

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -240,6 +240,7 @@
     .stat-card.all      { border-left-color: var(--border-hi); }
     .stat-card.enabled  { border-left-color: var(--accent); }
     .stat-card.disabled { border-left-color: var(--amber); }
+    .stat-card.due      { border-left-color: var(--red); }
     .stat-card.unreg    { border-left-color: var(--red); }
     .stat-card.system   { border-left-color: #7c8fc9; }
 
@@ -253,6 +254,7 @@
     .stat-val { font-size: 30px; color: var(--text-hi); line-height: 1.1; }
     .stat-val.c-accent { color: var(--accent); }
     .stat-val.c-amber  { color: var(--amber); }
+    .stat-val.c-red    { color: var(--red); }
 
     /* ── Section header ── */
     .section-hd {
@@ -328,6 +330,13 @@
     }
 
     .cell-time { font-size: 10px; color: var(--text-ghost); }
+
+    /* ── Next run ── */
+    .cell-next            { line-height: 1.25; }
+    .cell-next-when       { color: var(--text-hi); font-size: 12px; }
+    .cell-next-until      { font-size: 10px; color: var(--text-mid); margin-top: 1px; }
+    .cell-next-until.soon { color: var(--red); }
+    .cell-next.muted      { font-size: 12px; color: var(--text-ghost); }
 
     /* ── Toggle ── */
     .toggle { position: relative; width: 34px; height: 18px; cursor: pointer; display: block; }

--- a/ui/src/cron_jobs.rs
+++ b/ui/src/cron_jobs.rs
@@ -6,7 +6,9 @@
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use chrono::{DateTime, Duration, Local};
 use gloo_net::http::Request;
+use gloo_timers::future::TimeoutFuture;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as Json;
 use wasm_bindgen_futures::spawn_local;
@@ -15,7 +17,14 @@ use yew::prelude::*;
 
 use crate::day_timeline::{DayTimeline, TimelineItem};
 use crate::machines::MachinesPicker;
+use crate::schedule::{fires_within, fmt_until, fmt_when, next_fire_after};
 use crate::{describe_cron_live, reltime, ToastKind};
+
+/// How long ahead a job's next fire counts as "due soon" for the KPI tile.
+const DUE_SOON_WINDOW_SECS: i64 = 3_600;
+/// Cadence of the live tick that keeps next-run countdowns and the due-soon
+/// count current without a manual reload.
+const NEXT_RUN_TICK_MS: u32 = 30_000;
 
 // ─── Types (mirror server API exactly) ────────────────────────────────────────
 
@@ -333,6 +342,22 @@ pub fn cron_jobs_page(props: &CronJobsPageProps) -> Html {
     let state = use_reducer(CState::default);
     let toast = props.on_toast.clone();
 
+    // Live "now", advanced on a fixed tick so next-run countdowns and the
+    // due-soon KPI stay current without a manual reload. Both the stats bar and
+    // the table read this same instant so the view is internally consistent.
+    let now = use_state(Local::now);
+    {
+        let now = now.clone();
+        use_effect_with((), move |_| {
+            spawn_local(async move {
+                loop {
+                    TimeoutFuture::new(NEXT_RUN_TICK_MS).await;
+                    now.set(Local::now());
+                }
+            });
+        });
+    }
+
     let ok_toast = {
         let toast = toast.clone();
         move |msg: &str| toast.emit((msg.to_string(), ToastKind::Ok))
@@ -616,6 +641,7 @@ pub fn cron_jobs_page(props: &CronJobsPageProps) -> Html {
 
     let jobs = state.jobs.clone();
     let loading = state.loading;
+    let now_val = *now;
     let view = state.view;
     let page = state.page.clone();
     let modal = state.modal.clone();
@@ -644,7 +670,7 @@ pub fn cron_jobs_page(props: &CronJobsPageProps) -> Html {
                     },
                     CPage::List => html! {
                         <main>
-                            <StatsBar jobs={jobs.clone()} />
+                            <StatsBar jobs={jobs.clone()} now={now_val} />
                             <div class="section-hd">
                                 <div class="section-label">{"SCHEDULED JOBS"}</div>
                                 <div class="section-acts">
@@ -666,6 +692,7 @@ pub fn cron_jobs_page(props: &CronJobsPageProps) -> Html {
                                             <JobTable
                                                 jobs={jobs}
                                                 loading={loading}
+                                                now={now_val}
                                                 selected={selected}
                                                 on_edit={on_edit}
                                                 on_delete={on_ask_delete}
@@ -758,6 +785,8 @@ pub fn cron_view_toggle(props: &CronViewToggleProps) -> Html {
 #[derive(Properties, PartialEq)]
 pub struct StatsProps {
     pub jobs: Vec<CronJob>,
+    /// Reference instant for the "due soon" computation; advanced on a live tick.
+    pub now: DateTime<Local>,
 }
 
 #[function_component(StatsBar)]
@@ -765,6 +794,14 @@ pub fn stats_bar(props: &StatsProps) -> Html {
     let total = props.jobs.len();
     let enabled = props.jobs.iter().filter(|j| j.enabled).count();
     let disabled = total - enabled;
+    // Enabled jobs whose next fire is within the due-soon window — the most
+    // operationally urgent fact, surfaced as a first-class KPI tile.
+    let window = Duration::seconds(DUE_SOON_WINDOW_SECS);
+    let due_soon = props
+        .jobs
+        .iter()
+        .filter(|j| j.enabled && fires_within(&j.schedule, props.now, window))
+        .count();
 
     html! {
         <div class="stats">
@@ -775,6 +812,10 @@ pub fn stats_bar(props: &StatsProps) -> Html {
             <div class="stat-card enabled">
                 <div class="stat-label">{"ENABLED"}</div>
                 <div class="stat-val c-accent">{enabled}</div>
+            </div>
+            <div class="stat-card due">
+                <div class="stat-label">{"DUE SOON"}</div>
+                <div class="stat-val c-red">{due_soon}</div>
             </div>
             <div class="stat-card disabled">
                 <div class="stat-label">{"DISABLED"}</div>
@@ -790,6 +831,8 @@ pub fn stats_bar(props: &StatsProps) -> Html {
 pub struct JobTableProps {
     pub jobs: Vec<CronJob>,
     pub loading: bool,
+    /// Reference instant for next-run cells; advanced on a live tick.
+    pub now: DateTime<Local>,
     pub selected: HashSet<String>,
     pub on_edit: Callback<String>,
     pub on_delete: Callback<(String, String)>,
@@ -844,6 +887,7 @@ pub fn job_table(props: &JobTableProps) -> Html {
                         </th>
                         <th>{"ID"}</th>
                         <th>{"SCHEDULE"}</th>
+                        <th>{"NEXT RUN"}</th>
                         <th>{"HANDLER"}</th>
                         <th>{"METADATA"}</th>
                         <th>{"ENABLED"}</th>
@@ -856,6 +900,7 @@ pub fn job_table(props: &JobTableProps) -> Html {
                         <JobRow
                             key={job.id.clone()}
                             job={job.clone()}
+                            now={props.now}
                             selected={props.selected.contains(&job.id)}
                             on_edit={props.on_edit.clone()}
                             on_delete={props.on_delete.clone()}
@@ -876,6 +921,8 @@ pub fn job_table(props: &JobTableProps) -> Html {
 #[derive(Properties, PartialEq)]
 pub struct JobRowProps {
     pub job: CronJob,
+    /// Reference instant for this row's next-run cell; advanced on a live tick.
+    pub now: DateTime<Local>,
     pub selected: bool,
     pub on_edit: Callback<String>,
     pub on_delete: Callback<(String, String)>,
@@ -883,6 +930,33 @@ pub struct JobRowProps {
     pub on_trigger: Callback<String>,
     pub on_logs: Callback<String>,
     pub on_select: Callback<(String, SelectKind)>,
+}
+
+/// Render a job's NEXT RUN cell: `paused` when disabled, an absolute *when* plus
+/// a relative countdown when its schedule fires again, or `—` when the schedule
+/// is invalid or never fires. The countdown gets a `soon` accent once the fire
+/// falls inside the due-soon window, matching the DUE SOON KPI tile.
+fn next_run_cell(job: &CronJob, now: DateTime<Local>) -> Html {
+    if !job.enabled {
+        return html! { <span class="cell-next muted">{"paused"}</span> };
+    }
+    match next_fire_after(&job.schedule, now) {
+        Some(then) => {
+            let soon = then - now <= Duration::seconds(DUE_SOON_WINDOW_SECS);
+            let until_cls = if soon {
+                "cell-next-until soon"
+            } else {
+                "cell-next-until"
+            };
+            html! {
+                <div class="cell-next">
+                    <div class="cell-next-when">{fmt_when(now, then)}</div>
+                    <div class={until_cls}>{fmt_until(now, then)}</div>
+                </div>
+            }
+        }
+        None => html! { <span class="cell-next muted">{"—"}</span> },
+    }
 }
 
 #[function_component(JobRow)]
@@ -896,6 +970,7 @@ pub fn job_row(props: &JobRowProps) -> Html {
         .to_string();
     let meta = meta_preview(&job.metadata);
     let updated = reltime(job.updated_at);
+    let next_run = next_run_cell(job, props.now);
 
     let on_edit = {
         let cb = props.on_edit.clone();
@@ -962,6 +1037,7 @@ pub fn job_row(props: &JobRowProps) -> Html {
                 <div class="cell-schedule">{&job.schedule}</div>
                 <div class="cell-schedule-human">{cron_text}</div>
             </td>
+            <td>{next_run}</td>
             <td><span class="cell-handler">{&job.handler}</span></td>
             <td><span class="cell-meta">{meta}</span></td>
             <td>

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -10,6 +10,7 @@ mod cron_jobs;
 mod day_timeline;
 mod machines;
 mod routines;
+mod schedule;
 use cron_jobs::CronJobsPage;
 use routines::RoutinesPage;
 

--- a/ui/src/schedule.rs
+++ b/ui/src/schedule.rs
@@ -1,0 +1,78 @@
+//! Pure schedule math for the cron-jobs "next run" capability: given a cron
+//! expression and the current instant, compute the next fire time and format it
+//! both as an absolute *when* ("14:30", "tomorrow 09:00", "Jun 24, 09:00") and a
+//! relative countdown ("in 5m", "in 2h 10m", "in 3d").
+//!
+//! Deliberately free of any DOM/wasm dependency so it is unit-testable on the
+//! host (see `schedule_tests.rs`). The only inputs are the schedule string and a
+//! caller-supplied `now`, keeping every function deterministic.
+
+use chrono::{DateTime, Datelike, Duration, Local};
+
+use crate::parse_cron;
+
+/// Month abbreviations for absolute fire times more than a day out.
+const MONTHS: [&str; 12] = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+/// The next fire time strictly after `now` for `schedule`, or `None` when the
+/// expression is empty/invalid or never fires again.
+pub(crate) fn next_fire_after(schedule: &str, now: DateTime<Local>) -> Option<DateTime<Local>> {
+    parse_cron(schedule)?.iter_after(now).next()
+}
+
+/// `true` when `schedule`'s next fire lands within `window` of `now`.
+pub(crate) fn fires_within(schedule: &str, now: DateTime<Local>, window: Duration) -> bool {
+    match next_fire_after(schedule, now) {
+        Some(then) => then - now <= window,
+        None => false,
+    }
+}
+
+/// Format `then` as a relative countdown from `now`: "in 5m", "in 2h 10m",
+/// "in 3d", "in <1m", or "now" when it is due this instant.
+pub(crate) fn fmt_until(now: DateTime<Local>, then: DateTime<Local>) -> String {
+    let secs = (then - now).num_seconds();
+    if secs <= 0 {
+        return "now".into();
+    }
+    let mins = secs / 60;
+    if mins < 1 {
+        return "in <1m".into();
+    }
+    if mins < 60 {
+        return format!("in {mins}m");
+    }
+    let hours = mins / 60;
+    if hours < 24 {
+        let rem = mins % 60;
+        return if rem == 0 {
+            format!("in {hours}h")
+        } else {
+            format!("in {hours}h {rem}m")
+        };
+    }
+    let days = hours / 24;
+    format!("in {days}d")
+}
+
+/// Format `then` as an absolute fire time relative to `now`'s calendar day:
+/// "14:30" when today, "tomorrow 09:00" the next day, else "Jun 24, 09:00".
+pub(crate) fn fmt_when(now: DateTime<Local>, then: DateTime<Local>) -> String {
+    let hm = then.format("%H:%M").to_string();
+    let days = (then.date_naive() - now.date_naive()).num_days();
+    if days == 0 {
+        hm
+    } else if days == 1 {
+        format!("tomorrow {hm}")
+    } else {
+        let month = MONTHS[then.month0() as usize];
+        let day = then.day();
+        format!("{month} {day}, {hm}")
+    }
+}
+
+#[cfg(test)]
+#[path = "schedule_tests.rs"]
+mod schedule_tests;

--- a/ui/src/schedule_tests.rs
+++ b/ui/src/schedule_tests.rs
@@ -1,0 +1,86 @@
+//! Unit tests for the pure schedule math in [`super`]. A fixed `now` keeps every
+//! assertion deterministic regardless of the host clock or time zone.
+
+use super::*;
+use chrono::TimeZone;
+
+/// A fixed reference instant: Sun 2026-06-21 12:00:30 local. Off the minute
+/// boundary so `next_fire_after` against a top-of-hour schedule is unambiguous.
+fn now() -> DateTime<Local> {
+    Local.with_ymd_and_hms(2026, 6, 21, 12, 0, 30).unwrap()
+}
+
+#[test]
+fn next_fire_after_returns_next_top_of_hour() {
+    let then = next_fire_after("0 * * * *", now()).expect("schedule fires");
+    let expected = Local.with_ymd_and_hms(2026, 6, 21, 13, 0, 0).unwrap();
+    assert_eq!(then, expected);
+}
+
+#[test]
+fn next_fire_after_rejects_invalid_schedule() {
+    assert!(next_fire_after("not a cron", now()).is_none());
+    assert!(next_fire_after("", now()).is_none());
+}
+
+#[test]
+fn fires_within_true_when_next_fire_inside_window() {
+    // Next fire is 13:00:00, i.e. 59m30s out — inside a one-hour window.
+    assert!(fires_within("0 * * * *", now(), Duration::hours(1)));
+}
+
+#[test]
+fn fires_within_false_when_next_fire_beyond_window() {
+    assert!(!fires_within("0 * * * *", now(), Duration::minutes(30)));
+}
+
+#[test]
+fn fires_within_false_for_invalid_schedule() {
+    assert!(!fires_within("nonsense", now(), Duration::hours(1)));
+}
+
+#[test]
+fn fmt_until_now_when_due() {
+    assert_eq!(fmt_until(now(), now()), "now");
+}
+
+#[test]
+fn fmt_until_sub_minute() {
+    assert_eq!(fmt_until(now(), now() + Duration::seconds(30)), "in <1m");
+}
+
+#[test]
+fn fmt_until_minutes() {
+    assert_eq!(fmt_until(now(), now() + Duration::minutes(5)), "in 5m");
+}
+
+#[test]
+fn fmt_until_whole_hours() {
+    assert_eq!(fmt_until(now(), now() + Duration::hours(2)), "in 2h");
+}
+
+#[test]
+fn fmt_until_hours_and_minutes() {
+    let then = now() + Duration::hours(2) + Duration::minutes(10);
+    assert_eq!(fmt_until(now(), then), "in 2h 10m");
+}
+
+#[test]
+fn fmt_until_days() {
+    assert_eq!(fmt_until(now(), now() + Duration::days(3)), "in 3d");
+}
+
+#[test]
+fn fmt_when_today_is_bare_time() {
+    assert_eq!(fmt_when(now(), now() + Duration::hours(1)), "13:00");
+}
+
+#[test]
+fn fmt_when_tomorrow_is_prefixed() {
+    assert_eq!(fmt_when(now(), now() + Duration::days(1)), "tomorrow 12:00");
+}
+
+#[test]
+fn fmt_when_far_uses_month_and_day() {
+    assert_eq!(fmt_when(now(), now() + Duration::days(3)), "Jun 24, 12:00");
+}


### PR DESCRIPTION
Closes #597.

## What ships

1. **`NEXT RUN` column** in the scheduled-jobs table — absolute next fire time (`14:30`, `tomorrow 09:00`, `Jun 24, 09:00`) plus a relative countdown (`in 5m`, `in 2h 10m`, `in 3d`). Disabled jobs read `paused`; unparseable/never-firing schedules read `—`. The countdown turns red once the fire lands inside the due-soon window.
2. **`DUE SOON` KPI tile** in the stats bar — count of enabled jobs whose next fire is within the next hour.
3. **Live refresh** — a 30 s tick keeps countdowns and the due-soon count current without a manual reload.

## How

Pure schedule math (`next_fire_after`, `fires_within`, `fmt_until`, `fmt_when`) lands in a new `ui/src/schedule.rs` with host-side unit tests in `ui/src/schedule_tests.rs` (14 tests). Fire times are computed via the `croner` crate already bundled in the UI — the same engine that powers the DAY timeline. **No backend, API, or data-model change**; built only on `CronJob.schedule`, which the UI already fetches.

## Best-practice rationale

- **Next run + countdown as a first-class signal** — Cronicle and Cronmaster both surface "time until next run" as the primary operational fact about a schedule.
- **KPI where the eye lands first** — observability dashboards put the most decision-relevant metric in a top tile; "what's about to fire" earns one.
- **Consistent visual language** — reuses the existing stat-card and table-cell styling and the existing `croner` fire-time engine.

## Verification

- `cargo build` ✅ (server + ui wasm bundle)
- `cargo clippy -p ui --all-targets -- -D warnings` ✅ clean
- `cargo test -p ui` ✅ 14/14 schedule tests pass
- Diff is confined to `ui/` (generated `prebuilt.html` deliberately not committed).

Scope note: this PR touches `ui/` only and intentionally does not edit root-level `CHANGELOG.md`, so the `skip-changelog` label is applied.

---
_This pull request was opened by the **UI dashboard feature builder (research → issue → PR → merge)** routine of moadim._