### PR TITLE
feat(ui): bulk actions for the Routines page — select, enable, disable, delete (#676)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Added
 
+- **Bulk actions for the Routines page.** Each routine row now has a leading selection
+  checkbox; a header checkbox toggles "all visible selected ↔ none" (respects the active
+  filter so hidden rows are never touched). When at least one routine is selected, a
+  floating bulk-action bar appears with **ENABLE**, **DISABLE**, and **DELETE** actions plus
+  a **CLEAR** affordance. Bulk enable/disable fires `PATCH /routines/{id}` for each
+  selected routine and surfaces a single summary toast. Bulk delete shows a confirmation
+  dialog and removes via `DELETE /routines/{id}`. Selection is automatically pruned on
+  reload so stale IDs never carry over. Pure frontend — no backend change. Closes #676.
 - **Light/dark theme toggle.** A ☀/🌙 button in the header switches between the dark
   terminal aesthetic and a clean light palette. The choice persists to `localStorage`
   under `moadim.theme` and is applied flash-free via an inline `<head>` script before

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -459,6 +459,7 @@ pub enum RModal {
     None,
     Edit(String),
     ConfirmDelete { id: String, title: String },
+    ConfirmBulkDelete { count: usize },
 }
 
 /// How the list page presents routines: a table, or a month calendar of upcoming fire times.
@@ -515,6 +516,8 @@ pub struct RState {
     pub sort: RSort,
     /// `true` sorts descending (newest / Z→A first).
     pub sort_desc: bool,
+    /// IDs of currently selected routines (multiselect for bulk actions).
+    pub selected: BTreeSet<String>,
 }
 
 impl Default for RState {
@@ -528,6 +531,7 @@ impl Default for RState {
             filter: RoutineFilter::default(),
             sort: RSort::default(),
             sort_desc: false,
+            selected: BTreeSet::new(),
         }
     }
 }
@@ -538,7 +542,11 @@ pub enum RAction {
     GoToList,
     GoToLogs(String),
     OpenEdit(String),
-    OpenConfirmDelete { id: String, title: String },
+    OpenConfirmDelete {
+        id: String,
+        title: String,
+    },
+    OpenConfirmBulkDelete,
     CloseModal,
     SetView(RView),
     SetQuery(String),
@@ -550,6 +558,14 @@ pub enum RAction {
     ToggleSortDir,
     Upsert(Box<Routine>),
     Remove(String),
+    /// Remove multiple routines after a confirmed bulk delete.
+    RemoveMany(Vec<String>),
+    /// Toggle one routine in/out of the selection set.
+    SelectRoutine(String),
+    /// Select exactly the given (visible/filtered) routine ids.
+    SelectAll(Vec<String>),
+    /// Clear the entire selection.
+    ClearSelection,
 }
 
 impl Reducible for RState {
@@ -559,6 +575,9 @@ impl Reducible for RState {
         let mut s = (*self).clone();
         match action {
             RAction::Loaded(r) => {
+                // Drop selections for routines that no longer exist after a reload.
+                let ids: BTreeSet<&String> = r.iter().map(|x| &x.id).collect();
+                s.selected.retain(|id| ids.contains(id));
                 s.routines = r;
                 s.loading = false;
             }
@@ -568,6 +587,11 @@ impl Reducible for RState {
             RAction::OpenEdit(id) => s.modal = RModal::Edit(id),
             RAction::OpenConfirmDelete { id, title } => {
                 s.modal = RModal::ConfirmDelete { id, title }
+            }
+            RAction::OpenConfirmBulkDelete => {
+                s.modal = RModal::ConfirmBulkDelete {
+                    count: s.selected.len(),
+                };
             }
             RAction::CloseModal => s.modal = RModal::None,
             RAction::SetView(view) => s.view = view,
@@ -586,7 +610,26 @@ impl Reducible for RState {
                     s.routines.push(routine);
                 }
             }
-            RAction::Remove(id) => s.routines.retain(|x| x.id != id),
+            RAction::Remove(id) => {
+                s.routines.retain(|x| x.id != id);
+                s.selected.remove(&id);
+            }
+            RAction::RemoveMany(ids) => {
+                let drop: BTreeSet<&String> = ids.iter().collect();
+                s.routines.retain(|r| !drop.contains(&r.id));
+                s.selected.retain(|id| !drop.contains(id));
+            }
+            RAction::SelectRoutine(id) => {
+                if !s.selected.remove(&id) {
+                    s.selected.insert(id);
+                }
+            }
+            RAction::SelectAll(ids) => {
+                s.selected = ids.into_iter().collect();
+            }
+            RAction::ClearSelection => {
+                s.selected.clear();
+            }
         }
         s.into()
     }
@@ -942,6 +985,118 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
         })
     };
 
+    // ── Bulk selection ────────────────────────────────────────────────────────
+    let on_select = {
+        let state = state.clone();
+        Callback::from(move |id: String| state.dispatch(RAction::SelectRoutine(id)))
+    };
+
+    // Header checkbox: toggle "all visible selected ↔ none" (filter-scoped).
+    let on_select_all = {
+        let state = state.clone();
+        let now = now.clone();
+        Callback::from(move |_: ()| {
+            let window = Duration::seconds(DUE_SOON_WINDOW_SECS);
+            let visible = filter_routines(&state.routines, &state.filter, *now, window);
+            let all_visible_selected =
+                !visible.is_empty() && visible.iter().all(|r| state.selected.contains(&r.id));
+            if all_visible_selected {
+                state.dispatch(RAction::ClearSelection);
+            } else {
+                state.dispatch(RAction::SelectAll(
+                    visible.into_iter().map(|r| r.id).collect(),
+                ));
+            }
+        })
+    };
+
+    let on_clear_selection = {
+        let state = state.clone();
+        Callback::from(move |_: ()| state.dispatch(RAction::ClearSelection))
+    };
+
+    // Bulk enable/disable: PATCH each selected routine, surface one summary toast.
+    let bulk_set_enabled = {
+        let state = state.clone();
+        let toast = toast.clone();
+        move |enabled: bool| {
+            let state = state.clone();
+            let toast = toast.clone();
+            let ids: Vec<String> = state.selected.iter().cloned().collect();
+            if ids.is_empty() {
+                return;
+            }
+            spawn_local(async move {
+                let mut ok = 0usize;
+                let mut failed = 0usize;
+                for id in ids {
+                    let req = UpdateRoutineRequest {
+                        enabled: Some(enabled),
+                        ..Default::default()
+                    };
+                    match api_update(&id, &req).await {
+                        Ok(r) => {
+                            state.dispatch(RAction::Upsert(Box::new(r)));
+                            ok += 1;
+                        }
+                        Err(_) => failed += 1,
+                    }
+                }
+                let verb = if enabled { "enabled" } else { "disabled" };
+                if failed == 0 {
+                    toast.emit((format!("{ok} routine(s) {verb}"), ToastKind::Ok));
+                } else {
+                    toast.emit((format!("{ok} {verb}, {failed} failed"), ToastKind::Err));
+                }
+            });
+        }
+    };
+
+    let on_bulk_enable = {
+        let f = bulk_set_enabled.clone();
+        Callback::from(move |_: ()| f(true))
+    };
+    let on_bulk_disable = {
+        let f = bulk_set_enabled.clone();
+        Callback::from(move |_: ()| f(false))
+    };
+
+    let on_bulk_delete = {
+        let state = state.clone();
+        Callback::from(move |_: ()| state.dispatch(RAction::OpenConfirmBulkDelete))
+    };
+
+    let on_confirm_bulk_delete = {
+        let state = state.clone();
+        let toast = toast.clone();
+        Callback::from(move |_: ()| {
+            let state = state.clone();
+            let toast = toast.clone();
+            let ids: Vec<String> = state.selected.iter().cloned().collect();
+            spawn_local(async move {
+                let mut ok = 0usize;
+                let mut failed = 0usize;
+                let mut deleted: Vec<String> = Vec::new();
+                for id in ids {
+                    match api_delete(&id).await {
+                        Ok(()) => {
+                            deleted.push(id);
+                            ok += 1;
+                        }
+                        Err(_) => failed += 1,
+                    }
+                }
+                state.dispatch(RAction::RemoveMany(deleted));
+                state.dispatch(RAction::CloseModal);
+                if failed == 0 {
+                    toast.emit((format!("{ok} routine(s) deleted"), ToastKind::Ok));
+                } else {
+                    toast.emit((format!("{ok} deleted, {failed} failed"), ToastKind::Err));
+                }
+            });
+        })
+    };
+
     let routines = state.routines.clone();
     let loading = state.loading;
     let page = state.page.clone();
@@ -950,6 +1105,7 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
     let filter = state.filter.clone();
     let sort = state.sort;
     let sort_desc = state.sort_desc;
+    let selected = state.selected.clone();
 
     // Faceted filter + sort applied client-side.
     let now_val = *now;
@@ -1036,6 +1192,13 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
                                 on_set_sort={on_set_sort}
                                 on_toggle_sort_dir={on_toggle_sort_dir}
                             />
+                            <RoutineBulkBar
+                                count={selected.len()}
+                                on_enable={on_bulk_enable}
+                                on_disable={on_bulk_disable}
+                                on_delete={on_bulk_delete}
+                                on_clear={on_clear_selection}
+                            />
                             {
                                 match view {
                                     RView::Table => html! {
@@ -1044,6 +1207,9 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
                                             loading={loading}
                                             filter_active={filter_active}
                                             now={now_val}
+                                            selected={selected.clone()}
+                                            on_select={on_select}
+                                            on_select_all={on_select_all}
                                             on_edit={on_edit}
                                             on_delete={on_ask_delete}
                                             on_toggle={on_toggle}
@@ -1079,6 +1245,13 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
                             title={title.clone()}
                             on_cancel={on_close}
                             on_confirm={on_confirm_delete}
+                        />
+                    },
+                    RModal::ConfirmBulkDelete { count } => html! {
+                        <RoutineBulkDeleteDialog
+                            count={*count}
+                            on_cancel={on_close}
+                            on_confirm={on_confirm_bulk_delete}
                         />
                     },
                     RModal::None => html! {},
@@ -1525,6 +1698,12 @@ pub struct TableProps {
     pub filter_active: bool,
     /// Reference instant used to compute next-fire countdowns.
     pub now: chrono::DateTime<Local>,
+    /// Set of currently selected routine IDs.
+    pub selected: BTreeSet<String>,
+    /// Fired when the user clicks a row's selection checkbox.
+    pub on_select: Callback<String>,
+    /// Fired when the header checkbox is clicked (toggles all-visible).
+    pub on_select_all: Callback<()>,
     pub on_edit: Callback<String>,
     pub on_delete: Callback<(String, String)>,
     pub on_toggle: Callback<(String, bool)>,
@@ -1575,11 +1754,30 @@ pub fn routine_table(props: &TableProps) -> Html {
         };
     }
 
+    let all_visible_selected = !props.routines.is_empty()
+        && props
+            .routines
+            .iter()
+            .all(|r| props.selected.contains(&r.id));
+    let on_select_all = {
+        let cb = props.on_select_all.clone();
+        Callback::from(move |_: MouseEvent| cb.emit(()))
+    };
+
     html! {
         <div class="table-wrap">
             <table>
                 <thead>
                     <tr>
+                        <th class="col-select">
+                            <input
+                                type="checkbox"
+                                checked={all_visible_selected}
+                                onclick={on_select_all}
+                                aria-label="Select all visible routines"
+                                title="Select all visible"
+                            />
+                        </th>
                         <th>{"TITLE"}</th>
                         <th>{"SCHEDULE"}</th>
                         <th>{"NEXT RUN"}</th>
@@ -1597,6 +1795,8 @@ pub fn routine_table(props: &TableProps) -> Html {
                             key={r.id.clone()}
                             routine={r.clone()}
                             now={props.now}
+                            selected={props.selected.contains(&r.id)}
+                            on_select={props.on_select.clone()}
                             on_edit={props.on_edit.clone()}
                             on_delete={props.on_delete.clone()}
                             on_toggle={props.on_toggle.clone()}
@@ -1642,6 +1842,10 @@ pub struct RowProps {
     pub routine: Routine,
     /// Reference instant for the NEXT RUN countdown.
     pub now: chrono::DateTime<Local>,
+    /// Whether this row is currently selected.
+    pub selected: bool,
+    /// Fired when the selection checkbox is clicked.
+    pub on_select: Callback<String>,
     pub on_edit: Callback<String>,
     pub on_delete: Callback<(String, String)>,
     pub on_toggle: Callback<(String, bool)>,
@@ -1684,6 +1888,12 @@ pub fn routine_row(props: &RowProps) -> Html {
         Callback::from(move |_: MouseEvent| cb.emit(id.clone()))
     };
 
+    let on_select = {
+        let cb = props.on_select.clone();
+        let id = r.id.clone();
+        Callback::from(move |_: MouseEvent| cb.emit(id.clone()))
+    };
+
     let last_run: Html = {
         let manual = r.last_manual_trigger_at;
         let scheduled = r.last_scheduled_trigger_at;
@@ -1720,7 +1930,11 @@ pub fn routine_row(props: &RowProps) -> Html {
     let next_run = next_routine_run_cell(r, props.now);
 
     html! {
-        <tr>
+        <tr class={if props.selected { "row-selected" } else { "" }}>
+            <td class="col-select">
+                <input type="checkbox" checked={props.selected} onclick={on_select}
+                    aria-label={format!("Select {}", r.title)} />
+            </td>
             <td>
                 <div class="cell-schedule" title={r.id.clone()}>{&r.title}</div>
             </td>
@@ -2105,6 +2319,79 @@ pub fn routine_form(props: &FormProps) -> Html {
                 </div>
             </main>
         }
+    }
+}
+
+// ─── Bulk action bar ──────────────────────────────────────────────────────────
+
+#[derive(Properties, PartialEq)]
+pub struct RoutineBulkBarProps {
+    pub count: usize,
+    pub on_enable: Callback<()>,
+    pub on_disable: Callback<()>,
+    pub on_delete: Callback<()>,
+    pub on_clear: Callback<()>,
+}
+
+/// Floating bulk-action toolbar. Hidden until at least one routine is selected.
+///
+/// Best-practice (Eleken UX guide, GitHub Actions): the bar appears in-context
+/// as soon as a row is selected, shows the count, and offers primary actions
+/// (enable/disable/delete) plus a clear affordance — no separate "actions" menu
+/// needed.
+#[function_component(RoutineBulkBar)]
+pub fn routine_bulk_bar(props: &RoutineBulkBarProps) -> Html {
+    if props.count == 0 {
+        return html! {};
+    }
+    let mk = |cb: Callback<()>| Callback::from(move |_: MouseEvent| cb.emit(()));
+
+    html! {
+        <div class="bulk-bar">
+            <span class="bulk-count">{ format!("{} SELECTED", props.count) }</span>
+            <div class="bulk-acts">
+                <button class="btn btn-ghost btn-sm" onclick={mk(props.on_enable.clone())}>{"ENABLE"}</button>
+                <button class="btn btn-ghost btn-sm" onclick={mk(props.on_disable.clone())}>{"DISABLE"}</button>
+                <button class="btn btn-danger btn-sm" onclick={mk(props.on_delete.clone())}>{"DELETE"}</button>
+                <button class="btn btn-ghost btn-sm" onclick={mk(props.on_clear.clone())}>{"CLEAR"}</button>
+            </div>
+        </div>
+    }
+}
+
+// ─── Bulk delete confirm dialog ───────────────────────────────────────────────
+
+#[derive(Properties, PartialEq)]
+pub struct RoutineBulkDeleteProps {
+    pub count: usize,
+    pub on_cancel: Callback<()>,
+    pub on_confirm: Callback<()>,
+}
+
+#[function_component(RoutineBulkDeleteDialog)]
+pub fn routine_bulk_delete_dialog(props: &RoutineBulkDeleteProps) -> Html {
+    let on_cancel = {
+        let cb = props.on_cancel.clone();
+        Callback::from(move |_: MouseEvent| cb.emit(()))
+    };
+    let on_confirm = {
+        let cb = props.on_confirm.clone();
+        Callback::from(move |_: MouseEvent| cb.emit(()))
+    };
+
+    html! {
+        <div class="overlay open">
+            <div class="confirm-dialog">
+                <div class="confirm-title">{"⚠ DELETE ROUTINES"}</div>
+                <div class="confirm-msg">
+                    { format!("Delete {} selected routine(s)? This cannot be undone.", props.count) }
+                </div>
+                <div class="confirm-acts">
+                    <button class="btn btn-ghost btn-sm" onclick={on_cancel}>{"CANCEL"}</button>
+                    <button class="btn btn-danger btn-sm" onclick={on_confirm}>{"DELETE"}</button>
+                </div>
+            </div>
+        </div>
     }
 }
 

--- a/ui/src/routines_tests.rs
+++ b/ui/src/routines_tests.rs
@@ -437,3 +437,96 @@ fn unassigned_routines_count_counts_empty_machine_lists() {
     ];
     assert_eq!(unassigned_routines_count(&routines), 2);
 }
+
+// ── Bulk selection reducer actions ────────────────────────────────────────────
+
+use std::rc::Rc;
+use yew::Reducible;
+
+fn state_with_routines(ids: &[&str]) -> Rc<RState> {
+    let routines = ids
+        .iter()
+        .map(|id| routine(id, id, "claude", "0 * * * *", &["m1"], &[], true))
+        .collect();
+    Rc::new(RState {
+        routines,
+        loading: false,
+        ..RState::default()
+    })
+}
+
+#[test]
+fn select_routine_adds_id_to_selection() {
+    let s = state_with_routines(&["a", "b"]);
+    let s = s.reduce(RAction::SelectRoutine("a".into()));
+    assert!(s.selected.contains("a"));
+    assert!(!s.selected.contains("b"));
+}
+
+#[test]
+fn select_routine_toggles_already_selected_id_out() {
+    let s = state_with_routines(&["a"]);
+    let s = s.reduce(RAction::SelectRoutine("a".into()));
+    assert!(s.selected.contains("a"));
+    let s = s.reduce(RAction::SelectRoutine("a".into()));
+    assert!(!s.selected.contains("a"));
+}
+
+#[test]
+fn select_all_replaces_selection() {
+    let s = state_with_routines(&["a", "b", "c"]);
+    let s = s.reduce(RAction::SelectAll(vec!["a".into(), "c".into()]));
+    assert!(s.selected.contains("a"));
+    assert!(!s.selected.contains("b"));
+    assert!(s.selected.contains("c"));
+}
+
+#[test]
+fn clear_selection_empties_all() {
+    let s = state_with_routines(&["a", "b"]);
+    let s = s.reduce(RAction::SelectAll(vec!["a".into(), "b".into()]));
+    assert_eq!(s.selected.len(), 2);
+    let s = s.reduce(RAction::ClearSelection);
+    assert!(s.selected.is_empty());
+}
+
+#[test]
+fn open_confirm_bulk_delete_sets_modal_with_count() {
+    let s = state_with_routines(&["a", "b"]);
+    let s = s.reduce(RAction::SelectAll(vec!["a".into(), "b".into()]));
+    let s = s.reduce(RAction::OpenConfirmBulkDelete);
+    assert_eq!(s.modal, RModal::ConfirmBulkDelete { count: 2 });
+}
+
+#[test]
+fn remove_many_removes_routines_and_clears_from_selection() {
+    let s = state_with_routines(&["a", "b", "c"]);
+    let s = s.reduce(RAction::SelectAll(vec!["a".into(), "b".into(), "c".into()]));
+    let s = s.reduce(RAction::RemoveMany(vec!["a".into(), "c".into()]));
+    assert_eq!(s.routines.len(), 1);
+    assert_eq!(s.routines[0].id, "b");
+    assert!(!s.selected.contains("a"));
+    assert!(s.selected.contains("b"));
+    assert!(!s.selected.contains("c"));
+}
+
+#[test]
+fn loaded_drops_stale_selections() {
+    let s = state_with_routines(&["a", "b"]);
+    let s = s.reduce(RAction::SelectAll(vec!["a".into(), "b".into()]));
+    // Reload with only "a" — "b" should be dropped from selection.
+    let new_routines = vec![routine("a", "a", "claude", "0 * * * *", &["m1"], &[], true)];
+    let s = s.reduce(RAction::Loaded(new_routines));
+    assert!(s.selected.contains("a"));
+    assert!(!s.selected.contains("b"));
+}
+
+#[test]
+fn remove_also_clears_from_selection() {
+    let s = state_with_routines(&["a", "b"]);
+    let s = s.reduce(RAction::SelectAll(vec!["a".into(), "b".into()]));
+    let s = s.reduce(RAction::Remove("a".into()));
+    assert!(!s.selected.contains("a"));
+    assert!(s.selected.contains("b"));
+    assert_eq!(s.routines.len(), 1);
+}


### PR DESCRIPTION
## Summary

- Adds row-selection checkboxes to the Routines table and a floating **bulk-action toolbar** that appears as soon as one row is selected
- Header checkbox toggles "all visible selected ↔ none" (filter-scoped — hidden rows are never touched)
- Toolbar buttons: **ENABLE**, **DISABLE**, **DELETE** (with confirmation dialog), **CLEAR**
- Bulk enable/disable fires `PATCH /routines/{id}` for each selected routine in sequence and surfaces a single summary toast
- Bulk delete shows a confirmation dialog, then removes via `DELETE /routines/{id}`, then cleans state
- Selection is automatically pruned on reload so stale IDs never carry forward

## Best-practice rationale (from issue #676)

> "Checkboxes are the clearest way to signify that users can select more than one item. A floating toolbar that appears on selection keeps the interaction visible without cluttering the default view." — [Eleken bulk-actions UX guide](https://www.eleken.co/blog-posts/bulk-actions-ux)

The **Cron Jobs** page already ships this exact pattern. The Routines page — the primary operational surface — was the only place forcing one-at-a-time operations.

## What changed

| File | What |
|---|---|
| `ui/src/routines.rs` | `RModal::ConfirmBulkDelete`, `RState.selected`, `RAction` variants, reducer, `RoutineBulkBar`, `RoutineBulkDeleteDialog`, `TableProps`/`RowProps` updated |
| `ui/src/routines_tests.rs` | 8 new reducer tests covering `SelectRoutine`, `SelectAll`, `ClearSelection`, `OpenConfirmBulkDelete`, `RemoveMany`, `Loaded` / `Remove` selection pruning |
| `CHANGELOG.md` | Unreleased entry |

## Verification

- `cargo test -p ui` — 167 tests pass (was 159)
- `cargo clippy -p ui` — clean
- `cargo fmt --check` — clean
- `git diff --name-only origin/main...HEAD` — only `CHANGELOG.md` + `ui/src/` files

Closes #676.

---
*This pull request was opened by the **UI dashboard feature builder (research → issue → PR → merge)** routine of moadim. @tupe12334*