### PR TITLE
docs(contributing): add cargo-llvm-cov to prerequisites and fix pre-push command block

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@
 | [Trunk](https://trunkrs.dev/) | Build the Yew UI (`cargo install trunk`) |
 | `wasm32-unknown-unknown` target | UI target (`rustup target add wasm32-unknown-unknown`) |
 | [`typos`](https://github.com/crate-ci/typos) | Spell check, run by the pre-commit hook (`cargo install typos-cli`) |
+| [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov) + `llvm-tools-preview` | 100% line-coverage gate, enforced by the pre-push hook (`cargo install cargo-llvm-cov && rustup component add llvm-tools-preview`) |
 
 The `wasm32` target and Trunk are only needed when working on the browser UI
 (`ui/`). The daemon itself is a native binary and builds without them.
@@ -25,12 +26,15 @@ Run the checks the pre-push hook enforces before any push:
 ```sh
 cargo fmt --check
 cargo clippy --all-targets -- -D warnings
-cargo test
+cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'
 ```
 
 Use `--all-targets -- -D warnings` for clippy, exactly as the pre-push hook and
 the CI lint gate do — bare `cargo clippy` skips test/example/bench code and only
-warns, so it can pass locally yet fail the hook and CI.
+warns, so it can pass locally yet fail the hook and CI. The `cargo llvm-cov`
+command runs the test suite with instrumentation and enforces 100% line coverage
+(excluding `main.rs`); it subsumes a bare `cargo test`, so running it is enough
+to satisfy both the test and coverage gates in one pass.
 
 Enable the bundled git hooks once per clone:
 


### PR DESCRIPTION
## What and why

`CONTRIBUTING.md` told contributors to run:

\`\`\`sh
cargo fmt --check
cargo clippy --all-targets -- -D warnings
cargo test
\`\`\`

…as the commands that mirror the pre-push hook. But the actual hook (`.githooks/pre-push`, step 4) runs:

\`\`\`sh
cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'
\`\`\`

There is no bare `cargo test` step. A contributor following the old instructions would see green, push, and then be surprised when the pre-push hook or CI failed with "line coverage below 100%". This PR closes that gap.

## Changes

- **Prerequisites table**: added `cargo-llvm-cov` + `llvm-tools-preview` with install instructions.
- **Setup block**: replaced `cargo test` with the exact `cargo llvm-cov` invocation the hook uses, and added a note explaining that `llvm-cov` subsumes `cargo test`.

`CONTRIBUTING.md` is a docs-only change: no `src/` or `ui/` files are touched, so the `unreleased-entry` check is exempt.

---

*This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.*

/cc @tupe12334