### PR TITLE
chore(meta): fix homepage URL and improve crate description

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ opt-level = "z"
 name = "moadim"
 version = "0.15.0"
 edition = "2021"
-description = "Moadim.io MCP/REST server for managing cron jobs"
+description = "Loop engine for AI agents — cron jobs and routines over REST, MCP, and a built-in web UI"
 license = "MIT"
 repository = "https://github.com/moadim-io/daemon"
-homepage = "https://github.com/moadim-io/daemon"
+homepage = "https://moadim.io"
 keywords = ["cron", "scheduler", "mcp", "automation", "rest"]
 categories = ["command-line-utilities", "web-programming::http-server"]
 


### PR DESCRIPTION
## Why

`Cargo.toml` listed `homepage = "https://github.com/moadim-io/daemon"` — the same URL as the `repository` field. crates.io renders both links side-by-side, so the duplicate was redundant and wasted a slot that should point users to the product page.

The `description` said \"MCP/REST server for managing cron jobs\" but the daemon also schedules AI-agent **routines** and ships a **built-in web UI**. The old text undersold the tool and wouldn't match search terms like \"AI agent scheduler\".

## What changed

- `homepage` now points at `https://moadim.io` (the canonical product URL, not the repo mirror).
- `description` reworded to \"Loop engine for AI agents — cron jobs and routines over REST, MCP, and a built-in web UI\", which accurately covers all three interfaces.

No source files changed (`src/`, `ui/`), so no `CHANGELOG.md` entry is required.

---

@tupe12334 — This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.