### PR TITLE
docs(architecture): fix stale last_triggered_at field name

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -86,7 +86,7 @@ pub struct CronJob {
     pub source: String,                   // "managed" | "system:user-crontab" | "system:etc-crontab" | "system:cron.d/<file>"
     pub created_at: u64,                  // Unix seconds
     pub updated_at: u64,
-    pub last_triggered_at: Option<u64>,
+    pub last_manual_trigger_at: Option<u64>,  // only manual triggers update this; scheduled cron runs do not
 }
 ```
 
@@ -116,7 +116,7 @@ Both are cloned into `AppState` (REST) and `MoadimMcp` (MCP). Every write acquir
 | `svc_create` | Validates cron expr, assigns UUID v4, writes TOML, inserts into store |
 | `svc_update` | Partial-updates fields, bumps `updated_at`, rewrites TOML |
 | `svc_delete` | Removes from store, deletes job directory |
-| `svc_trigger` | Records `last_triggered_at = now`, rewrites TOML |
+| `svc_trigger` | Records `last_manual_trigger_at = now`, rewrites TOML |
 | `svc_logs_path` | Checks job exists, returns path to `job.local.log` |
 
 Both the HTTP handlers and MCP tools call these directly — there is no duplication of logic between the two transports.


### PR DESCRIPTION
Closes #244

## Changes

- Updated the `CronJob` struct listing in Architecture.md: renamed `last_triggered_at` to `last_manual_trigger_at` (the old name is now only a serde alias for backward-compat deserialization).
- Updated the `svc_trigger` service-layer table entry to say `last_manual_trigger_at = now` instead of `last_triggered_at = now`.
- Added an inline comment clarifying that scheduled cron runs do not update this field (only manual triggers do).

No source or test changes — docs-only fix.

---

This pull request was opened by the **Implement my assigned issues without a PR (daemon + landing)** routine of moadim.

/cc @tupe12334