### PR TITLE
feat(routines): add "The 1 Percent" built-in default routine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   a keyword search bar with match highlighting and navigation arrows, and an
   auto-tail toggle that keeps the viewport pinned to the last line as new output
   arrives. Closes #646.
+- **"The 1 Percent" built-in default routine.** A new daemon-managed default that fires
+  daily at 08:00 and audits the user's automation portfolio across six dimensions (coverage
+  gaps, redundancy, dead weight, prompt quality, schedule hygiene, machine targeting). Each
+  run it picks the single highest-impact improvement and opens a pull request on the routines
+  repository. If the routines folder is not a git repository the routine self-disables via
+  `update_routine`. Closes #640.
 - **Fleet schedule heatmap.** A new HEATMAP page (`/heatmap`) renders a forward-looking
   7-day × 24-hour fire-density grid that aggregates the next week's schedule of every
   enabled cron job and routine into one color-coded matrix, so an operator can see

--- a/src/routines/defaults.rs
+++ b/src/routines/defaults.rs
@@ -47,14 +47,97 @@ Steps:
 Report which versions you found and whether an update was performed.
 ";
 
+/// Prompt for the daily self-improvement routine.
+const THE_1_PERCENT_PROMPT: &str = "\
+You are \"The 1 Percent\" — a self-improving routines agent. Each day you make the user's \
+automation portfolio exactly 1% better: one focused, high-quality improvement, nothing more.
+
+## Step 1: Environment check
+
+Run:
+```bash
+git -C ~/.config/moadim rev-parse --is-inside-work-tree 2>/dev/null && echo IS_REPO || echo NOT_REPO
+```
+
+**If NOT_REPO:** use the moadim MCP tool `list_routines` to find the routine whose title is \
+\"The 1 Percent\", then call `update_routine` with `enabled: false` on that ID. \
+Log: \"Routines folder is not a git repository — self-disabled.\" Then stop.
+
+**If IS_REPO:** continue.
+
+## Step 2: Analyze the user's automation portfolio
+
+Use the moadim MCP tool `list_routines` to fetch all routines. For each one note: title, \
+schedule, agent, enabled, machines, last_scheduled_trigger_at, last_manual_trigger_at, and the \
+full prompt text.
+
+Evaluate across these dimensions:
+- **Coverage gaps** — life/work areas with zero automation (health, finances, learning, \
+communication, code quality, etc.)
+- **Redundancy** — two or more routines with overlapping intent that could be merged
+- **Dead weight** — disabled or never-triggered routines with no clear future use
+- **Prompt quality** — vague, ambiguous, or brittle prompts that likely produce poor results
+- **Schedule hygiene** — routines firing too often, at bad times, or not often enough
+- **Machine targeting** — routines with an empty machines list that will never fire
+
+## Step 3: Choose the single best improvement
+
+Rank by impact-to-effort ratio and pick ONE. Before acting, check for open PRs on the routines \
+repo to avoid duplicating a pending proposal:
+```bash
+origin=$(git -C ~/.config/moadim remote get-url origin 2>/dev/null)
+gh pr list --repo \"$origin\" --state open --json title,headRefName 2>/dev/null
+```
+If an equivalent improvement is already proposed, pick the next-best one.
+
+Good improvement examples:
+- Write a complete, precise new routine prompt for an unautomated area
+- Rewrite a vague prompt to be specific, testable, and effective
+- Merge two redundant routines into one stronger one
+- Fix a broken or wasteful schedule expression
+- Remove a demonstrably dead routine
+- Add a missing machine target so a routine actually fires
+
+## Step 4: Open the PR
+
+```bash
+git -C ~/.config/moadim checkout -b 1pct/$(date +%Y%m%d-%H%M)
+# Edit/add/delete files under ~/.config/moadim/routines/ as needed.
+# Only touch routine.toml files. Do NOT modify moadim daemon config.
+git -C ~/.config/moadim add -A
+git -C ~/.config/moadim commit -m \"routines: <concise description>\"
+git -C ~/.config/moadim push -u origin HEAD
+origin=$(git -C ~/.config/moadim remote get-url origin)
+gh pr create --repo \"$origin\" \
+  --title \"1%: <short description>\" \
+  --body \"$(printf '## What changed\\n<one paragraph>\\n\\n## Why this improves the portfolio\\n<one paragraph>\\n\\n## Expected impact\\n<one line>')\"
+```
+
+## Report
+
+Output exactly three lines:
+1. Env: IS_REPO or NOT_REPO (+ self-disabled if applicable)
+2. Improvement chosen: <type> — <one-line description>
+3. PR: <url> or \"Skipped: <reason>\"
+";
+
 /// Built-in default routines, reconciled onto disk on every startup.
-const DEFAULT_ROUTINES: &[DefaultRoutine] = &[DefaultRoutine {
-    title: "Update moadim cargo package",
-    // Daily at 09:00 local time.
-    schedule: "0 9 * * *",
-    agent: "claude",
-    prompt: UPDATE_MOADIM_PROMPT,
-}];
+const DEFAULT_ROUTINES: &[DefaultRoutine] = &[
+    DefaultRoutine {
+        title: "Update moadim cargo package",
+        // Daily at 09:00 local time.
+        schedule: "0 9 * * *",
+        agent: "claude",
+        prompt: UPDATE_MOADIM_PROMPT,
+    },
+    DefaultRoutine {
+        title: "The 1 Percent",
+        // Daily at 08:00 local time — runs before the cargo-update routine.
+        schedule: "0 8 * * *",
+        agent: "claude",
+        prompt: THE_1_PERCENT_PROMPT,
+    },
+];
 
 /// Build a concrete [`Routine`] from a [`DefaultRoutine`] spec, stamping `now` as the create/update
 /// time and normalizing the schedule. Kept separate from disk/store mutation so it can be unit

--- a/src/routines/defaults_tests.rs
+++ b/src/routines/defaults_tests.rs
@@ -190,10 +190,7 @@ fn ensure_default_routines_skips_up_to_date_existing() {
         // The existing up-to-date routine must not be duplicated (still exactly one entry with that
         // slug). Other defaults may have been seeded alongside it.
         let slug = slugify(spec.title);
-        let slug_count = after
-            .values()
-            .filter(|r| slugify(&r.title) == slug)
-            .count();
+        let slug_count = after.values().filter(|r| slugify(&r.title) == slug).count();
         assert_eq!(slug_count, 1, "up-to-date default must not be duplicated");
         assert!(
             after.contains_key(&existing_id),
@@ -221,10 +218,7 @@ fn ensure_default_routines_rewrites_drifted_existing() {
         // The drifted routine must be updated in-place, not duplicated (still exactly one entry
         // with that slug). Other defaults may have been seeded alongside it.
         let slug = slugify(spec.title);
-        let slug_count = after
-            .values()
-            .filter(|r| slugify(&r.title) == slug)
-            .count();
+        let slug_count = after.values().filter(|r| slugify(&r.title) == slug).count();
         assert_eq!(slug_count, 1, "drifted default must not be duplicated");
         let refreshed = after
             .get(&existing_id)

--- a/src/routines/defaults_tests.rs
+++ b/src/routines/defaults_tests.rs
@@ -187,7 +187,14 @@ fn ensure_default_routines_skips_up_to_date_existing() {
         ensure_default_routines(&store);
 
         let after = store.lock().unwrap();
-        assert_eq!(after.len(), 1, "up-to-date default must not be duplicated");
+        // The existing up-to-date routine must not be duplicated (still exactly one entry with that
+        // slug). Other defaults may have been seeded alongside it.
+        let slug = slugify(spec.title);
+        let slug_count = after
+            .values()
+            .filter(|r| slugify(&r.title) == slug)
+            .count();
+        assert_eq!(slug_count, 1, "up-to-date default must not be duplicated");
         assert!(
             after.contains_key(&existing_id),
             "the original entry must be preserved unchanged"
@@ -211,7 +218,14 @@ fn ensure_default_routines_rewrites_drifted_existing() {
         ensure_default_routines(&store);
 
         let after = store.lock().unwrap();
-        assert_eq!(after.len(), 1, "drifted default must not be duplicated");
+        // The drifted routine must be updated in-place, not duplicated (still exactly one entry
+        // with that slug). Other defaults may have been seeded alongside it.
+        let slug = slugify(spec.title);
+        let slug_count = after
+            .values()
+            .filter(|r| slugify(&r.title) == slug)
+            .count();
+        assert_eq!(slug_count, 1, "drifted default must not be duplicated");
         let refreshed = after
             .get(&existing_id)
             .expect("drifted default keeps its id");
@@ -233,12 +247,13 @@ fn ensure_default_routines_logs_and_skips_on_write_failure() {
     // `create_dir_all` inside write_routine errors. The failure is logged and skipped, so an empty
     // store stays empty (the routine is never inserted).
     with_redirected_home(|_home| {
-        let spec = &DEFAULT_ROUTINES[0];
-        let slug = slugify(spec.title);
         let routines = crate::paths::routines_dir();
         std::fs::create_dir_all(&routines).unwrap();
-        // Occupy the routine's directory path with a regular file so create_dir_all fails.
-        std::fs::write(routines.join(&slug), "i am a file, not a dir").unwrap();
+        // Block every default's directory path with a regular file so create_dir_all fails for all.
+        for spec in DEFAULT_ROUTINES {
+            let slug = slugify(spec.title);
+            std::fs::write(routines.join(&slug), "i am a file, not a dir").unwrap();
+        }
 
         let store = empty_store();
         ensure_default_routines(&store);
@@ -247,7 +262,9 @@ fn ensure_default_routines_logs_and_skips_on_write_failure() {
             store.lock().unwrap().is_empty(),
             "a write failure must not insert the routine into the store"
         );
-        // The blocking path remains a regular file (the write never overwrote it).
-        assert!(routines.join(&slug).is_file());
+        // Every blocking path must still be a regular file (no write overwrote any of them).
+        for spec in DEFAULT_ROUTINES {
+            assert!(routines.join(slugify(spec.title)).is_file());
+        }
     });
 }

--- a/src/routines/defaults_tests.rs
+++ b/src/routines/defaults_tests.rs
@@ -190,7 +190,10 @@ fn ensure_default_routines_skips_up_to_date_existing() {
         // The existing up-to-date routine must not be duplicated (still exactly one entry with that
         // slug). Other defaults may have been seeded alongside it.
         let slug = slugify(spec.title);
-        let slug_count = after.values().filter(|r| slugify(&r.title) == slug).count();
+        let slug_count = after
+            .values()
+            .filter(|routine| slugify(&routine.title) == slug)
+            .count();
         assert_eq!(slug_count, 1, "up-to-date default must not be duplicated");
         assert!(
             after.contains_key(&existing_id),
@@ -218,7 +221,10 @@ fn ensure_default_routines_rewrites_drifted_existing() {
         // The drifted routine must be updated in-place, not duplicated (still exactly one entry
         // with that slug). Other defaults may have been seeded alongside it.
         let slug = slugify(spec.title);
-        let slug_count = after.values().filter(|r| slugify(&r.title) == slug).count();
+        let slug_count = after
+            .values()
+            .filter(|routine| slugify(&routine.title) == slug)
+            .count();
         assert_eq!(slug_count, 1, "drifted default must not be duplicated");
         let refreshed = after
             .get(&existing_id)

--- a/src/routines/defaults_tests.rs
+++ b/src/routines/defaults_tests.rs
@@ -17,6 +17,15 @@ fn first_default_updates_moadim_cargo_package() {
 }
 
 #[test]
+fn second_default_is_the_1_percent() {
+    let spec = &DEFAULT_ROUTINES[1];
+    assert_eq!(spec.title, "The 1 Percent");
+    assert!(spec.prompt.contains("list_routines"));
+    assert!(spec.prompt.contains("update_routine"));
+    assert!(spec.prompt.contains("NOT_REPO"));
+}
+
+#[test]
 fn every_schedule_is_a_valid_cron() {
     for spec in DEFAULT_ROUTINES {
         let normalized = normalize_schedule(spec.schedule);


### PR DESCRIPTION
Closes #640.

## Summary

- Adds `THE_1_PERCENT_PROMPT` const and a second entry to `DEFAULT_ROUTINES` in `defaults.rs`
- Routine fires daily at 08:00 (before the cargo-update default at 09:00)
- Updates three `defaults_tests.rs` integration tests that assumed exactly one default existed (switched `len() == 1` guards to per-slug duplicate checks; blocked all default paths in the write-failure test)
- Adds `second_default_is_the_1_percent` unit test

## Behavior

Each morning the routine:
1. Checks whether `~/.config/moadim` is a git repo — if not, calls `update_routine(enabled: false)` on itself and stops
2. Fetches all routines via `list_routines` and audits them across six dimensions: coverage gaps, redundancy, dead weight, prompt quality, schedule hygiene, machine targeting
3. Picks the single highest-impact improvement (deduped against open PRs)
4. Branches, commits, and opens a `1pct/YYYYMMDD-HHmm` PR on the routines repo

## Test plan

- [ ] `cargo test routines::defaults` — all 15 tests pass
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] Pre-push hook passes (coverage, fmt, changelog)
- [ ] Daemon restart seeds "The 1 Percent" into `~/.config/moadim/routines/the-1-percent/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)