### PR TITLE
docs(readme): show routines get/replace in the CLI examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,9 @@ moadim cron-jobs delete <id>
 moadim routines create --schedule "0 8 * * *" --title "Daily" --agent claude --prompt "..." \
   --repositories '[{"repository":"https://github.com/me/repo","branch":"main"}]'
 moadim routines list
+moadim routines get <id>
 moadim routines update <id> --title "Renamed" --ttl-secs 3600
+moadim routines replace <id> --schedule "0 8 * * *" --title "Daily" --agent claude --prompt "..."
 moadim routines trigger <id>
 moadim routines logs <id>
 moadim routines ical          # iCalendar feed of upcoming fire times


### PR DESCRIPTION
## What

The **Data commands** → *Routines* example block in the README omitted `moadim routines get <id>` and `moadim routines replace <id>`, even though:

- the routines CLI supports both (`RoutineCmd::Get` / `RoutineCmd::Replace` in `src/commands.rs`),
- the man page lists them (`routines <create|list|get|update|replace|delete|trigger|logs|ical>`), and
- the sibling **cron-jobs** example block already shows `get` and `replace`.

## Change

Add the two missing example lines so the routines examples mirror the cron-jobs ones and document the full subcommand set. Docs-only — touches only `README.md`, so the `unreleased-entry` check is exempt.

---
This pull request was opened by the *Daemon + Landing auto-improve & auto-merge lint/docs PRs* routine of moadim.