### PR TITLE
feat(ui): surface `last_scheduled_trigger_at` in the routines table

### DIFF
--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -55,6 +55,8 @@ pub struct Routine {
     pub updated_at: u64,
     #[serde(default)]
     pub last_manual_trigger_at: Option<u64>,
+    #[serde(default)]
+    pub last_scheduled_trigger_at: Option<u64>,
     /// Workbench retention (seconds) for finished runs; `None` falls back to the server default.
     #[serde(default)]
     pub ttl_secs: Option<u64>,
@@ -1176,10 +1178,27 @@ pub fn routine_row(props: &RowProps) -> Html {
         Callback::from(move |_: MouseEvent| cb.emit(id.clone()))
     };
 
-    let last_run = r
-        .last_manual_trigger_at
-        .map(|t| format!("↻ {}", reltime(t)))
-        .unwrap_or_default();
+    let last_run: Html = {
+        let manual = r.last_manual_trigger_at;
+        let scheduled = r.last_scheduled_trigger_at;
+        match (manual, scheduled) {
+            (None, None) => html! {
+                <div class="cell-triggered" style="color:var(--text-ghost)">{"never fired"}</div>
+            },
+            (Some(m), Some(s)) if m >= s => html! {
+                <div class="cell-triggered">{format!("↻ {}", reltime(m))}</div>
+            },
+            (Some(_m), Some(s)) => html! {
+                <div class="cell-triggered">{format!("⏱ {}", reltime(s))}</div>
+            },
+            (Some(m), None) => html! {
+                <div class="cell-triggered">{format!("↻ {}", reltime(m))}</div>
+            },
+            (None, Some(s)) => html! {
+                <div class="cell-triggered">{format!("⏱ {}", reltime(s))}</div>
+            },
+        }
+    };
 
     let agent_dot = if r.agent_registered {
         "handler-dot ok"
@@ -1217,9 +1236,7 @@ pub fn routine_row(props: &RowProps) -> Html {
             </td>
             <td>
                 <div class="cell-time">{updated}</div>
-                if !last_run.is_empty() {
-                    <div class="cell-triggered">{last_run}</div>
-                }
+                {last_run}
             </td>
             <td>
                 <div class="row-actions">


### PR DESCRIPTION
## Summary

Issue #155 added `last_scheduled_trigger_at` to the routine REST response, but the web UI's `Routine` struct never deserialized the field — it was silently dropped. A routine that fires perfectly on schedule but was never manually triggered showed a blank "last run" cell, visually indistinguishable from a routine that has never run.

Changes to `ui/src/routines.rs`:

- Add `last_scheduled_trigger_at: Option<u64>` to the `Routine` struct (with `#[serde(default)]`) so the field is deserialized from the API.
- Replace the `last_run: String` computation with a `last_run: Html` block that:
  - Shows `"⏱ {time}"` when a scheduled trigger is more recent (or is the only one present).
  - Shows `"↻ {time}"` when a manual trigger is more recent (or is the only one present).
  - Shows `"never fired"` (muted) when both are `None`, so dead schedules stand out instead of blending with a blank cell.

No backend change required — the data is already in the API response.

Closes #487

---
This pull request was opened by the **Implement my assigned issues without a PR (daemon + landing)** routine of moadim.