### PR TITLE
feat(ui): bulk actions for the Routines page — select, enable, disable, delete (#690)

### DIFF
--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -4,7 +4,7 @@
 //! (claude, codex, …) on a schedule instead of running a handler script.
 
 use std::cell::Cell;
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashSet};
 use std::rc::Rc;
 
 use chrono::{DateTime, Datelike, Duration, Local, NaiveDate, TimeZone};
@@ -444,6 +444,20 @@ pub fn unassigned_routines_count(routines: &[Routine]) -> usize {
     routines.iter().filter(|r| r.machines.is_empty()).count()
 }
 
+// ─── Multiselect ──────────────────────────────────────────────────────────────
+
+/// How a row-selection click should mutate the selection set, derived from the
+/// modifier keys held during the click.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SelectKind {
+    /// Plain click — select only this item, clearing the rest.
+    Only,
+    /// Cmd/Ctrl+click — toggle this item in/out of the selection.
+    Toggle,
+    /// Shift+click — select the contiguous range from the anchor to this item.
+    Range,
+}
+
 // ─── State ────────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -459,6 +473,7 @@ pub enum RModal {
     None,
     Edit(String),
     ConfirmDelete { id: String, title: String },
+    ConfirmBulkDelete { count: usize },
 }
 
 /// How the list page presents routines: a table, or a month calendar of upcoming fire times.
@@ -515,6 +530,10 @@ pub struct RState {
     pub sort: RSort,
     /// `true` sorts descending (newest / Z→A first).
     pub sort_desc: bool,
+    /// IDs of currently selected routines (multiselect).
+    pub selected: HashSet<String>,
+    /// Anchor row for Shift+click range selection.
+    pub select_anchor: Option<String>,
 }
 
 impl Default for RState {
@@ -528,6 +547,8 @@ impl Default for RState {
             filter: RoutineFilter::default(),
             sort: RSort::default(),
             sort_desc: false,
+            selected: HashSet::new(),
+            select_anchor: None,
         }
     }
 }
@@ -539,6 +560,7 @@ pub enum RAction {
     GoToLogs(String),
     OpenEdit(String),
     OpenConfirmDelete { id: String, title: String },
+    OpenConfirmBulkDelete,
     CloseModal,
     SetView(RView),
     SetQuery(String),
@@ -550,6 +572,12 @@ pub enum RAction {
     ToggleSortDir,
     Upsert(Box<Routine>),
     Remove(String),
+    RemoveMany(Vec<String>),
+    /// Apply a selection click interpreted per `kind`.
+    SelectRoutine { id: String, kind: SelectKind },
+    /// Select exactly the given (visible/filtered) ids.
+    SelectAll(Vec<String>),
+    ClearSelection,
 }
 
 impl Reducible for RState {
@@ -559,6 +587,14 @@ impl Reducible for RState {
         let mut s = (*self).clone();
         match action {
             RAction::Loaded(r) => {
+                // Drop selections for routines that no longer exist after a reload.
+                let ids: HashSet<&String> = r.iter().map(|x| &x.id).collect();
+                s.selected.retain(|id| ids.contains(id));
+                if let Some(a) = &s.select_anchor {
+                    if !ids.contains(a) {
+                        s.select_anchor = None;
+                    }
+                }
                 s.routines = r;
                 s.loading = false;
             }
@@ -568,6 +604,11 @@ impl Reducible for RState {
             RAction::OpenEdit(id) => s.modal = RModal::Edit(id),
             RAction::OpenConfirmDelete { id, title } => {
                 s.modal = RModal::ConfirmDelete { id, title }
+            }
+            RAction::OpenConfirmBulkDelete => {
+                s.modal = RModal::ConfirmBulkDelete {
+                    count: s.selected.len(),
+                }
             }
             RAction::CloseModal => s.modal = RModal::None,
             RAction::SetView(view) => s.view = view,
@@ -586,7 +627,59 @@ impl Reducible for RState {
                     s.routines.push(routine);
                 }
             }
-            RAction::Remove(id) => s.routines.retain(|x| x.id != id),
+            RAction::Remove(id) => {
+                s.routines.retain(|x| x.id != id);
+                s.selected.remove(&id);
+                if s.select_anchor.as_ref() == Some(&id) {
+                    s.select_anchor = None;
+                }
+            }
+            RAction::RemoveMany(ids) => {
+                let drop: HashSet<&String> = ids.iter().collect();
+                s.routines.retain(|x| !drop.contains(&x.id));
+                s.selected.retain(|id| !drop.contains(id));
+                if let Some(a) = &s.select_anchor {
+                    if drop.contains(a) {
+                        s.select_anchor = None;
+                    }
+                }
+            }
+            RAction::SelectRoutine { id, kind } => match kind {
+                SelectKind::Only => {
+                    s.selected.clear();
+                    s.selected.insert(id.clone());
+                    s.select_anchor = Some(id);
+                }
+                SelectKind::Toggle => {
+                    if !s.selected.remove(&id) {
+                        s.selected.insert(id.clone());
+                    }
+                    s.select_anchor = Some(id);
+                }
+                SelectKind::Range => {
+                    let anchor = s.select_anchor.clone().unwrap_or_else(|| id.clone());
+                    let pos = |target: &str| s.routines.iter().position(|x| x.id == target);
+                    match (pos(&anchor), pos(&id)) {
+                        (Some(a), Some(b)) => {
+                            let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+                            for r in &s.routines[lo..=hi] {
+                                s.selected.insert(r.id.clone());
+                            }
+                        }
+                        _ => {
+                            s.selected.insert(id.clone());
+                        }
+                    }
+                    // Anchor stays put so further Shift+clicks extend from it.
+                }
+            },
+            RAction::SelectAll(ids) => {
+                s.selected = ids.into_iter().collect();
+            }
+            RAction::ClearSelection => {
+                s.selected.clear();
+                s.select_anchor = None;
+            }
         }
         s.into()
     }
@@ -799,6 +892,118 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
         Callback::from(move |_: ()| state.dispatch(RAction::ToggleSortDir))
     };
 
+    // ── Multiselect ──
+    let on_select = {
+        let state = state.clone();
+        Callback::from(move |(id, kind): (String, SelectKind)| {
+            state.dispatch(RAction::SelectRoutine { id, kind })
+        })
+    };
+
+    // Header checkbox toggles between "all visible selected" and "none". Operates
+    // over the filtered+sorted rows so select-all never reaches hidden routines.
+    let on_select_all = {
+        let state = state.clone();
+        let now = now.clone();
+        Callback::from(move |_: ()| {
+            let window = Duration::seconds(DUE_SOON_WINDOW_SECS);
+            let visible = filter_routines(&state.routines, &state.filter, *now, window);
+            let all_selected =
+                !visible.is_empty() && visible.iter().all(|r| state.selected.contains(&r.id));
+            if all_selected {
+                state.dispatch(RAction::ClearSelection);
+            } else {
+                state.dispatch(RAction::SelectAll(
+                    visible.into_iter().map(|r| r.id).collect(),
+                ));
+            }
+        })
+    };
+
+    let on_clear_selection = {
+        let state = state.clone();
+        Callback::from(move |_: ()| state.dispatch(RAction::ClearSelection))
+    };
+
+    // Bulk enable/disable: PATCH each selected routine, emit one summary toast.
+    let bulk_set_enabled = {
+        let state = state.clone();
+        let toast = toast.clone();
+        move |enabled: bool| {
+            let state = state.clone();
+            let toast = toast.clone();
+            let ids: Vec<String> = state.selected.iter().cloned().collect();
+            if ids.is_empty() {
+                return;
+            }
+            spawn_local(async move {
+                let mut ok = 0usize;
+                let mut failed = 0usize;
+                for id in ids {
+                    let req = UpdateRoutineRequest {
+                        enabled: Some(enabled),
+                        ..Default::default()
+                    };
+                    match api_update(&id, &req).await {
+                        Ok(r) => {
+                            state.dispatch(RAction::Upsert(Box::new(r)));
+                            ok += 1;
+                        }
+                        Err(_) => failed += 1,
+                    }
+                }
+                let verb = if enabled { "enabled" } else { "disabled" };
+                if failed == 0 {
+                    toast.emit((format!("{ok} routine(s) {verb}"), ToastKind::Ok));
+                } else {
+                    toast.emit((format!("{ok} {verb}, {failed} failed"), ToastKind::Err));
+                }
+            });
+        }
+    };
+
+    let on_bulk_enable = {
+        let f = bulk_set_enabled.clone();
+        Callback::from(move |_: ()| f(true))
+    };
+    let on_bulk_disable = {
+        let f = bulk_set_enabled.clone();
+        Callback::from(move |_: ()| f(false))
+    };
+
+    let on_bulk_delete = {
+        let state = state.clone();
+        Callback::from(move |_: ()| state.dispatch(RAction::OpenConfirmBulkDelete))
+    };
+
+    let on_confirm_bulk_delete = {
+        let state = state.clone();
+        let toast = toast.clone();
+        Callback::from(move |_: ()| {
+            let state = state.clone();
+            let toast = toast.clone();
+            let ids: Vec<String> = state.selected.iter().cloned().collect();
+            state.dispatch(RAction::CloseModal);
+            spawn_local(async move {
+                let mut deleted = Vec::new();
+                let mut failed = 0usize;
+                for id in ids {
+                    match api_delete(&id).await {
+                        Ok(()) => deleted.push(id),
+                        Err(_) => failed += 1,
+                    }
+                }
+                let n = deleted.len();
+                state.dispatch(RAction::RemoveMany(deleted));
+                if failed == 0 {
+                    toast.emit((format!("{n} routine(s) deleted"), ToastKind::Ok));
+                } else {
+                    toast.emit((format!("{n} deleted, {failed} failed"), ToastKind::Err));
+                }
+            });
+        })
+    };
+
     let on_create = {
         let state = state.clone();
         let toast = toast.clone();
@@ -950,6 +1155,7 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
     let filter = state.filter.clone();
     let sort = state.sort;
     let sort_desc = state.sort_desc;
+    let selected = state.selected.clone();
 
     // Faceted filter + sort applied client-side.
     let now_val = *now;
@@ -1036,6 +1242,13 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
                                 on_set_sort={on_set_sort}
                                 on_toggle_sort_dir={on_toggle_sort_dir}
                             />
+                            <RoutineBulkBar
+                                count={selected.len()}
+                                on_enable={on_bulk_enable}
+                                on_disable={on_bulk_disable}
+                                on_delete={on_bulk_delete}
+                                on_clear={on_clear_selection}
+                            />
                             {
                                 match view {
                                     RView::Table => html! {
@@ -1044,12 +1257,15 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
                                             loading={loading}
                                             filter_active={filter_active}
                                             now={now_val}
+                                            selected={selected}
                                             on_edit={on_edit}
                                             on_delete={on_ask_delete}
                                             on_toggle={on_toggle}
                                             on_trigger={on_trigger}
                                             on_logs={on_logs}
                                             on_clear_filters={on_clear_filters}
+                                            on_select={on_select}
+                                            on_select_all={on_select_all}
                                         />
                                     },
                                     RView::Calendar => html! {
@@ -1079,6 +1295,13 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
                             title={title.clone()}
                             on_cancel={on_close}
                             on_confirm={on_confirm_delete}
+                        />
+                    },
+                    RModal::ConfirmBulkDelete { count } => html! {
+                        <RoutineBulkDeleteDialog
+                            count={*count}
+                            on_cancel={on_close}
+                            on_confirm={on_confirm_bulk_delete}
                         />
                     },
                     RModal::None => html! {},
@@ -1525,12 +1748,16 @@ pub struct TableProps {
     pub filter_active: bool,
     /// Reference instant used to compute next-fire countdowns.
     pub now: chrono::DateTime<Local>,
+    /// Currently selected routine ids.
+    pub selected: HashSet<String>,
     pub on_edit: Callback<String>,
     pub on_delete: Callback<(String, String)>,
     pub on_toggle: Callback<(String, bool)>,
     pub on_trigger: Callback<String>,
     pub on_logs: Callback<String>,
     pub on_clear_filters: Callback<()>,
+    pub on_select: Callback<(String, SelectKind)>,
+    pub on_select_all: Callback<()>,
 }
 
 #[function_component(RoutineTable)]
@@ -1575,11 +1802,28 @@ pub fn routine_table(props: &TableProps) -> Html {
         };
     }
 
+    let all_selected =
+        !props.routines.is_empty() && props.routines.iter().all(|r| props.selected.contains(&r.id));
+    let on_select_all = {
+        let cb = props.on_select_all.clone();
+        Callback::from(move |_: MouseEvent| cb.emit(()))
+    };
+
     html! {
         <div class="table-wrap">
             <table>
                 <thead>
                     <tr>
+                        <th class="th-select">
+                            <input
+                                type="checkbox"
+                                class="row-check"
+                                title="Select all"
+                                aria-label="Select all routines"
+                                checked={all_selected}
+                                onclick={on_select_all}
+                            />
+                        </th>
                         <th>{"TITLE"}</th>
                         <th>{"SCHEDULE"}</th>
                         <th>{"NEXT RUN"}</th>
@@ -1597,11 +1841,13 @@ pub fn routine_table(props: &TableProps) -> Html {
                             key={r.id.clone()}
                             routine={r.clone()}
                             now={props.now}
+                            selected={props.selected.contains(&r.id)}
                             on_edit={props.on_edit.clone()}
                             on_delete={props.on_delete.clone()}
                             on_toggle={props.on_toggle.clone()}
                             on_trigger={props.on_trigger.clone()}
                             on_logs={props.on_logs.clone()}
+                            on_select={props.on_select.clone()}
                         />
                     }) }
                 </tbody>
@@ -1642,11 +1888,13 @@ pub struct RowProps {
     pub routine: Routine,
     /// Reference instant for the NEXT RUN countdown.
     pub now: chrono::DateTime<Local>,
+    pub selected: bool,
     pub on_edit: Callback<String>,
     pub on_delete: Callback<(String, String)>,
     pub on_toggle: Callback<(String, bool)>,
     pub on_trigger: Callback<String>,
     pub on_logs: Callback<String>,
+    pub on_select: Callback<(String, SelectKind)>,
 }
 
 #[function_component(RoutineRow)]
@@ -1683,6 +1931,20 @@ pub fn routine_row(props: &RowProps) -> Html {
         let id = r.id.clone();
         Callback::from(move |_: MouseEvent| cb.emit(id.clone()))
     };
+    let on_select = {
+        let cb = props.on_select.clone();
+        let id = r.id.clone();
+        Callback::from(move |e: MouseEvent| {
+            let kind = if e.shift_key() {
+                SelectKind::Range
+            } else if e.ctrl_key() || e.meta_key() {
+                SelectKind::Toggle
+            } else {
+                SelectKind::Only
+            };
+            cb.emit((id.clone(), kind));
+        })
+    };
 
     let last_run: Html = {
         let manual = r.last_manual_trigger_at;
@@ -1718,9 +1980,19 @@ pub fn routine_row(props: &RowProps) -> Html {
     };
 
     let next_run = next_routine_run_cell(r, props.now);
+    let row_class = if props.selected { "row-selected" } else { "" };
 
     html! {
-        <tr>
+        <tr class={row_class}>
+            <td class="td-select">
+                <input
+                    type="checkbox"
+                    class="row-check"
+                    aria-label="Select routine"
+                    checked={props.selected}
+                    onclick={on_select}
+                />
+            </td>
             <td>
                 <div class="cell-schedule" title={r.id.clone()}>{&r.title}</div>
             </td>
@@ -2214,6 +2486,73 @@ pub fn routine_logs(props: &LogsProps) -> Html {
                 err={(*err).clone()}
             />
         </main>
+    }
+}
+
+// ─── Bulk action bar ──────────────────────────────────────────────────────────
+
+#[derive(Properties, PartialEq)]
+pub struct RoutineBulkBarProps {
+    pub count: usize,
+    pub on_enable: Callback<()>,
+    pub on_disable: Callback<()>,
+    pub on_delete: Callback<()>,
+    pub on_clear: Callback<()>,
+}
+
+#[function_component(RoutineBulkBar)]
+pub fn routine_bulk_bar(props: &RoutineBulkBarProps) -> Html {
+    if props.count == 0 {
+        return html! {};
+    }
+    let mk = |cb: Callback<()>| Callback::from(move |_: MouseEvent| cb.emit(()));
+
+    html! {
+        <div class="bulk-bar">
+            <span class="bulk-count">{ format!("{} SELECTED", props.count) }</span>
+            <div class="bulk-acts">
+                <button class="btn btn-ghost btn-sm" onclick={mk(props.on_enable.clone())}>{"ENABLE"}</button>
+                <button class="btn btn-ghost btn-sm" onclick={mk(props.on_disable.clone())}>{"DISABLE"}</button>
+                <button class="btn btn-danger btn-sm" onclick={mk(props.on_delete.clone())}>{"DELETE"}</button>
+                <button class="btn btn-ghost btn-sm" onclick={mk(props.on_clear.clone())}>{"CLEAR"}</button>
+            </div>
+        </div>
+    }
+}
+
+// ─── Bulk delete confirm dialog ───────────────────────────────────────────────
+
+#[derive(Properties, PartialEq)]
+pub struct RoutineBulkDeleteProps {
+    pub count: usize,
+    pub on_cancel: Callback<()>,
+    pub on_confirm: Callback<()>,
+}
+
+#[function_component(RoutineBulkDeleteDialog)]
+pub fn routine_bulk_delete_dialog(props: &RoutineBulkDeleteProps) -> Html {
+    let on_cancel = {
+        let cb = props.on_cancel.clone();
+        Callback::from(move |_: MouseEvent| cb.emit(()))
+    };
+    let on_confirm = {
+        let cb = props.on_confirm.clone();
+        Callback::from(move |_: MouseEvent| cb.emit(()))
+    };
+
+    html! {
+        <div class="overlay open">
+            <div class="confirm-dialog">
+                <div class="confirm-title">{"⚠ DELETE ROUTINES"}</div>
+                <div class="confirm-msg">
+                    { format!("Delete {} selected routine(s)? This cannot be undone.", props.count) }
+                </div>
+                <div class="confirm-acts">
+                    <button class="btn btn-ghost btn-sm" onclick={on_cancel}>{"CANCEL"}</button>
+                    <button class="btn btn-danger btn-sm" onclick={on_confirm}>{"DELETE"}</button>
+                </div>
+            </div>
+        </div>
     }
 }
 

--- a/ui/src/routines_tests.rs
+++ b/ui/src/routines_tests.rs
@@ -437,3 +437,138 @@ fn unassigned_routines_count_counts_empty_machine_lists() {
     ];
     assert_eq!(unassigned_routines_count(&routines), 2);
 }
+
+// ── Selection state transitions ───────────────────────────────────────────────
+
+fn make_state(ids: &[&str]) -> RState {
+    let routines = ids
+        .iter()
+        .map(|id| routine(id, "t", "claude", "0 * * * *", &[], &[], true))
+        .collect();
+    RState {
+        routines,
+        ..RState::default()
+    }
+}
+
+#[test]
+fn select_only_clears_others_and_sets_anchor() {
+    use std::rc::Rc;
+    let mut s = make_state(&["a", "b", "c"]);
+    s.selected.insert("b".into());
+    let s = RState::reduce(
+        Rc::new(s),
+        RAction::SelectRoutine {
+            id: "a".into(),
+            kind: SelectKind::Only,
+        },
+    );
+    assert_eq!(s.selected.len(), 1);
+    assert!(s.selected.contains("a"));
+    assert_eq!(s.select_anchor.as_deref(), Some("a"));
+}
+
+#[test]
+fn select_toggle_adds_when_absent_and_removes_when_present() {
+    use std::rc::Rc;
+    let s = make_state(&["a", "b"]);
+    let s = RState::reduce(
+        Rc::new(s),
+        RAction::SelectRoutine {
+            id: "a".into(),
+            kind: SelectKind::Toggle,
+        },
+    );
+    assert!(s.selected.contains("a"));
+
+    let s = RState::reduce(
+        s,
+        RAction::SelectRoutine {
+            id: "a".into(),
+            kind: SelectKind::Toggle,
+        },
+    );
+    assert!(!s.selected.contains("a"));
+}
+
+#[test]
+fn select_range_covers_contiguous_slice() {
+    use std::rc::Rc;
+    let mut s = make_state(&["a", "b", "c", "d"]);
+    // Anchor at "a".
+    s = (*RState::reduce(
+        Rc::new(s),
+        RAction::SelectRoutine {
+            id: "a".into(),
+            kind: SelectKind::Only,
+        },
+    ))
+    .clone();
+    // Shift+click "c" — should select a, b, c.
+    let s = RState::reduce(
+        Rc::new(s),
+        RAction::SelectRoutine {
+            id: "c".into(),
+            kind: SelectKind::Range,
+        },
+    );
+    assert!(s.selected.contains("a"));
+    assert!(s.selected.contains("b"));
+    assert!(s.selected.contains("c"));
+    assert!(!s.selected.contains("d"));
+}
+
+#[test]
+fn select_all_selects_given_ids() {
+    use std::rc::Rc;
+    let s = make_state(&["a", "b", "c"]);
+    let s = RState::reduce(
+        Rc::new(s),
+        RAction::SelectAll(vec!["a".into(), "c".into()]),
+    );
+    assert_eq!(s.selected.len(), 2);
+    assert!(s.selected.contains("a"));
+    assert!(s.selected.contains("c"));
+    assert!(!s.selected.contains("b"));
+}
+
+#[test]
+fn clear_selection_empties_set_and_anchor() {
+    use std::rc::Rc;
+    let mut s = make_state(&["a", "b"]);
+    s.selected.insert("a".into());
+    s.select_anchor = Some("a".into());
+    let s = RState::reduce(Rc::new(s), RAction::ClearSelection);
+    assert!(s.selected.is_empty());
+    assert!(s.select_anchor.is_none());
+}
+
+#[test]
+fn remove_many_drops_from_selection_and_routines() {
+    use std::rc::Rc;
+    let mut s = make_state(&["a", "b", "c"]);
+    s.selected.insert("a".into());
+    s.selected.insert("b".into());
+    let s = RState::reduce(
+        Rc::new(s),
+        RAction::RemoveMany(vec!["a".into(), "b".into()]),
+    );
+    assert_eq!(s.routines.len(), 1);
+    assert_eq!(s.routines[0].id, "c");
+    assert!(s.selected.is_empty());
+}
+
+#[test]
+fn loaded_drops_stale_selections() {
+    use std::rc::Rc;
+    let mut s = make_state(&["a", "b"]);
+    s.selected.insert("a".into());
+    s.selected.insert("gone".into()); // no longer in the new list
+    let new_routines = vec![
+        routine("a", "t", "claude", "0 * * * *", &[], &[], true),
+        routine("c", "t", "claude", "0 * * * *", &[], &[], true),
+    ];
+    let s = RState::reduce(Rc::new(s), RAction::Loaded(new_routines));
+    assert!(s.selected.contains("a"));
+    assert!(!s.selected.contains("gone"));
+}


### PR DESCRIPTION
## Summary

Closes #690.

Adds multiselect with bulk enable / disable / delete to the Routines table, bringing feature-parity with the Cron Jobs page which already ships this capability.

**Best-practice rationale:** Operations dashboards for job schedulers (GitHub Actions, Buildkite, Temporal, Airflow) consistently surface batch operations on list views. Reprovisioning a machine or rotating an agent config may require toggling dozens of routines — without bulk actions this is an O(n) chore.

- **Row checkboxes** — plain click selects only that row; Cmd/Ctrl+click toggles; Shift+click extends the range from the last anchor.
- **Header "select all" checkbox** — selects all currently-visible (post-filter) rows; clicking it when all are selected clears the selection.
- **RoutineBulkBar** — contextual action bar that appears only when ≥1 row is selected, showing a count + ENABLE / DISABLE / DELETE / CLEAR.
- **RoutineBulkDeleteDialog** — confirmation gate before the destructive multi-delete, matching the single-delete pattern.
- **Selection pruning** — `Loaded()` drops stale IDs when the list refreshes, so a reload never leaves phantom selections.

## What changed

All changes are confined to `ui/src/`:

| File | What changed |
|------|-------------|
| `routines.rs` | `SelectKind` enum; `selected` + `select_anchor` in `RState`; 5 new `RAction` variants + reducer cases; `RoutineBulkBar` + `RoutineBulkDeleteDialog` components; `TableProps` + `RowProps` extended; header checkbox + per-row checkbox |
| `routines_tests.rs` | 7 new host-side unit tests covering all selection state transitions |

## Test plan

- [x] `cargo test -p ui` — all 166 tests pass (7 new selection tests added)
- [x] `cargo clippy -p ui` — clean (no warnings or errors)
- [x] `git diff --name-only origin/main...HEAD` — only `ui/src/routines.rs` and `ui/src/routines_tests.rs`

This pull request was opened by the **UI dashboard feature builder (research → issue → PR → merge)** routine of moadim. @tupe12334

🤖 Generated with [Claude Code](https://claude.com/claude-code)