### PR TITLE
feat(ui): light/dark theme toggle — flash-free, localStorage-persisted (#664)

### DIFF
--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -19,7 +19,7 @@ chrono = "0.4"
 gloo-net = { version = "0.6", features = ["http"] }
 gloo-timers = { version = "0.4", features = ["futures"] }
 js-sys = "0.3"
-web-sys = { version = "0.3", features = ["Element", "EventTarget", "HtmlElement", "HtmlInputElement", "HtmlSelectElement", "KeyboardEvent", "Storage", "Window"] }
+web-sys = { version = "0.3", features = ["Document", "DomTokenList", "Element", "EventTarget", "HtmlElement", "HtmlInputElement", "HtmlSelectElement", "KeyboardEvent", "Storage", "Window"] }
 log = "0.4"
 console_log = "1"
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -9,6 +9,8 @@
   <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet" />
   <!-- trunk replaces this with the compiled WASM loader -->
   <link data-trunk rel="rust" data-wasm-opt="z" />
+  <!-- Flash-free theme init: apply stored preference before first paint. -->
+  <script>(function(){var t=localStorage.getItem('moadim.theme');if(t==='light')document.documentElement.classList.add('theme-light');}());</script>
   <style>
     :root {
       --bg:           #050905;
@@ -29,6 +31,30 @@
       --amber-dim:    #271b06;
       --mono:         'Share Tech Mono', 'Courier New', monospace;
     }
+
+    /* Light theme — overrides every token; components inherit with no changes. */
+    html.theme-light {
+      --bg:           #f4fbf2;
+      --bg-2:         #ecf7e8;
+      --bg-3:         #dff0d8;
+      --border:       #b8d8b0;
+      --border-hi:    #8abe80;
+      --text-ghost:   #a8c8a0;
+      --text-dim:     #4a7a42;
+      --text-mid:     #2e6028;
+      --text:         #1a3d16;
+      --text-hi:      #0a200a;
+      --accent:       #16a34a;
+      --accent-dim:   #d9f9e4;
+      --red:          #dc2626;
+      --red-dim:      #fee2e2;
+      --amber:        #d97706;
+      --amber-dim:    #fef3c7;
+    }
+    /* Heatmap density cells use hard-coded greens in dark mode; remap for light. */
+    html.theme-light .hm-cell.lvl-1 { background: #c6e8c0; }
+    html.theme-light .hm-cell.lvl-2 { background: #7ecc72; }
+    html.theme-light .hm-cell.lvl-3 { background: #2ea34a; }
 
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -181,6 +207,19 @@
       line-height: 1;
     }
     .btn-cmdk:hover { color: var(--accent); border-color: var(--border-hi); }
+
+    .btn-theme {
+      background: none;
+      border: 1px solid var(--border);
+      color: var(--text-dim);
+      font-family: var(--mono);
+      font-size: 14px;
+      padding: 4px 10px;
+      cursor: pointer;
+      transition: color 0.12s, border-color 0.12s;
+      line-height: 1;
+    }
+    .btn-theme:hover { color: var(--accent); border-color: var(--border-hi); }
 
     /* ── Command palette (⌘K) ── */
     .cmdk {
@@ -1300,6 +1339,7 @@
     .btn:focus-visible,
     .btn-refresh:focus-visible,
     .btn-stop:focus-visible,
+    .btn-theme:focus-visible,
     .tab-btn:focus-visible,
     .act-btn:focus-visible,
     .view-btn:focus-visible,

--- a/ui/src/command_palette.rs
+++ b/ui/src/command_palette.rs
@@ -48,6 +48,8 @@ pub(crate) enum CmdKind {
     ActionRefresh,
     /// Open the stop-server confirmation (the header's ⏻ action).
     ActionStop,
+    /// Toggle light/dark theme (the header's ☀/☽ action).
+    ActionToggleTheme,
 }
 
 /// The destination page a [`CmdKind`] resolves to, independent of the wasm
@@ -86,7 +88,7 @@ pub(crate) fn route_for(kind: CmdKind) -> Option<RouteKind> {
         CmdKind::NavCronJobs | CmdKind::Cron => Some(RouteKind::CronJobs),
         CmdKind::NavRoutines | CmdKind::Routine => Some(RouteKind::Routines),
         CmdKind::NavHeatmap => Some(RouteKind::Heatmap),
-        CmdKind::ActionRefresh | CmdKind::ActionStop => None,
+        CmdKind::ActionRefresh | CmdKind::ActionStop | CmdKind::ActionToggleTheme => None,
     }
 }
 
@@ -100,7 +102,7 @@ pub(crate) fn badge_for(kind: CmdKind) -> &'static str {
         | CmdKind::NavHeatmap => "GO",
         CmdKind::Cron => "CRON",
         CmdKind::Routine => "ROUTINE",
-        CmdKind::ActionRefresh | CmdKind::ActionStop => "ACTION",
+        CmdKind::ActionRefresh | CmdKind::ActionStop | CmdKind::ActionToggleTheme => "ACTION",
     }
 }
 
@@ -213,6 +215,12 @@ pub(crate) fn build_commands(crons: &[CronJob], routines: &[Routine]) -> Vec<Com
             keywords: "reload health status action".into(),
         },
         Command {
+            kind: CmdKind::ActionToggleTheme,
+            title: "Toggle Theme".into(),
+            subtitle: "Switch between dark and light mode".into(),
+            keywords: "theme dark light mode appearance color".into(),
+        },
+        Command {
             kind: CmdKind::ActionStop,
             title: "Stop Server".into(),
             subtitle: "Shut the moadim server down".into(),
@@ -301,6 +309,8 @@ pub struct PaletteProps {
     pub on_refresh: Callback<()>,
     /// Runs the "Stop Server" action (open the shutdown confirmation).
     pub on_stop: Callback<()>,
+    /// Runs the "Toggle Theme" action (flip dark/light mode).
+    pub on_toggle_theme: Callback<()>,
 }
 
 /// The ⌘K command palette overlay. Mounted permanently by the shell; renders
@@ -349,6 +359,7 @@ pub fn command_palette(props: &PaletteProps) -> Html {
         let on_close = props.on_close.clone();
         let on_refresh = props.on_refresh.clone();
         let on_stop = props.on_stop.clone();
+        let on_toggle_theme = props.on_toggle_theme.clone();
         let commands = commands.clone();
         let order = order.clone();
         Callback::from(move |row: usize| {
@@ -356,6 +367,7 @@ pub fn command_palette(props: &PaletteProps) -> Html {
                 match command.kind {
                     CmdKind::ActionRefresh => on_refresh.emit(()),
                     CmdKind::ActionStop => on_stop.emit(()),
+                    CmdKind::ActionToggleTheme => on_toggle_theme.emit(()),
                     kind => {
                         if let (Some(nav), Some(route_kind)) = (navigator.clone(), route_for(kind))
                         {
@@ -438,7 +450,9 @@ pub fn command_palette(props: &PaletteProps) -> Html {
             let badge_cls = match command.kind {
                 CmdKind::Cron => "kind-badge cron",
                 CmdKind::Routine => "kind-badge routine",
-                CmdKind::ActionRefresh | CmdKind::ActionStop => "kind-badge action",
+                CmdKind::ActionRefresh
+                | CmdKind::ActionStop
+                | CmdKind::ActionToggleTheme => "kind-badge action",
                 _ => "kind-badge nav",
             };
             let launch = launch.clone();

--- a/ui/src/command_palette_tests.rs
+++ b/ui/src/command_palette_tests.rs
@@ -162,21 +162,22 @@ fn build_lists_pages_then_crons_then_routines() {
     let crons = vec![cron("backup", "0 * * * *", "snapshot", Some("Every hour"))];
     let routines = vec![routine("r1", "Nightly Audit", "claude", "0 0 * * *", None)];
     let commands = build_commands(&crons, &routines);
-    assert_eq!(commands.len(), 8); // 4 nav + 2 action + 1 cron + 1 routine
+    assert_eq!(commands.len(), 9); // 4 nav + 3 action + 1 cron + 1 routine
     assert_eq!(commands[0].kind, CmdKind::NavOverview);
     assert_eq!(commands[1].kind, CmdKind::NavCronJobs);
     assert_eq!(commands[2].kind, CmdKind::NavRoutines);
     assert_eq!(commands[3].kind, CmdKind::NavHeatmap);
     assert_eq!(commands[4].kind, CmdKind::ActionRefresh);
-    assert_eq!(commands[5].kind, CmdKind::ActionStop);
-    assert_eq!(commands[6].kind, CmdKind::Cron);
-    assert_eq!(commands[6].title, "backup");
-    assert_eq!(commands[6].subtitle, "Every hour"); // human description wins
-    assert!(commands[6].keywords.contains("snapshot"));
-    assert_eq!(commands[7].kind, CmdKind::Routine);
-    assert_eq!(commands[7].title, "Nightly Audit");
-    assert_eq!(commands[7].subtitle, "0 0 * * *"); // falls back to raw expr
-    assert!(commands[7].keywords.contains("claude"));
+    assert_eq!(commands[5].kind, CmdKind::ActionToggleTheme);
+    assert_eq!(commands[6].kind, CmdKind::ActionStop);
+    assert_eq!(commands[7].kind, CmdKind::Cron);
+    assert_eq!(commands[7].title, "backup");
+    assert_eq!(commands[7].subtitle, "Every hour"); // human description wins
+    assert!(commands[7].keywords.contains("snapshot"));
+    assert_eq!(commands[8].kind, CmdKind::Routine);
+    assert_eq!(commands[8].title, "Nightly Audit");
+    assert_eq!(commands[8].subtitle, "0 0 * * *"); // falls back to raw expr
+    assert!(commands[8].keywords.contains("claude"));
 }
 
 #[test]
@@ -208,6 +209,7 @@ fn route_for_maps_every_kind() {
     // Action commands run a callback, not a navigation.
     assert_eq!(route_for(CmdKind::ActionRefresh), None);
     assert_eq!(route_for(CmdKind::ActionStop), None);
+    assert_eq!(route_for(CmdKind::ActionToggleTheme), None);
 }
 
 #[test]
@@ -220,6 +222,7 @@ fn badge_for_maps_every_kind() {
     assert_eq!(badge_for(CmdKind::Routine), "ROUTINE");
     assert_eq!(badge_for(CmdKind::ActionRefresh), "ACTION");
     assert_eq!(badge_for(CmdKind::ActionStop), "ACTION");
+    assert_eq!(badge_for(CmdKind::ActionToggleTheme), "ACTION");
 }
 
 // ─── selection-index helpers ───────────────────────────────────────────────────

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -78,6 +78,8 @@ pub struct ShellState {
     pub next_toast: u32,
     pub show_shutdown: bool,
     pub show_palette: bool,
+    /// Whether the light theme is active (`false` = dark, the default).
+    pub theme_light: bool,
 }
 
 pub enum ShellAction {
@@ -87,6 +89,7 @@ pub enum ShellAction {
     CloseShutdown,
     TogglePalette,
     ClosePalette,
+    ToggleTheme,
 }
 
 impl Reducible for ShellState {
@@ -112,6 +115,7 @@ impl Reducible for ShellState {
             ShellAction::CloseShutdown => s.show_shutdown = false,
             ShellAction::TogglePalette => s.show_palette = !s.show_palette,
             ShellAction::ClosePalette => s.show_palette = false,
+            ShellAction::ToggleTheme => s.theme_light = !s.theme_light,
         }
         s.into()
     }
@@ -174,7 +178,42 @@ pub fn app() -> Html {
 /// the global shutdown dialog, and the toast stack. Lives inside the router so nav `Link`s work.
 #[function_component(Shell)]
 pub fn shell() -> Html {
-    let state = use_reducer(ShellState::default);
+    let state = use_reducer(|| {
+        // Read the persisted theme preference synchronously so the initial render
+        // matches what the flash-prevention script already applied to <html>.
+        let light = web_sys::window()
+            .and_then(|w| w.local_storage().ok().flatten())
+            .and_then(|s| s.get_item("moadim.theme").ok().flatten())
+            .map(|v| v == "light")
+            .unwrap_or(false);
+        ShellState {
+            theme_light: light,
+            ..Default::default()
+        }
+    });
+
+    // Keep the <html> class and localStorage in sync whenever the theme toggles.
+    {
+        let theme_light = state.theme_light;
+        use_effect_with(theme_light, move |light| {
+            let light = *light;
+            if let Some(window) = web_sys::window() {
+                if let Some(doc) = window.document() {
+                    if let Some(html) = doc.document_element() {
+                        if light {
+                            let _ = html.class_list().add_1("theme-light");
+                        } else {
+                            let _ = html.class_list().remove_1("theme-light");
+                        }
+                    }
+                }
+                if let Ok(Some(storage)) = window.local_storage() {
+                    let _ = storage
+                        .set_item("moadim.theme", if light { "light" } else { "dark" });
+                }
+            }
+        });
+    }
 
     // Initial health poll on mount.
     {
@@ -244,8 +283,8 @@ pub fn shell() -> Html {
         Callback::from(move |_: MouseEvent| state.dispatch(ShellAction::TogglePalette))
     };
 
-    // Palette "Refresh" / "Stop Server" actions mirror the header buttons but
-    // take the `()` payload the palette emits.
+    // Palette "Refresh" / "Stop Server" / "Toggle Theme" actions mirror the
+    // header buttons but take the `()` payload the palette emits.
     let on_palette_refresh = {
         let state = state.clone();
         Callback::from(move |_: ()| {
@@ -256,6 +295,15 @@ pub fn shell() -> Html {
     let on_palette_stop = {
         let state = state.clone();
         Callback::from(move |_: ()| state.dispatch(ShellAction::OpenShutdown))
+    };
+    let on_palette_toggle_theme = {
+        let state = state.clone();
+        Callback::from(move |_: ()| state.dispatch(ShellAction::ToggleTheme))
+    };
+
+    let on_toggle_theme = {
+        let state = state.clone();
+        Callback::from(move |_: MouseEvent| state.dispatch(ShellAction::ToggleTheme))
     };
 
     let on_refresh = {
@@ -324,10 +372,19 @@ pub fn shell() -> Html {
     let toasts = state.toasts.clone();
     let show_shutdown = state.show_shutdown;
     let show_palette = state.show_palette;
+    let theme_light = state.theme_light;
 
     html! {
         <>
-            <Header health={health} ok={health_ok} on_refresh={on_refresh} on_stop={on_stop} on_palette={on_open_palette} />
+            <Header
+                health={health}
+                ok={health_ok}
+                on_refresh={on_refresh}
+                on_stop={on_stop}
+                on_palette={on_open_palette}
+                theme_light={theme_light}
+                on_toggle_theme={on_toggle_theme}
+            />
             <Nav />
             <Switch<Route> render={switch} />
             <CommandPalette
@@ -335,6 +392,7 @@ pub fn shell() -> Html {
                 on_close={on_close_palette}
                 on_refresh={on_palette_refresh}
                 on_stop={on_palette_stop}
+                on_toggle_theme={on_palette_toggle_theme}
             />
             {
                 if show_shutdown {
@@ -392,6 +450,10 @@ pub struct HeaderProps {
     pub on_refresh: Callback<MouseEvent>,
     pub on_stop: Callback<MouseEvent>,
     pub on_palette: Callback<MouseEvent>,
+    /// Whether the light theme is currently active.
+    pub theme_light: bool,
+    /// Toggle between dark and light theme.
+    pub on_toggle_theme: Callback<MouseEvent>,
 }
 
 #[function_component(Header)]
@@ -413,6 +475,11 @@ pub fn header(props: &HeaderProps) -> Html {
         .uptime_secs
         .map(|s| format!("/ UP {}", fmt_uptime(s)))
         .unwrap_or_default();
+    let (theme_icon, theme_title) = if props.theme_light {
+        ("☽", "Switch to dark theme")
+    } else {
+        ("☀", "Switch to light theme")
+    };
 
     html! {
         <header>
@@ -429,6 +496,15 @@ pub fn header(props: &HeaderProps) -> Html {
                 </div>
                 <button class="btn-cmdk" title="Command palette (⌘K)" aria-label="Open command palette" onclick={props.on_palette.clone()}>
                     {"⌘K"}
+                </button>
+                <button
+                    class="btn-theme"
+                    title={theme_title}
+                    aria-label={theme_title}
+                    aria-pressed={props.theme_light.to_string()}
+                    onclick={props.on_toggle_theme.clone()}
+                >
+                    {theme_icon}
                 </button>
                 <button class="btn-refresh" title="Refresh" aria-label="Refresh" onclick={props.on_refresh.clone()}>{"↻"}</button>
                 <button class="btn-stop" title="Stop the server" disabled={!props.ok} onclick={props.on_stop.clone()}>{"⏻ STOP"}</button>


### PR DESCRIPTION
## Summary

Closes #664. Implements the light/dark theme toggle for the moadim operations dashboard.

**Best-practice rationale**: Every major monitoring tool (Grafana, Datadog, PagerDuty) ships theme persistence because operations dashboards are used in varied lighting conditions — bright-lit offices, conference rooms, and dark server rooms. WCAG recommends offering both modes for contrast compliance. The UI already used CSS custom properties everywhere, making a full light theme a single `.theme-light { }` override block.

## Changes (all under `ui/`)

- **Flash-free init** — inline `<script>` in `<head>` reads `localStorage('moadim.theme')` and applies `.theme-light` to `<html>` before the first paint (no dark→light flash on reload)
- **Light theme** — `.theme-light` CSS block overrides all `--bg`, `--text`, `--accent`, `--red`, and `--amber` tokens with a legible green-on-light palette; heatmap density cells remapped
- **Header toggle button** — ☀ (dark → light) / ☽ (light → dark) button between `⌘K` and `↻`, with `aria-pressed` for accessibility
- **`⌘K` command palette entry** — "Toggle Theme" (`ActionToggleTheme`) with keyword aliases so keyboard-first operators can switch without reaching for the mouse
- **Persisted preference** — `ShellState.theme_light` initialised synchronously from `localStorage` in the `use_reducer` closure; toggling writes back immediately

## Tests

All 159 host-side tests pass. New coverage:
- `route_for(CmdKind::ActionToggleTheme)` returns `None`
- `badge_for(CmdKind::ActionToggleTheme)` returns `"ACTION"`
- `build_commands` count updated (8→9), index assertions for new entry verified

Clippy clean (all-deny).

---
*This pull request was opened by the UI dashboard feature builder (research → issue → PR → merge) routine of moadim. @tupe12334 — tagging you for visibility.*