### PR TITLE
feat(ui): enhanced log viewer — line numbers, keyword search, auto-tail (#646)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Added
 
+- **Enhanced log viewer.** Both the routines and cron-jobs log pages now render
+  line numbers, a sticky keyword search bar with live `N / total` match count,
+  per-line keyword highlighting (amber on dark amber-dim), and auto-tail behaviour
+  that scrolls to the bottom on every load so the latest entry is always visible.
+  The filter/count logic lives in pure, host-testable helpers (`filter_lines`,
+  `match_count`) covered by 15 new unit tests.  Zero backend changes.  Closes #646.
 - **Fleet schedule heatmap.** A new HEATMAP page (`/heatmap`) renders a forward-looking
   7-day × 24-hour fire-density grid that aggregates the next week's schedule of every
   enabled cron job and routine into one color-coded matrix, so an operator can see

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,6 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Added
 
-- **Enhanced log viewer.** Both the routines and cron-jobs log pages now render
-  line numbers, a sticky keyword search bar with live `N / total` match count,
-  per-line keyword highlighting (amber on dark amber-dim), and auto-tail behaviour
-  that scrolls to the bottom on every load so the latest entry is always visible.
-  The filter/count logic lives in pure, host-testable helpers (`filter_lines`,
-  `match_count`) covered by 15 new unit tests.  Zero backend changes.  Closes #646.
 - **Fleet schedule heatmap.** A new HEATMAP page (`/heatmap`) renders a forward-looking
   7-day × 24-hour fire-density grid that aggregates the next week's schedule of every
   enabled cron job and routine into one color-coded matrix, so an operator can see

--- a/ui/index.html
+++ b/ui/index.html
@@ -1203,6 +1203,81 @@
       .day-chip { font-size: 9px; }
     }
 
+    /* ── Enhanced log viewer ── */
+    /* Search bar — sticky so it stays visible while scrolling long logs. */
+    .log-search {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      border-bottom: 1px solid var(--border);
+      background: var(--bg-3);
+      position: sticky;
+      top: 0;
+      z-index: 1;
+    }
+    .log-search-input {
+      flex: 1;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      color: var(--text);
+      font-family: var(--mono);
+      font-size: 12px;
+      padding: 5px 9px;
+      outline: none;
+      min-width: 0;
+      transition: border-color 0.12s;
+    }
+    .log-search-input:focus { border-color: var(--accent); }
+    .log-search-input::placeholder { color: var(--text-ghost); }
+    /* Search clear button — type=search gives a native clear affordance but
+       we keep our styled button for visual consistency. */
+    input[type="search"]::-webkit-search-cancel-button { display: none; }
+    .log-match-count {
+      font-size: 10px;
+      letter-spacing: 0.06em;
+      color: var(--text-ghost);
+      white-space: nowrap;
+      margin-left: auto;
+    }
+    /* Numbered lines */
+    .log-lines { padding: 6px 0; }
+    .log-line {
+      display: flex;
+      font-family: var(--mono);
+      font-size: 12px;
+      line-height: 1.7;
+    }
+    .log-line:hover { background: var(--bg-3); }
+    .log-ln {
+      min-width: 44px;
+      padding: 0 8px 0 12px;
+      text-align: right;
+      color: var(--text-ghost);
+      user-select: none;
+      flex-shrink: 0;
+      border-right: 1px solid var(--border);
+      font-variant-numeric: tabular-nums;
+    }
+    .log-lc {
+      padding: 0 12px;
+      color: var(--text-mid);
+      flex: 1;
+      min-width: 0;
+      white-space: pre-wrap;
+      word-break: break-all;
+    }
+    /* Keyword highlight — amber on dark amber-dim, amber border, no border-radius
+       keeps the terminal aesthetic. */
+    mark.log-hl {
+      background: var(--amber-dim);
+      color: var(--amber);
+      border: 1px solid var(--amber);
+      padding: 0 1px;
+      border-radius: 0;
+    }
+    mark.log-hl:focus-visible { outline: 1px solid var(--accent); }
+
     /* ── Reduced motion ── */
     /* Honor the user's OS/browser "reduce motion" preference: settle the
        decorative, continuous animations (glow pulse, refresh/loader spin) and

--- a/ui/src/cron_jobs.rs
+++ b/ui/src/cron_jobs.rs
@@ -19,6 +19,7 @@ use web_sys::{HtmlElement, HtmlInputElement, HtmlSelectElement, KeyboardEvent};
 use yew::prelude::*;
 
 use crate::day_timeline::{DayTimeline, TimelineItem};
+use crate::log_viewer::LogViewer;
 use crate::machines::MachinesPicker;
 use crate::refresh::{RefreshControl, RefreshInterval};
 use crate::schedule::{fires_within, fmt_until, fmt_when, next_fire_after};
@@ -2187,24 +2188,6 @@ pub fn logs_page(props: &LogsPageProps) -> Html {
         })
     };
 
-    let is_loading = *loading;
-    let err_msg = (*err).clone();
-    let log_text = (*content).clone();
-
-    let body = if is_loading {
-        html! { <div class="empty"><div class="spinner"></div></div> }
-    } else if let Some(e) = err_msg {
-        html! { <div class="logs-error">{format!("Error: {e}")}</div> }
-    } else if let Some(text) = log_text {
-        if text.is_empty() {
-            html! { <div class="logs-empty">{"— no logs yet —"}</div> }
-        } else {
-            html! { <pre class="logs-content">{text}</pre> }
-        }
-    } else {
-        html! {}
-    };
-
     html! {
         <main class="logs-page">
             <div class="page-hd">
@@ -2212,9 +2195,11 @@ pub fn logs_page(props: &LogsPageProps) -> Html {
                 <div class="page-title">{format!("LOGS / {}", props.handler)}</div>
                 <button class="btn-refresh" title="Refresh" aria-label="Refresh" onclick={on_refresh}>{"↻"}</button>
             </div>
-            <div class="logs-wrap">
-                {body}
-            </div>
+            <LogViewer
+                content={(*content).clone()}
+                loading={*loading}
+                err={(*err).clone()}
+            />
         </main>
     }
 }

--- a/ui/src/log_viewer.rs
+++ b/ui/src/log_viewer.rs
@@ -1,0 +1,200 @@
+//! Reusable enhanced log viewer: line numbers, keyword search/highlight, and auto-tail.
+//!
+//! Best-practice for ops/CI dashboards (GitLab, Harness, Datadog): a log panel must let
+//! operators zero in on errors without manual scrolling.  Three patterns drive this:
+//!
+//! 1. **Line numbers** — anchor copy-paste references and support "go to line N" mental model.
+//! 2. **Keyword search + highlight** — filter to matching lines and highlight the term, with
+//!    a live `N / total` count so the operator knows the scope of a hit.
+//! 3. **Auto-tail** — scroll to bottom on content load so the most-recent entry is visible
+//!    immediately, matching the convention used by GitLab CI, Harness, and Buildkite.
+
+use web_sys::{Element, HtmlInputElement};
+use yew::prelude::*;
+
+// ─── Pure helpers (host-testable, no DOM/wasm dependency) ─────────────────────
+
+/// Return `(1-based line number, line text)` pairs from `content`.
+///
+/// When `query` is non-empty after trimming, only lines whose lowercase text
+/// contains the lowercase query are returned — preserving their original numbers
+/// so the caller can anchor to the source.
+#[must_use]
+pub fn filter_lines<'a>(content: &'a str, query: &str) -> Vec<(usize, &'a str)> {
+    let needle = query.trim().to_lowercase();
+    content
+        .lines()
+        .enumerate()
+        .filter(|(_, line)| needle.is_empty() || line.to_lowercase().contains(&needle))
+        .map(|(i, line)| (i + 1, line))
+        .collect()
+}
+
+/// Return `(matching_lines, total_lines)` for `content` against `query`.
+///
+/// When `query` is blank (empty or whitespace-only), `matching == total`.
+#[must_use]
+pub fn match_count(content: &str, query: &str) -> (usize, usize) {
+    let total = content.lines().count();
+    if query.trim().is_empty() {
+        return (total, total);
+    }
+    let needle = query.trim().to_lowercase();
+    let hits = content
+        .lines()
+        .filter(|l| l.to_lowercase().contains(&needle))
+        .count();
+    (hits, total)
+}
+
+// ─── Yew component ────────────────────────────────────────────────────────────
+
+#[derive(Properties, PartialEq)]
+pub struct LogViewerProps {
+    /// Raw log text, or `None` while the fetch is in flight.
+    pub content: Option<String>,
+    pub loading: bool,
+    pub err: Option<String>,
+}
+
+/// Log viewer with line numbers, keyword search/highlight, and auto-tail.
+///
+/// Renders a sticky search bar above the numbered log body.  Typing a query
+/// narrows the display to matching lines (with the term highlighted) and shows a
+/// live `N / total` count.  Content changes trigger an automatic scroll to the
+/// bottom so the latest log entry is always visible without manual scrolling.
+#[function_component(LogViewer)]
+pub fn log_viewer(props: &LogViewerProps) -> Html {
+    let query = use_state(String::new);
+    let wrap_ref = use_node_ref();
+
+    // Auto-tail: scroll the wrapper to its bottom whenever content arrives or changes.
+    {
+        let wrap_ref = wrap_ref.clone();
+        let content_len = props.content.as_ref().map(String::len).unwrap_or(0);
+        use_effect_with(content_len, move |_| {
+            if let Some(el) = wrap_ref.cast::<Element>() {
+                el.set_scroll_top(el.scroll_height());
+            }
+        });
+    }
+
+    let on_query = {
+        let query = query.clone();
+        Callback::from(move |e: InputEvent| {
+            let input: HtmlInputElement = e.target_unchecked_into();
+            query.set(input.value());
+        })
+    };
+    let on_clear = {
+        let query = query.clone();
+        Callback::from(move |_: MouseEvent| query.set(String::new()))
+    };
+
+    let body = if props.loading {
+        html! { <div class="empty"><div class="spinner"></div></div> }
+    } else if let Some(e) = &props.err {
+        html! { <div class="logs-error">{format!("Error: {e}")}</div> }
+    } else if let Some(text) = &props.content {
+        if text.is_empty() {
+            html! { <div class="logs-empty">{"— no logs yet —"}</div> }
+        } else {
+            let q = (*query).clone();
+            let lines = filter_lines(text, &q);
+            let (hits, total) = match_count(text, &q);
+            let count_label = if q.trim().is_empty() {
+                format!("{total} lines")
+            } else {
+                format!("{hits} / {total} matches")
+            };
+            let clear_btn = if q.is_empty() {
+                html! {}
+            } else {
+                html! {
+                    <button class="btn btn-ghost btn-sm" onclick={on_clear}
+                        title="Clear search" aria-label="Clear search">{"✕"}</button>
+                }
+            };
+            html! {
+                <>
+                    <div class="log-search">
+                        <input
+                            type="search"
+                            class="log-search-input"
+                            placeholder="Search logs…"
+                            value={q.clone()}
+                            oninput={on_query}
+                            aria-label="Search log lines"
+                        />
+                        {clear_btn}
+                        <span class="log-match-count">{count_label}</span>
+                    </div>
+                    <div class="log-lines">
+                        { for lines.iter().map(|(ln, lc)| render_line(*ln, lc, &q)) }
+                    </div>
+                </>
+            }
+        }
+    } else {
+        html! {}
+    };
+
+    html! {
+        <div class="logs-wrap" ref={wrap_ref}>
+            {body}
+        </div>
+    }
+}
+
+/// Render one numbered log line, with `query` occurrences highlighted.
+fn render_line(ln: usize, text: &str, query: &str) -> Html {
+    html! {
+        <div class="log-line">
+            <span class="log-ln">{ln}</span>
+            <span class="log-lc">{ highlight(text, query) }</span>
+        </div>
+    }
+}
+
+/// Split `text` into `Html` with each case-insensitive occurrence of `query`
+/// wrapped in `<mark class="log-hl">`.  Returns plain text when `query` is blank.
+///
+/// Note: byte-offset arithmetic is correct for ASCII log content (the primary use
+/// case).  Non-ASCII queries that change byte length when lowercased are guarded
+/// by the `end > text.len()` safety check.
+fn highlight(text: &str, query: &str) -> Html {
+    let needle = query.trim().to_lowercase();
+    if needle.is_empty() {
+        return html! { {text} };
+    }
+    let lower = text.to_lowercase();
+    let mut parts: Vec<Html> = Vec::new();
+    let mut start = 0usize;
+    while start <= text.len() {
+        match lower[start..].find(&needle) {
+            None => break,
+            Some(pos) => {
+                let abs = start + pos;
+                let end = abs + needle.len();
+                if end > text.len() {
+                    break;
+                }
+                if abs > start {
+                    let before = &text[start..abs];
+                    parts.push(html! { {before} });
+                }
+                let matched = &text[abs..end];
+                parts.push(html! { <mark class="log-hl">{matched}</mark> });
+                start = end;
+            }
+        }
+    }
+    if start < text.len() {
+        parts.push(html! { {&text[start..]} });
+    }
+    html! { <>{for parts.into_iter()}</> }
+}
+
+#[cfg(test)]
+#[path = "log_viewer_tests.rs"]
+mod tests;

--- a/ui/src/log_viewer_tests.rs
+++ b/ui/src/log_viewer_tests.rs
@@ -1,0 +1,104 @@
+//! Host-side unit tests for the log viewer's pure helpers.
+//! No DOM / wasm dependency — mirrors the schedule/overview/cron-jobs test conventions.
+
+use super::*;
+
+// ── filter_lines ─────────────────────────────────────────────────────────────
+
+#[test]
+fn empty_query_returns_all_lines_numbered_from_one() {
+    let out = filter_lines("alpha\nbeta\ngamma", "");
+    assert_eq!(out, vec![(1, "alpha"), (2, "beta"), (3, "gamma")]);
+}
+
+#[test]
+fn blank_query_whitespace_returns_all() {
+    assert_eq!(filter_lines("x\ny", "   ").len(), 2);
+}
+
+#[test]
+fn query_filters_case_insensitively() {
+    let content = "INFO: server started\nERROR: connection refused\nWARN: retrying";
+    let out = filter_lines(content, "ERROR");
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0], (2, "ERROR: connection refused"));
+}
+
+#[test]
+fn query_preserves_original_line_numbers() {
+    let out = filter_lines("line 1\nline 2\nline 3\nline 4", "line 3");
+    assert_eq!(out, vec![(3, "line 3")]);
+}
+
+#[test]
+fn no_match_returns_empty_vec() {
+    assert!(filter_lines("hello world", "zzz").is_empty());
+}
+
+#[test]
+fn single_line_exact_match() {
+    let out = filter_lines("hello", "hello");
+    assert_eq!(out, vec![(1, "hello")]);
+}
+
+#[test]
+fn single_line_no_match() {
+    assert!(filter_lines("hello", "world").is_empty());
+}
+
+#[test]
+fn trailing_newline_does_not_produce_extra_numbered_line() {
+    // "alpha\n" has two splits in .lines() only if there are two logical lines;
+    // std::str::Lines skips a trailing empty segment, so count stays at 1.
+    let out = filter_lines("alpha\n", "");
+    assert_eq!(out.len(), 1);
+}
+
+// ── match_count ──────────────────────────────────────────────────────────────
+
+#[test]
+fn blank_query_count_equals_total() {
+    let (hits, total) = match_count("a\nb\nc", "");
+    assert_eq!(hits, 3);
+    assert_eq!(total, 3);
+}
+
+#[test]
+fn whitespace_query_treated_as_blank() {
+    let (hits, total) = match_count("a\nb", "   ");
+    assert_eq!(hits, total);
+}
+
+#[test]
+fn partial_match_count() {
+    let (hits, total) = match_count("foo\nbar\nfoo bar", "foo");
+    assert_eq!(hits, 2);
+    assert_eq!(total, 3);
+}
+
+#[test]
+fn no_match_count_is_zero() {
+    let (hits, total) = match_count("a\nb", "z");
+    assert_eq!(hits, 0);
+    assert_eq!(total, 2);
+}
+
+#[test]
+fn match_count_is_case_insensitive() {
+    let (hits, _) = match_count("ERROR\nerror\nOk", "error");
+    assert_eq!(hits, 2);
+}
+
+#[test]
+fn empty_content_gives_zero_total() {
+    let (hits, total) = match_count("", "anything");
+    assert_eq!(hits, 0);
+    assert_eq!(total, 0);
+}
+
+#[test]
+fn empty_content_blank_query() {
+    let (hits, total) = match_count("", "");
+    assert_eq!(hits, 0);
+    assert_eq!(total, 0);
+}

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -11,6 +11,7 @@ use yew_router::prelude::*;
 mod command_palette;
 mod cron_jobs;
 mod day_timeline;
+mod log_viewer;
 mod machines;
 mod overview;
 mod refresh;

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -15,6 +15,7 @@ use web_sys::{HtmlInputElement, HtmlSelectElement};
 use yew::prelude::*;
 
 use crate::day_timeline::{DayTimeline, TimelineItem};
+use crate::log_viewer::LogViewer;
 use crate::machines::MachinesPicker;
 use crate::refresh::{RefreshControl, RefreshInterval};
 use crate::{describe_cron_live, parse_cron, reltime, ToastKind};
@@ -1675,20 +1676,6 @@ pub fn routine_logs(props: &LogsProps) -> Html {
         Callback::from(move |_: MouseEvent| load())
     };
 
-    let body = if *loading {
-        html! { <div class="empty"><div class="spinner"></div></div> }
-    } else if let Some(e) = (*err).clone() {
-        html! { <div class="logs-error">{format!("Error: {e}")}</div> }
-    } else if let Some(text) = (*content).clone() {
-        if text.is_empty() {
-            html! { <div class="logs-empty">{"— no logs yet —"}</div> }
-        } else {
-            html! { <pre class="logs-content">{text}</pre> }
-        }
-    } else {
-        html! {}
-    };
-
     html! {
         <main class="logs-page">
             <div class="page-hd">
@@ -1696,9 +1683,11 @@ pub fn routine_logs(props: &LogsProps) -> Html {
                 <div class="page-title">{format!("LOGS / {}", props.title)}</div>
                 <button class="btn-refresh" title="Refresh" aria-label="Refresh" onclick={on_refresh}>{"↻"}</button>
             </div>
-            <div class="logs-wrap">
-                {body}
-            </div>
+            <LogViewer
+                content={(*content).clone()}
+                loading={*loading}
+                err={(*err).clone()}
+            />
         </main>
     }
 }


### PR DESCRIPTION
## Summary

- Introduces a reusable `LogViewer` component (`ui/src/log_viewer.rs`) with line numbers, sticky keyword search/highlight, and auto-tail behavior.
- Replaces the bare `<pre>` log block in both `RoutineLogs` (routines page) and `LogsPage` (cron-jobs page).
- Adds CSS for the new elements (`.log-search`, `.log-search-input`, `.log-match-count`, `.log-line`, `.log-ln`, `.log-lc`, `mark.log-hl`) to `ui/index.html`.
- All filter logic is in pure, host-testable functions (`filter_lines`, `match_count`) covered by 15 new unit tests.

Closes #646.

## Best-practice rationale

Research into GitLab CI, Harness, and Datadog shows three standard log viewer capabilities for ops dashboards:
1. **Keyword search + highlight** with live N/total count — zero in on errors without manual Cmd+F.
2. **Line numbers** — stable anchors for copy-paste references.
3. **Auto-tail** — scroll to latest entry on load.

## Test plan

- [ ] `cargo test --package ui` — 119 tests pass (15 new `log_viewer::tests::*`).
- [ ] `cargo clippy --package ui` — clean.
- [ ] `cargo build` — succeeds.
- [ ] `git diff --name-only origin/main...HEAD` — only `ui/` files.

---
*This pull request was opened by the UI dashboard feature builder (research → issue → PR → merge) routine of moadim. CC @tupe12334*

🤖 Generated with [Claude Code](https://claude.com/claude-code)