### PR TITLE
feat(ui): light/dark theme toggle with localStorage persistence (#674)

### DIFF
--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -19,7 +19,7 @@ chrono = "0.4"
 gloo-net = { version = "0.6", features = ["http"] }
 gloo-timers = { version = "0.4", features = ["futures"] }
 js-sys = "0.3"
-web-sys = { version = "0.3", features = ["Element", "EventTarget", "HtmlElement", "HtmlInputElement", "HtmlSelectElement", "KeyboardEvent", "Storage", "Window"] }
+web-sys = { version = "0.3", features = ["Document", "Element", "EventTarget", "HtmlElement", "HtmlInputElement", "HtmlSelectElement", "KeyboardEvent", "Storage", "Window"] }
 log = "0.4"
 console_log = "1"
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -30,6 +30,29 @@
       --mono:         'Share Tech Mono', 'Courier New', monospace;
     }
 
+    /* ── Light theme palette ─────────────────────────────────────────────────── */
+    /* Forest-green on parchment — same mono aesthetic, readable in daylight.
+       Applied via [data-theme="light"] on <html> set by the flash-free init
+       script below; overrides every :root variable so zero inline styles change. */
+    [data-theme="light"] {
+      --bg:           #f5f9f5;
+      --bg-2:         #ebf3eb;
+      --bg-3:         #deeade;
+      --border:       #bfd8bf;
+      --border-hi:    #97c297;
+      --text-ghost:   #88b888;
+      --text-dim:     #527852;
+      --text-mid:     #316331;
+      --text:         #193d19;
+      --text-hi:      #091a09;
+      --accent:       #16a34a;
+      --accent-dim:   #d1fae5;
+      --red:          #dc2626;
+      --red-dim:      #fee2e2;
+      --amber:        #b45309;
+      --amber-dim:    #fef3c7;
+    }
+
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
     html, body {
@@ -126,6 +149,11 @@
       0%,100% { box-shadow: 0 0 0 0 rgba(74,222,128,0.5); }
       50%      { box-shadow: 0 0 0 5px rgba(74,222,128,0); }
     }
+    @keyframes glow-light {
+      0%,100% { box-shadow: 0 0 0 0 rgba(22,163,74,0.5); }
+      50%      { box-shadow: 0 0 0 5px rgba(22,163,74,0); }
+    }
+    [data-theme="light"] .health-dot.ok { animation-name: glow-light; }
 
     .health-status { color: var(--text-mid); letter-spacing: 0.06em; }
     .health-uptime  { color: var(--text-ghost); }
@@ -181,6 +209,19 @@
       line-height: 1;
     }
     .btn-cmdk:hover { color: var(--accent); border-color: var(--border-hi); }
+
+    .btn-theme {
+      background: none;
+      border: 1px solid var(--border);
+      color: var(--text-dim);
+      font-family: var(--mono);
+      font-size: 14px;
+      padding: 4px 10px;
+      cursor: pointer;
+      transition: color 0.12s, border-color 0.12s;
+      line-height: 1;
+    }
+    .btn-theme:hover { color: var(--accent); border-color: var(--border-hi); }
 
     /* ── Command palette (⌘K) ── */
     .cmdk {
@@ -1300,6 +1341,8 @@
     .btn:focus-visible,
     .btn-refresh:focus-visible,
     .btn-stop:focus-visible,
+    .btn-cmdk:focus-visible,
+    .btn-theme:focus-visible,
     .tab-btn:focus-visible,
     .act-btn:focus-visible,
     .view-btn:focus-visible,
@@ -1409,7 +1452,24 @@
       margin-left: 10px; letter-spacing: 0.06em;
       color: var(--text-ghost); text-transform: none;
     }
+
+    /* ── Light-mode heatmap intensity overrides ── */
+    /* lvl-1/2/3 are hardcoded dark-green fills; swap to green-on-light. */
+    [data-theme="light"] .hm-cell.lvl-1 { background: #c7e8c7; }
+    [data-theme="light"] .hm-cell.lvl-2 { background: #7ec87e; }
+    [data-theme="light"] .hm-cell.lvl-3 { background: #3aad5c; }
   </style>
+  <!-- Flash-free theme init: runs synchronously in <head> before first paint.
+       Reads moadim-theme from localStorage and stamps data-theme on <html> so
+       the correct palette is active before the WASM module renders anything. -->
+  <script>
+    (function () {
+      try {
+        var t = localStorage.getItem('moadim-theme');
+        document.documentElement.setAttribute('data-theme', t === 'light' ? 'light' : 'dark');
+      } catch (_) {}
+    })();
+  </script>
 </head>
 <body></body>
 </html>

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -26,6 +26,51 @@ use schedule_heatmap::HeatmapPage;
 
 // ─── Shared types ─────────────────────────────────────────────────────────────
 
+/// Active colour palette. Defaults to dark (the `:root` definition in index.html).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Theme {
+    #[default]
+    Dark,
+    Light,
+}
+
+impl Theme {
+    pub(crate) fn toggle(self) -> Self {
+        match self {
+            Theme::Dark => Theme::Light,
+            Theme::Light => Theme::Dark,
+        }
+    }
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Theme::Dark => "dark",
+            Theme::Light => "light",
+        }
+    }
+    /// Icon shown on the toggle button — indicates the mode you will switch TO.
+    pub(crate) fn icon(self) -> &'static str {
+        match self {
+            Theme::Dark => "☀",
+            Theme::Light => "◑",
+        }
+    }
+    pub(crate) fn aria_label(self) -> &'static str {
+        match self {
+            Theme::Dark => "Switch to light mode",
+            Theme::Light => "Switch to dark mode",
+        }
+    }
+}
+
+/// Parse a `localStorage` value into a [`Theme`]. Any value other than `"light"`
+/// resolves to `Dark`, matching the flash-free script's default behaviour.
+pub(crate) fn parse_theme(val: Option<&str>) -> Theme {
+    match val {
+        Some("light") => Theme::Light,
+        _ => Theme::Dark,
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, PartialEq, Default)]
 pub struct Health {
     pub status: String,
@@ -78,6 +123,7 @@ pub struct ShellState {
     pub next_toast: u32,
     pub show_shutdown: bool,
     pub show_palette: bool,
+    pub theme: Theme,
 }
 
 pub enum ShellAction {
@@ -87,6 +133,7 @@ pub enum ShellAction {
     CloseShutdown,
     TogglePalette,
     ClosePalette,
+    SetTheme(Theme),
 }
 
 impl Reducible for ShellState {
@@ -112,6 +159,7 @@ impl Reducible for ShellState {
             ShellAction::CloseShutdown => s.show_shutdown = false,
             ShellAction::TogglePalette => s.show_palette = !s.show_palette,
             ShellAction::ClosePalette => s.show_palette = false,
+            ShellAction::SetTheme(t) => s.theme = t,
         }
         s.into()
     }
@@ -227,6 +275,19 @@ pub fn shell() -> Html {
         });
     }
 
+    // Read the persisted theme from localStorage on mount and sync the reducer.
+    // The flash-free <script> in index.html already stamped data-theme on <html>
+    // before first paint; this just brings the Rust state into sync with it.
+    {
+        let state = state.clone();
+        use_effect_with((), move |_| {
+            let stored = web_sys::window()
+                .and_then(|w| w.local_storage().ok().flatten())
+                .and_then(|s| s.get_item("moadim-theme").ok().flatten());
+            state.dispatch(ShellAction::SetTheme(parse_theme(stored.as_deref())));
+        });
+    }
+
     let on_toast = {
         let state = state.clone();
         Callback::from(move |(msg, kind): (String, ToastKind)| {
@@ -270,6 +331,25 @@ pub fn shell() -> Html {
     let on_stop = {
         let state = state.clone();
         Callback::from(move |_: MouseEvent| state.dispatch(ShellAction::OpenShutdown))
+    };
+
+    let on_theme = {
+        let state = state.clone();
+        Callback::from(move |_: MouseEvent| {
+            let new_theme = state.theme.toggle();
+            // Stamp data-theme on <html> and persist to localStorage.
+            if let Some(window) = web_sys::window() {
+                if let Some(doc) = window.document() {
+                    if let Some(el) = doc.document_element() {
+                        let _ = el.set_attribute("data-theme", new_theme.as_str());
+                    }
+                }
+                if let Ok(Some(storage)) = window.local_storage() {
+                    let _ = storage.set_item("moadim-theme", new_theme.as_str());
+                }
+            }
+            state.dispatch(ShellAction::SetTheme(new_theme));
+        })
     };
 
     let on_close_shutdown = {
@@ -324,10 +404,11 @@ pub fn shell() -> Html {
     let toasts = state.toasts.clone();
     let show_shutdown = state.show_shutdown;
     let show_palette = state.show_palette;
+    let theme = state.theme;
 
     html! {
         <>
-            <Header health={health} ok={health_ok} on_refresh={on_refresh} on_stop={on_stop} on_palette={on_open_palette} />
+            <Header health={health} ok={health_ok} on_refresh={on_refresh} on_stop={on_stop} on_palette={on_open_palette} on_theme={on_theme} theme={theme} />
             <Nav />
             <Switch<Route> render={switch} />
             <CommandPalette
@@ -392,6 +473,8 @@ pub struct HeaderProps {
     pub on_refresh: Callback<MouseEvent>,
     pub on_stop: Callback<MouseEvent>,
     pub on_palette: Callback<MouseEvent>,
+    pub on_theme: Callback<MouseEvent>,
+    pub theme: Theme,
 }
 
 #[function_component(Header)]
@@ -429,6 +512,9 @@ pub fn header(props: &HeaderProps) -> Html {
                 </div>
                 <button class="btn-cmdk" title="Command palette (⌘K)" aria-label="Open command palette" onclick={props.on_palette.clone()}>
                     {"⌘K"}
+                </button>
+                <button class="btn-theme" title={props.theme.aria_label()} aria-label={props.theme.aria_label()} onclick={props.on_theme.clone()}>
+                    {props.theme.icon()}
                 </button>
                 <button class="btn-refresh" title="Refresh" aria-label="Refresh" onclick={props.on_refresh.clone()}>{"↻"}</button>
                 <button class="btn-stop" title="Stop the server" disabled={!props.ok} onclick={props.on_stop.clone()}>{"⏻ STOP"}</button>
@@ -563,4 +649,57 @@ fn fmt_uptime(secs: u64) -> String {
 fn main() {
     console_log::init_with_level(log::Level::Info).unwrap_or_default();
     yew::Renderer::<App>::new().render();
+}
+
+#[cfg(test)]
+mod main_tests {
+    use super::{parse_theme, Theme};
+
+    #[test]
+    fn parse_theme_none_is_dark() {
+        assert_eq!(parse_theme(None), Theme::Dark);
+    }
+
+    #[test]
+    fn parse_theme_dark_string() {
+        assert_eq!(parse_theme(Some("dark")), Theme::Dark);
+    }
+
+    #[test]
+    fn parse_theme_unrecognised_is_dark() {
+        assert_eq!(parse_theme(Some("system")), Theme::Dark);
+        assert_eq!(parse_theme(Some("")), Theme::Dark);
+    }
+
+    #[test]
+    fn parse_theme_light_string() {
+        assert_eq!(parse_theme(Some("light")), Theme::Light);
+    }
+
+    #[test]
+    fn theme_toggle_cycles() {
+        assert_eq!(Theme::Dark.toggle(), Theme::Light);
+        assert_eq!(Theme::Light.toggle(), Theme::Dark);
+    }
+
+    #[test]
+    fn theme_as_str_round_trips() {
+        assert_eq!(Theme::Dark.as_str(), "dark");
+        assert_eq!(Theme::Light.as_str(), "light");
+        assert_eq!(parse_theme(Some(Theme::Dark.as_str())), Theme::Dark);
+        assert_eq!(parse_theme(Some(Theme::Light.as_str())), Theme::Light);
+    }
+
+    #[test]
+    fn theme_icon_and_label_nonempty() {
+        assert!(!Theme::Dark.icon().is_empty());
+        assert!(!Theme::Light.icon().is_empty());
+        assert!(!Theme::Dark.aria_label().is_empty());
+        assert!(!Theme::Light.aria_label().is_empty());
+    }
+
+    #[test]
+    fn theme_default_is_dark() {
+        assert_eq!(Theme::default(), Theme::Dark);
+    }
 }


### PR DESCRIPTION
## Summary

Adds a **☀ / ◑ theme toggle button** to the dashboard header. Clicking it switches between the existing phosphor-green-on-black dark palette and a new forest-green-on-parchment light palette, with the choice persisted across hard refreshes.

- **Flash-free load** — a tiny synchronous `<script>` in `<head>` reads `localStorage` and stamps `data-theme` on `<html>` before the WASM module initialises, eliminating the white-flash anti-pattern. This is the same technique used by Datadog, Grafana, and GitHub's own UI.
- **CSS-variable swap** — the entire palette is already expressed as `--bg`, `--text`, `--accent`, … CSS variables on `:root`; the light theme adds a `[data-theme="light"]` block that overrides all of them, so no inline styles change.
- **Heatmap overrides** — the three hardcoded dark-green heatmap intensity fills (`lvl-1/2/3`) are overridden with readable greens for light mode.
- **Keyboard accessible** — the button has a descriptive `aria-label` and is included in the existing `:focus-visible` ring rule.
- **8 new host-side unit tests** for `parse_theme`, `Theme::toggle`, `Theme::as_str`, icon/label, and default.

## Changed files (all under `ui/`)

| File | What changed |
|---|---|
| `ui/index.html` | Light palette CSS vars, heatmap lvl overrides, `.btn-theme` style, `glow-light` keyframe, flash-free init script |
| `ui/Cargo.toml` | Added `"Document"` to web-sys features (needed for `document_element()`) |
| `ui/src/main.rs` | `Theme` enum + `parse_theme()`, `SetTheme` action, mount effect, `on_theme` callback, Header props + button |

No backend, API, endpoint, data-model, or `prebuilt.html` changes.

## Test plan

- [ ] `cargo test --package ui` → 167 tests pass
- [ ] `cargo clippy --package ui` → clean
- [ ] `cargo fmt --check --package ui` → clean
- [ ] `git diff --name-only origin/main...HEAD` → only `ui/` files

Closes #674.

---

*This pull request was opened by the UI dashboard feature builder (research → issue → PR → merge) routine of moadim. @tupe12334*

🤖 Generated with [Claude Code](https://claude.com/claude-code)