### PR TITLE
feat(ui): light/dark theme toggle persisted to localStorage (#677)

### DIFF
--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -19,7 +19,7 @@ chrono = "0.4"
 gloo-net = { version = "0.6", features = ["http"] }
 gloo-timers = { version = "0.4", features = ["futures"] }
 js-sys = "0.3"
-web-sys = { version = "0.3", features = ["Element", "EventTarget", "HtmlElement", "HtmlInputElement", "HtmlSelectElement", "KeyboardEvent", "Storage", "Window"] }
+web-sys = { version = "0.3", features = ["Document", "DomTokenList", "Element", "EventTarget", "HtmlElement", "HtmlInputElement", "HtmlSelectElement", "KeyboardEvent", "Storage", "Window"] }
 log = "0.4"
 console_log = "1"
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>MOADIM — Cron Control</title>
+  <script>
+    (function(){var t=localStorage.getItem('moadim.theme');if(t==='light')document.documentElement.classList.add('theme-light');})();
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
   <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet" />
@@ -29,6 +32,29 @@
       --amber-dim:    #271b06;
       --mono:         'Share Tech Mono', 'Courier New', monospace;
     }
+
+    /* ── Light theme — full CSS-variable override so every component inherits ── */
+    html.theme-light {
+      --bg:           #f5f5f0;
+      --bg-2:         #ebebе6;
+      --bg-3:         #e0e0db;
+      --border:       #cccccc;
+      --border-hi:    #aaaaaa;
+      --text-ghost:   #999999;
+      --text-dim:     #666666;
+      --text-mid:     #444444;
+      --text:         #1a1a1a;
+      --text-hi:      #000000;
+      --accent:       #187a3d;
+      --accent-dim:   #e0f5e8;
+      --red:          #b91c1c;
+      --red-dim:      #fee2e2;
+      --amber:        #b45309;
+      --amber-dim:    #fef3c7;
+    }
+    /* Remove terminal eye-candy in bright surroundings */
+    html.theme-light body::before,
+    html.theme-light body::after { opacity: 0; }
 
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -181,6 +207,19 @@
       line-height: 1;
     }
     .btn-cmdk:hover { color: var(--accent); border-color: var(--border-hi); }
+
+    .btn-theme {
+      background: none;
+      border: 1px solid var(--border);
+      color: var(--text-dim);
+      font-family: var(--mono);
+      font-size: 13px;
+      padding: 4px 9px;
+      cursor: pointer;
+      transition: color 0.12s, border-color 0.12s;
+      line-height: 1;
+    }
+    .btn-theme:hover { color: var(--accent); border-color: var(--border-hi); }
 
     /* ── Command palette (⌘K) ── */
     .cmdk {

--- a/ui/src/command_palette.rs
+++ b/ui/src/command_palette.rs
@@ -48,6 +48,8 @@ pub(crate) enum CmdKind {
     ActionRefresh,
     /// Open the stop-server confirmation (the header's ⏻ action).
     ActionStop,
+    /// Toggle the light/dark theme (persisted to localStorage).
+    ActionToggleTheme,
 }
 
 /// The destination page a [`CmdKind`] resolves to, independent of the wasm
@@ -86,7 +88,7 @@ pub(crate) fn route_for(kind: CmdKind) -> Option<RouteKind> {
         CmdKind::NavCronJobs | CmdKind::Cron => Some(RouteKind::CronJobs),
         CmdKind::NavRoutines | CmdKind::Routine => Some(RouteKind::Routines),
         CmdKind::NavHeatmap => Some(RouteKind::Heatmap),
-        CmdKind::ActionRefresh | CmdKind::ActionStop => None,
+        CmdKind::ActionRefresh | CmdKind::ActionStop | CmdKind::ActionToggleTheme => None,
     }
 }
 
@@ -100,7 +102,7 @@ pub(crate) fn badge_for(kind: CmdKind) -> &'static str {
         | CmdKind::NavHeatmap => "GO",
         CmdKind::Cron => "CRON",
         CmdKind::Routine => "ROUTINE",
-        CmdKind::ActionRefresh | CmdKind::ActionStop => "ACTION",
+        CmdKind::ActionRefresh | CmdKind::ActionStop | CmdKind::ActionToggleTheme => "ACTION",
     }
 }
 
@@ -218,6 +220,12 @@ pub(crate) fn build_commands(crons: &[CronJob], routines: &[Routine]) -> Vec<Com
             subtitle: "Shut the moadim server down".into(),
             keywords: "shutdown halt kill quit action".into(),
         },
+        Command {
+            kind: CmdKind::ActionToggleTheme,
+            title: "Toggle Theme".into(),
+            subtitle: "Switch between dark and light mode".into(),
+            keywords: "theme light dark mode toggle appearance action".into(),
+        },
     ];
     for job in crons {
         commands.push(Command {
@@ -301,6 +309,8 @@ pub struct PaletteProps {
     pub on_refresh: Callback<()>,
     /// Runs the "Stop Server" action (open the shutdown confirmation).
     pub on_stop: Callback<()>,
+    /// Runs the "Toggle Theme" action (switch light/dark mode).
+    pub on_toggle_theme: Callback<()>,
 }
 
 /// The ⌘K command palette overlay. Mounted permanently by the shell; renders
@@ -349,6 +359,7 @@ pub fn command_palette(props: &PaletteProps) -> Html {
         let on_close = props.on_close.clone();
         let on_refresh = props.on_refresh.clone();
         let on_stop = props.on_stop.clone();
+        let on_toggle_theme = props.on_toggle_theme.clone();
         let commands = commands.clone();
         let order = order.clone();
         Callback::from(move |row: usize| {
@@ -356,6 +367,7 @@ pub fn command_palette(props: &PaletteProps) -> Html {
                 match command.kind {
                     CmdKind::ActionRefresh => on_refresh.emit(()),
                     CmdKind::ActionStop => on_stop.emit(()),
+                    CmdKind::ActionToggleTheme => on_toggle_theme.emit(()),
                     kind => {
                         if let (Some(nav), Some(route_kind)) = (navigator.clone(), route_for(kind))
                         {
@@ -438,7 +450,9 @@ pub fn command_palette(props: &PaletteProps) -> Html {
             let badge_cls = match command.kind {
                 CmdKind::Cron => "kind-badge cron",
                 CmdKind::Routine => "kind-badge routine",
-                CmdKind::ActionRefresh | CmdKind::ActionStop => "kind-badge action",
+                CmdKind::ActionRefresh
+                | CmdKind::ActionStop
+                | CmdKind::ActionToggleTheme => "kind-badge action",
                 _ => "kind-badge nav",
             };
             let launch = launch.clone();

--- a/ui/src/command_palette_tests.rs
+++ b/ui/src/command_palette_tests.rs
@@ -162,21 +162,23 @@ fn build_lists_pages_then_crons_then_routines() {
     let crons = vec![cron("backup", "0 * * * *", "snapshot", Some("Every hour"))];
     let routines = vec![routine("r1", "Nightly Audit", "claude", "0 0 * * *", None)];
     let commands = build_commands(&crons, &routines);
-    assert_eq!(commands.len(), 8); // 4 nav + 2 action + 1 cron + 1 routine
+    assert_eq!(commands.len(), 9); // 4 nav + 3 action + 1 cron + 1 routine
     assert_eq!(commands[0].kind, CmdKind::NavOverview);
     assert_eq!(commands[1].kind, CmdKind::NavCronJobs);
     assert_eq!(commands[2].kind, CmdKind::NavRoutines);
     assert_eq!(commands[3].kind, CmdKind::NavHeatmap);
     assert_eq!(commands[4].kind, CmdKind::ActionRefresh);
     assert_eq!(commands[5].kind, CmdKind::ActionStop);
-    assert_eq!(commands[6].kind, CmdKind::Cron);
-    assert_eq!(commands[6].title, "backup");
-    assert_eq!(commands[6].subtitle, "Every hour"); // human description wins
-    assert!(commands[6].keywords.contains("snapshot"));
-    assert_eq!(commands[7].kind, CmdKind::Routine);
-    assert_eq!(commands[7].title, "Nightly Audit");
-    assert_eq!(commands[7].subtitle, "0 0 * * *"); // falls back to raw expr
-    assert!(commands[7].keywords.contains("claude"));
+    assert_eq!(commands[6].kind, CmdKind::ActionToggleTheme);
+    assert!(commands[6].keywords.contains("theme"));
+    assert_eq!(commands[7].kind, CmdKind::Cron);
+    assert_eq!(commands[7].title, "backup");
+    assert_eq!(commands[7].subtitle, "Every hour"); // human description wins
+    assert!(commands[7].keywords.contains("snapshot"));
+    assert_eq!(commands[8].kind, CmdKind::Routine);
+    assert_eq!(commands[8].title, "Nightly Audit");
+    assert_eq!(commands[8].subtitle, "0 0 * * *"); // falls back to raw expr
+    assert!(commands[8].keywords.contains("claude"));
 }
 
 #[test]
@@ -208,6 +210,7 @@ fn route_for_maps_every_kind() {
     // Action commands run a callback, not a navigation.
     assert_eq!(route_for(CmdKind::ActionRefresh), None);
     assert_eq!(route_for(CmdKind::ActionStop), None);
+    assert_eq!(route_for(CmdKind::ActionToggleTheme), None);
 }
 
 #[test]
@@ -220,6 +223,7 @@ fn badge_for_maps_every_kind() {
     assert_eq!(badge_for(CmdKind::Routine), "ROUTINE");
     assert_eq!(badge_for(CmdKind::ActionRefresh), "ACTION");
     assert_eq!(badge_for(CmdKind::ActionStop), "ACTION");
+    assert_eq!(badge_for(CmdKind::ActionToggleTheme), "ACTION");
 }
 
 // ─── selection-index helpers ───────────────────────────────────────────────────

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -24,6 +24,41 @@ use overview::OverviewPage;
 use routines::RoutinesPage;
 use schedule_heatmap::HeatmapPage;
 
+// ─── Theme ────────────────────────────────────────────────────────────────────
+
+/// localStorage key for the theme preference.
+pub(crate) const THEME_KEY: &str = "moadim.theme";
+
+/// Read the persisted theme from localStorage. Returns `true` for light theme.
+pub(crate) fn load_theme_light() -> bool {
+    web_sys::window()
+        .and_then(|win| win.local_storage().ok().flatten())
+        .and_then(|store| store.get_item(THEME_KEY).ok().flatten())
+        .is_some_and(|val| val == "light")
+}
+
+/// Persist the theme choice to localStorage (best-effort; ignores storage errors).
+pub(crate) fn save_theme_light(light: bool) {
+    if let Some(store) = web_sys::window().and_then(|win| win.local_storage().ok().flatten()) {
+        let _ = store.set_item(THEME_KEY, if light { "light" } else { "dark" });
+    }
+}
+
+/// Apply or remove the `theme-light` CSS class from `<html>`.
+pub(crate) fn apply_theme(light: bool) {
+    if let Some(root) = web_sys::window()
+        .and_then(|win| win.document())
+        .and_then(|doc| doc.document_element())
+    {
+        let list = root.class_list();
+        if light {
+            let _ = list.add_1("theme-light");
+        } else {
+            let _ = list.remove_1("theme-light");
+        }
+    }
+}
+
 // ─── Shared types ─────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Default)]
@@ -78,6 +113,8 @@ pub struct ShellState {
     pub next_toast: u32,
     pub show_shutdown: bool,
     pub show_palette: bool,
+    /// `true` when the light theme is active; persisted to localStorage.
+    pub show_theme_light: bool,
 }
 
 pub enum ShellAction {
@@ -87,6 +124,7 @@ pub enum ShellAction {
     CloseShutdown,
     TogglePalette,
     ClosePalette,
+    ToggleTheme,
 }
 
 impl Reducible for ShellState {
@@ -112,6 +150,11 @@ impl Reducible for ShellState {
             ShellAction::CloseShutdown => s.show_shutdown = false,
             ShellAction::TogglePalette => s.show_palette = !s.show_palette,
             ShellAction::ClosePalette => s.show_palette = false,
+            ShellAction::ToggleTheme => {
+                s.show_theme_light = !s.show_theme_light;
+                save_theme_light(s.show_theme_light);
+                apply_theme(s.show_theme_light);
+            }
         }
         s.into()
     }
@@ -174,7 +217,18 @@ pub fn app() -> Html {
 /// the global shutdown dialog, and the toast stack. Lives inside the router so nav `Link`s work.
 #[function_component(Shell)]
 pub fn shell() -> Html {
-    let state = use_reducer(ShellState::default);
+    let state = use_reducer(|| ShellState {
+        show_theme_light: load_theme_light(),
+        ..ShellState::default()
+    });
+
+    // Apply the initial theme class from persisted preference.
+    {
+        let light = state.show_theme_light;
+        use_effect_with((), move |_| {
+            apply_theme(light);
+        });
+    }
 
     // Initial health poll on mount.
     {
@@ -257,6 +311,10 @@ pub fn shell() -> Html {
         let state = state.clone();
         Callback::from(move |_: ()| state.dispatch(ShellAction::OpenShutdown))
     };
+    let on_palette_toggle_theme = {
+        let state = state.clone();
+        Callback::from(move |_: ()| state.dispatch(ShellAction::ToggleTheme))
+    };
 
     let on_refresh = {
         let state = state.clone();
@@ -324,10 +382,15 @@ pub fn shell() -> Html {
     let toasts = state.toasts.clone();
     let show_shutdown = state.show_shutdown;
     let show_palette = state.show_palette;
+    let show_theme_light = state.show_theme_light;
+    let on_theme = {
+        let state = state.clone();
+        Callback::from(move |_: MouseEvent| state.dispatch(ShellAction::ToggleTheme))
+    };
 
     html! {
         <>
-            <Header health={health} ok={health_ok} on_refresh={on_refresh} on_stop={on_stop} on_palette={on_open_palette} />
+            <Header health={health} ok={health_ok} light={show_theme_light} on_refresh={on_refresh} on_stop={on_stop} on_palette={on_open_palette} on_theme={on_theme} />
             <Nav />
             <Switch<Route> render={switch} />
             <CommandPalette
@@ -335,6 +398,7 @@ pub fn shell() -> Html {
                 on_close={on_close_palette}
                 on_refresh={on_palette_refresh}
                 on_stop={on_palette_stop}
+                on_toggle_theme={on_palette_toggle_theme}
             />
             {
                 if show_shutdown {
@@ -389,9 +453,12 @@ pub fn nav() -> Html {
 pub struct HeaderProps {
     pub health: Health,
     pub ok: bool,
+    /// `true` when the light theme is active (controls the toggle button icon).
+    pub light: bool,
     pub on_refresh: Callback<MouseEvent>,
     pub on_stop: Callback<MouseEvent>,
     pub on_palette: Callback<MouseEvent>,
+    pub on_theme: Callback<MouseEvent>,
 }
 
 #[function_component(Header)]
@@ -413,6 +480,12 @@ pub fn header(props: &HeaderProps) -> Html {
         .uptime_secs
         .map(|s| format!("/ UP {}", fmt_uptime(s)))
         .unwrap_or_default();
+    let theme_icon = if props.light { "☀" } else { "🌙" };
+    let theme_title = if props.light {
+        "Switch to dark mode"
+    } else {
+        "Switch to light mode"
+    };
 
     html! {
         <header>
@@ -427,6 +500,9 @@ pub fn header(props: &HeaderProps) -> Html {
                     <span class="health-status">{status}</span>
                     <span class="health-uptime">{uptime}</span>
                 </div>
+                <button class="btn-theme" title={theme_title} aria-label={theme_title} onclick={props.on_theme.clone()}>
+                    {theme_icon}
+                </button>
                 <button class="btn-cmdk" title="Command palette (⌘K)" aria-label="Open command palette" onclick={props.on_palette.clone()}>
                     {"⌘K"}
                 </button>


### PR DESCRIPTION
## Summary

Closes #677.

This PR implements a flash-free light/dark theme toggle for the operations dashboard, following best practices from Datadog, Linear, and Next.js `next-themes`.

- **Flash-free init**: an inline `<script>` in `<head>` reads `localStorage['moadim.theme']` and applies `theme-light` to `<html>` before the first paint — no FOUC on reload.
- **CSS variable override**: `html.theme-light` re-declares every `--bg-*`, `--text-*`, `--accent-*`, `--red-*`, and `--amber-*` token to a clean light palette; no per-component changes needed. Scanline eye-candy is hidden in light mode.
- **Header button**: a ☀/🌙 button (`btn-theme`) sits next to ⌘K; icon and aria-label reflect the active theme.
- **Command palette**: adds `ActionToggleTheme` to the ⌘K palette (keywords: theme, light, dark, mode, appearance) so keyboard-first operators never need to reach for the mouse.

## Files changed (all under `ui/`)

| File | Change |
|------|--------|
| `ui/Cargo.toml` | Add `Document`, `DomTokenList` web-sys features for classList manipulation |
| `ui/index.html` | Flash-free init script + `html.theme-light` CSS overrides + `btn-theme` style |
| `ui/src/main.rs` | `THEME_KEY`, `load_theme_light`, `save_theme_light`, `apply_theme`; `ShellState.show_theme_light`; `ShellAction::ToggleTheme`; Header `light` + `on_theme` props |
| `ui/src/command_palette.rs` | `CmdKind::ActionToggleTheme`; wired into `launch` callback and badge/route match |
| `ui/src/command_palette_tests.rs` | Updated command count (8→9); added assertions for `ActionToggleTheme` in all three test functions |

## Test plan

- [ ] CI green (rustfmt, clippy, cargo test, typos, unreleased-entry)
- [ ] `git diff --name-only origin/main...HEAD` shows only `ui/` paths — confirmed before opening

---
*This pull request was opened by the **UI dashboard feature builder (research → issue → PR → merge)** routine of moadim. Tagging @tupe12334 for visibility.*