### PR TITLE
test(error): assert the AppError JSON response body, not just status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   (`|e| e.ok()`, `|s| s.to_string()`, `|p| p.into_inner()`) with the method
   path itself (`Result::ok`, `ToString::to_string`,
   `std::sync::PoisonError::into_inner`). No behavior change.
+- Pinned the `AppError` HTTP response **body** contract: tests now assert that
+  every variant serializes to `{"error": <message>}`, not just the right status
+  code, so the JSON error envelope clients parse can't silently regress. Tests
+  only; no behavior change.
 
 ## [0.15.0] - 2026-06-21
 

--- a/src/error_tests.rs
+++ b/src/error_tests.rs
@@ -62,3 +62,40 @@ fn into_response_conflict_is_409() {
         StatusCode::CONFLICT
     );
 }
+
+/// Decode an [`AppError`] response body into its `{"error": ...}` JSON.
+async fn response_error_field(err: AppError) -> String {
+    let body = err.into_response().into_body();
+    let bytes = axum::body::to_bytes(body, usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    json["error"].as_str().unwrap().to_string()
+}
+
+#[tokio::test]
+async fn into_response_body_carries_bad_request_message() {
+    assert_eq!(
+        response_error_field(AppError::BadRequest("oops".into())).await,
+        "bad request: oops"
+    );
+}
+
+#[tokio::test]
+async fn into_response_body_carries_conflict_message() {
+    assert_eq!(
+        response_error_field(AppError::Conflict("duplicate".into())).await,
+        "conflict: duplicate"
+    );
+}
+
+#[tokio::test]
+async fn into_response_body_carries_not_found_message() {
+    assert_eq!(response_error_field(AppError::NotFound).await, "not found");
+}
+
+#[tokio::test]
+async fn into_response_body_carries_internal_message() {
+    assert_eq!(
+        response_error_field(AppError::Internal).await,
+        "internal server error"
+    );
+}


### PR DESCRIPTION
## What

The `AppError` tests in `src/error_tests.rs` already covered every variant's
`Display` string and its HTTP status code — but never the **response body**.

`AppError::into_response` wraps the message as:

```json
{ "error": "<Display string>" }
```

That JSON envelope is the contract REST clients parse, yet nothing verified it.
The `error` key name or the body shape could regress silently while every
existing test stayed green.

## Change

Adds four `#[tokio::test]` cases — one per variant (`BadRequest`, `Conflict`,
`NotFound`, `Internal`) — that decode the response body via
`axum::body::to_bytes` (no new dependency; `to_bytes` is re-exported by the
already-vendored axum 0.8) and assert the `error` field carries the expected
message.

Tests only. No `src` behavior change, no public API change.

## Why it's low-risk

- Touches only `src/error_tests.rs` (test module) and adds a CHANGELOG bullet.
- Strengthens an existing contract rather than changing behavior.
- Pure additive coverage, so the 100%-line-coverage gate stays satisfied.

## Verified locally

- `cargo fmt --check` — pass
- `cargo clippy --all-targets -- -D warnings` — pass (exit 0, no warnings)
- `cargo test error_tests` — pass (12/12, including the 4 new body tests)

Full `cargo test` and the coverage gate were not run end-to-end locally (heavy
build), but this is an additive test-only change that does not alter any covered
code path.

---

This pull request was opened by the 'Daemon + Landing auto-improve & auto-merge lint/docs PRs' routine of moadim.

CC @tupe12334