### PR TITLE
feat(ui): enhanced log viewer — line numbers, keyword search, auto-tail (#633)

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -893,6 +893,89 @@
     .act-btn.logs { color: var(--text-ghost); }
     .act-btn.logs:hover { color: var(--text-mid); border-color: var(--border-hi); }
 
+    /* ── Enhanced log viewer ── */
+    .logs-hd-acts { display: flex; align-items: center; gap: 8px; margin-left: auto; }
+
+    .logs-tail-btn {
+      border-color: var(--border-hi);
+      color: var(--text-ghost);
+    }
+    .logs-tail-btn:hover { color: var(--accent); border-color: var(--accent-dim); }
+    .logs-tail-btn.active { border-color: var(--accent); color: var(--accent); }
+
+    .logs-toolbar {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 6px 12px;
+      border-bottom: 1px solid var(--border);
+      background: var(--bg-3);
+      position: sticky;
+      top: 0;
+      z-index: 1;
+    }
+
+    .logs-count {
+      font-size: 10px;
+      color: var(--text-ghost);
+      letter-spacing: 0.1em;
+      white-space: nowrap;
+    }
+
+    .logs-live {
+      font-size: 10px;
+      color: var(--accent);
+      letter-spacing: 0.1em;
+      white-space: nowrap;
+      animation: glow 2.4s ease-in-out infinite;
+    }
+
+    .logs-search {
+      flex: 1;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      color: var(--text);
+      font-family: var(--mono);
+      font-size: 11px;
+      padding: 3px 8px;
+      outline: none;
+      min-width: 0;
+    }
+    .logs-search:focus { border-color: var(--accent); }
+    .logs-search::placeholder { color: var(--text-ghost); }
+
+    .logs-table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    .logs-gutter {
+      user-select: none;
+      text-align: right;
+      padding: 0 10px 0 14px;
+      width: 1%;
+      white-space: nowrap;
+      font-family: var(--mono);
+      font-size: 11px;
+      color: var(--text-ghost);
+      vertical-align: top;
+      line-height: 1.7;
+      border-right: 1px solid var(--border);
+    }
+
+    .logs-line {
+      padding: 0 14px;
+      font-family: var(--mono);
+      font-size: 12px;
+      color: var(--text-mid);
+      white-space: pre-wrap;
+      word-break: break-all;
+      line-height: 1.7;
+      vertical-align: top;
+    }
+
+    .logs-row.dimmed { opacity: 0.2; }
+
     /* ── View toggle ── */
     .section-acts { display: flex; align-items: center; gap: 10px; }
 

--- a/ui/src/cron_jobs.rs
+++ b/ui/src/cron_jobs.rs
@@ -19,6 +19,7 @@ use web_sys::{HtmlElement, HtmlInputElement, HtmlSelectElement, KeyboardEvent};
 use yew::prelude::*;
 
 use crate::day_timeline::{DayTimeline, TimelineItem};
+use crate::logs::LogViewer;
 use crate::machines::MachinesPicker;
 use crate::refresh::{RefreshControl, RefreshInterval};
 use crate::schedule::{fires_within, fmt_until, fmt_when, next_fire_after};
@@ -307,17 +308,6 @@ async fn api_trigger(id: &str) -> Result<CronJob, String> {
         return Err(format!("HTTP {}", resp.status()));
     }
     resp.json::<CronJob>().await.map_err(|e| e.to_string())
-}
-
-async fn api_logs(id: &str) -> Result<String, String> {
-    let resp = Request::get(&format!("/api/v1/cron-jobs/{id}/logs"))
-        .send()
-        .await
-        .map_err(|e| e.to_string())?;
-    if !resp.ok() {
-        return Err(format!("HTTP {}", resp.status()));
-    }
-    resp.text().await.map_err(|e| e.to_string())
 }
 
 // ─── State ────────────────────────────────────────────────────────────────────
@@ -991,7 +981,11 @@ pub fn cron_jobs_page(props: &CronJobsPageProps) -> Html {
                             .map(|j| j.handler.clone())
                             .unwrap_or_default();
                         html! {
-                            <LogsPage job_id={id} handler={handler} on_back={on_back} />
+                            <LogViewer
+                                fetch_url={format!("/api/v1/cron-jobs/{id}/logs")}
+                                title={handler}
+                                on_back={on_back}
+                            />
                         }
                     },
                     CPage::List => html! {
@@ -2117,105 +2111,6 @@ pub fn bulk_delete_dialog(props: &BulkDeleteProps) -> Html {
                 </div>
             </div>
         </div>
-    }
-}
-
-// ─── Logs page ────────────────────────────────────────────────────────────────
-
-#[derive(Properties, PartialEq)]
-pub struct LogsPageProps {
-    pub job_id: String,
-    pub handler: String,
-    pub on_back: Callback<()>,
-}
-
-#[function_component(LogsPage)]
-pub fn logs_page(props: &LogsPageProps) -> Html {
-    let content: UseStateHandle<Option<String>> = use_state(|| None);
-    let loading = use_state(|| true);
-    let err: UseStateHandle<Option<String>> = use_state(|| None);
-
-    {
-        let id = props.job_id.clone();
-        let content = content.clone();
-        let loading = loading.clone();
-        let err = err.clone();
-        use_effect_with(id.clone(), move |id| {
-            let id = id.clone();
-            let content = content.clone();
-            let loading = loading.clone();
-            let err = err.clone();
-            spawn_local(async move {
-                match api_logs(&id).await {
-                    Ok(text) => {
-                        content.set(Some(text));
-                        err.set(None);
-                    }
-                    Err(e) => err.set(Some(e)),
-                }
-                loading.set(false);
-            });
-        });
-    }
-
-    let on_back = {
-        let cb = props.on_back.clone();
-        Callback::from(move |_: MouseEvent| cb.emit(()))
-    };
-
-    let on_refresh = {
-        let id = props.job_id.clone();
-        let content = content.clone();
-        let loading = loading.clone();
-        let err = err.clone();
-        Callback::from(move |_: MouseEvent| {
-            let id = id.clone();
-            let content = content.clone();
-            let loading = loading.clone();
-            let err = err.clone();
-            loading.set(true);
-            spawn_local(async move {
-                match api_logs(&id).await {
-                    Ok(text) => {
-                        content.set(Some(text));
-                        err.set(None);
-                    }
-                    Err(e) => err.set(Some(e)),
-                }
-                loading.set(false);
-            });
-        })
-    };
-
-    let is_loading = *loading;
-    let err_msg = (*err).clone();
-    let log_text = (*content).clone();
-
-    let body = if is_loading {
-        html! { <div class="empty"><div class="spinner"></div></div> }
-    } else if let Some(e) = err_msg {
-        html! { <div class="logs-error">{format!("Error: {e}")}</div> }
-    } else if let Some(text) = log_text {
-        if text.is_empty() {
-            html! { <div class="logs-empty">{"— no logs yet —"}</div> }
-        } else {
-            html! { <pre class="logs-content">{text}</pre> }
-        }
-    } else {
-        html! {}
-    };
-
-    html! {
-        <main class="logs-page">
-            <div class="page-hd">
-                <button class="btn btn-ghost btn-sm" onclick={on_back}>{"← BACK"}</button>
-                <div class="page-title">{format!("LOGS / {}", props.handler)}</div>
-                <button class="btn-refresh" title="Refresh" aria-label="Refresh" onclick={on_refresh}>{"↻"}</button>
-            </div>
-            <div class="logs-wrap">
-                {body}
-            </div>
-        </main>
     }
 }
 

--- a/ui/src/logs.rs
+++ b/ui/src/logs.rs
@@ -1,0 +1,298 @@
+//! Shared enhanced log viewer: line numbers, keyword search, and auto-tail.
+//!
+//! Best practice (GitHub Actions, Grafana Loki, Buildkite): live tailing is the
+//! #1 operator ask; line numbers turn a log wall into a navigable document;
+//! inline keyword search removes the terminal grep round-trip.
+//!
+//! `split_lines` and `line_counts` are pure and host-testable (see
+//! `logs_tests.rs`); only `LogViewer` and `fetch_log` touch the network layer.
+
+use gloo_net::http::Request;
+use gloo_timers::future::TimeoutFuture;
+use wasm_bindgen_futures::spawn_local;
+use web_sys::HtmlInputElement;
+use yew::prelude::*;
+
+// ─── Pure helpers ─────────────────────────────────────────────────────────────
+
+/// Split `text` into `(1-based line number, line content, matches_search)` tuples.
+/// When `query` is blank (empty or whitespace-only) every line is marked matching.
+pub(crate) fn split_lines<'a>(text: &'a str, query: &str) -> Vec<(usize, &'a str, bool)> {
+    let q = query.trim().to_ascii_lowercase();
+    text.lines()
+        .enumerate()
+        .map(|(i, line)| {
+            let m = q.is_empty() || line.to_ascii_lowercase().contains(q.as_str());
+            (i + 1, line, m)
+        })
+        .collect()
+}
+
+/// Returns `(total_lines, matching_lines)` for a keyword search over `text`.
+/// When `query` is blank every line is counted as matching.
+pub(crate) fn line_counts(text: &str, query: &str) -> (usize, usize) {
+    let q = query.trim().to_ascii_lowercase();
+    let total = text.lines().count();
+    if q.is_empty() {
+        (total, total)
+    } else {
+        let matching = text
+            .lines()
+            .filter(|l| l.to_ascii_lowercase().contains(q.as_str()))
+            .count();
+        (total, matching)
+    }
+}
+
+// ─── Network ──────────────────────────────────────────────────────────────────
+
+async fn fetch_log(url: &str) -> Result<String, String> {
+    let resp = Request::get(url)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    resp.text().await.map_err(|e| e.to_string())
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+#[derive(Properties, PartialEq)]
+pub struct LogViewerProps {
+    /// Full log-endpoint URL, e.g. `/api/v1/routines/{id}/logs`.
+    pub fetch_url: AttrValue,
+    /// Shown in the page header as `LOGS / {title}`.
+    pub title: AttrValue,
+    pub on_back: Callback<()>,
+}
+
+#[function_component(LogViewer)]
+pub fn log_viewer(props: &LogViewerProps) -> Html {
+    let content: UseStateHandle<Option<String>> = use_state(|| None);
+    let loading = use_state(|| true);
+    let err: UseStateHandle<Option<String>> = use_state(|| None);
+    let tail = use_state(|| false);
+    let search = use_state(String::new);
+    // Monotonic counter bumped on each successful fetch; cheap scroll-trigger dep.
+    let version = use_state(|| 0u32);
+    let log_ref = use_node_ref();
+
+    // Shared fetch callback. `set_loading` shows the spinner (initial load /
+    // manual refresh); auto-tail silent-polls with `set_loading = false`.
+    let load = {
+        let content = content.clone();
+        let loading = loading.clone();
+        let err = err.clone();
+        let version = version.clone();
+        let url = props.fetch_url.clone();
+        move |set_loading: bool| {
+            let content = content.clone();
+            let loading = loading.clone();
+            let err = err.clone();
+            let version = version.clone();
+            let url = url.clone();
+            if set_loading {
+                loading.set(true);
+            }
+            spawn_local(async move {
+                match fetch_log(&url).await {
+                    Ok(text) => {
+                        content.set(Some(text));
+                        err.set(None);
+                        version.set(*version + 1);
+                    }
+                    Err(e) => err.set(Some(e)),
+                }
+                loading.set(false);
+            });
+        }
+    };
+
+    // Reset transient state and fetch fresh content when the URL changes.
+    {
+        let load = load.clone();
+        let content = content.clone();
+        let err = err.clone();
+        let search = search.clone();
+        let tail = tail.clone();
+        let version = version.clone();
+        use_effect_with(props.fetch_url.clone(), move |_| {
+            content.set(None);
+            err.set(None);
+            search.set(String::new());
+            tail.set(false);
+            version.set(0);
+            load(true);
+        });
+    }
+
+    let is_tail = *tail;
+    let version_val = *version;
+
+    // Scroll the log container to the bottom when new content arrives and tail
+    // is active. The `version` dep fires only on actual content changes, not
+    // on every re-render.
+    {
+        let log_ref = log_ref.clone();
+        use_effect_with((version_val, is_tail), move |_| {
+            if is_tail {
+                if let Some(el) = log_ref.cast::<web_sys::Element>() {
+                    el.set_scroll_top(el.scroll_height());
+                }
+            }
+        });
+    }
+
+    // Auto-tail polling loop: fires every 2 s while tail is on; self-terminates
+    // when the operator disables tail (checked at the top of each iteration so
+    // the loop exits within one sleep after the toggle).
+    {
+        let load = load.clone();
+        let tail = tail.clone();
+        use_effect_with(is_tail, move |is_tailing| {
+            if !*is_tailing {
+                return;
+            }
+            let load = load.clone();
+            let tail = tail.clone();
+            spawn_local(async move {
+                loop {
+                    TimeoutFuture::new(2_000).await;
+                    if !*tail {
+                        break;
+                    }
+                    load(false);
+                }
+            });
+        });
+    }
+
+    let on_back = {
+        let cb = props.on_back.clone();
+        Callback::from(move |_: MouseEvent| cb.emit(()))
+    };
+    let on_refresh = {
+        let load = load.clone();
+        Callback::from(move |_: MouseEvent| load(true))
+    };
+    let on_toggle_tail = {
+        let load = load.clone();
+        let tail = tail.clone();
+        Callback::from(move |_: MouseEvent| {
+            let new_tail = !*tail;
+            tail.set(new_tail);
+            if new_tail {
+                // Fetch immediately so the operator sees fresh content right away.
+                load(false);
+            }
+        })
+    };
+    let on_search = {
+        let search = search.clone();
+        Callback::from(move |e: InputEvent| {
+            let input: HtmlInputElement = e.target_unchecked_into();
+            search.set(input.value());
+        })
+    };
+
+    let is_loading = *loading;
+    let search_q = (*search).clone();
+
+    let body = if is_loading && (*content).is_none() {
+        html! { <div class="empty"><div class="spinner"></div></div> }
+    } else if let Some(ref e) = *err {
+        html! { <div class="logs-error">{format!("Error: {e}")}</div> }
+    } else if let Some(ref text) = *content {
+        if text.is_empty() {
+            html! { <div class="logs-empty">{"— no logs yet —"}</div> }
+        } else {
+            let lines = split_lines(text, &search_q);
+            let (total, matching) = line_counts(text, &search_q);
+            let count_label = if search_q.trim().is_empty() {
+                format!("{total} lines")
+            } else {
+                format!("{matching}/{total} lines")
+            };
+            html! {
+                <>
+                    <div class="logs-toolbar">
+                        <span class="logs-count">{count_label}</span>
+                        {
+                            if is_tail {
+                                html! { <span class="logs-live">{"● LIVE"}</span> }
+                            } else {
+                                html! {}
+                            }
+                        }
+                        <input
+                            class="logs-search"
+                            type="search"
+                            placeholder="Search logs…"
+                            value={search_q.clone()}
+                            oninput={on_search}
+                            aria-label="Search log lines"
+                        />
+                    </div>
+                    <table class="logs-table" aria-label="Log output">
+                        <tbody>
+                            { for lines.iter().map(|(n, line, matches)| {
+                                let row_cls = if *matches { "logs-row" } else { "logs-row dimmed" };
+                                html! {
+                                    <tr class={row_cls} key={*n}>
+                                        <td class="logs-gutter" aria-hidden="true">{n}</td>
+                                        <td class="logs-line">{*line}</td>
+                                    </tr>
+                                }
+                            }) }
+                        </tbody>
+                    </table>
+                </>
+            }
+        }
+    } else {
+        html! {}
+    };
+
+    let tail_cls = if is_tail {
+        "btn btn-sm logs-tail-btn active"
+    } else {
+        "btn btn-sm logs-tail-btn"
+    };
+
+    html! {
+        <main class="logs-page">
+            <div class="page-hd">
+                <button class="btn btn-ghost btn-sm" onclick={on_back}>{"← BACK"}</button>
+                <div class="page-title">{format!("LOGS / {}", props.title)}</div>
+                <div class="logs-hd-acts">
+                    <button
+                        class={tail_cls}
+                        title="Auto-tail: poll every 2s and scroll to bottom"
+                        aria-pressed={is_tail.to_string()}
+                        onclick={on_toggle_tail}
+                    >{"⬇ TAIL"}</button>
+                    {
+                        if !is_tail {
+                            html! {
+                                <button
+                                    class="btn-refresh"
+                                    title="Refresh"
+                                    aria-label="Refresh"
+                                    onclick={on_refresh}
+                                >{"↻"}</button>
+                            }
+                        } else {
+                            html! {}
+                        }
+                    }
+                </div>
+            </div>
+            <div class="logs-wrap" ref={log_ref}>
+                {body}
+            </div>
+        </main>
+    }
+}
+
+#[cfg(test)]
+#[path = "logs_tests.rs"]
+mod logs_tests;

--- a/ui/src/logs_tests.rs
+++ b/ui/src/logs_tests.rs
@@ -1,0 +1,126 @@
+//! Host-side unit tests for the pure log-viewer helpers in [`super`]:
+//! `split_lines` and `line_counts`. No DOM/wasm dependency.
+
+use super::*;
+
+// ─── split_lines ──────────────────────────────────────────────────────────────
+
+#[test]
+fn split_lines_empty_text_gives_no_rows() {
+    assert!(split_lines("", "").is_empty());
+    assert!(split_lines("", "foo").is_empty());
+}
+
+#[test]
+fn split_lines_blank_query_all_match() {
+    let rows = split_lines("alpha\nbeta\ngamma", "");
+    assert_eq!(rows.len(), 3);
+    assert!(rows.iter().all(|(_, _, m)| *m));
+}
+
+#[test]
+fn split_lines_whitespace_only_query_all_match() {
+    let rows = split_lines("alpha\nbeta", "   ");
+    assert_eq!(rows.len(), 2);
+    assert!(rows.iter().all(|(_, _, m)| *m));
+}
+
+#[test]
+fn split_lines_numbers_are_one_based() {
+    let rows = split_lines("a\nb\nc", "");
+    assert_eq!(rows[0].0, 1);
+    assert_eq!(rows[1].0, 2);
+    assert_eq!(rows[2].0, 3);
+}
+
+#[test]
+fn split_lines_content_preserved() {
+    let text = "hello world\nfoo bar";
+    let rows = split_lines(text, "");
+    assert_eq!(rows[0].1, "hello world");
+    assert_eq!(rows[1].1, "foo bar");
+}
+
+#[test]
+fn split_lines_case_insensitive_match() {
+    let rows = split_lines("ALPHA\nbeta\nAlPhA", "alpha");
+    assert!(rows[0].2, "ALPHA should match 'alpha'");
+    assert!(!rows[1].2, "beta should not match 'alpha'");
+    assert!(rows[2].2, "AlPhA should match 'alpha'");
+}
+
+#[test]
+fn split_lines_non_matching_rows_flagged_false() {
+    let rows = split_lines("match\nnope\nmatch again", "match");
+    assert!(rows[0].2);
+    assert!(!rows[1].2);
+    assert!(rows[2].2);
+}
+
+#[test]
+fn split_lines_single_line_match() {
+    let rows = split_lines("only line", "only");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, 1);
+    assert_eq!(rows[0].1, "only line");
+    assert!(rows[0].2);
+}
+
+#[test]
+fn split_lines_single_line_no_match() {
+    let rows = split_lines("only line", "other");
+    assert_eq!(rows.len(), 1);
+    assert!(!rows[0].2);
+}
+
+// ─── line_counts ──────────────────────────────────────────────────────────────
+
+#[test]
+fn line_counts_empty_text_blank_query() {
+    assert_eq!(line_counts("", ""), (0, 0));
+}
+
+#[test]
+fn line_counts_empty_text_with_query() {
+    assert_eq!(line_counts("", "foo"), (0, 0));
+}
+
+#[test]
+fn line_counts_blank_query_all_match() {
+    assert_eq!(line_counts("a\nb\nc", ""), (3, 3));
+}
+
+#[test]
+fn line_counts_whitespace_query_all_match() {
+    assert_eq!(line_counts("a\nb\nc", "  "), (3, 3));
+}
+
+#[test]
+fn line_counts_partial_match() {
+    assert_eq!(line_counts("foo\nbar\nfoo baz", "foo"), (3, 2));
+}
+
+#[test]
+fn line_counts_no_match() {
+    assert_eq!(line_counts("alpha\nbeta", "gamma"), (2, 0));
+}
+
+#[test]
+fn line_counts_case_insensitive() {
+    assert_eq!(line_counts("FOO\nbar\nFoo", "foo"), (3, 2));
+}
+
+#[test]
+fn line_counts_all_match() {
+    assert_eq!(line_counts("foo\nfoo\nfoo", "foo"), (3, 3));
+}
+
+#[test]
+fn line_counts_single_line_match() {
+    assert_eq!(line_counts("hello", "hello"), (1, 1));
+}
+
+#[test]
+fn line_counts_single_line_no_match() {
+    assert_eq!(line_counts("hello", "world"), (1, 0));
+}

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -11,6 +11,7 @@ use yew_router::prelude::*;
 mod command_palette;
 mod cron_jobs;
 mod day_timeline;
+mod logs;
 mod machines;
 mod overview;
 mod refresh;

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -15,6 +15,7 @@ use web_sys::{HtmlInputElement, HtmlSelectElement};
 use yew::prelude::*;
 
 use crate::day_timeline::{DayTimeline, TimelineItem};
+use crate::logs::LogViewer;
 use crate::machines::MachinesPicker;
 use crate::refresh::{RefreshControl, RefreshInterval};
 use crate::{describe_cron_live, parse_cron, reltime, ToastKind};
@@ -190,17 +191,6 @@ async fn api_cleanup() -> Result<usize, String> {
         .await
         .map(|r| r.removed)
         .map_err(|e| e.to_string())
-}
-
-async fn api_logs(id: &str) -> Result<String, String> {
-    let resp = Request::get(&format!("/api/v1/routines/{id}/logs"))
-        .send()
-        .await
-        .map_err(|e| e.to_string())?;
-    if !resp.ok() {
-        return Err(format!("HTTP {}", resp.status()));
-    }
-    resp.text().await.map_err(|e| e.to_string())
 }
 
 // ─── State ────────────────────────────────────────────────────────────────────
@@ -674,7 +664,13 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
                             .find(|r| r.id == id)
                             .map(|r| r.title.clone())
                             .unwrap_or_default();
-                        html! { <RoutineLogs id={id} title={title} on_back={on_back} /> }
+                        html! {
+                            <LogViewer
+                                fetch_url={format!("/api/v1/routines/{id}/logs")}
+                                title={title}
+                                on_back={on_back}
+                            />
+                        }
                     },
                     RPage::List => html! {
                         <main>
@@ -1620,85 +1616,3 @@ pub fn confirm_delete(props: &ConfirmProps) -> Html {
     }
 }
 
-// ─── Logs page ────────────────────────────────────────────────────────────────
-
-#[derive(Properties, PartialEq)]
-pub struct LogsProps {
-    pub id: String,
-    pub title: String,
-    pub on_back: Callback<()>,
-}
-
-#[function_component(RoutineLogs)]
-pub fn routine_logs(props: &LogsProps) -> Html {
-    let content: UseStateHandle<Option<String>> = use_state(|| None);
-    let loading = use_state(|| true);
-    let err: UseStateHandle<Option<String>> = use_state(|| None);
-
-    let load = {
-        let id = props.id.clone();
-        let content = content.clone();
-        let loading = loading.clone();
-        let err = err.clone();
-        move || {
-            let id = id.clone();
-            let content = content.clone();
-            let loading = loading.clone();
-            let err = err.clone();
-            loading.set(true);
-            spawn_local(async move {
-                match api_logs(&id).await {
-                    Ok(text) => {
-                        content.set(Some(text));
-                        err.set(None);
-                    }
-                    Err(e) => err.set(Some(e)),
-                }
-                loading.set(false);
-            });
-        }
-    };
-
-    {
-        let load = load.clone();
-        use_effect_with(props.id.clone(), move |_| {
-            load();
-        });
-    }
-
-    let on_back = {
-        let cb = props.on_back.clone();
-        Callback::from(move |_: MouseEvent| cb.emit(()))
-    };
-    let on_refresh = {
-        let load = load.clone();
-        Callback::from(move |_: MouseEvent| load())
-    };
-
-    let body = if *loading {
-        html! { <div class="empty"><div class="spinner"></div></div> }
-    } else if let Some(e) = (*err).clone() {
-        html! { <div class="logs-error">{format!("Error: {e}")}</div> }
-    } else if let Some(text) = (*content).clone() {
-        if text.is_empty() {
-            html! { <div class="logs-empty">{"— no logs yet —"}</div> }
-        } else {
-            html! { <pre class="logs-content">{text}</pre> }
-        }
-    } else {
-        html! {}
-    };
-
-    html! {
-        <main class="logs-page">
-            <div class="page-hd">
-                <button class="btn btn-ghost btn-sm" onclick={on_back}>{"← BACK"}</button>
-                <div class="page-title">{format!("LOGS / {}", props.title)}</div>
-                <button class="btn-refresh" title="Refresh" aria-label="Refresh" onclick={on_refresh}>{"↻"}</button>
-            </div>
-            <div class="logs-wrap">
-                {body}
-            </div>
-        </main>
-    }
-}


### PR DESCRIPTION
## Summary

Closes #633.

Replaces the static `<pre>` log dump in both the cron-jobs and routines pages with a shared `LogViewer` component (new `ui/src/logs.rs`) that delivers three capabilities cited in [#633](https://github.com/moadim-io/daemon/issues/633):

- **Line numbers** — numbered gutter (1-based, monospaced, right-aligned) so log references can be cited precisely. Matches GitHub Actions UX.
- **Inline keyword search** — case-insensitive; non-matching lines are dimmed; header shows `N/total lines` while a query is active.
- **Auto-tail (⬇ TAIL)** — polls every 2 s and scrolls the container to the bottom after each update; shows a `● LIVE` badge. The loop self-terminates within one sleep when the operator disables tail. Manual `↻` refresh remains available when tail is off.

### Best-practice rationale

> *"Live log tailing is the #1 feature operators ask for in ops dashboards."*  
> *"Line numbers turn a log wall into a navigable document — every incident report cites line N."*  
> *"Inline search removes the need to pipe logs to grep; it is the single highest-impact log-viewer quality-of-life improvement."*
>
> — Grafana/GitHub Actions/Buildkite UX patterns, as cited in issue #633

### Implementation details

- New **`ui/src/logs.rs`** — `LogViewer` component + two pure helpers (`split_lines`, `line_counts`)
- New **`ui/src/logs_tests.rs`** — 19 host-side tests covering all pure logic; all pass
- **`ui/src/cron_jobs.rs`** + **`ui/src/routines.rs`** — old inline `LogsPage` / `RoutineLogs` replaced with `<LogViewer fetch_url=... title=... on_back=... />`
- **`ui/index.html`** — CSS for gutter, toolbar, search input, LIVE badge, dimmed rows
- No backend changes — uses existing `GET /api/v1/{cron-jobs,routines}/{id}/logs` endpoints

## Test plan

- [ ] `cargo build` passes ✅
- [ ] `cargo clippy --package ui --target wasm32-unknown-unknown` clean ✅
- [ ] `cargo test --package ui` — 123 tests pass ✅
- [ ] `git diff --name-only origin/main...HEAD` shows only `ui/` files ✅
- [ ] Manually open a log page: verify line numbers in gutter, search filters lines, TAIL button polls and scrolls

---
This pull request was opened by the **UI dashboard feature builder (research → issue → PR → merge)** routine of moadim. @tupe12334