### PR TITLE
chore(paths): mark public path builders #[must_use]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   every variant serializes to `{"error": <message>}`, not just the right status
   code, so the JSON error envelope clients parse can't silently regress. Tests
   only; no behavior change.
+- Marked every public path builder in `paths` (`jobs_dir`, `routine_toml_path`,
+  `pid_file`, `moadim_home`, …) `#[must_use]`. These functions are pure and the
+  returned `PathBuf` is the whole point of calling them, so discarding it is
+  always a mistake; the attribute lets clippy flag such a call at compile time
+  instead of letting it silently no-op. No behavior change.
 
 ### Fixed
 

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -19,6 +19,7 @@ pub(crate) fn home() -> Option<PathBuf> {
 }
 
 /// Returns the path to `~/.config/moadim/jobs/`.
+#[must_use]
 pub fn jobs_dir() -> PathBuf {
     jobs_dir_from_home(home())
 }
@@ -32,6 +33,7 @@ pub(crate) fn jobs_dir_from_home(home: Option<PathBuf>) -> PathBuf {
 }
 
 /// Returns the path to `~/.config/moadim/handlers/`.
+#[must_use]
 pub fn handlers_dir() -> PathBuf {
     handlers_dir_from_home(home())
 }
@@ -45,26 +47,31 @@ pub(crate) fn handlers_dir_from_home(home: Option<PathBuf>) -> PathBuf {
 }
 
 /// Returns the path to `{jobs_dir}/{id}/`.
+#[must_use]
 pub fn job_dir(id: &str) -> PathBuf {
     jobs_dir().join(id)
 }
 
 /// Returns the path to `{jobs_dir}/{id}/job.toml`.
+#[must_use]
 pub fn job_toml_path(id: &str) -> PathBuf {
     job_dir(id).join("job.toml")
 }
 
 /// Returns the path to `{jobs_dir}/{id}/job.local.toml`.
+#[must_use]
 pub fn job_local_toml_path(id: &str) -> PathBuf {
     job_dir(id).join("job.local.toml")
 }
 
 /// Returns the path to `{jobs_dir}/{id}/.gitignore`.
+#[must_use]
 pub fn job_gitignore_path(id: &str) -> PathBuf {
     job_dir(id).join(".gitignore")
 }
 
 /// Returns the path to `{jobs_dir}/{id}/job.local.log`.
+#[must_use]
 pub fn job_log_path(id: &str) -> PathBuf {
     job_dir(id).join("job.local.log")
 }
@@ -72,6 +79,7 @@ pub fn job_log_path(id: &str) -> PathBuf {
 // ─── Routines ────────────────────────────────────────────────────────────────
 
 /// Returns the path to `~/.config/moadim/routines/`.
+#[must_use]
 pub fn routines_dir() -> PathBuf {
     routines_dir_from_home(home())
 }
@@ -85,21 +93,25 @@ pub(crate) fn routines_dir_from_home(home: Option<PathBuf>) -> PathBuf {
 }
 
 /// Returns the path to `{routines_dir}/{id}/`.
+#[must_use]
 pub fn routine_dir(id: &str) -> PathBuf {
     routines_dir().join(id)
 }
 
 /// Returns the path to `{routines_dir}/{id}/routine.toml`.
+#[must_use]
 pub fn routine_toml_path(id: &str) -> PathBuf {
     routine_dir(id).join("routine.toml")
 }
 
 /// Returns the path to `{routines_dir}/{id}/prompt.md`.
+#[must_use]
 pub fn routine_prompt_path(id: &str) -> PathBuf {
     routine_dir(id).join("prompt.md")
 }
 
 /// Returns the path to `{routines_dir}/{id}/.gitignore`.
+#[must_use]
 pub fn routine_gitignore_path(id: &str) -> PathBuf {
     routine_dir(id).join(".gitignore")
 }
@@ -109,6 +121,7 @@ pub fn routine_gitignore_path(id: &str) -> PathBuf {
 ///
 /// The `.local.` infix matches the `*.local.*` pattern seeded into each routine's `.gitignore`, so
 /// trigger churn never produces version-control diffs.
+#[must_use]
 pub fn routine_state_path(id: &str) -> PathBuf {
     routine_dir(id).join("state.local.toml")
 }
@@ -121,6 +134,7 @@ pub fn routine_state_path(id: &str) -> PathBuf {
 /// only ever *read* by the daemon — kept in its own file so a daemon-side re-persist of
 /// `state.local.toml` can't clobber the scheduler-written timestamp. The `.local.` infix matches the
 /// `*.local.*` `.gitignore` pattern, so scheduled-fire churn never produces version-control diffs.
+#[must_use]
 pub fn routine_scheduled_state_path(id: &str) -> PathBuf {
     routine_dir(id).join("scheduled.local.toml")
 }
@@ -130,6 +144,7 @@ pub fn routine_scheduled_state_path(id: &str) -> PathBuf {
 /// No longer generated — the crontab line now invokes `moadim schedule trigger <id>` directly. The
 /// path is retained so [`crate::routine_storage::write_routine`] can delete any stale script left by
 /// an older daemon.
+#[must_use]
 pub fn routine_script_path(id: &str) -> PathBuf {
     routine_dir(id).join("run.sh")
 }
@@ -137,6 +152,7 @@ pub fn routine_script_path(id: &str) -> PathBuf {
 // ─── Agent registry ──────────────────────────────────────────────────────────
 
 /// Returns the path to `~/.config/moadim/agents/`.
+#[must_use]
 pub fn agents_dir() -> PathBuf {
     agents_dir_from_home(home())
 }
@@ -150,6 +166,7 @@ pub(crate) fn agents_dir_from_home(home: Option<PathBuf>) -> PathBuf {
 }
 
 /// Returns the path to `~/.config/moadim/agents/{name}.toml`.
+#[must_use]
 pub fn agent_toml_path(name: &str) -> PathBuf {
     agents_dir().join(format!("{name}.toml"))
 }
@@ -157,6 +174,7 @@ pub fn agent_toml_path(name: &str) -> PathBuf {
 // ─── Daemon runtime files ────────────────────────────────────────────────────
 
 /// Returns the path to `~/.config/moadim/`.
+#[must_use]
 pub fn config_dir() -> PathBuf {
     config_dir_from_home(home())
 }
@@ -169,17 +187,20 @@ pub(crate) fn config_dir_from_home(home: Option<PathBuf>) -> PathBuf {
 }
 
 /// Returns the path to `~/.config/moadim/moadim.pid`, where the running server records its PID.
+#[must_use]
 pub fn pid_file() -> PathBuf {
     config_dir().join("moadim.pid")
 }
 
 /// Returns the path to `~/.config/moadim/daemon.log`, where a backgrounded server writes its output.
+#[must_use]
 pub fn daemon_log_file() -> PathBuf {
     config_dir().join("daemon.log")
 }
 
 /// Returns the path to `~/.config/moadim/.gitignore`, used to keep generated runtime
 /// files (`*.pid`, `*.log`) out of version control when the config dir is tracked.
+#[must_use]
 pub fn config_gitignore_path() -> PathBuf {
     config_dir().join(".gitignore")
 }
@@ -188,6 +209,7 @@ pub fn config_gitignore_path() -> PathBuf {
 /// that records this install's machine identity (the `name` used to match a routine/job's
 /// `machines` targeting list). The `.local.` infix matches the `*.local.*` pattern seeded into the
 /// config `.gitignore`, so a machine name set on one host never leaks into the shared config repo.
+#[must_use]
 pub fn machine_config_path() -> PathBuf {
     machine_config_path_from_home(home())
 }
@@ -204,6 +226,7 @@ pub(crate) fn machine_config_path_from_home(home: Option<PathBuf>) -> PathBuf {
 
 /// Returns the path to `~/.config/moadim/user_prompt.md`, where the user writes a persistent
 /// system prompt injected into every agent workbench `CLAUDE.md` alongside the moadim prompt.
+#[must_use]
 pub fn user_prompt_path() -> PathBuf {
     user_prompt_path_from_home(home())
 }
@@ -219,6 +242,7 @@ pub(crate) fn user_prompt_path_from_home(home: Option<PathBuf>) -> PathBuf {
 // ─── Workbenches ─────────────────────────────────────────────────────────────
 
 /// Returns the path to `~/.moadim/`.
+#[must_use]
 pub fn moadim_home() -> PathBuf {
     moadim_home_from_home(home())
 }
@@ -229,6 +253,7 @@ pub(crate) fn moadim_home_from_home(home: Option<PathBuf>) -> PathBuf {
 }
 
 /// Returns the path to `~/.moadim/workbenches/`.
+#[must_use]
 pub fn workbenches_dir() -> PathBuf {
     moadim_home().join("workbenches")
 }


### PR DESCRIPTION
## What

Adds `#[must_use]` to every public path-builder function in the `paths` module (25 functions: `jobs_dir`, `job_toml_path`, `routine_toml_path`, `pid_file`, `moadim_home`, `workbenches_dir`, …).

## Why

These functions are pure: they take no shared state and exist only to compute and return a `PathBuf`. Calling one and discarding the result is therefore always a bug — the call does nothing. Without `#[must_use]` such a mistake compiles silently.

The crate enforces `clippy::all = "deny"` but not the pedantic `clippy::must_use_candidate`, so today there's no automated guard against this. Annotating the functions explicitly opts each one into the check, so clippy flags an ignored result at compile time.

## Risk

Additive only — `#[must_use]` changes no runtime behavior, and every existing call site already uses the returned path, so nothing breaks. `cargo fmt --check`, `cargo clippy --all-targets`, and the `paths` tests all pass locally. A CHANGELOG entry is added under `## [Unreleased] → Changed` so the `unreleased-entry` check is satisfied.

---
This pull request was opened by the "Daemon + Landing auto-improve & auto-merge lint/docs PRs" routine of moadim.