### PR TITLE
feat(ui): faceted filter toolbar for the cron jobs page (#621)

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -361,6 +361,22 @@
 
     .stat-val { font-size: 30px; color: var(--text-hi); line-height: 1.1; }
     .stat-val.c-accent { color: var(--accent); }
+
+    /* Cross-filtering KPI tiles: the cron StatsBar renders each card as a button
+       that applies its status facet. Reset native button chrome and add a
+       pressed/active state; non-clickable StatsBars (overview/routines) keep the
+       plain <div>. */
+    button.stat-card {
+      font: inherit;
+      color: inherit;
+      text-align: left;
+      cursor: pointer;
+      transition: background 0.12s, border-color 0.12s;
+    }
+    button.stat-card:hover { border-color: var(--border-hi); background: var(--bg-3); }
+    button.stat-card:focus-visible { outline: 1px solid var(--accent); outline-offset: 2px; }
+    .stat-card.active { background: var(--accent-dim); }
+    .stat-card.active .stat-label { color: var(--text-mid); }
     .stat-val.c-amber  { color: var(--amber); }
     .stat-val.c-red    { color: var(--red); }
     /* Time strings ("in 4m", "tomorrow 09:00") are textual, not a single
@@ -940,6 +956,13 @@
       transition: border-color 0.12s;
     }
     .filter-select:focus { border-color: var(--accent); }
+    .filter-count {
+      font-family: var(--mono);
+      font-size: 11px;
+      letter-spacing: 0.04em;
+      color: var(--text-dim);
+      white-space: nowrap;
+    }
 
     /* ── Calendar ── */
     .cal-wrap {

--- a/ui/src/cron_jobs.rs
+++ b/ui/src/cron_jobs.rs
@@ -3,7 +3,7 @@
 //! Self-contained like [`crate::routines::RoutinesPage`]: owns its own reducer state and talks to
 //! the `/cron-jobs` API. Toasts bubble up to the shell via the `on_toast` callback.
 
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 use std::rc::Rc;
 
 use chrono::{DateTime, Duration, Local};
@@ -11,8 +11,10 @@ use gloo_net::http::Request;
 use gloo_timers::future::TimeoutFuture;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as Json;
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::spawn_local;
-use web_sys::HtmlInputElement;
+use web_sys::{HtmlElement, HtmlInputElement, HtmlSelectElement, KeyboardEvent};
 use yew::prelude::*;
 
 use crate::day_timeline::{DayTimeline, TimelineItem};
@@ -69,6 +71,179 @@ pub struct UpdateRequest {
     pub machines: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
+}
+
+// ─── Faceted filter ─────────────────────────────────────────────────────────
+//
+// Pure, host-testable filtering of the loaded jobs. The view binds a search box,
+// a status facet, and a machine facet to a `JobFilter`; the table and day
+// timeline render `filter_jobs(...)` instead of the raw list. Best-practice
+// (Datadog/Grafana/BI dashboards): free-text + facets narrow a dense list, a
+// live result count keeps the active filter legible, and clicking a summary KPI
+// cross-filters the detail list.
+
+/// Enabled/disabled/due-soon status facet. `DueSoon` reuses the same
+/// `fires_within` window that backs the DUE SOON KPI tile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum StatusFacet {
+    #[default]
+    All,
+    Enabled,
+    Disabled,
+    DueSoon,
+}
+
+impl StatusFacet {
+    /// Stable token used as the cross-filter id and the segmented-control value.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            StatusFacet::All => "all",
+            StatusFacet::Enabled => "enabled",
+            StatusFacet::Disabled => "disabled",
+            StatusFacet::DueSoon => "due",
+        }
+    }
+
+    #[must_use]
+    pub fn from_str(s: &str) -> Self {
+        match s {
+            "enabled" => StatusFacet::Enabled,
+            "disabled" => StatusFacet::Disabled,
+            "due" => StatusFacet::DueSoon,
+            _ => StatusFacet::All,
+        }
+    }
+}
+
+/// Sentinel select values for the machine facet's non-machine choices. Real
+/// machine ids never collide with these (they carry no leading NUL).
+const MACHINE_ANY: &str = "\u{0}any";
+const MACHINE_UNASSIGNED: &str = "\u{0}unassigned";
+
+/// Machine facet: any machine, the dormant (no-machine) jobs, or one specific
+/// machine drawn from the distinct machines across the loaded jobs.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum MachineFacet {
+    #[default]
+    Any,
+    Unassigned,
+    Machine(String),
+}
+
+impl MachineFacet {
+    /// Encode for the `<select>` option value.
+    #[must_use]
+    pub fn as_value(&self) -> String {
+        match self {
+            MachineFacet::Any => MACHINE_ANY.to_string(),
+            MachineFacet::Unassigned => MACHINE_UNASSIGNED.to_string(),
+            MachineFacet::Machine(m) => m.clone(),
+        }
+    }
+
+    /// Decode from a selected `<select>` option value.
+    #[must_use]
+    pub fn from_value(v: &str) -> Self {
+        match v {
+            MACHINE_ANY => MachineFacet::Any,
+            MACHINE_UNASSIGNED => MachineFacet::Unassigned,
+            other => MachineFacet::Machine(other.to_string()),
+        }
+    }
+}
+
+/// Combined free-text + facet filter applied client-side to the loaded jobs.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct JobFilter {
+    pub query: String,
+    pub status: StatusFacet,
+    pub machine: MachineFacet,
+}
+
+impl JobFilter {
+    /// Whether any facet is narrowing the list — drives the "Clear filters"
+    /// affordance and the filter-aware empty state.
+    #[must_use]
+    pub fn is_active(&self) -> bool {
+        !self.query.trim().is_empty()
+            || self.status != StatusFacet::All
+            || self.machine != MachineFacet::Any
+    }
+
+    /// Does this job survive the filter? Facets AND together; free-text matches
+    /// across id, handler, schedule, the human description, and metadata.
+    #[must_use]
+    pub fn matches(&self, job: &CronJob, now: DateTime<Local>, window: Duration) -> bool {
+        match self.status {
+            StatusFacet::All => {}
+            StatusFacet::Enabled if !job.enabled => return false,
+            StatusFacet::Disabled if job.enabled => return false,
+            StatusFacet::DueSoon if !(job.enabled && fires_within(&job.schedule, now, window)) => {
+                return false
+            }
+            _ => {}
+        }
+        match &self.machine {
+            MachineFacet::Any => {}
+            MachineFacet::Unassigned if !job.machines.is_empty() => return false,
+            MachineFacet::Machine(m) if !job.machines.iter().any(|x| x == m) => return false,
+            _ => {}
+        }
+        let q = self.query.trim().to_lowercase();
+        if !q.is_empty() {
+            let desc = job
+                .schedule_description
+                .as_deref()
+                .unwrap_or_default()
+                .to_lowercase();
+            let hay = format!(
+                "{} {} {} {} {}",
+                job.id.to_lowercase(),
+                job.handler.to_lowercase(),
+                job.schedule.to_lowercase(),
+                desc,
+                job.metadata.to_string().to_lowercase(),
+            );
+            if !hay.contains(&q) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+/// Jobs surviving `filter`, preserving the input order.
+#[must_use]
+pub fn filter_jobs(
+    jobs: &[CronJob],
+    filter: &JobFilter,
+    now: DateTime<Local>,
+    window: Duration,
+) -> Vec<CronJob> {
+    jobs.iter()
+        .filter(|j| filter.matches(j, now, window))
+        .cloned()
+        .collect()
+}
+
+/// Distinct machine ids across all jobs, sorted, for the machine-facet options.
+#[must_use]
+pub fn distinct_machines(jobs: &[CronJob]) -> Vec<String> {
+    let mut set: BTreeSet<String> = BTreeSet::new();
+    for j in jobs {
+        for m in &j.machines {
+            set.insert(m.clone());
+        }
+    }
+    set.into_iter().collect()
+}
+
+/// Count of dormant jobs (no machine assigned) — surfaced as the "Unassigned"
+/// machine-facet option only when at least one such job exists.
+#[must_use]
+pub fn unassigned_count(jobs: &[CronJob]) -> usize {
+    jobs.iter().filter(|j| j.machines.is_empty()).count()
 }
 
 // ─── API layer ────────────────────────────────────────────────────────────────
@@ -192,6 +367,8 @@ pub struct CState {
     pub selected: HashSet<String>,
     /// Anchor row for `Shift`+click range selection.
     pub select_anchor: Option<String>,
+    /// Active faceted filter applied to the list/day views.
+    pub filter: JobFilter,
 }
 
 impl Default for CState {
@@ -204,6 +381,7 @@ impl Default for CState {
             view: CView::default(),
             selected: HashSet::new(),
             select_anchor: None,
+            filter: JobFilter::default(),
         }
     }
 }
@@ -229,8 +407,13 @@ pub enum CAction {
         id: String,
         kind: SelectKind,
     },
-    SelectAll,
+    /// Select exactly the given (visible/filtered) ids.
+    SelectAll(Vec<String>),
     ClearSelection,
+    SetQuery(String),
+    SetStatus(StatusFacet),
+    SetMachineFacet(MachineFacet),
+    ClearFilters,
 }
 
 impl Reducible for CState {
@@ -318,13 +501,17 @@ impl Reducible for CState {
                     // Anchor stays put so further Shift+clicks re-anchor from it.
                 }
             },
-            CAction::SelectAll => {
-                s.selected = s.jobs.iter().map(|j| j.id.clone()).collect();
+            CAction::SelectAll(ids) => {
+                s.selected = ids.into_iter().collect();
             }
             CAction::ClearSelection => {
                 s.selected.clear();
                 s.select_anchor = None;
             }
+            CAction::SetQuery(q) => s.filter.query = q,
+            CAction::SetStatus(status) => s.filter.status = status,
+            CAction::SetMachineFacet(m) => s.filter.machine = m,
+            CAction::ClearFilters => s.filter = JobFilter::default(),
         }
         s.into()
     }
@@ -538,14 +725,22 @@ pub fn cron_jobs_page(props: &CronJobsPageProps) -> Html {
         })
     };
 
-    // Header checkbox toggles between "all selected" and "none selected".
+    // Header checkbox toggles between "all visible selected" and "none". Operates
+    // over the filtered rows, so select-all never reaches hidden jobs.
     let on_select_all = {
         let state = state.clone();
+        let now = now.clone();
         Callback::from(move |_: ()| {
-            if state.selected.len() == state.jobs.len() && !state.jobs.is_empty() {
+            let window = Duration::seconds(DUE_SOON_WINDOW_SECS);
+            let visible = filter_jobs(&state.jobs, &state.filter, *now, window);
+            let all_visible_selected =
+                !visible.is_empty() && visible.iter().all(|j| state.selected.contains(&j.id));
+            if all_visible_selected {
                 state.dispatch(CAction::ClearSelection);
             } else {
-                state.dispatch(CAction::SelectAll);
+                state.dispatch(CAction::SelectAll(
+                    visible.into_iter().map(|j| j.id).collect(),
+                ));
             }
         })
     };
@@ -554,6 +749,70 @@ pub fn cron_jobs_page(props: &CronJobsPageProps) -> Html {
         let state = state.clone();
         Callback::from(move |_: ()| state.dispatch(CAction::ClearSelection))
     };
+
+    // ── Faceted filter ──
+    let on_set_query = {
+        let state = state.clone();
+        Callback::from(move |q: String| state.dispatch(CAction::SetQuery(q)))
+    };
+    let on_set_status = {
+        let state = state.clone();
+        Callback::from(move |status: StatusFacet| state.dispatch(CAction::SetStatus(status)))
+    };
+    let on_set_machine = {
+        let state = state.clone();
+        Callback::from(move |m: MachineFacet| state.dispatch(CAction::SetMachineFacet(m)))
+    };
+    let on_clear_filters = {
+        let state = state.clone();
+        Callback::from(move |_: ()| state.dispatch(CAction::ClearFilters))
+    };
+
+    // `/` focuses the search box from anywhere on the page (skipped while the
+    // user is already typing in a field), matching the GitHub/Slack convention
+    // and complementing the ⌘K command palette.
+    let search_ref = use_node_ref();
+    {
+        let search_ref = search_ref.clone();
+        use_effect_with((), move |_| {
+            let on_key =
+                Closure::<dyn Fn(KeyboardEvent)>::wrap(Box::new(move |event: KeyboardEvent| {
+                    if event.key() != "/" || event.meta_key() || event.ctrl_key() || event.alt_key()
+                    {
+                        return;
+                    }
+                    // Don't steal "/" while the user is typing in another control.
+                    let typing = event
+                        .target()
+                        .and_then(|t| t.dyn_into::<HtmlElement>().ok())
+                        .map(|el| {
+                            let tag = el.tag_name();
+                            tag == "INPUT" || tag == "TEXTAREA" || tag == "SELECT"
+                        })
+                        .unwrap_or(false);
+                    if typing {
+                        return;
+                    }
+                    if let Some(input) = search_ref.cast::<HtmlInputElement>() {
+                        event.prevent_default();
+                        let _ = input.focus();
+                    }
+                }));
+            let window = web_sys::window().expect("window exists");
+            window
+                .add_event_listener_with_callback("keydown", on_key.as_ref().unchecked_ref())
+                .expect("keydown listener attaches");
+            move || {
+                if let Some(window) = web_sys::window() {
+                    let _ = window.remove_event_listener_with_callback(
+                        "keydown",
+                        on_key.as_ref().unchecked_ref(),
+                    );
+                }
+                drop(on_key);
+            }
+        });
+    }
 
     // Bulk enable/disable: update each selected job, surface one summary toast.
     let bulk_set_enabled = {
@@ -646,6 +905,17 @@ pub fn cron_jobs_page(props: &CronJobsPageProps) -> Html {
     let page = state.page.clone();
     let modal = state.modal.clone();
     let selected = state.selected.clone();
+    let filter = state.filter.clone();
+
+    // Faceted view of the list: the table and day timeline render the filtered
+    // set; the KPI tiles stay over the full fleet.
+    let window = Duration::seconds(DUE_SOON_WINDOW_SECS);
+    let filtered = filter_jobs(&jobs, &filter, now_val, window);
+    let total_jobs = jobs.len();
+    let shown = filtered.len();
+    let machine_options = distinct_machines(&jobs);
+    let has_unassigned = unassigned_count(&jobs) > 0;
+    let filter_active = filter.is_active();
 
     let edit_job = match &modal {
         CModal::Edit(id) => jobs.iter().find(|j| j.id == *id).cloned(),
@@ -670,7 +940,12 @@ pub fn cron_jobs_page(props: &CronJobsPageProps) -> Html {
                     },
                     CPage::List => html! {
                         <main>
-                            <StatsBar jobs={jobs.clone()} now={now_val} />
+                            <StatsBar
+                                jobs={jobs.clone()}
+                                now={now_val}
+                                active={filter.status}
+                                on_status={on_set_status.clone()}
+                            />
                             <div class="section-hd">
                                 <div class="section-label">{"SCHEDULED JOBS"}</div>
                                 <div class="section-acts">
@@ -678,6 +953,18 @@ pub fn cron_jobs_page(props: &CronJobsPageProps) -> Html {
                                     <button class="btn btn-primary btn-sm" onclick={on_new}>{"+ NEW JOB"}</button>
                                 </div>
                             </div>
+                            <CronFilterBar
+                                filter={filter.clone()}
+                                machines={machine_options}
+                                has_unassigned={has_unassigned}
+                                shown={shown}
+                                total={total_jobs}
+                                search_ref={search_ref.clone()}
+                                on_query={on_set_query}
+                                on_status={on_set_status}
+                                on_machine={on_set_machine}
+                                on_clear={on_clear_filters.clone()}
+                            />
                             {
                                 match view {
                                     CView::Table => html! {
@@ -690,10 +977,11 @@ pub fn cron_jobs_page(props: &CronJobsPageProps) -> Html {
                                                 on_clear={on_clear_selection}
                                             />
                                             <JobTable
-                                                jobs={jobs}
+                                                jobs={filtered}
                                                 loading={loading}
                                                 now={now_val}
                                                 selected={selected}
+                                                filter_active={filter_active}
                                                 on_edit={on_edit}
                                                 on_delete={on_ask_delete}
                                                 on_toggle={on_toggle}
@@ -701,11 +989,12 @@ pub fn cron_jobs_page(props: &CronJobsPageProps) -> Html {
                                                 on_logs={on_logs}
                                                 on_select={on_select}
                                                 on_select_all={on_select_all}
+                                                on_clear_filters={on_clear_filters}
                                             />
                                         </>
                                     },
                                     CView::Day => {
-                                        let items = jobs.iter().filter(|j| j.enabled).map(|j| TimelineItem {
+                                        let items = filtered.iter().filter(|j| j.enabled).map(|j| TimelineItem {
                                             label: j.handler.clone(),
                                             schedule: j.schedule.clone(),
                                         }).collect::<Vec<_>>();
@@ -787,6 +1076,11 @@ pub struct StatsProps {
     pub jobs: Vec<CronJob>,
     /// Reference instant for the "due soon" computation; advanced on a live tick.
     pub now: DateTime<Local>,
+    /// Currently active status facet, so the matching tile reads as selected.
+    pub active: StatusFacet,
+    /// Cross-filter: clicking a tile applies its status facet (or clears it when
+    /// the tile is already active).
+    pub on_status: Callback<StatusFacet>,
 }
 
 #[function_component(StatsBar)]
@@ -803,23 +1097,152 @@ pub fn stats_bar(props: &StatsProps) -> Html {
         .filter(|j| j.enabled && fires_within(&j.schedule, props.now, window))
         .count();
 
+    // Render one tile. Clicking toggles the status facet; the active tile (and
+    // TOTAL while no facet is active) reads as pressed for a clear cross-filter.
+    let active = props.active;
+    let tile = |facet: StatusFacet,
+                extra: &'static str,
+                label: &'static str,
+                val: usize,
+                val_cls: &'static str| {
+        let on_status = props.on_status.clone();
+        let onclick = Callback::from(move |_: MouseEvent| {
+            // Re-clicking the active facet clears it back to All.
+            let next = if active == facet {
+                StatusFacet::All
+            } else {
+                facet
+            };
+            on_status.emit(next);
+        });
+        let is_active = active == facet;
+        let cls = if is_active {
+            format!("stat-card {extra} active")
+        } else {
+            format!("stat-card {extra}")
+        };
+        html! {
+            <button type="button" class={cls} onclick={onclick}
+                aria-pressed={is_active.to_string()}
+                title={format!("Filter: {label}")}>
+                <div class="stat-label">{label}</div>
+                <div class={classes!("stat-val", val_cls)}>{val}</div>
+            </button>
+        }
+    };
+
     html! {
         <div class="stats">
-            <div class="stat-card all">
-                <div class="stat-label">{"TOTAL JOBS"}</div>
-                <div class="stat-val">{total}</div>
+            { tile(StatusFacet::All, "all", "TOTAL JOBS", total, "") }
+            { tile(StatusFacet::Enabled, "enabled", "ENABLED", enabled, "c-accent") }
+            { tile(StatusFacet::DueSoon, "due", "DUE SOON", due_soon, "c-red") }
+            { tile(StatusFacet::Disabled, "disabled", "DISABLED", disabled, "c-amber") }
+        </div>
+    }
+}
+
+// ─── Filter bar ───────────────────────────────────────────────────────────────
+
+#[derive(Properties, PartialEq)]
+pub struct CronFilterBarProps {
+    pub filter: JobFilter,
+    /// Distinct machines across all jobs, for the machine-facet options.
+    pub machines: Vec<String>,
+    /// Whether at least one dormant (no-machine) job exists.
+    pub has_unassigned: bool,
+    /// Count after filtering / total loaded — rendered as "Showing N of M".
+    pub shown: usize,
+    pub total: usize,
+    pub search_ref: NodeRef,
+    pub on_query: Callback<String>,
+    pub on_status: Callback<StatusFacet>,
+    pub on_machine: Callback<MachineFacet>,
+    pub on_clear: Callback<()>,
+}
+
+#[function_component(CronFilterBar)]
+pub fn cron_filter_bar(props: &CronFilterBarProps) -> Html {
+    let on_input = {
+        let cb = props.on_query.clone();
+        Callback::from(move |e: InputEvent| {
+            let input: HtmlInputElement = e.target_unchecked_into();
+            cb.emit(input.value());
+        })
+    };
+    let on_status_change = {
+        let cb = props.on_status.clone();
+        Callback::from(move |e: Event| {
+            let select: HtmlSelectElement = e.target_unchecked_into();
+            cb.emit(StatusFacet::from_str(&select.value()));
+        })
+    };
+    let on_machine_change = {
+        let cb = props.on_machine.clone();
+        Callback::from(move |e: Event| {
+            let select: HtmlSelectElement = e.target_unchecked_into();
+            cb.emit(MachineFacet::from_value(&select.value()));
+        })
+    };
+    let on_clear = {
+        let cb = props.on_clear.clone();
+        Callback::from(move |_: MouseEvent| cb.emit(()))
+    };
+
+    let status = props.filter.status.as_str();
+    let machine_val = props.filter.machine.as_value();
+    let active = props.filter.is_active();
+
+    html! {
+        <div class="filter-bar">
+            <div class="filter-field">
+                <input
+                    ref={props.search_ref.clone()}
+                    type="text"
+                    class="filter-input"
+                    placeholder="Search jobs…  ( / )"
+                    aria-label="Search jobs"
+                    value={props.filter.query.clone()}
+                    oninput={on_input}
+                />
+                <span class="filter-label">{"STATUS"}</span>
+                <select class="filter-select" aria-label="Status filter" onchange={on_status_change}>
+                    <option value="all" selected={status == "all"}>{"All"}</option>
+                    <option value="enabled" selected={status == "enabled"}>{"Enabled"}</option>
+                    <option value="disabled" selected={status == "disabled"}>{"Disabled"}</option>
+                    <option value="due" selected={status == "due"}>{"Due soon"}</option>
+                </select>
+                <span class="filter-label">{"MACHINE"}</span>
+                <select class="filter-select" aria-label="Machine filter" onchange={on_machine_change}>
+                    <option value={MACHINE_ANY} selected={machine_val == MACHINE_ANY}>{"Any"}</option>
+                    {
+                        if props.has_unassigned {
+                            html! {
+                                <option value={MACHINE_UNASSIGNED}
+                                    selected={machine_val == MACHINE_UNASSIGNED}>{"Unassigned"}</option>
+                            }
+                        } else {
+                            html! {}
+                        }
+                    }
+                    { for props.machines.iter().map(|m| html! {
+                        <option value={m.clone()} selected={machine_val == *m}>{m.clone()}</option>
+                    }) }
+                </select>
             </div>
-            <div class="stat-card enabled">
-                <div class="stat-label">{"ENABLED"}</div>
-                <div class="stat-val c-accent">{enabled}</div>
-            </div>
-            <div class="stat-card due">
-                <div class="stat-label">{"DUE SOON"}</div>
-                <div class="stat-val c-red">{due_soon}</div>
-            </div>
-            <div class="stat-card disabled">
-                <div class="stat-label">{"DISABLED"}</div>
-                <div class="stat-val c-amber">{disabled}</div>
+            <div class="filter-field">
+                <span class="filter-count">
+                    {format!("Showing {} of {}", props.shown, props.total)}
+                </span>
+                {
+                    if active {
+                        html! {
+                            <button class="btn btn-ghost btn-sm" onclick={on_clear}
+                                title="Clear all filters">{"CLEAR"}</button>
+                        }
+                    } else {
+                        html! {}
+                    }
+                }
             </div>
         </div>
     }
@@ -834,6 +1257,8 @@ pub struct JobTableProps {
     /// Reference instant for next-run cells; advanced on a live tick.
     pub now: DateTime<Local>,
     pub selected: HashSet<String>,
+    /// Whether a filter is narrowing the list — selects the filtered-empty state.
+    pub filter_active: bool,
     pub on_edit: Callback<String>,
     pub on_delete: Callback<(String, String)>,
     pub on_toggle: Callback<(String, bool)>,
@@ -841,6 +1266,7 @@ pub struct JobTableProps {
     pub on_logs: Callback<String>,
     pub on_select: Callback<(String, SelectKind)>,
     pub on_select_all: Callback<()>,
+    pub on_clear_filters: Callback<()>,
 }
 
 #[function_component(JobTable)]
@@ -853,6 +1279,25 @@ pub fn job_table(props: &JobTableProps) -> Html {
         };
     }
     if props.jobs.is_empty() {
+        // Filter-aware empty state: "no matches" (with a clear action) is a
+        // different message from the genuine "nothing scheduled" zero state, so
+        // an operator is never left wondering "is it broken or just filtered?".
+        if props.filter_active {
+            let on_clear = {
+                let cb = props.on_clear_filters.clone();
+                Callback::from(move |_: MouseEvent| cb.emit(()))
+            };
+            return html! {
+                <div class="table-wrap">
+                    <div class="empty">
+                        <div class="empty-icon">{"⦰"}</div>
+                        <div class="empty-msg">{"NO MATCHING JOBS"}</div>
+                        <div class="empty-sub">{"no jobs match the active filter"}</div>
+                        <button class="btn btn-ghost btn-sm" onclick={on_clear}>{"CLEAR FILTERS"}</button>
+                    </div>
+                </div>
+            };
+        }
         return html! {
             <div class="table-wrap">
                 <div class="empty">
@@ -1730,3 +2175,7 @@ fn meta_preview(v: &Json) -> String {
         other => other.to_string().chars().take(24).collect(),
     }
 }
+
+#[cfg(test)]
+#[path = "cron_jobs_tests.rs"]
+mod cron_jobs_tests;

--- a/ui/src/cron_jobs_tests.rs
+++ b/ui/src/cron_jobs_tests.rs
@@ -1,0 +1,302 @@
+//! Host-side unit tests for the cron-jobs faceted filter: the `StatusFacet` /
+//! `MachineFacet` codecs and the pure `JobFilter` matching + list helpers that
+//! back the search box, status/machine facets, and live result count. All
+//! deterministic given a fixed `now`; no DOM/wasm dependency (mirrors the
+//! `schedule.rs` / `overview.rs` test conventions).
+
+use super::*;
+use chrono::{Local, TimeZone};
+
+/// A fixed reference instant 30s past the top of the hour, so a top-of-hour
+/// schedule's next fire (13:00) lands ~59.5m out — inside a 1h "due soon"
+/// window but not a 5m one.
+fn now() -> DateTime<Local> {
+    Local.with_ymd_and_hms(2026, 6, 22, 12, 0, 30).unwrap()
+}
+
+fn window() -> Duration {
+    Duration::seconds(DUE_SOON_WINDOW_SECS)
+}
+
+/// Build a job with the fields the filter reads; the rest are inert.
+fn job(id: &str, handler: &str, schedule: &str, machines: &[&str], enabled: bool) -> CronJob {
+    CronJob {
+        id: id.into(),
+        schedule: schedule.into(),
+        handler: handler.into(),
+        metadata: serde_json::json!({}),
+        machines: machines.iter().map(|m| (*m).to_string()).collect(),
+        enabled,
+        created_at: 0,
+        updated_at: 0,
+        last_manual_trigger_at: None,
+        schedule_description: None,
+    }
+}
+
+// ── Facet codecs ──────────────────────────────────────────────────────────────
+
+#[test]
+fn status_facet_roundtrips_and_defaults_to_all() {
+    for f in [
+        StatusFacet::All,
+        StatusFacet::Enabled,
+        StatusFacet::Disabled,
+        StatusFacet::DueSoon,
+    ] {
+        assert_eq!(StatusFacet::from_str(f.as_str()), f);
+    }
+    assert_eq!(StatusFacet::from_str("nonsense"), StatusFacet::All);
+    assert_eq!(StatusFacet::default(), StatusFacet::All);
+}
+
+#[test]
+fn machine_facet_roundtrips_through_select_value() {
+    let any = MachineFacet::Any;
+    let unassigned = MachineFacet::Unassigned;
+    let specific = MachineFacet::Machine("alpha".into());
+    assert_eq!(MachineFacet::from_value(&any.as_value()), any);
+    assert_eq!(MachineFacet::from_value(&unassigned.as_value()), unassigned);
+    assert_eq!(MachineFacet::from_value(&specific.as_value()), specific);
+    assert_eq!(MachineFacet::default(), MachineFacet::Any);
+}
+
+#[test]
+fn machine_facet_decodes_a_plain_id_as_specific() {
+    assert_eq!(
+        MachineFacet::from_value("worker-1"),
+        MachineFacet::Machine("worker-1".into())
+    );
+}
+
+// ── is_active ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn default_filter_is_inactive() {
+    assert!(!JobFilter::default().is_active());
+}
+
+#[test]
+fn is_active_detects_each_facet() {
+    let q = JobFilter {
+        query: "  x ".into(),
+        ..Default::default()
+    };
+    assert!(q.is_active());
+    // Whitespace-only query is not active.
+    let blank = JobFilter {
+        query: "   ".into(),
+        ..Default::default()
+    };
+    assert!(!blank.is_active());
+
+    let s = JobFilter {
+        status: StatusFacet::Enabled,
+        ..Default::default()
+    };
+    assert!(s.is_active());
+
+    let m = JobFilter {
+        machine: MachineFacet::Unassigned,
+        ..Default::default()
+    };
+    assert!(m.is_active());
+}
+
+// ── Status facet matching ─────────────────────────────────────────────────────
+
+#[test]
+fn status_all_matches_regardless_of_enabled() {
+    let f = JobFilter::default();
+    assert!(f.matches(&job("a", "h", "0 * * * *", &[], true), now(), window()));
+    assert!(f.matches(&job("b", "h", "0 * * * *", &[], false), now(), window()));
+}
+
+#[test]
+fn status_enabled_and_disabled_partition() {
+    let on = job("a", "h", "0 * * * *", &[], true);
+    let off = job("b", "h", "0 * * * *", &[], false);
+    let enabled = JobFilter {
+        status: StatusFacet::Enabled,
+        ..Default::default()
+    };
+    let disabled = JobFilter {
+        status: StatusFacet::Disabled,
+        ..Default::default()
+    };
+    assert!(enabled.matches(&on, now(), window()));
+    assert!(!enabled.matches(&off, now(), window()));
+    assert!(disabled.matches(&off, now(), window()));
+    assert!(!disabled.matches(&on, now(), window()));
+}
+
+#[test]
+fn status_due_soon_needs_enabled_and_an_imminent_fire() {
+    let f = JobFilter {
+        status: StatusFacet::DueSoon,
+        ..Default::default()
+    };
+    // Enabled, fires at the next top of hour (~59.5m) → inside the 1h window.
+    let soon = job("a", "h", "0 * * * *", &[], true);
+    assert!(f.matches(&soon, now(), window()));
+    // Same schedule but disabled → never "due".
+    let soon_off = job("b", "h", "0 * * * *", &[], false);
+    assert!(!f.matches(&soon_off, now(), window()));
+    // Enabled but far away (annually, Jan 1) → outside the window.
+    let far = job("c", "h", "0 0 1 1 *", &[], true);
+    assert!(!f.matches(&far, now(), window()));
+}
+
+// ── Machine facet matching ────────────────────────────────────────────────────
+
+#[test]
+fn machine_any_matches_all() {
+    let f = JobFilter::default();
+    assert!(f.matches(&job("a", "h", "0 * * * *", &["m1"], true), now(), window()));
+    assert!(f.matches(&job("b", "h", "0 * * * *", &[], true), now(), window()));
+}
+
+#[test]
+fn machine_specific_requires_membership() {
+    let f = JobFilter {
+        machine: MachineFacet::Machine("m1".into()),
+        ..Default::default()
+    };
+    assert!(f.matches(
+        &job("a", "h", "0 * * * *", &["m1", "m2"], true),
+        now(),
+        window()
+    ));
+    assert!(!f.matches(&job("b", "h", "0 * * * *", &["m2"], true), now(), window()));
+    assert!(!f.matches(&job("c", "h", "0 * * * *", &[], true), now(), window()));
+}
+
+#[test]
+fn machine_unassigned_matches_only_empty() {
+    let f = JobFilter {
+        machine: MachineFacet::Unassigned,
+        ..Default::default()
+    };
+    assert!(f.matches(&job("a", "h", "0 * * * *", &[], true), now(), window()));
+    assert!(!f.matches(&job("b", "h", "0 * * * *", &["m1"], true), now(), window()));
+}
+
+// ── Free-text matching ────────────────────────────────────────────────────────
+
+#[test]
+fn query_matches_across_id_handler_and_schedule() {
+    let j = job("nightly-backup", "run-backup", "0 3 * * *", &[], true);
+    let by_id = JobFilter {
+        query: "nightly".into(),
+        ..Default::default()
+    };
+    let by_handler = JobFilter {
+        query: "BACKUP".into(),
+        ..Default::default()
+    };
+    let by_schedule = JobFilter {
+        query: "0 3".into(),
+        ..Default::default()
+    };
+    assert!(by_id.matches(&j, now(), window()));
+    assert!(by_handler.matches(&j, now(), window())); // case-insensitive
+    assert!(by_schedule.matches(&j, now(), window()));
+}
+
+#[test]
+fn query_matches_description_and_metadata() {
+    let mut j = job("j1", "h", "0 3 * * *", &[], true);
+    j.schedule_description = Some("Every day at 03:00".into());
+    j.metadata = serde_json::json!({ "recipient": "ops-team@example.com" });
+    let by_desc = JobFilter {
+        query: "every day".into(),
+        ..Default::default()
+    };
+    let by_meta = JobFilter {
+        query: "ops-team".into(),
+        ..Default::default()
+    };
+    assert!(by_desc.matches(&j, now(), window()));
+    assert!(by_meta.matches(&j, now(), window()));
+}
+
+#[test]
+fn query_is_trimmed_and_non_match_is_excluded() {
+    let j = job("alpha", "beta", "0 3 * * *", &[], true);
+    let trimmed = JobFilter {
+        query: "  alpha  ".into(),
+        ..Default::default()
+    };
+    let miss = JobFilter {
+        query: "zeta".into(),
+        ..Default::default()
+    };
+    assert!(trimmed.matches(&j, now(), window()));
+    assert!(!miss.matches(&j, now(), window()));
+}
+
+#[test]
+fn facets_and_together() {
+    // Enabled AND on m1 AND query "back".
+    let f = JobFilter {
+        query: "back".into(),
+        status: StatusFacet::Enabled,
+        machine: MachineFacet::Machine("m1".into()),
+    };
+    let hit = job("backup", "h", "0 * * * *", &["m1"], true);
+    let wrong_machine = job("backup", "h", "0 * * * *", &["m2"], true);
+    let disabled = job("backup", "h", "0 * * * *", &["m1"], false);
+    let wrong_text = job("cleanup", "h", "0 * * * *", &["m1"], true);
+    assert!(f.matches(&hit, now(), window()));
+    assert!(!f.matches(&wrong_machine, now(), window()));
+    assert!(!f.matches(&disabled, now(), window()));
+    assert!(!f.matches(&wrong_text, now(), window()));
+}
+
+// ── List helpers ──────────────────────────────────────────────────────────────
+
+#[test]
+fn filter_jobs_preserves_order_and_narrows() {
+    let jobs = vec![
+        job("a", "keep", "0 * * * *", &[], true),
+        job("b", "drop", "0 * * * *", &[], false),
+        job("c", "keep", "0 * * * *", &[], true),
+    ];
+    let f = JobFilter {
+        status: StatusFacet::Enabled,
+        ..Default::default()
+    };
+    let out = filter_jobs(&jobs, &f, now(), window());
+    let ids: Vec<&str> = out.iter().map(|j| j.id.as_str()).collect();
+    assert_eq!(ids, vec!["a", "c"]);
+}
+
+#[test]
+fn filter_jobs_unfiltered_returns_all() {
+    let jobs = vec![
+        job("a", "h", "0 * * * *", &[], true),
+        job("b", "h", "0 * * * *", &[], false),
+    ];
+    let out = filter_jobs(&jobs, &JobFilter::default(), now(), window());
+    assert_eq!(out.len(), 2);
+}
+
+#[test]
+fn distinct_machines_are_sorted_and_deduped() {
+    let jobs = vec![
+        job("a", "h", "0 * * * *", &["m2", "m1"], true),
+        job("b", "h", "0 * * * *", &["m1", "m3"], true),
+        job("c", "h", "0 * * * *", &[], true),
+    ];
+    assert_eq!(distinct_machines(&jobs), vec!["m1", "m2", "m3"]);
+}
+
+#[test]
+fn unassigned_count_tallies_dormant_jobs() {
+    let jobs = vec![
+        job("a", "h", "0 * * * *", &["m1"], true),
+        job("b", "h", "0 * * * *", &[], true),
+        job("c", "h", "0 * * * *", &[], false),
+    ];
+    assert_eq!(unassigned_count(&jobs), 2);
+}


### PR DESCRIPTION
Closes #621 (and supersedes the duplicate #617).

## What

Adds a **faceted filter toolbar** to the Cron Jobs list — previously the table rendered every job unconditionally, with no search, status, or machine filtering. This brings the page to parity with (and beyond) the Routines page.

- **Free-text search** across job id, handler, schedule expression, the server's human schedule description, and metadata — case-insensitive, live as you type. **`/`** focuses the search box from anywhere on the page (skipped while typing in another field), complementing the existing ⌘K palette.
- **Status facet**: `All / Enabled / Disabled / Due soon` — *Due soon* reuses the existing `fires_within` + `DUE_SOON_WINDOW_SECS` logic that backs the KPI tile.
- **Machine facet**: `Any / Unassigned` (dormant, no-machine jobs) `/` one entry per distinct machine across the loaded jobs.
- **Live result count** — "Showing N of M" — plus a `CLEAR` action when any facet is active.
- **Cross-filtering KPI tiles**: the TOTAL / ENABLED / DUE SOON / DISABLED stat cards are now buttons that apply the matching status facet and read as pressed when active. KPIs stay computed over the **full fleet**; only the table/day list narrows.
- **Filter-aware empty state** ("NO MATCHING JOBS" + clear) — distinct from the genuine "NO JOBS SCHEDULED" zero state, so an operator is never left wondering "is it broken or just filtered?".
- The filtered set feeds **both** the table and the Day timeline; bulk select-all operates over the **visible** rows.

## Best-practice rationale (research)

Operations/monitoring dashboards (Datadog, Grafana, GitHub Actions, BI tools) converge on these patterns:
1. **Faceted filtering + free-text search** is the baseline for any dense operational list — narrow from "everything" to "the thing I care about" without leaving the page. Facets AND across groups; the live result count keeps the active filter legible ([faceted-search best practices](https://www.brokenrubik.com/blog/faceted-search-best-practices), [Algolia faceting guide](https://www.algolia.com/doc/guides/managing-results/refine-results/faceting)).
2. **Cross-filtering** (clicking a summary KPI to filter the detail list) is a staple of BI dashboards and observability tools ([New Relic facet filtering](https://docs.newrelic.com/docs/query-your-data/explore-query-data/dashboards/filter-new-relic-one-dashboards-facets/)).
3. A persistent **result count** + a **filter-aware empty state** prevent the classic "is it broken or just filtered?" confusion.
4. **Keyboard-first focus** (`/` to search) is standard in developer tooling.

## Scope / safety

- **Frontend-only, confined to `ui/`.** Built entirely on data the UI already fetches from `GET /api/v1/cron-jobs`. No backend / API / data-model changes.
- Filter logic is factored into pure, host-testable functions (`JobFilter::matches`, `filter_jobs`, `distinct_machines`, `unassigned_count`, facet codecs) with unit tests in `ui/src/cron_jobs_tests.rs` (mirrors the `schedule.rs` / `overview.rs` test conventions).

## Verification

- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings` clean (ui sets clippy `all = "deny"`)
- `cargo test` — 78 ui tests pass (24 new)
- `cargo build -p ui --target wasm32-unknown-unknown` succeeds

`prebuilt.html` is intentionally **not** committed (it is generated from `ui/` at build time); the diff is `ui/`-only. Applying `skip-changelog` since this is a self-contained UI feature.

---
This pull request was opened by the "UI dashboard feature builder (research → issue → PR → merge)" routine of moadim.