### PR TITLE
feat(ui): live auto-refresh — persisted interval + freshness cue for cron-jobs & routines tables (#618)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Added
 
+- **Live auto-refresh for the cron-jobs & routines tables.** Each list's action row
+  gains a Grafana/Datadog-style refresh-interval selector (`Off` default, `5s`, `15s`,
+  `30s`, `60s`) plus an "updated Ns ago" freshness cue, so an operator can keep the data
+  current on a cadence they choose instead of reloading the SPA. The choice persists to
+  `localStorage` under a shared key, so it is consistent across both pages and survives
+  navigation and reload; `Off` preserves the historical load-once behaviour (no background
+  traffic until opted in). Re-fetches use the existing `GET /api/v1/cron-jobs` /
+  `GET /api/v1/routines` endpoints — no backend change. Closes #618.
 - **Operations overview landing page.** The root `/` route now serves a single-pane
   OVERVIEW summary that aggregates both cron jobs and routines, so an operator sees
   whole-system state at a glance: five cross-entity KPI tiles (`SCHEDULED`, `ENABLED`,

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -19,7 +19,7 @@ chrono = "0.4"
 gloo-net = { version = "0.6", features = ["http"] }
 gloo-timers = { version = "0.4", features = ["futures"] }
 js-sys = "0.3"
-web-sys = { version = "0.3", features = ["Element", "EventTarget", "HtmlElement", "HtmlInputElement", "HtmlSelectElement", "KeyboardEvent", "Window"] }
+web-sys = { version = "0.3", features = ["Element", "EventTarget", "HtmlElement", "HtmlInputElement", "HtmlSelectElement", "KeyboardEvent", "Storage", "Window"] }
 log = "0.4"
 console_log = "1"
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -896,6 +896,35 @@
     /* ── View toggle ── */
     .section-acts { display: flex; align-items: center; gap: 10px; }
 
+    /* ── Auto-refresh control ── */
+    .refresh-control { display: flex; align-items: center; gap: 7px; }
+    .refresh-lbl {
+      font-family: var(--mono);
+      font-size: 9px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--text-dim);
+    }
+    .refresh-select {
+      background: var(--bg-3);
+      border: 1px solid var(--border);
+      color: var(--text);
+      font-family: var(--mono);
+      font-size: 11px;
+      padding: 4px 8px;
+      outline: none;
+      cursor: pointer;
+      transition: border-color 0.12s;
+    }
+    .refresh-select:focus { border-color: var(--accent); }
+    .refresh-fresh {
+      font-family: var(--mono);
+      font-size: 10px;
+      letter-spacing: 0.04em;
+      color: var(--text-ghost);
+      white-space: nowrap;
+    }
+
     .view-toggle { display: flex; border: 1px solid var(--border); }
 
     .view-btn {

--- a/ui/src/cron_jobs.rs
+++ b/ui/src/cron_jobs.rs
@@ -3,6 +3,7 @@
 //! Self-contained like [`crate::routines::RoutinesPage`]: owns its own reducer state and talks to
 //! the `/cron-jobs` API. Toasts bubble up to the shell via the `on_toast` callback.
 
+use std::cell::Cell;
 use std::collections::{BTreeSet, HashSet};
 use std::rc::Rc;
 
@@ -19,6 +20,7 @@ use yew::prelude::*;
 
 use crate::day_timeline::{DayTimeline, TimelineItem};
 use crate::machines::MachinesPicker;
+use crate::refresh::{RefreshControl, RefreshInterval};
 use crate::schedule::{fires_within, fmt_until, fmt_when, next_fire_after};
 use crate::{describe_cron_live, reltime, ToastKind};
 
@@ -545,6 +547,11 @@ pub fn cron_jobs_page(props: &CronJobsPageProps) -> Html {
         });
     }
 
+    // Operator-chosen auto-refresh cadence (persisted), and the `Date.now()`
+    // (ms) of the last successful list load that drives the freshness cue.
+    let interval = use_state(crate::refresh::load_interval);
+    let updated_at = use_state(|| 0.0_f64);
+
     let ok_toast = {
         let toast = toast.clone();
         move |msg: &str| toast.emit((msg.to_string(), ToastKind::Ok))
@@ -554,15 +561,64 @@ pub fn cron_jobs_page(props: &CronJobsPageProps) -> Html {
     {
         let state = state.clone();
         let toast = toast.clone();
+        let updated_at = updated_at.clone();
         use_effect_with((), move |_| {
             spawn_local(async move {
                 match api_list().await {
-                    Ok(jobs) => state.dispatch(CAction::Loaded(jobs)),
+                    Ok(jobs) => {
+                        state.dispatch(CAction::Loaded(jobs));
+                        updated_at.set(js_sys::Date::now());
+                    }
                     Err(e) => toast.emit((format!("Failed to load jobs: {e}"), ToastKind::Err)),
                 }
             });
         });
     }
+
+    // Auto-refresh loop, re-armed whenever the chosen interval changes. `Off`
+    // installs no loop (today's load-once behaviour); any cadence re-fetches the
+    // list on that period via the existing endpoint. The cleanup flag stops the
+    // running loop when the interval changes or the page unmounts.
+    {
+        let state = state.clone();
+        let toast = toast.clone();
+        let updated_at = updated_at.clone();
+        use_effect_with(*interval, move |interval| {
+            let cancelled = Rc::new(Cell::new(false));
+            if let Some(period_ms) = interval.as_millis() {
+                let cancelled = cancelled.clone();
+                spawn_local(async move {
+                    loop {
+                        TimeoutFuture::new(period_ms).await;
+                        if cancelled.get() {
+                            break;
+                        }
+                        match api_list().await {
+                            Ok(jobs) => {
+                                if cancelled.get() {
+                                    break;
+                                }
+                                state.dispatch(CAction::Loaded(jobs));
+                                updated_at.set(js_sys::Date::now());
+                            }
+                            Err(e) => {
+                                toast.emit((format!("Auto-refresh failed: {e}"), ToastKind::Err));
+                            }
+                        }
+                    }
+                });
+            }
+            move || cancelled.set(true)
+        });
+    }
+
+    let on_set_interval = {
+        let interval = interval.clone();
+        Callback::from(move |next: RefreshInterval| {
+            crate::refresh::save_interval(next);
+            interval.set(next);
+        })
+    };
 
     let on_new = {
         let state = state.clone();
@@ -949,6 +1005,11 @@ pub fn cron_jobs_page(props: &CronJobsPageProps) -> Html {
                             <div class="section-hd">
                                 <div class="section-label">{"SCHEDULED JOBS"}</div>
                                 <div class="section-acts">
+                                    <RefreshControl
+                                        interval={*interval}
+                                        updated_at_ms={*updated_at}
+                                        on_change={on_set_interval}
+                                    />
                                     <CronViewToggle view={view} on_set_view={on_set_view} />
                                     <button class="btn btn-primary btn-sm" onclick={on_new}>{"+ NEW JOB"}</button>
                                 </div>

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -13,6 +13,7 @@ mod cron_jobs;
 mod day_timeline;
 mod machines;
 mod overview;
+mod refresh;
 mod routines;
 mod schedule;
 use command_palette::CommandPalette;

--- a/ui/src/refresh.rs
+++ b/ui/src/refresh.rs
@@ -1,0 +1,208 @@
+//! Live auto-refresh control for the data tables.
+//!
+//! Renders a Grafana/Datadog-style refresh-interval selector plus an "updated
+//! Ns ago" freshness cue, letting an operator keep the cron-jobs and routines
+//! lists current on a cadence they choose (Off / 5s / 15s / 30s / 60s) instead
+//! of reloading the SPA. The chosen interval is persisted to `localStorage`
+//! under a shared key, so it is consistent across both pages and survives
+//! navigation and reload.
+//!
+//! The interval codec and freshness formatting are pure and host-tested (see
+//! `refresh_tests.rs`); only the `RefreshControl` component, its 1s display
+//! tick, and the `localStorage` round-trip touch the DOM/wasm layer.
+
+use gloo_timers::future::TimeoutFuture;
+use wasm_bindgen_futures::spawn_local;
+use web_sys::HtmlSelectElement;
+use yew::prelude::*;
+
+/// `localStorage` key the selected interval persists under. Shared by both the
+/// cron-jobs and routines pages so the choice is fleet-wide.
+const STORAGE_KEY: &str = "moadim.refresh-interval";
+
+/// Operator-selectable auto-refresh cadence for a data table. `Off` (the
+/// default) preserves the historical load-once behaviour — no background
+/// traffic until the operator opts in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RefreshInterval {
+    /// No auto-refresh; the list loads once on mount.
+    #[default]
+    Off,
+    /// Refresh every 5 seconds.
+    S5,
+    /// Refresh every 15 seconds.
+    S15,
+    /// Refresh every 30 seconds.
+    S30,
+    /// Refresh every 60 seconds.
+    S60,
+}
+
+impl RefreshInterval {
+    /// Every variant in selector order, for rendering the dropdown.
+    pub const ALL: [RefreshInterval; 5] = [
+        RefreshInterval::Off,
+        RefreshInterval::S5,
+        RefreshInterval::S15,
+        RefreshInterval::S30,
+        RefreshInterval::S60,
+    ];
+
+    /// The cadence in milliseconds, or `None` for `Off` (no auto-refresh).
+    pub fn as_millis(self) -> Option<u32> {
+        match self {
+            RefreshInterval::Off => None,
+            RefreshInterval::S5 => Some(5_000),
+            RefreshInterval::S15 => Some(15_000),
+            RefreshInterval::S30 => Some(30_000),
+            RefreshInterval::S60 => Some(60_000),
+        }
+    }
+
+    /// Short human label shown in the dropdown.
+    pub fn label(self) -> &'static str {
+        match self {
+            RefreshInterval::Off => "Off",
+            RefreshInterval::S5 => "5s",
+            RefreshInterval::S15 => "15s",
+            RefreshInterval::S30 => "30s",
+            RefreshInterval::S60 => "60s",
+        }
+    }
+
+    /// Stable token used as the `<option>` value and the persisted form.
+    pub fn to_token(self) -> &'static str {
+        match self {
+            RefreshInterval::Off => "off",
+            RefreshInterval::S5 => "5",
+            RefreshInterval::S15 => "15",
+            RefreshInterval::S30 => "30",
+            RefreshInterval::S60 => "60",
+        }
+    }
+
+    /// Parse a token back into an interval, defaulting to `Off` for anything
+    /// unrecognized (older/garbage `localStorage` values fall back safely).
+    pub fn from_token(token: &str) -> RefreshInterval {
+        match token {
+            "5" => RefreshInterval::S5,
+            "15" => RefreshInterval::S15,
+            "30" => RefreshInterval::S30,
+            "60" => RefreshInterval::S60,
+            _ => RefreshInterval::Off,
+        }
+    }
+}
+
+/// Format "time since last load" for the freshness cue: "updated just now"
+/// under a minute, then "updated Nm ago" / "updated Nh ago".
+pub fn fmt_freshness(secs_ago: u64) -> String {
+    if secs_ago < 60 {
+        "updated just now".into()
+    } else if secs_ago < 3_600 {
+        format!("updated {}m ago", secs_ago / 60)
+    } else {
+        format!("updated {}h ago", secs_ago / 3_600)
+    }
+}
+
+/// Read the persisted interval from `localStorage`, defaulting to `Off` when
+/// storage is unavailable or holds no/garbage value.
+pub fn load_interval() -> RefreshInterval {
+    let token = web_sys::window()
+        .and_then(|win| win.local_storage().ok().flatten())
+        .and_then(|store| store.get_item(STORAGE_KEY).ok().flatten());
+    match token {
+        Some(token) => RefreshInterval::from_token(&token),
+        None => RefreshInterval::Off,
+    }
+}
+
+/// Persist the chosen interval to `localStorage`. Best-effort: a storage error
+/// (e.g. private-mode quota) is silently ignored — the in-memory choice still
+/// applies for the session.
+pub fn save_interval(interval: RefreshInterval) {
+    if let Some(store) = web_sys::window().and_then(|win| win.local_storage().ok().flatten()) {
+        let _ = store.set_item(STORAGE_KEY, interval.to_token());
+    }
+}
+
+#[derive(Properties, PartialEq)]
+pub struct RefreshControlProps {
+    /// Currently selected interval.
+    pub interval: RefreshInterval,
+    /// `Date.now()` (ms) of the last successful list load; `0.0` means the list
+    /// has not loaded yet, which hides the freshness cue.
+    pub updated_at_ms: f64,
+    /// Emitted with the newly chosen interval when the operator changes it.
+    pub on_change: Callback<RefreshInterval>,
+}
+
+/// Interval dropdown + live freshness label for a data table's action row.
+#[function_component(RefreshControl)]
+pub fn refresh_control(props: &RefreshControlProps) -> Html {
+    // A local 1s tick re-renders just this widget so the "updated Ns ago" label
+    // stays live, without forcing the parent table to re-render every second.
+    // The stored instant is only a re-render trigger, so each tick stamps a
+    // fresh value; the label is recomputed from `updated_at_ms` below.
+    let tick = use_state(|| 0.0_f64);
+    {
+        let tick = tick.clone();
+        use_effect_with((), move |_| {
+            spawn_local(async move {
+                loop {
+                    TimeoutFuture::new(1_000).await;
+                    tick.set(js_sys::Date::now());
+                }
+            });
+        });
+    }
+
+    let on_select = {
+        let on_change = props.on_change.clone();
+        Callback::from(move |event: Event| {
+            let select: HtmlSelectElement = event.target_unchecked_into();
+            on_change.emit(RefreshInterval::from_token(&select.value()));
+        })
+    };
+
+    let current = props.interval;
+    let freshness = if props.updated_at_ms > 0.0 {
+        let secs = ((js_sys::Date::now() - props.updated_at_ms).max(0.0) / 1000.0) as u64;
+        Some(fmt_freshness(secs))
+    } else {
+        None
+    };
+
+    html! {
+        <div class="refresh-control">
+            <label class="refresh-lbl" for="refresh-interval">{"AUTO"}</label>
+            <select
+                id="refresh-interval"
+                class="refresh-select"
+                onchange={on_select}
+                aria-label="Auto-refresh interval"
+            >
+                { for RefreshInterval::ALL.iter().map(|interval| html! {
+                    <option value={interval.to_token()} selected={*interval == current}>
+                        { interval.label() }
+                    </option>
+                }) }
+            </select>
+            {
+                match freshness {
+                    Some(text) => html! {
+                        <span class="refresh-fresh" title="Time since the list last refreshed">
+                            { text }
+                        </span>
+                    },
+                    None => html! {},
+                }
+            }
+        </div>
+    }
+}
+
+#[cfg(test)]
+#[path = "refresh_tests.rs"]
+mod refresh_tests;

--- a/ui/src/refresh_tests.rs
+++ b/ui/src/refresh_tests.rs
@@ -1,0 +1,79 @@
+//! Host-side unit tests for the pure auto-refresh logic in [`super`]: the
+//! `RefreshInterval` codec (token round-trip, millis, labels) and the
+//! `fmt_freshness` staleness formatter. No DOM/wasm dependency (mirrors the
+//! `schedule.rs` / `cron_jobs.rs` test conventions).
+
+use super::*;
+
+#[test]
+fn token_roundtrips_for_every_variant() {
+    for interval in RefreshInterval::ALL {
+        assert_eq!(RefreshInterval::from_token(interval.to_token()), interval);
+    }
+}
+
+#[test]
+fn from_token_defaults_to_off_for_unknown() {
+    assert_eq!(RefreshInterval::from_token(""), RefreshInterval::Off);
+    assert_eq!(RefreshInterval::from_token("off"), RefreshInterval::Off);
+    assert_eq!(
+        RefreshInterval::from_token("nonsense"),
+        RefreshInterval::Off
+    );
+    assert_eq!(RefreshInterval::from_token("7"), RefreshInterval::Off);
+}
+
+#[test]
+fn default_is_off() {
+    assert_eq!(RefreshInterval::default(), RefreshInterval::Off);
+}
+
+#[test]
+fn off_has_no_cadence_others_do() {
+    assert_eq!(RefreshInterval::Off.as_millis(), None);
+    assert_eq!(RefreshInterval::S5.as_millis(), Some(5_000));
+    assert_eq!(RefreshInterval::S15.as_millis(), Some(15_000));
+    assert_eq!(RefreshInterval::S30.as_millis(), Some(30_000));
+    assert_eq!(RefreshInterval::S60.as_millis(), Some(60_000));
+}
+
+#[test]
+fn labels_are_stable() {
+    assert_eq!(RefreshInterval::Off.label(), "Off");
+    assert_eq!(RefreshInterval::S5.label(), "5s");
+    assert_eq!(RefreshInterval::S15.label(), "15s");
+    assert_eq!(RefreshInterval::S30.label(), "30s");
+    assert_eq!(RefreshInterval::S60.label(), "60s");
+}
+
+#[test]
+fn all_lists_every_variant_in_selector_order() {
+    assert_eq!(
+        RefreshInterval::ALL,
+        [
+            RefreshInterval::Off,
+            RefreshInterval::S5,
+            RefreshInterval::S15,
+            RefreshInterval::S30,
+            RefreshInterval::S60,
+        ]
+    );
+}
+
+#[test]
+fn fmt_freshness_sub_minute_is_just_now() {
+    assert_eq!(fmt_freshness(0), "updated just now");
+    assert_eq!(fmt_freshness(59), "updated just now");
+}
+
+#[test]
+fn fmt_freshness_minutes() {
+    assert_eq!(fmt_freshness(60), "updated 1m ago");
+    assert_eq!(fmt_freshness(3_599), "updated 59m ago");
+}
+
+#[test]
+fn fmt_freshness_hours() {
+    assert_eq!(fmt_freshness(3_600), "updated 1h ago");
+    assert_eq!(fmt_freshness(7_200), "updated 2h ago");
+}

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -3,10 +3,12 @@
 //! Mirrors the cron-jobs UI but targets the `/routines` API. A routine launches an AI agent
 //! (claude, codex, …) on a schedule instead of running a handler script.
 
+use std::cell::Cell;
 use std::rc::Rc;
 
 use chrono::{Datelike, Duration, Local, NaiveDate, TimeZone};
 use gloo_net::http::Request;
+use gloo_timers::future::TimeoutFuture;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen_futures::spawn_local;
 use web_sys::{HtmlInputElement, HtmlSelectElement};
@@ -14,6 +16,7 @@ use yew::prelude::*;
 
 use crate::day_timeline::{DayTimeline, TimelineItem};
 use crate::machines::MachinesPicker;
+use crate::refresh::{RefreshControl, RefreshInterval};
 use crate::{describe_cron_live, parse_cron, reltime, ToastKind};
 
 /// Agents the daemon ships built-in configs for (see `src/routines/agents`). Keep in sync with
@@ -352,6 +355,11 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
     let state = use_reducer(RState::default);
     let toast = props.on_toast.clone();
 
+    // Operator-chosen auto-refresh cadence (persisted), and the `Date.now()`
+    // (ms) of the last successful list load that drives the freshness cue.
+    let interval = use_state(crate::refresh::load_interval);
+    let updated_at = use_state(|| 0.0_f64);
+
     let ok_toast = {
         let toast = toast.clone();
         move |msg: &str| toast.emit((msg.to_string(), ToastKind::Ok))
@@ -361,15 +369,64 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
     {
         let state = state.clone();
         let toast = toast.clone();
+        let updated_at = updated_at.clone();
         use_effect_with((), move |_| {
             spawn_local(async move {
                 match api_list().await {
-                    Ok(r) => state.dispatch(RAction::Loaded(r)),
+                    Ok(r) => {
+                        state.dispatch(RAction::Loaded(r));
+                        updated_at.set(js_sys::Date::now());
+                    }
                     Err(e) => toast.emit((format!("Failed to load routines: {e}"), ToastKind::Err)),
                 }
             });
         });
     }
+
+    // Auto-refresh loop, re-armed whenever the chosen interval changes. `Off`
+    // installs no loop (today's load-once behaviour); any cadence re-fetches the
+    // list on that period via the existing endpoint. The cleanup flag stops the
+    // running loop when the interval changes or the page unmounts.
+    {
+        let state = state.clone();
+        let toast = toast.clone();
+        let updated_at = updated_at.clone();
+        use_effect_with(*interval, move |interval| {
+            let cancelled = Rc::new(Cell::new(false));
+            if let Some(period_ms) = interval.as_millis() {
+                let cancelled = cancelled.clone();
+                spawn_local(async move {
+                    loop {
+                        TimeoutFuture::new(period_ms).await;
+                        if cancelled.get() {
+                            break;
+                        }
+                        match api_list().await {
+                            Ok(r) => {
+                                if cancelled.get() {
+                                    break;
+                                }
+                                state.dispatch(RAction::Loaded(r));
+                                updated_at.set(js_sys::Date::now());
+                            }
+                            Err(e) => {
+                                toast.emit((format!("Auto-refresh failed: {e}"), ToastKind::Err));
+                            }
+                        }
+                    }
+                });
+            }
+            move || cancelled.set(true)
+        });
+    }
+
+    let on_set_interval = {
+        let interval = interval.clone();
+        Callback::from(move |next: RefreshInterval| {
+            crate::refresh::save_interval(next);
+            interval.set(next);
+        })
+    };
 
     let on_new = {
         let state = state.clone();
@@ -625,6 +682,11 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
                             <div class="section-hd">
                                 <div class="section-label">{"SCHEDULED ROUTINES"}</div>
                                 <div class="section-acts">
+                                    <RefreshControl
+                                        interval={*interval}
+                                        updated_at_ms={*updated_at}
+                                        on_change={on_set_interval}
+                                    />
                                     <ViewToggle view={view} on_set_view={on_set_view} />
                                     <button class="btn btn-ghost btn-sm" onclick={on_cleanup}
                                         title="Reap finished, expired run workbenches now">{"CLEANUP NOW"}</button>


### PR DESCRIPTION
## Summary

Closes #618.

Adds a **user-controllable, persisted live auto-refresh** to the cron-jobs and routines data tables — a Grafana/Datadog-style refresh-interval selector plus an "updated Ns ago" freshness cue — so an operator can watch list state update on a cadence they choose instead of manually reloading the SPA.

Before this, both tables fetched **once on mount** and never re-fetched; the only way to see new state was a full reload.

## Best-practice rationale (research)

Leading monitoring/ops dashboards expose an explicit, user-owned refresh cadence rather than a hidden fixed one:

- **Grafana** puts a refresh-interval dropdown (Off / 5s / 10s / 30s / 1m / …) in the top-right, with a visual cue when a refresh runs.
- **Splunk AppDynamics**, **Power BI** (Automatic Page Refresh), and **MS Fabric Real-Time Dashboards** all offer a selectable fixed-interval refresh and recommend letting the user turn it off / slow it down to balance freshness against load.
- Common pattern: predefined intervals incl. an **Off** option, a **"last updated N ago"** staleness cue, and **persisting** the choice so it survives navigation/reload.

## What changed (UI-only, existing API)

- **New `ui/src/refresh.rs` module**
  - `RefreshInterval` enum — `Off` (default), `5s`, `15s`, `30s`, `60s` — with a stable token codec (`to_token`/`from_token`), `as_millis`, and `label`.
  - `fmt_freshness(secs_ago)` → `"updated just now"` / `"updated Nm ago"` / `"updated Nh ago"`.
  - `localStorage` load/save under a shared key `moadim.refresh-interval` (best-effort; safe fallback to `Off`).
  - `RefreshControl` component: interval `<select>` + a self-ticking (1 s) freshness label that re-renders only the widget, not the parent table.
- **Cron Jobs & Routines pages** render `RefreshControl` in their section-action row, persist the choice, stamp `updated_at` on each successful load, and re-arm an auto-refresh loop (with cancel-on-change/unmount) keyed on the interval. `Off` installs no loop, preserving today's load-once behaviour (no surprise traffic).
- CSS for the control; `Storage` web-sys feature; CHANGELOG entry.

No backend, daemon, API, data-model, or cron/routine-semantics change. Re-fetches use the existing `GET /api/v1/cron-jobs` / `GET /api/v1/routines`.

## Tests

Pure logic (interval token round-trip, `as_millis`, labels, `ALL` order, `fmt_freshness` boundaries) is unit-tested in `ui/src/refresh_tests.rs`. `cargo test -p ui`, `cargo fmt -p ui --check`, and `cargo clippy -p ui --all-targets -- -D warnings` all pass locally.

## Scope

Diff is confined to `ui/` source plus the mandated root `CHANGELOG.md`. `prebuilt.html` is intentionally **not** touched (it is generated, never hand-committed).

---
_This pull request was opened by the "UI dashboard feature builder (research → issue → PR → merge)" routine of moadim._