### PR TITLE
docs(contributing): document the SKIP_CHANGELOG=1 push bypass

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,12 @@ cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'
 1. Branch from `main` — name it `feat/...`, `fix/...`, `chore/...`, or `docs/...`.
 2. Keep commits focused; one logical change per commit.
 3. Note user-facing changes under `## [Unreleased]` in
-   [`CHANGELOG.md`](CHANGELOG.md) (Keep a Changelog format).
+   [`CHANGELOG.md`](CHANGELOG.md) (Keep a Changelog format). The pre-push hook
+   (and the CI `unreleased-entry` check) reject a push that touches `src/` or
+   `ui/` without a matching `CHANGELOG.md` edit. For a deliberately undocumented
+   change — e.g. a pure internal refactor with no user-facing effect — bypass
+   the local hook with `SKIP_CHANGELOG=1 git push`; the in-repo equivalent on
+   the PR is the `skip-changelog` label.
 4. Open a PR against `main`; fill in what changed and why.
 
 ## Releasing


### PR DESCRIPTION
## What

Document the `SKIP_CHANGELOG=1` escape hatch under the changelog step in `CONTRIBUTING.md`.

## Why

The pre-push hook (`.githooks/pre-push`) already supports `SKIP_CHANGELOG=1` to skip the changelog gate for deliberately undocumented `src/`/`ui/` changes — described in the hook itself as "the local equivalent of the `skip-changelog` PR label". But `CONTRIBUTING.md` only stated the changelog requirement, never the bypass. A contributor making a pure internal refactor with no user-facing effect would hit the hook with no documented way out.

This notes the bypass (and its in-repo `skip-changelog` label equivalent) right where the changelog requirement is introduced, so the docs match what the hook and CI actually enforce.

## Scope

Docs only — touches `CONTRIBUTING.md`, no `src/`/`ui/`, so the `unreleased-entry` check is exempt.

---

This pull request was opened by the "Daemon + Landing auto-improve & auto-merge lint/docs PRs" routine of moadim.