### PR TITLE
feat(ui): light/dark theme toggle with anti-FOUC localStorage persistence (#671)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Added
 
+- **Light/dark theme toggle with flash-free localStorage persistence.** A `☀`/`◑`
+  button in the dashboard header switches between the original dark (near-black green)
+  palette and a new light (pale green) palette suited to bright environments. The chosen
+  theme persists in `localStorage` under `moadim-theme` and is restored flash-free by an
+  inline `<script>` in `<head>` that sets `data-theme="light"` on `<html>` before the
+  first paint — no white flash on reload. The light palette redefines all CSS custom
+  properties (`--bg`, `--text`, etc.) in a `[data-theme="light"]` block; the Yew shell
+  reads the DOM attribute on mount to stay in sync. Pure frontend change — no backend
+  or API modification. Closes #671.
+
 - **NEXT RUN countdown column in the Routines table.** The Routines table gains a
   live **NEXT RUN** column (absolute fire time + relative countdown + due-soon accent)
   matching the already-shipped column on the Cron Jobs page, so operators see per-routine

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -19,7 +19,7 @@ chrono = "0.4"
 gloo-net = { version = "0.6", features = ["http"] }
 gloo-timers = { version = "0.4", features = ["futures"] }
 js-sys = "0.3"
-web-sys = { version = "0.3", features = ["Element", "EventTarget", "HtmlElement", "HtmlInputElement", "HtmlSelectElement", "KeyboardEvent", "Storage", "Window"] }
+web-sys = { version = "0.3", features = ["Document", "Element", "EventTarget", "HtmlElement", "HtmlInputElement", "HtmlSelectElement", "KeyboardEvent", "Storage", "Window"] }
 log = "0.4"
 console_log = "1"
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -7,6 +7,16 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
   <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet" />
+  <!-- Anti-FOUC: restore persisted theme before first paint so no flash occurs.
+       Runs synchronously in <head> before CSS is applied. -->
+  <script>
+    (function() {
+      try {
+        var t = localStorage.getItem('moadim-theme');
+        if (t === 'light') document.documentElement.setAttribute('data-theme', 'light');
+      } catch (_) {}
+    })();
+  </script>
   <!-- trunk replaces this with the compiled WASM loader -->
   <link data-trunk rel="rust" data-wasm-opt="z" />
   <style>
@@ -29,6 +39,52 @@
       --amber-dim:    #271b06;
       --mono:         'Share Tech Mono', 'Courier New', monospace;
     }
+
+    /* ── Light theme overrides ── */
+    /* Applied when <html data-theme="light"> is set — either by the anti-FOUC
+       script (localStorage restore) or toggled by the Yew shell. Keeps the
+       terminal monospace aesthetic but in a pale-green, high-contrast palette
+       suited to bright environments. */
+    [data-theme="light"] {
+      --bg:           #f0f5ee;
+      --bg-2:         #e4ede0;
+      --bg-3:         #d8e5d2;
+      --border:       #bdd4b5;
+      --border-hi:    #9cc090;
+      --text-ghost:   #7a9870;
+      --text-dim:     #4e7a42;
+      --text-mid:     #2d5524;
+      --text:         #1a3812;
+      --text-hi:      #0c2008;
+      --accent:       #177a28;
+      --accent-dim:   #c8e8cc;
+      --red:          #b52c1c;
+      --red-dim:      #fce8e4;
+      --amber:        #956010;
+      --amber-dim:    #fdf0d8;
+    }
+
+    /* Scanlines are decorative noise — soften them in light mode. */
+    [data-theme="light"] body::before { opacity: 0.04; }
+    [data-theme="light"] body::after  { opacity: 0.01; }
+
+    /* Overlay backdrop in light mode uses a pale green wash. */
+    [data-theme="light"] .overlay { background: rgba(200, 220, 192, 0.88); }
+
+    /* System-row blue accents: readable on both themes, but the dark hover
+       background needs a light-mode override. */
+    [data-theme="light"] tbody tr.sys-row:hover { background: #d8e8f4; }
+    [data-theme="light"] .badge-readonly {
+      background: #e4eaf4;
+      color:      #3a5aaa;
+      border-color: #3a5aaa;
+    }
+
+    /* Heatmap intensity levels: dark-green shades don't read well on light bg. */
+    [data-theme="light"] .hm-cell.lvl-1 { background: #c4e0c8; }
+    [data-theme="light"] .hm-cell.lvl-2 { background: #80c888; }
+    [data-theme="light"] .hm-cell.lvl-3 { background: #38a050; }
+    [data-theme="light"] .hm-cell.lvl-4 { background: var(--accent); color: var(--bg); }
 
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -167,6 +223,19 @@
     }
     .btn-refresh:hover { color: var(--accent); border-color: var(--border-hi); }
     .btn-refresh.spinning { animation: spin 0.6s linear infinite; }
+
+    .btn-theme {
+      background: none;
+      border: 1px solid var(--border);
+      color: var(--text-dim);
+      font-family: var(--mono);
+      font-size: 15px;
+      padding: 2px 9px;
+      cursor: pointer;
+      transition: color 0.12s, border-color 0.12s;
+      line-height: 1.4;
+    }
+    .btn-theme:hover { color: var(--accent); border-color: var(--border-hi); }
 
     .btn-cmdk {
       background: none;
@@ -1299,6 +1368,7 @@
        used by .row-check. */
     .btn:focus-visible,
     .btn-refresh:focus-visible,
+    .btn-theme:focus-visible,
     .btn-stop:focus-visible,
     .tab-btn:focus-visible,
     .act-btn:focus-visible,

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -24,6 +24,78 @@ use overview::OverviewPage;
 use routines::RoutinesPage;
 use schedule_heatmap::HeatmapPage;
 
+// ─── Theme ────────────────────────────────────────────────────────────────────
+
+/// Dashboard colour scheme. `Dark` (the default) uses the original near-black
+/// green palette; `Light` switches to a pale-green palette suited to bright
+/// environments. Both keep the terminal monospace aesthetic.
+///
+/// Persistence: the chosen theme is stored in `localStorage` under
+/// `"moadim-theme"` and restored flash-free by an inline `<script>` in
+/// `index.html` that runs before the first paint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Theme {
+    #[default]
+    Dark,
+    Light,
+}
+
+impl Theme {
+    /// Token stored in `localStorage` and used as the `data-theme` attribute value.
+    pub fn to_token(self) -> &'static str {
+        match self {
+            Theme::Dark => "dark",
+            Theme::Light => "light",
+        }
+    }
+
+    /// Parse from a `localStorage` value or `data-theme` attribute.
+    pub fn from_token(s: &str) -> Self {
+        if s == "light" {
+            Theme::Light
+        } else {
+            Theme::Dark
+        }
+    }
+}
+
+/// Read the current theme from the `<html data-theme>` attribute set by the
+/// anti-FOUC inline script. Called once on mount so Yew state matches the DOM.
+fn read_theme_from_dom() -> Theme {
+    web_sys::window()
+        .and_then(|w| w.document())
+        .and_then(|d| d.document_element())
+        .and_then(|el| el.get_attribute("data-theme"))
+        .as_deref()
+        .map(Theme::from_token)
+        .unwrap_or_default()
+}
+
+/// Apply a theme: set/clear `data-theme` on `<html>` and persist to
+/// `localStorage`. Best-effort — errors are silently ignored.
+fn apply_theme(theme: Theme) {
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let Some(doc) = window.document() else {
+        return;
+    };
+    let Some(el) = doc.document_element() else {
+        return;
+    };
+    match theme {
+        Theme::Dark => {
+            let _ = el.remove_attribute("data-theme");
+        }
+        Theme::Light => {
+            let _ = el.set_attribute("data-theme", "light");
+        }
+    }
+    if let Ok(Some(store)) = window.local_storage() {
+        let _ = store.set_item("moadim-theme", theme.to_token());
+    }
+}
+
 // ─── Shared types ─────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Default)]
@@ -78,15 +150,27 @@ pub struct ShellState {
     pub next_toast: u32,
     pub show_shutdown: bool,
     pub show_palette: bool,
+    pub theme: Theme,
 }
 
 pub enum ShellAction {
-    HealthLoaded { health: Health, ok: bool },
-    AddToast { msg: String, kind: ToastKind },
+    HealthLoaded {
+        health: Health,
+        ok: bool,
+    },
+    AddToast {
+        msg: String,
+        kind: ToastKind,
+    },
     OpenShutdown,
     CloseShutdown,
     TogglePalette,
     ClosePalette,
+    /// Flip between dark and light theme; DOM + localStorage update is a side
+    /// effect handled via `use_effect_with(state.theme, …)` in `Shell`.
+    ToggleTheme,
+    /// Set theme to a specific value (used on mount to sync from DOM).
+    SetTheme(Theme),
 }
 
 impl Reducible for ShellState {
@@ -112,6 +196,13 @@ impl Reducible for ShellState {
             ShellAction::CloseShutdown => s.show_shutdown = false,
             ShellAction::TogglePalette => s.show_palette = !s.show_palette,
             ShellAction::ClosePalette => s.show_palette = false,
+            ShellAction::ToggleTheme => {
+                s.theme = match s.theme {
+                    Theme::Dark => Theme::Light,
+                    Theme::Light => Theme::Dark,
+                };
+            }
+            ShellAction::SetTheme(t) => s.theme = t,
         }
         s.into()
     }
@@ -176,6 +267,26 @@ pub fn app() -> Html {
 pub fn shell() -> Html {
     let state = use_reducer(ShellState::default);
 
+    // Sync theme from DOM on mount — the anti-FOUC inline script may have set
+    // `data-theme="light"` before WASM loaded; this brings Yew state in line.
+    {
+        let state = state.clone();
+        use_effect_with((), move |_| {
+            let dom_theme = read_theme_from_dom();
+            if dom_theme != Theme::Dark {
+                state.dispatch(ShellAction::SetTheme(dom_theme));
+            }
+        });
+    }
+
+    // Apply theme to DOM + localStorage whenever the in-memory value changes.
+    {
+        let theme = state.theme;
+        use_effect_with(theme, move |t| {
+            apply_theme(*t);
+        });
+    }
+
     // Initial health poll on mount.
     {
         let state = state.clone();
@@ -232,6 +343,11 @@ pub fn shell() -> Html {
         Callback::from(move |(msg, kind): (String, ToastKind)| {
             state.dispatch(ShellAction::AddToast { msg, kind })
         })
+    };
+
+    let on_toggle_theme = {
+        let state = state.clone();
+        Callback::from(move |_: MouseEvent| state.dispatch(ShellAction::ToggleTheme))
     };
 
     let on_close_palette = {
@@ -324,10 +440,11 @@ pub fn shell() -> Html {
     let toasts = state.toasts.clone();
     let show_shutdown = state.show_shutdown;
     let show_palette = state.show_palette;
+    let theme = state.theme;
 
     html! {
         <>
-            <Header health={health} ok={health_ok} on_refresh={on_refresh} on_stop={on_stop} on_palette={on_open_palette} />
+            <Header health={health} ok={health_ok} theme={theme} on_refresh={on_refresh} on_stop={on_stop} on_palette={on_open_palette} on_theme={on_toggle_theme} />
             <Nav />
             <Switch<Route> render={switch} />
             <CommandPalette
@@ -389,9 +506,11 @@ pub fn nav() -> Html {
 pub struct HeaderProps {
     pub health: Health,
     pub ok: bool,
+    pub theme: Theme,
     pub on_refresh: Callback<MouseEvent>,
     pub on_stop: Callback<MouseEvent>,
     pub on_palette: Callback<MouseEvent>,
+    pub on_theme: Callback<MouseEvent>,
 }
 
 #[function_component(Header)]
@@ -413,6 +532,12 @@ pub fn header(props: &HeaderProps) -> Html {
         .uptime_secs
         .map(|s| format!("/ UP {}", fmt_uptime(s)))
         .unwrap_or_default();
+    // Show the "opposite" icon so clicking it makes sense: in dark mode, show
+    // ☀ (switch to light); in light mode, show ◑ (switch to dark).
+    let (theme_icon, theme_title) = match props.theme {
+        Theme::Dark => ("☀", "Switch to light theme"),
+        Theme::Light => ("◑", "Switch to dark theme"),
+    };
 
     html! {
         <header>
@@ -427,6 +552,9 @@ pub fn header(props: &HeaderProps) -> Html {
                     <span class="health-status">{status}</span>
                     <span class="health-uptime">{uptime}</span>
                 </div>
+                <button class="btn-theme" title={theme_title} aria-label={theme_title} onclick={props.on_theme.clone()}>
+                    {theme_icon}
+                </button>
                 <button class="btn-cmdk" title="Command palette (⌘K)" aria-label="Open command palette" onclick={props.on_palette.clone()}>
                     {"⌘K"}
                 </button>


### PR DESCRIPTION
## Summary

- Adds a `☀`/`◑` theme-toggle button in the dashboard header (between ⌘K and ↻)
- Switches between the original dark palette and a new pale-green **light** palette
- Theme persists to `localStorage['moadim-theme']` and is restored **flash-free** on reload via an inline `<script>` in `<head>` that sets `data-theme="light"` on `<html>` before the first paint
- `[data-theme="light"]` CSS block redefines all `--bg`/`--text`/`--accent`/etc. tokens; includes heatmap-level, overlay, and system-badge light-mode overrides
- Yew shell syncs from DOM on mount (`read_theme_from_dom`) and applies changes via `use_effect_with(state.theme, …)`
- Pure frontend change — no backend, API, or cron/routine semantics modified

Closes #671.

## Diff scope check

All changed files are under `ui/` (+ `CHANGELOG.md`):
- `ui/Cargo.toml` — adds `"Document"` to web-sys features (needed for `document.document_element()`)
- `ui/index.html` — anti-FOUC script, `[data-theme="light"]` CSS, `.btn-theme` style
- `ui/src/main.rs` — `Theme` enum, `ShellState.theme`, `ToggleTheme`/`SetTheme` actions, effects, `Header` button

## Test plan

- [ ] CI green (lint, test, changelog, spellcheck)
- [ ] Click `☀` → switches to light palette; reload → stays light (no flash)
- [ ] Click `◑` → switches back to dark palette; reload → stays dark
- [ ] `localStorage['moadim-theme']` updates on each toggle
- [ ] All existing tests pass (`cargo test`)

---

*This pull request was opened by the UI dashboard feature builder (research → issue → PR → merge) routine of moadim. @tupe12334*