### PR TITLE
feat(ui): command palette (⌘K) — fuzzy launcher across pages, jobs & routines

### DIFF
--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -19,7 +19,7 @@ chrono = "0.4"
 gloo-net = { version = "0.6", features = ["http"] }
 gloo-timers = { version = "0.4", features = ["futures"] }
 js-sys = "0.3"
-web-sys = { version = "0.3", features = ["Element", "HtmlInputElement", "HtmlSelectElement"] }
+web-sys = { version = "0.3", features = ["Element", "EventTarget", "HtmlElement", "HtmlInputElement", "HtmlSelectElement", "KeyboardEvent", "Window"] }
 log = "0.4"
 console_log = "1"
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -167,6 +167,113 @@
     }
     .btn-refresh:hover { color: var(--accent); border-color: var(--border-hi); }
     .btn-refresh.spinning { animation: spin 0.6s linear infinite; }
+
+    .btn-cmdk {
+      background: none;
+      border: 1px solid var(--border);
+      color: var(--text-dim);
+      font-family: var(--mono);
+      font-size: 11px;
+      letter-spacing: 0.08em;
+      padding: 4px 9px;
+      cursor: pointer;
+      transition: color 0.12s, border-color 0.12s;
+      line-height: 1;
+    }
+    .btn-cmdk:hover { color: var(--accent); border-color: var(--border-hi); }
+
+    /* ── Command palette (⌘K) ── */
+    .cmdk {
+      align-self: flex-start;
+      margin-top: 11vh;
+      width: 560px;
+      max-width: 92vw;
+      background: var(--bg-2);
+      border: 1px solid var(--border-hi);
+      box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
+      transform: translateY(10px);
+      transition: transform 0.18s;
+      display: flex;
+      flex-direction: column;
+      max-height: 70vh;
+    }
+    .overlay.open .cmdk { transform: translateY(0); }
+
+    .cmdk-search {
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      padding: 12px 14px;
+      border-bottom: 1px solid var(--border);
+    }
+    .cmdk-prompt { color: var(--accent); font-size: 15px; line-height: 1; }
+    .cmdk-input {
+      flex: 1;
+      background: none;
+      border: none;
+      outline: none;
+      color: var(--text-hi);
+      font-family: var(--mono);
+      font-size: 14px;
+    }
+    .cmdk-input::placeholder { color: var(--text-ghost); }
+    .cmdk-hint {
+      font-size: 9px;
+      letter-spacing: 0.12em;
+      color: var(--text-ghost);
+      border: 1px solid var(--border);
+      padding: 2px 5px;
+    }
+
+    .cmdk-list {
+      list-style: none;
+      margin: 0;
+      padding: 6px;
+      overflow-y: auto;
+    }
+    .cmdk-row {
+      display: flex;
+      align-items: center;
+      gap: 11px;
+      padding: 8px 10px;
+      cursor: pointer;
+      border: 1px solid transparent;
+    }
+    .cmdk-row.active { background: var(--bg-3); border-color: var(--border-hi); }
+    .cmdk-row-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+    .cmdk-row-title {
+      color: var(--text-hi);
+      font-size: 13px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .cmdk-row-sub {
+      color: var(--text-dim);
+      font-size: 10px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .kind-badge.nav { border-color: var(--border-hi); color: var(--accent); }
+    .kind-badge.action { border-color: var(--amber); color: var(--amber); }
+
+    .cmdk-empty { padding: 30px 18px; text-align: center; }
+
+    .cmdk-foot {
+      display: flex;
+      gap: 16px;
+      padding: 9px 14px;
+      border-top: 1px solid var(--border);
+      font-size: 10px;
+      color: var(--text-ghost);
+    }
+    .cmdk-key {
+      color: var(--text-mid);
+      border: 1px solid var(--border);
+      padding: 1px 5px;
+      margin-right: 4px;
+    }
     @keyframes spin { to { transform: rotate(360deg); } }
 
     .btn-stop {

--- a/ui/src/command_palette.rs
+++ b/ui/src/command_palette.rs
@@ -1,0 +1,511 @@
+//! The command palette (⌘K / Ctrl-K): a global, keyboard-first launcher that
+//! fuzzy-searches every navigable destination — the three pages plus every
+//! cron job and routine — and jumps to it on Enter. It is the power-user
+//! complement to the nav tabs: no mouse, no remembering which tab a job lives
+//! under, just type a few characters and go.
+//!
+//! Best practice (Superhuman / Linear / VS Code command palettes, and the
+//! WAI-ARIA combobox+listbox pattern): bind to the de-facto ⌘K shortcut, show
+//! all destinations before the user types, fuzzy-match against a title *and*
+//! aliases (agent, handler, schedule, id), group results by category, and drive
+//! the whole interaction from the keyboard (↑/↓ to move, Home/End to jump,
+//! Enter to launch, Esc to dismiss) while exposing it to assistive tech via
+//! `role="combobox"`/`role="listbox"` and `aria-activedescendant`.
+//!
+//! It reads the existing `/api/v1/cron-jobs` and `/api/v1/routines` endpoints —
+//! no backend change. All match/rank/build logic lives in pure, host-tested
+//! functions below (see `command_palette_tests.rs`); the component is a thin
+//! shell that fetches the records, ranks them against the query, and renders.
+
+use wasm_bindgen_futures::spawn_local;
+use web_sys::{HtmlElement, HtmlInputElement};
+use yew::prelude::*;
+use yew_router::prelude::*;
+
+use crate::cron_jobs::CronJob;
+use crate::overview::{fetch_crons, fetch_routines};
+use crate::routines::Routine;
+use crate::Route;
+
+/// What a palette entry points at — a fixed page, or an entity that lives on a
+/// page. Kept free of `yew_router::Route` so the ranking/build logic is fully
+/// host-testable; the component maps each variant to a concrete route.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum CmdKind {
+    /// Jump to the OVERVIEW page.
+    NavOverview,
+    /// Jump to the CRON JOBS page.
+    NavCronJobs,
+    /// Jump to the ROUTINES page.
+    NavRoutines,
+    /// A specific cron job (lands on the CRON JOBS page).
+    Cron,
+    /// A specific routine (lands on the ROUTINES page).
+    Routine,
+    /// Re-poll server health (the header's ↻ action).
+    ActionRefresh,
+    /// Open the stop-server confirmation (the header's ⏻ action).
+    ActionStop,
+}
+
+/// The destination page a [`CmdKind`] resolves to, independent of the wasm
+/// router so it can be asserted on the host.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum RouteKind {
+    /// The OVERVIEW page (`/`).
+    Home,
+    /// The CRON JOBS page (`/cron-jobs`).
+    CronJobs,
+    /// The ROUTINES page (`/routines`).
+    Routines,
+}
+
+/// One searchable destination in the palette.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub(crate) struct Command {
+    /// What this entry points at.
+    pub kind: CmdKind,
+    /// Primary label shown and matched first.
+    pub title: String,
+    /// Secondary line (schedule description / route hint).
+    pub subtitle: String,
+    /// Extra terms folded into the fuzzy haystack (agent, handler, id, …) so a
+    /// match on an alias still surfaces the entry.
+    pub keywords: String,
+}
+
+/// The page a command navigates to, or `None` for an action command (which
+/// runs a callback instead of navigating).
+pub(crate) fn route_for(kind: CmdKind) -> Option<RouteKind> {
+    match kind {
+        CmdKind::NavOverview => Some(RouteKind::Home),
+        CmdKind::NavCronJobs | CmdKind::Cron => Some(RouteKind::CronJobs),
+        CmdKind::NavRoutines | CmdKind::Routine => Some(RouteKind::Routines),
+        CmdKind::ActionRefresh | CmdKind::ActionStop => None,
+    }
+}
+
+/// The short category badge text for a command (used in the row and as the
+/// group separator label).
+pub(crate) fn badge_for(kind: CmdKind) -> &'static str {
+    match kind {
+        CmdKind::NavOverview | CmdKind::NavCronJobs | CmdKind::NavRoutines => "GO",
+        CmdKind::Cron => "CRON",
+        CmdKind::Routine => "ROUTINE",
+        CmdKind::ActionRefresh | CmdKind::ActionStop => "ACTION",
+    }
+}
+
+/// Score how well `query` fuzzy-matches `text`: both are compared
+/// case-insensitively, and `query` must appear as an ordered subsequence of
+/// `text`. A higher score is a better match. Returns `None` when `query` is not
+/// a subsequence; an empty (or whitespace-only) query matches everything with a
+/// neutral score of `0`, so the unfiltered list keeps its natural order.
+///
+/// Bonuses reward the matches users perceive as "good": a hit at the very start
+/// of the text, a hit right after a word boundary, and runs of consecutive
+/// characters. Longer texts are mildly penalized so a tight match on a short
+/// label outranks a scattered one on a long string.
+pub(crate) fn fuzzy_score(text: &str, query: &str) -> Option<i32> {
+    let needle = query.trim();
+    if needle.is_empty() {
+        return Some(0);
+    }
+    let hay: Vec<char> = text.to_lowercase().chars().collect();
+    let pins: Vec<char> = needle.to_lowercase().chars().collect();
+    let mut score = 0i32;
+    let mut cursor = 0usize;
+    let mut prev: Option<usize> = None;
+    for &needle_ch in &pins {
+        let mut hit = None;
+        while cursor < hay.len() {
+            let hay_ch = hay[cursor];
+            cursor += 1;
+            if hay_ch == needle_ch {
+                hit = Some(cursor - 1);
+                break;
+            }
+        }
+        let pos = hit?;
+        score += 1;
+        if pos == 0 {
+            score += 10; // start of string
+        } else if !hay[pos - 1].is_alphanumeric() {
+            score += 6; // start of a word
+        }
+        if let Some(prev_pos) = prev {
+            if pos == prev_pos + 1 {
+                score += 8; // consecutive run
+            }
+        }
+        prev = Some(pos);
+    }
+    score -= hay.len() as i32 / 16;
+    Some(score)
+}
+
+/// Best fuzzy score for a command against `query`, matching the title at full
+/// weight and the keyword aliases at a slight discount so a title hit wins a
+/// tie. `None` when neither field matches.
+fn command_score(command: &Command, query: &str) -> Option<i32> {
+    let title = fuzzy_score(&command.title, query);
+    let alias = fuzzy_score(&command.keywords, query).map(|raw| raw - 4);
+    match (title, alias) {
+        (Some(left), Some(right)) => Some(left.max(right)),
+        (left, right) => left.or(right),
+    }
+}
+
+/// Indices of `commands` that match `query`, best-first. Ties keep the input
+/// order (which is already grouped: pages, then cron jobs, then routines), so
+/// an empty query returns every command in its natural grouping.
+pub(crate) fn rank(commands: &[Command], query: &str) -> Vec<usize> {
+    let mut scored: Vec<(usize, i32)> = commands
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, command)| command_score(command, query).map(|score| (idx, score)))
+        .collect();
+    scored.sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
+    scored.into_iter().map(|(idx, _)| idx).collect()
+}
+
+/// Build the full command list: the three pages first, then one entry per cron
+/// job, then one per routine. Subtitles prefer the server's human schedule
+/// description and fall back to the raw expression.
+pub(crate) fn build_commands(crons: &[CronJob], routines: &[Routine]) -> Vec<Command> {
+    let mut commands = vec![
+        Command {
+            kind: CmdKind::NavOverview,
+            title: "Overview".into(),
+            subtitle: "Fleet summary & upcoming runs".into(),
+            keywords: "home dashboard kpi summary landing".into(),
+        },
+        Command {
+            kind: CmdKind::NavCronJobs,
+            title: "Cron Jobs".into(),
+            subtitle: "Manage scheduled handler jobs".into(),
+            keywords: "schedule handler tasks".into(),
+        },
+        Command {
+            kind: CmdKind::NavRoutines,
+            title: "Routines".into(),
+            subtitle: "Manage agent-driven routines".into(),
+            keywords: "agents automation".into(),
+        },
+        Command {
+            kind: CmdKind::ActionRefresh,
+            title: "Refresh".into(),
+            subtitle: "Re-poll server health".into(),
+            keywords: "reload health status action".into(),
+        },
+        Command {
+            kind: CmdKind::ActionStop,
+            title: "Stop Server".into(),
+            subtitle: "Shut the moadim server down".into(),
+            keywords: "shutdown halt kill quit action".into(),
+        },
+    ];
+    for job in crons {
+        commands.push(Command {
+            kind: CmdKind::Cron,
+            title: job.id.clone(),
+            subtitle: schedule_label(&job.schedule_description, &job.schedule),
+            keywords: format!("{} {} cron job", job.handler, job.schedule),
+        });
+    }
+    for routine in routines {
+        commands.push(Command {
+            kind: CmdKind::Routine,
+            title: routine.title.clone(),
+            subtitle: schedule_label(&routine.schedule_description, &routine.schedule),
+            keywords: format!(
+                "{} {} {} routine",
+                routine.id, routine.agent, routine.schedule
+            ),
+        });
+    }
+    commands
+}
+
+/// The human schedule description when present, else the raw expression, else a
+/// dash so a row never renders an empty subtitle.
+fn schedule_label(human: &Option<String>, raw: &str) -> String {
+    match human {
+        Some(text) if !text.is_empty() => text.clone(),
+        _ if !raw.trim().is_empty() => raw.to_string(),
+        _ => "—".into(),
+    }
+}
+
+/// Clamp `selected` to a valid row index for a result list of `len` rows: stays
+/// at `0` when empty, otherwise never points past the last row.
+pub(crate) fn clamp_selection(selected: usize, len: usize) -> usize {
+    if len == 0 {
+        0
+    } else {
+        selected.min(len - 1)
+    }
+}
+
+/// Next selection index when pressing ↓: advances by one but never past the
+/// last row (no wrap), and stays at `0` for an empty list.
+pub(crate) fn next_index(selected: usize, len: usize) -> usize {
+    if len == 0 {
+        0
+    } else {
+        (selected + 1).min(len - 1)
+    }
+}
+
+/// Previous selection index when pressing ↑: retreats by one, saturating at the
+/// first row (no wrap).
+pub(crate) fn prev_index(selected: usize) -> usize {
+    selected.saturating_sub(1)
+}
+
+/// Last selection index when pressing End: the final row, or `0` when empty.
+pub(crate) fn last_index(len: usize) -> usize {
+    len.saturating_sub(1)
+}
+
+// ─── Component ─────────────────────────────────────────────────────────────────
+
+/// Loaded records the palette ranks over.
+#[derive(Clone, PartialEq, Default)]
+struct Records {
+    crons: Vec<CronJob>,
+    routines: Vec<Routine>,
+}
+
+#[derive(Properties, PartialEq)]
+pub struct PaletteProps {
+    /// Whether the palette overlay is shown.
+    pub open: bool,
+    /// Invoked when the palette asks to close (Esc, backdrop click, or launch).
+    pub on_close: Callback<()>,
+    /// Runs the "Refresh" action (re-poll health).
+    pub on_refresh: Callback<()>,
+    /// Runs the "Stop Server" action (open the shutdown confirmation).
+    pub on_stop: Callback<()>,
+}
+
+/// The ⌘K command palette overlay. Mounted permanently by the shell; renders
+/// nothing while closed. Opening it fetches the records, focuses the input, and
+/// resets the query/selection.
+#[function_component(CommandPalette)]
+pub fn command_palette(props: &PaletteProps) -> Html {
+    let navigator = use_navigator();
+    let records = use_state(Records::default);
+    let query = use_state(String::new);
+    let selected = use_state(|| 0usize);
+    let input_ref = use_node_ref();
+
+    // On each open: re-fetch the records (so a job created elsewhere shows up),
+    // reset the query/selection, and move focus into the input. The effect
+    // re-runs whenever `open` flips.
+    {
+        let records = records.clone();
+        let query = query.clone();
+        let selected = selected.clone();
+        let input_ref = input_ref.clone();
+        let open = props.open;
+        use_effect_with(open, move |_| {
+            if open {
+                query.set(String::new());
+                selected.set(0);
+                if let Some(input) = input_ref.cast::<HtmlElement>() {
+                    let _ = input.focus();
+                }
+                spawn_local(async move {
+                    let crons = fetch_crons().await.unwrap_or_default();
+                    let routines = fetch_routines().await.unwrap_or_default();
+                    records.set(Records { crons, routines });
+                });
+            }
+            || ()
+        });
+    }
+
+    let commands = build_commands(&records.crons, &records.routines);
+    let order = rank(&commands, &query);
+    let sel = clamp_selection(*selected, order.len());
+
+    let launch = {
+        let navigator = navigator.clone();
+        let on_close = props.on_close.clone();
+        let on_refresh = props.on_refresh.clone();
+        let on_stop = props.on_stop.clone();
+        let commands = commands.clone();
+        let order = order.clone();
+        Callback::from(move |row: usize| {
+            if let Some(command) = order.get(row).and_then(|&idx| commands.get(idx)) {
+                match command.kind {
+                    CmdKind::ActionRefresh => on_refresh.emit(()),
+                    CmdKind::ActionStop => on_stop.emit(()),
+                    kind => {
+                        if let (Some(nav), Some(route_kind)) = (navigator.clone(), route_for(kind))
+                        {
+                            let route = match route_kind {
+                                RouteKind::Home => Route::Home,
+                                RouteKind::CronJobs => Route::CronJobs,
+                                RouteKind::Routines => Route::Routines,
+                            };
+                            nav.push(&route);
+                        }
+                    }
+                }
+            }
+            on_close.emit(());
+        })
+    };
+
+    let on_input = {
+        let query = query.clone();
+        let selected = selected.clone();
+        Callback::from(move |event: InputEvent| {
+            let input: HtmlInputElement = event.target_unchecked_into();
+            query.set(input.value());
+            selected.set(0);
+        })
+    };
+
+    let on_keydown = {
+        let selected = selected.clone();
+        let on_close = props.on_close.clone();
+        let launch = launch.clone();
+        let len = order.len();
+        Callback::from(move |event: KeyboardEvent| match event.key().as_str() {
+            "ArrowDown" => {
+                event.prevent_default();
+                selected.set(next_index(sel, len));
+            }
+            "ArrowUp" => {
+                event.prevent_default();
+                selected.set(prev_index(sel));
+            }
+            "Home" => {
+                event.prevent_default();
+                selected.set(0);
+            }
+            "End" => {
+                event.prevent_default();
+                selected.set(last_index(len));
+            }
+            "Enter" => {
+                event.prevent_default();
+                launch.emit(sel);
+            }
+            "Escape" => {
+                event.prevent_default();
+                on_close.emit(());
+            }
+            _ => {}
+        })
+    };
+
+    let on_backdrop = {
+        let on_close = props.on_close.clone();
+        Callback::from(move |_: MouseEvent| on_close.emit(()))
+    };
+    // Clicks inside the dialog must not bubble to the backdrop-close handler.
+    let stop = Callback::from(|event: MouseEvent| event.stop_propagation());
+
+    if !props.open {
+        return html! {};
+    }
+
+    let rows = html! {
+        { for order.iter().enumerate().map(|(row, &cmd_idx)| {
+            let command = &commands[cmd_idx];
+            let active = row == sel;
+            let row_cls = if active { "cmdk-row active" } else { "cmdk-row" };
+            let badge = badge_for(command.kind);
+            let badge_cls = match command.kind {
+                CmdKind::Cron => "kind-badge cron",
+                CmdKind::Routine => "kind-badge routine",
+                CmdKind::ActionRefresh | CmdKind::ActionStop => "kind-badge action",
+                _ => "kind-badge nav",
+            };
+            let launch = launch.clone();
+            let selected = selected.clone();
+            let onclick = Callback::from(move |_: MouseEvent| launch.emit(row));
+            let onmouseenter = Callback::from(move |_: MouseEvent| selected.set(row));
+            html! {
+                <li
+                    id={format!("cmdk-opt-{row}")}
+                    class={row_cls}
+                    role="option"
+                    aria-selected={active.to_string()}
+                    {onclick}
+                    {onmouseenter}
+                >
+                    <span class={badge_cls}>{badge}</span>
+                    <span class="cmdk-row-text">
+                        <span class="cmdk-row-title">{command.title.clone()}</span>
+                        <span class="cmdk-row-sub">{command.subtitle.clone()}</span>
+                    </span>
+                </li>
+            }
+        }) }
+    };
+
+    let active_id = (!order.is_empty()).then(|| format!("cmdk-opt-{sel}"));
+
+    html! {
+        <div class="overlay open" onclick={on_backdrop}>
+            <div
+                class="cmdk"
+                role="dialog"
+                aria-modal="true"
+                aria-label="Command palette"
+                onclick={stop}
+            >
+                <div class="cmdk-search">
+                    <span class="cmdk-prompt" aria-hidden="true">{"›"}</span>
+                    <input
+                        ref={input_ref}
+                        class="cmdk-input"
+                        type="text"
+                        placeholder="Search pages, cron jobs, routines…"
+                        autocomplete="off"
+                        spellcheck="false"
+                        role="combobox"
+                        aria-expanded="true"
+                        aria-controls="cmdk-listbox"
+                        aria-autocomplete="list"
+                        aria-activedescendant={active_id}
+                        value={(*query).clone()}
+                        oninput={on_input}
+                        onkeydown={on_keydown}
+                    />
+                    <span class="cmdk-hint" aria-hidden="true">{"ESC"}</span>
+                </div>
+                {
+                    if order.is_empty() {
+                        html! {
+                            <div class="cmdk-empty">
+                                <div class="empty-msg">{"NO MATCHES"}</div>
+                                <div class="empty-sub">{"no page, cron job, or routine matches"}</div>
+                            </div>
+                        }
+                    } else {
+                        html! {
+                            <ul id="cmdk-listbox" class="cmdk-list" role="listbox" aria-label="Results">
+                                {rows}
+                            </ul>
+                        }
+                    }
+                }
+                <div class="cmdk-foot" aria-hidden="true">
+                    <span><span class="cmdk-key">{"↑↓"}</span>{" navigate"}</span>
+                    <span><span class="cmdk-key">{"↵"}</span>{" open"}</span>
+                    <span><span class="cmdk-key">{"esc"}</span>{" close"}</span>
+                </div>
+            </div>
+        </div>
+    }
+}
+
+#[cfg(test)]
+#[path = "command_palette_tests.rs"]
+mod command_palette_tests;

--- a/ui/src/command_palette_tests.rs
+++ b/ui/src/command_palette_tests.rs
@@ -84,9 +84,14 @@ fn word_boundary_hit_is_rewarded() {
 
 #[test]
 fn consecutive_run_beats_scattered() {
-    let consecutive = fuzzy_score("overview", "ove").expect("matches");
-    let scattered = fuzzy_score("o_v_e_rment", "ove").expect("matches");
-    assert!(consecutive > scattered);
+    // A tight run of the query characters outscores the same characters spread
+    // apart. Neutral tokens keep the spell-checker happy.
+    let consecutive = fuzzy_score("zzabczz", "abc").expect("matches");
+    let scattered = fuzzy_score("axbxc", "abc").expect("matches");
+    assert!(
+        consecutive > scattered,
+        "consecutive {consecutive} > scattered {scattered}"
+    );
 }
 
 #[test]

--- a/ui/src/command_palette_tests.rs
+++ b/ui/src/command_palette_tests.rs
@@ -1,0 +1,242 @@
+//! Host-side unit tests for the command palette's pure logic: fuzzy scoring,
+//! command ranking, the records→`Command` builder, route/badge mapping, and the
+//! keyboard selection-index helpers. All deterministic and DOM-free.
+
+use super::*;
+use serde_json::Value;
+
+fn cron(id: &str, schedule: &str, handler: &str, human: Option<&str>) -> CronJob {
+    CronJob {
+        id: id.into(),
+        schedule: schedule.into(),
+        handler: handler.into(),
+        metadata: Value::Null,
+        machines: vec![],
+        enabled: true,
+        created_at: 0,
+        updated_at: 0,
+        last_manual_trigger_at: None,
+        schedule_description: human.map(Into::into),
+    }
+}
+
+fn routine(id: &str, title: &str, agent: &str, schedule: &str, human: Option<&str>) -> Routine {
+    Routine {
+        id: id.into(),
+        schedule: schedule.into(),
+        title: title.into(),
+        agent: agent.into(),
+        prompt: String::new(),
+        repositories: vec![],
+        machines: vec![],
+        enabled: true,
+        source: String::new(),
+        created_at: 0,
+        updated_at: 0,
+        last_manual_trigger_at: None,
+        ttl_secs: None,
+        agent_registered: false,
+        file_path: String::new(),
+        schedule_description: human.map(Into::into),
+    }
+}
+
+fn cmd(kind: CmdKind, title: &str, keywords: &str) -> Command {
+    Command {
+        kind,
+        title: title.into(),
+        subtitle: String::new(),
+        keywords: keywords.into(),
+    }
+}
+
+// ─── fuzzy_score ────────────────────────────────────────────────────────────
+
+#[test]
+fn empty_query_matches_with_neutral_score() {
+    assert_eq!(fuzzy_score("anything", ""), Some(0));
+    assert_eq!(fuzzy_score("anything", "   "), Some(0));
+}
+
+#[test]
+fn non_subsequence_does_not_match() {
+    assert_eq!(fuzzy_score("abc", "xyz"), None);
+    assert_eq!(fuzzy_score("abc", "cab"), None); // out of order
+}
+
+#[test]
+fn start_of_string_outranks_later_hit() {
+    let lead = fuzzy_score("overview", "o").expect("matches");
+    let mid = fuzzy_score("retro", "o").expect("matches");
+    assert!(lead > mid, "leading hit {lead} should beat mid hit {mid}");
+}
+
+#[test]
+fn word_boundary_hit_is_rewarded() {
+    // 'j' after the space scores the word-boundary bonus.
+    let boundary = fuzzy_score("cron jobs", "j").expect("matches");
+    let interior = fuzzy_score("major", "j").expect("matches");
+    assert!(
+        boundary > interior,
+        "boundary {boundary} > interior {interior}"
+    );
+}
+
+#[test]
+fn consecutive_run_beats_scattered() {
+    let consecutive = fuzzy_score("overview", "ove").expect("matches");
+    let scattered = fuzzy_score("o_v_e_rment", "ove").expect("matches");
+    assert!(consecutive > scattered);
+}
+
+#[test]
+fn longer_text_is_penalized() {
+    let short = fuzzy_score("ab", "a").expect("matches");
+    let long = fuzzy_score(&"a".repeat(40), "a").expect("matches");
+    // Same leading match, but the 40-char text loses points to the length term.
+    assert!(short > long, "short {short} > long {long}");
+}
+
+#[test]
+fn case_is_ignored() {
+    assert!(fuzzy_score("Overview", "OVERVIEW").is_some());
+}
+
+// ─── rank (and command_score via it) ─────────────────────────────────────────
+
+#[test]
+fn empty_query_keeps_natural_order() {
+    let commands = vec![
+        cmd(CmdKind::NavOverview, "Overview", ""),
+        cmd(CmdKind::Cron, "backup", ""),
+    ];
+    assert_eq!(rank(&commands, ""), vec![0, 1]);
+}
+
+#[test]
+fn title_match_outranks_keyword_only_match() {
+    let commands = vec![
+        // index 0: matches only via keyword alias
+        cmd(CmdKind::Cron, "nightly", "backup database"),
+        // index 1: matches directly in the title
+        cmd(CmdKind::Routine, "backup", "misc"),
+    ];
+    let order = rank(&commands, "backup");
+    assert_eq!(order.first(), Some(&1), "title hit should rank first");
+    assert_eq!(order.len(), 2);
+}
+
+#[test]
+fn keyword_only_match_still_surfaces() {
+    // Title has no 'z'; only the keywords do. Exercises the (None, Some) arm.
+    let commands = vec![cmd(CmdKind::Cron, "alpha", "zeta")];
+    assert_eq!(rank(&commands, "zeta"), vec![0]);
+}
+
+#[test]
+fn title_match_with_unmatched_keywords() {
+    // Exercises the (Some, None) arm: title matches, keywords do not.
+    let commands = vec![cmd(CmdKind::Routine, "deploy", "xxxxx")];
+    assert_eq!(rank(&commands, "deploy"), vec![0]);
+}
+
+#[test]
+fn non_matching_commands_are_dropped() {
+    let commands = vec![
+        cmd(CmdKind::Cron, "alpha", "one"),
+        cmd(CmdKind::Cron, "beta", "two"),
+    ];
+    assert!(rank(&commands, "zzz").is_empty());
+}
+
+// ─── build_commands ──────────────────────────────────────────────────────────
+
+#[test]
+fn build_lists_pages_then_crons_then_routines() {
+    let crons = vec![cron("backup", "0 * * * *", "snapshot", Some("Every hour"))];
+    let routines = vec![routine("r1", "Nightly Audit", "claude", "0 0 * * *", None)];
+    let commands = build_commands(&crons, &routines);
+    assert_eq!(commands.len(), 7); // 3 nav + 2 action + 1 cron + 1 routine
+    assert_eq!(commands[0].kind, CmdKind::NavOverview);
+    assert_eq!(commands[1].kind, CmdKind::NavCronJobs);
+    assert_eq!(commands[2].kind, CmdKind::NavRoutines);
+    assert_eq!(commands[3].kind, CmdKind::ActionRefresh);
+    assert_eq!(commands[4].kind, CmdKind::ActionStop);
+    assert_eq!(commands[5].kind, CmdKind::Cron);
+    assert_eq!(commands[5].title, "backup");
+    assert_eq!(commands[5].subtitle, "Every hour"); // human description wins
+    assert!(commands[5].keywords.contains("snapshot"));
+    assert_eq!(commands[6].kind, CmdKind::Routine);
+    assert_eq!(commands[6].title, "Nightly Audit");
+    assert_eq!(commands[6].subtitle, "0 0 * * *"); // falls back to raw expr
+    assert!(commands[6].keywords.contains("claude"));
+}
+
+#[test]
+fn schedule_label_prefers_human_then_raw_then_dash() {
+    assert_eq!(
+        schedule_label(&Some("At noon".into()), "0 12 * * *"),
+        "At noon"
+    );
+    // Empty human description falls through to the raw expression.
+    assert_eq!(
+        schedule_label(&Some(String::new()), "0 12 * * *"),
+        "0 12 * * *"
+    );
+    assert_eq!(schedule_label(&None, "0 12 * * *"), "0 12 * * *");
+    // Neither present → a dash, never an empty string.
+    assert_eq!(schedule_label(&None, "   "), "—");
+}
+
+// ─── route_for / badge_for ────────────────────────────────────────────────────
+
+#[test]
+fn route_for_maps_every_kind() {
+    assert_eq!(route_for(CmdKind::NavOverview), Some(RouteKind::Home));
+    assert_eq!(route_for(CmdKind::NavCronJobs), Some(RouteKind::CronJobs));
+    assert_eq!(route_for(CmdKind::NavRoutines), Some(RouteKind::Routines));
+    assert_eq!(route_for(CmdKind::Cron), Some(RouteKind::CronJobs));
+    assert_eq!(route_for(CmdKind::Routine), Some(RouteKind::Routines));
+    // Action commands run a callback, not a navigation.
+    assert_eq!(route_for(CmdKind::ActionRefresh), None);
+    assert_eq!(route_for(CmdKind::ActionStop), None);
+}
+
+#[test]
+fn badge_for_maps_every_kind() {
+    assert_eq!(badge_for(CmdKind::NavOverview), "GO");
+    assert_eq!(badge_for(CmdKind::NavCronJobs), "GO");
+    assert_eq!(badge_for(CmdKind::NavRoutines), "GO");
+    assert_eq!(badge_for(CmdKind::Cron), "CRON");
+    assert_eq!(badge_for(CmdKind::Routine), "ROUTINE");
+    assert_eq!(badge_for(CmdKind::ActionRefresh), "ACTION");
+    assert_eq!(badge_for(CmdKind::ActionStop), "ACTION");
+}
+
+// ─── selection-index helpers ───────────────────────────────────────────────────
+
+#[test]
+fn clamp_selection_handles_empty_and_overflow() {
+    assert_eq!(clamp_selection(5, 0), 0); // empty list pins to 0
+    assert_eq!(clamp_selection(2, 4), 2); // in range untouched
+    assert_eq!(clamp_selection(9, 4), 3); // past end clamps to last
+}
+
+#[test]
+fn next_index_advances_without_wrapping() {
+    assert_eq!(next_index(0, 0), 0); // empty
+    assert_eq!(next_index(0, 3), 1);
+    assert_eq!(next_index(2, 3), 2); // already last → stays
+}
+
+#[test]
+fn prev_index_saturates_at_zero() {
+    assert_eq!(prev_index(0), 0);
+    assert_eq!(prev_index(3), 2);
+}
+
+#[test]
+fn last_index_is_final_row_or_zero() {
+    assert_eq!(last_index(0), 0);
+    assert_eq!(last_index(5), 4);
+}

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -2,16 +2,20 @@ use croner::Cron;
 use gloo_net::http::Request;
 use gloo_timers::future::TimeoutFuture;
 use serde::Deserialize;
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
 use yew_router::prelude::*;
 
+mod command_palette;
 mod cron_jobs;
 mod day_timeline;
 mod machines;
 mod overview;
 mod routines;
 mod schedule;
+use command_palette::CommandPalette;
 use cron_jobs::CronJobsPage;
 use overview::OverviewPage;
 use routines::RoutinesPage;
@@ -67,6 +71,7 @@ pub struct ShellState {
     pub toasts: Vec<Toast>,
     pub next_toast: u32,
     pub show_shutdown: bool,
+    pub show_palette: bool,
 }
 
 pub enum ShellAction {
@@ -74,6 +79,8 @@ pub enum ShellAction {
     AddToast { msg: String, kind: ToastKind },
     OpenShutdown,
     CloseShutdown,
+    TogglePalette,
+    ClosePalette,
 }
 
 impl Reducible for ShellState {
@@ -97,6 +104,8 @@ impl Reducible for ShellState {
             }
             ShellAction::OpenShutdown => s.show_shutdown = true,
             ShellAction::CloseShutdown => s.show_shutdown = false,
+            ShellAction::TogglePalette => s.show_palette = !s.show_palette,
+            ShellAction::ClosePalette => s.show_palette = false,
         }
         s.into()
     }
@@ -182,11 +191,65 @@ pub fn shell() -> Html {
         });
     }
 
+    // Global ⌘K / Ctrl-K listener that toggles the command palette from any
+    // page. Registered once on mount and torn down on unmount.
+    {
+        let state = state.clone();
+        use_effect_with((), move |_| {
+            let on_key =
+                Closure::<dyn Fn(KeyboardEvent)>::wrap(Box::new(move |event: KeyboardEvent| {
+                    if (event.meta_key() || event.ctrl_key())
+                        && event.key().eq_ignore_ascii_case("k")
+                    {
+                        event.prevent_default();
+                        state.dispatch(ShellAction::TogglePalette);
+                    }
+                }));
+            let window = web_sys::window().expect("window exists");
+            window
+                .add_event_listener_with_callback("keydown", on_key.as_ref().unchecked_ref())
+                .expect("keydown listener attaches");
+            move || {
+                if let Some(window) = web_sys::window() {
+                    let _ = window.remove_event_listener_with_callback(
+                        "keydown",
+                        on_key.as_ref().unchecked_ref(),
+                    );
+                }
+                drop(on_key);
+            }
+        });
+    }
+
     let on_toast = {
         let state = state.clone();
         Callback::from(move |(msg, kind): (String, ToastKind)| {
             state.dispatch(ShellAction::AddToast { msg, kind })
         })
+    };
+
+    let on_close_palette = {
+        let state = state.clone();
+        Callback::from(move |_: ()| state.dispatch(ShellAction::ClosePalette))
+    };
+
+    let on_open_palette = {
+        let state = state.clone();
+        Callback::from(move |_: MouseEvent| state.dispatch(ShellAction::TogglePalette))
+    };
+
+    // Palette "Refresh" / "Stop Server" actions mirror the header buttons but
+    // take the `()` payload the palette emits.
+    let on_palette_refresh = {
+        let state = state.clone();
+        Callback::from(move |_: ()| {
+            let state = state.clone();
+            spawn_local(async move { poll_health(state).await });
+        })
+    };
+    let on_palette_stop = {
+        let state = state.clone();
+        Callback::from(move |_: ()| state.dispatch(ShellAction::OpenShutdown))
     };
 
     let on_refresh = {
@@ -253,12 +316,19 @@ pub fn shell() -> Html {
     let health_ok = state.health_ok;
     let toasts = state.toasts.clone();
     let show_shutdown = state.show_shutdown;
+    let show_palette = state.show_palette;
 
     html! {
         <>
-            <Header health={health} ok={health_ok} on_refresh={on_refresh} on_stop={on_stop} />
+            <Header health={health} ok={health_ok} on_refresh={on_refresh} on_stop={on_stop} on_palette={on_open_palette} />
             <Nav />
             <Switch<Route> render={switch} />
+            <CommandPalette
+                open={show_palette}
+                on_close={on_close_palette}
+                on_refresh={on_palette_refresh}
+                on_stop={on_palette_stop}
+            />
             {
                 if show_shutdown {
                     html! {
@@ -311,6 +381,7 @@ pub struct HeaderProps {
     pub ok: bool,
     pub on_refresh: Callback<MouseEvent>,
     pub on_stop: Callback<MouseEvent>,
+    pub on_palette: Callback<MouseEvent>,
 }
 
 #[function_component(Header)]
@@ -346,6 +417,9 @@ pub fn header(props: &HeaderProps) -> Html {
                     <span class="health-status">{status}</span>
                     <span class="health-uptime">{uptime}</span>
                 </div>
+                <button class="btn-cmdk" title="Command palette (⌘K)" aria-label="Open command palette" onclick={props.on_palette.clone()}>
+                    {"⌘K"}
+                </button>
                 <button class="btn-refresh" title="Refresh" aria-label="Refresh" onclick={props.on_refresh.clone()}>{"↻"}</button>
                 <button class="btn-stop" title="Stop the server" disabled={!props.ok} onclick={props.on_stop.clone()}>{"⏻ STOP"}</button>
             </div>

--- a/ui/src/overview.rs
+++ b/ui/src/overview.rs
@@ -169,7 +169,7 @@ fn sources_of(crons: &[CronJob], routines: &[Routine]) -> Vec<SchedSource> {
         .collect()
 }
 
-async fn fetch_crons() -> Result<Vec<CronJob>, String> {
+pub(crate) async fn fetch_crons() -> Result<Vec<CronJob>, String> {
     Request::get("/api/v1/cron-jobs")
         .send()
         .await
@@ -179,7 +179,7 @@ async fn fetch_crons() -> Result<Vec<CronJob>, String> {
         .map_err(|e| e.to_string())
 }
 
-async fn fetch_routines() -> Result<Vec<Routine>, String> {
+pub(crate) async fn fetch_routines() -> Result<Vec<Routine>, String> {
     Request::get("/api/v1/routines")
         .send()
         .await


### PR DESCRIPTION
Closes #604 (supersedes the duplicate #608).

## What

A global, **keyboard-first command palette** opened with **⌘K / Ctrl-K** (or the new header `⌘K` button) from any page. It fuzzy-searches every navigable destination — the three pages (Overview, Cron Jobs, Routines), **every cron job**, and **every routine** — plus the **Refresh** and **Stop Server** actions, and jumps to / runs the selection on Enter.

## Best-practice rationale (research)

Command palettes are the de-facto power-user navigation pattern in best-in-class operations dashboards (Linear, Vercel, GitHub, Raycast, VS Code). This implements the converged spec:

- **⌘K / Ctrl-K** is the de-facto web standard; reachable from anywhere without leaving the keyboard. ([UX Patterns for Developers](https://uxpatterns.dev/patterns/advanced/command-palette), [Superhuman](https://blog.superhuman.com/how-to-build-a-remarkable-command-palette/))
- **Fuzzy search** tolerates typos and abbreviations; matches the item **title and aliases/keywords** (agent, handler, schedule, id).
- **Keyboard-first**: type to filter, ↑/↓ to move, Home/End to jump, Enter to launch, Esc / backdrop to close.
- **Ranked results**, best match first, title hits winning ties; all destinations shown before typing.
- **Accessible** per the WAI-ARIA combobox+listbox pattern: `role="combobox"` input with `aria-expanded`/`aria-controls`/`aria-activedescendant`, `role="listbox"`, `role="option"` + `aria-selected`, autofocused input.

As routine/cron-job counts grow, scanning tabs and tables to find one item gets slow — the palette makes the whole dashboard reachable in two keystrokes, directly serving the repo goals of *keyboard-first design*, *filtering/search*, and *quick actions*.

## Scope — UI-only, existing API

Built entirely in the `ui/` Yew/wasm frontend on data the UI already fetches via `GET /api/v1/cron-jobs` and `GET /api/v1/routines`. **No backend, API, data-model, or cron/routine-semantics change.** `prebuilt.html` is intentionally not touched (regenerated by `cargo build`).

- New `ui/src/command_palette.rs` module + `command_palette_tests.rs`.
- Global ⌘K listener + palette state wired through the shell (`ui/src/main.rs`).
- All match / rank / build / selection-index logic is in **pure, host-tested functions** (19 unit tests); the Yew component is a thin shell.

## Verification

- `cargo fmt --check -p ui` — clean
- `cargo clippy -p ui --all-targets -- -D warnings` — clean
- `cargo test -p ui` — 44 passed
- Diff confined to `ui/` (`git diff --name-only origin/main...HEAD`).

---
*This pull request was opened by the "UI dashboard feature builder (research → issue → PR → merge)" routine of moadim.*