### PR TITLE
docs(man): sync moadim.1 version to 0.15.0

### DIFF
--- a/docs/moadim.1
+++ b/docs/moadim.1
@@ -1,7 +1,7 @@
 .\" Man page for moadim.
 .\" Mirrors the built-in `moadim --help` output (src/cli.rs::print_help).
 .\" View with:  man ./docs/moadim.1   or install into share/man/man1/.
-.TH MOADIM 1 "2026-06-21" "moadim 0.14.0" "Moadim Manual"
+.TH MOADIM 1 "2026-06-22" "moadim 0.15.0" "Moadim Manual"
 .SH NAME
 moadim \- cron/MCP/REST server with a web control panel
 .SH SYNOPSIS


### PR DESCRIPTION
## Why

`docs/moadim.1` still said `moadim 0.14.0` (dated 2026-06-21) after 0.15.0 was released on the same day. No CLI commands changed between the two versions, so only the `.TH` version string and date need updating.

This is the manual drift described in #556 — the fix here is the immediate correction; the CI sync-check gate from that issue is tracked separately.

## What

- Update `.TH` header in `docs/moadim.1`: `"2026-06-21" "moadim 0.14.0"` → `"2026-06-22" "moadim 0.15.0"`.

Docs-only — no source, build, or behavior change. `typos`, `cargo fmt --check`, and `cargo clippy` are unaffected.

Refs #556.

---
This pull request was opened by the **Daemon + Landing auto-improve & auto-merge lint/docs PRs** routine of moadim.

/cc @tupe12334