### PR TITLE
feat(routines): add Token Trim built-in default routine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   selected routine and surfaces a single summary toast. Bulk delete shows a confirmation
   dialog and removes via `DELETE /routines/{id}`. Selection is automatically pruned on
   reload so stale IDs never carry over. Pure frontend — no backend change. Closes #676.
+- **Token Trim default routine.** A new built-in weekly routine (Sundays 07:00) that audits
+  routine prompts for redundancy, verbosity, dead scaffolding, and duplication, then opens one
+  PR per week that reduces LLM token consumption without degrading output quality.
 - **Light/dark theme toggle.** A ☀/🌙 button in the header switches between the dark
   terminal aesthetic and a clean light palette. The choice persists to `localStorage`
   under `moadim.theme` and is applied flash-free via an inline `<head>` script before

--- a/src/routines/defaults.rs
+++ b/src/routines/defaults.rs
@@ -121,6 +121,86 @@ Output exactly three lines:
 3. PR: <url> or \"Skipped: <reason>\"
 ";
 
+/// Prompt for the weekly token-efficiency routine.
+const TOKEN_TRIM_PROMPT: &str = "\
+You are \"Token Trim\" — a token-efficiency agent. Each week you analyze the user's \
+automation portfolio and open one PR that reduces LLM token consumption without \
+degrading output quality.
+
+## Step 1: Environment check
+
+Run:
+```bash
+git -C ~/.config/moadim rev-parse --is-inside-work-tree 2>/dev/null && echo IS_REPO || echo NOT_REPO
+```
+
+**If NOT_REPO:** use the moadim MCP tool `list_routines` to find the routine whose title is \
+\"Token Trim\", then call `update_routine` with `enabled: false` on that ID. \
+Log: \"Routines folder is not a git repository — self-disabled.\" Then stop.
+
+**If IS_REPO:** continue.
+
+## Step 2: Audit token costs
+
+Use the moadim MCP tool `list_routines` to fetch all routines. For each enabled routine, \
+examine the full prompt text and score it on:
+
+- **Redundancy** — repeated instructions, restated context, or examples that duplicate \
+  what the LLM already knows
+- **Verbosity** — multi-sentence explanations a single precise sentence would cover; \
+  enumerations that collapse to a pattern
+- **Dead scaffolding** — section headers, bullet lead-ins, or transition phrases that \
+  add tokens but no information (\"Please make sure to\", \"As a next step\", \"Note that\")
+- **Over-specified steps** — step-by-step breakdowns for tasks the model handles reliably \
+  without hand-holding
+- **Prompt duplication** — two or more routines whose prompts share large identical or \
+  near-identical passages that could be factored out
+
+Estimate a rough token saving for each finding (small < 50 tokens, medium 50–200, large > 200).
+
+## Step 3: Choose the single best improvement
+
+Pick ONE finding with the best saving-to-risk ratio (prefer high saving, low risk of \
+degrading output quality). Before acting, check for open PRs:
+```bash
+origin=$(git -C ~/.config/moadim remote get-url origin 2>/dev/null)
+gh pr list --repo \"$origin\" --state open --json title,headRefName 2>/dev/null
+```
+If an equivalent improvement is already proposed, pick the next-best one.
+
+Good improvement examples:
+- Compress a verbose multi-paragraph prompt to a tight, precise equivalent
+- Remove a redundant section that duplicates another routine's instructions
+- Collapse an over-specified step list into a single goal statement
+- Delete dead scaffolding phrases and filler transitions
+- Deduplicate a shared preamble that appears across two or more routines
+
+**Constraint:** the rewritten prompt must preserve all observable behavior — same tool \
+calls, same outputs, same decision logic. When in doubt, keep the instruction.
+
+## Step 4: Open the PR
+
+```bash
+git -C ~/.config/moadim checkout -b token-trim/$(date +%Y%m%d-%H%M)
+# Edit the relevant routine.toml / prompt.md file(s) under ~/.config/moadim/routines/.
+# Only touch routine prompt files. Do NOT modify moadim daemon config.
+git -C ~/.config/moadim add -A
+git -C ~/.config/moadim commit -m \"routines: trim token cost in <routine-name>\"
+git -C ~/.config/moadim push -u origin HEAD
+origin=$(git -C ~/.config/moadim remote get-url origin)
+gh pr create --repo \"$origin\" \\
+  --title \"token-trim: <short description>\" \\
+  --body \"$(printf '## What changed\\n<one paragraph>\\n\\n## Estimated token saving\\n~<N> tokens per run\\n\\n## Risk\\n<none|low|medium> — <one line>')\"
+```
+
+## Report
+
+Output exactly three lines:
+1. Env: IS_REPO or NOT_REPO (+ self-disabled if applicable)
+2. Improvement chosen: <type> — <one-line description> (~<N> tokens saved per run)
+3. PR: <url> or \"Skipped: <reason>\"
+";
+
 /// Built-in default routines, reconciled onto disk on every startup.
 const DEFAULT_ROUTINES: &[DefaultRoutine] = &[
     DefaultRoutine {
@@ -136,6 +216,13 @@ const DEFAULT_ROUTINES: &[DefaultRoutine] = &[
         schedule: "0 8 * * *",
         agent: "claude",
         prompt: THE_1_PERCENT_PROMPT,
+    },
+    DefaultRoutine {
+        title: "Token Trim",
+        // Weekly on Sundays at 07:00 local time — before the daily routines.
+        schedule: "0 7 * * 0",
+        agent: "claude",
+        prompt: TOKEN_TRIM_PROMPT,
     },
 ];
 

--- a/src/routines/defaults_tests.rs
+++ b/src/routines/defaults_tests.rs
@@ -26,6 +26,16 @@ fn second_default_is_the_1_percent() {
 }
 
 #[test]
+fn third_default_is_token_trim() {
+    let spec = &DEFAULT_ROUTINES[2];
+    assert_eq!(spec.title, "Token Trim");
+    assert!(spec.prompt.contains("list_routines"));
+    assert!(spec.prompt.contains("update_routine"));
+    assert!(spec.prompt.contains("NOT_REPO"));
+    assert!(spec.prompt.contains("token"));
+}
+
+#[test]
 fn every_schedule_is_a_valid_cron() {
     for spec in DEFAULT_ROUTINES {
         let normalized = normalize_schedule(spec.schedule);


### PR DESCRIPTION
## Summary

- Adds a new built-in default routine **Token Trim** (Sundays 07:00 local time, `0 7 * * 0`)
- Each week it audits all enabled routine prompts for redundancy, verbosity, dead scaffolding, over-specified steps, and cross-routine duplication
- Picks the single highest-saving/lowest-risk improvement and opens one PR to the routines repo with the trimmed prompt
- Self-disables if the routines folder is not a git repo (same pattern as The 1 Percent)

## Test plan

- [ ] `cargo test routines::defaults` — all 16 tests pass including new `third_default_is_token_trim`
- [ ] `every_schedule_is_a_valid_cron` validates the `0 7 * * 0` expression
- [ ] `every_agent_is_a_known_builtin` validates `claude` agent key
- [ ] Daemon startup seeds/reconciles the new routine alongside existing defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)