### PR TITLE
feat(ui): sortable column headers for the Routines table (#679)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Added
 
+- **Sortable column headers for the Routines table.** Clicking any of the TITLE, NEXT RUN,
+  AGENT, ENABLED, or UPDATED column headers sorts the table by that field; clicking the
+  active column again reverses direction. An ▲/▼ arrow indicator shows the active sort
+  column and direction. The separate sort dropdown and direction toggle button have been
+  removed from the filter bar — column-header clicks are the single, discoverable sort
+  control. Sort state lives in component memory (no URL pollution) and resets to server
+  order on page reload. Pure client-side — no backend change. Closes #679.
 - **Light/dark theme toggle.** A ☀/🌙 button in the header switches between the dark
   terminal aesthetic and a clean light palette. The choice persists to `localStorage`
   under `moadim.theme` and is applied flash-free via an inline `<head>` script before

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -470,36 +470,14 @@ pub enum RView {
     Day,
 }
 
-/// Field the routine table is sorted by.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+/// Column in the routine table that is currently sorted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RSort {
-    #[default]
-    Created,
-    Updated,
     Title,
-    Repository,
-}
-
-impl RSort {
-    /// Parse the value of the sort `<select>`.
-    fn from_str(s: &str) -> Self {
-        match s {
-            "updated" => RSort::Updated,
-            "title" => RSort::Title,
-            "repository" => RSort::Repository,
-            _ => RSort::Created,
-        }
-    }
-
-    /// `<option>` value for this sort field.
-    fn as_str(self) -> &'static str {
-        match self {
-            RSort::Created => "created",
-            RSort::Updated => "updated",
-            RSort::Title => "title",
-            RSort::Repository => "repository",
-        }
-    }
+    NextRun,
+    Agent,
+    Enabled,
+    Updated,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -511,9 +489,9 @@ pub struct RState {
     pub view: RView,
     /// Active faceted filter.
     pub filter: RoutineFilter,
-    /// Field the table is sorted by.
-    pub sort: RSort,
-    /// `true` sorts descending (newest / Z→A first).
+    /// Column the table is sorted by; `None` = natural (server) order.
+    pub sort_col: Option<RSort>,
+    /// `true` sorts descending.
     pub sort_desc: bool,
 }
 
@@ -526,7 +504,7 @@ impl Default for RState {
             modal: RModal::None,
             view: RView::default(),
             filter: RoutineFilter::default(),
-            sort: RSort::default(),
+            sort_col: None,
             sort_desc: false,
         }
     }
@@ -546,8 +524,7 @@ pub enum RAction {
     SetAgentFacet(AgentFacet),
     SetMachineFacet(RoutineMachineFacet),
     ClearFilters,
-    SetSort(RSort),
-    ToggleSortDir,
+    ClickSortCol(RSort),
     Upsert(Box<Routine>),
     Remove(String),
 }
@@ -576,8 +553,14 @@ impl Reducible for RState {
             RAction::SetAgentFacet(ag) => s.filter.agent = ag,
             RAction::SetMachineFacet(m) => s.filter.machine = m,
             RAction::ClearFilters => s.filter = RoutineFilter::default(),
-            RAction::SetSort(sort) => s.sort = sort,
-            RAction::ToggleSortDir => s.sort_desc = !s.sort_desc,
+            RAction::ClickSortCol(col) => {
+                if s.sort_col == Some(col) {
+                    s.sort_desc = !s.sort_desc;
+                } else {
+                    s.sort_col = Some(col);
+                    s.sort_desc = false;
+                }
+            }
             RAction::Upsert(routine) => {
                 let routine = *routine;
                 if let Some(i) = s.routines.iter().position(|x| x.id == routine.id) {
@@ -590,6 +573,50 @@ impl Reducible for RState {
         }
         s.into()
     }
+}
+
+// ─── Sort ─────────────────────────────────────────────────────────────────────
+
+/// Return `routines` sorted by `col` in `desc` order.
+/// When `col` is `None` the server / insertion order is preserved.
+/// Ties break by `id` for a stable sort.
+#[must_use]
+pub fn sort_routines(
+    mut routines: Vec<Routine>,
+    col: Option<RSort>,
+    desc: bool,
+    now: chrono::DateTime<Local>,
+) -> Vec<Routine> {
+    let col = match col {
+        Some(c) => c,
+        None => return routines,
+    };
+    routines.sort_by(|a, b| {
+        let primary = match col {
+            RSort::Title => a.title.to_lowercase().cmp(&b.title.to_lowercase()),
+            RSort::NextRun => {
+                let next_of = |r: &Routine| {
+                    if r.enabled {
+                        next_fire_after(&r.schedule, now)
+                    } else {
+                        None
+                    }
+                };
+                match (next_of(a), next_of(b)) {
+                    (Some(ta), Some(tb)) => ta.cmp(&tb),
+                    (Some(_), None) => std::cmp::Ordering::Less,
+                    (None, Some(_)) => std::cmp::Ordering::Greater,
+                    (None, None) => std::cmp::Ordering::Equal,
+                }
+            }
+            RSort::Agent => a.agent.to_lowercase().cmp(&b.agent.to_lowercase()),
+            RSort::Enabled => a.enabled.cmp(&b.enabled),
+            RSort::Updated => a.updated_at.cmp(&b.updated_at),
+        };
+        let directed = if desc { primary.reverse() } else { primary };
+        directed.then_with(|| a.id.cmp(&b.id))
+    });
+    routines
 }
 
 // ─── Page component ───────────────────────────────────────────────────────────
@@ -790,13 +817,9 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
         });
     }
 
-    let on_set_sort = {
+    let on_sort_col = {
         let state = state.clone();
-        Callback::from(move |sort: RSort| state.dispatch(RAction::SetSort(sort)))
-    };
-    let on_toggle_sort_dir = {
-        let state = state.clone();
-        Callback::from(move |_: ()| state.dispatch(RAction::ToggleSortDir))
+        Callback::from(move |col: RSort| state.dispatch(RAction::ClickSortCol(col)))
     };
 
     let on_create = {
@@ -948,7 +971,7 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
     let modal = state.modal.clone();
     let view = state.view;
     let filter = state.filter.clone();
-    let sort = state.sort;
+    let sort_col = state.sort_col;
     let sort_desc = state.sort_desc;
 
     // Faceted filter + sort applied client-side.
@@ -959,22 +982,12 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
     let machine_options = distinct_machines_r(&routines);
     let has_unassigned = unassigned_routines_count(&routines) > 0;
     let filter_active = filter.is_active();
-    let visible = {
-        let mut v = filter_routines(&routines, &filter, now_val, window);
-        match sort {
-            RSort::Created => v.sort_by_key(|r| r.created_at),
-            RSort::Updated => v.sort_by_key(|r| r.updated_at),
-            RSort::Title => v.sort_by_key(|r| r.title.to_lowercase()),
-            RSort::Repository => v.sort_by_key(|r| match r.repositories.first() {
-                Some(repo) => (false, repo.repository.to_lowercase()),
-                None => (true, String::new()),
-            }),
-        }
-        if sort_desc {
-            v.reverse();
-        }
-        v
-    };
+    let visible = sort_routines(
+        filter_routines(&routines, &filter, now_val, window),
+        sort_col,
+        sort_desc,
+        now_val,
+    );
     let shown = visible.len();
 
     let edit_routine = match &modal {
@@ -1025,16 +1038,12 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
                                 has_unassigned={has_unassigned}
                                 shown={shown}
                                 total={total_routines}
-                                sort={sort}
-                                sort_desc={sort_desc}
                                 search_ref={search_ref.clone()}
                                 on_query={on_set_query}
                                 on_status={on_set_status}
                                 on_agent={on_set_agent}
                                 on_machine={on_set_machine}
                                 on_clear={on_clear_filters.clone()}
-                                on_set_sort={on_set_sort}
-                                on_toggle_sort_dir={on_toggle_sort_dir}
                             />
                             {
                                 match view {
@@ -1044,6 +1053,9 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
                                             loading={loading}
                                             filter_active={filter_active}
                                             now={now_val}
+                                            sort_col={sort_col}
+                                            sort_desc={sort_desc}
+                                            on_sort={on_sort_col.clone()}
                                             on_edit={on_edit}
                                             on_delete={on_ask_delete}
                                             on_toggle={on_toggle}
@@ -1207,8 +1219,6 @@ pub struct FilterSortBarProps {
     /// Count after filtering / total loaded — rendered as "Showing N of M".
     pub shown: usize,
     pub total: usize,
-    pub sort: RSort,
-    pub sort_desc: bool,
     /// NodeRef forwarded from the page so the `/` shortcut can focus this input.
     pub search_ref: NodeRef,
     pub on_query: Callback<String>,
@@ -1216,11 +1226,10 @@ pub struct FilterSortBarProps {
     pub on_agent: Callback<AgentFacet>,
     pub on_machine: Callback<RoutineMachineFacet>,
     pub on_clear: Callback<()>,
-    pub on_set_sort: Callback<RSort>,
-    pub on_toggle_sort_dir: Callback<()>,
 }
 
-/// Full-text search + status / agent / machine facets + sort controls for the routine table.
+/// Full-text search + status / agent / machine facets for the routine table.
+/// Sorting is handled by clicking column headers in the table itself.
 #[function_component(FilterSortBar)]
 pub fn filter_sort_bar(props: &FilterSortBarProps) -> Html {
     let on_input = {
@@ -1255,24 +1264,7 @@ pub fn filter_sort_bar(props: &FilterSortBarProps) -> Html {
         let cb = props.on_clear.clone();
         Callback::from(move |_: MouseEvent| cb.emit(()))
     };
-    let on_sort_change = {
-        let cb = props.on_set_sort.clone();
-        Callback::from(move |e: Event| {
-            let select: HtmlSelectElement = e.target_unchecked_into();
-            cb.emit(RSort::from_str(&select.value()));
-        })
-    };
-    let on_dir = {
-        let cb = props.on_toggle_sort_dir.clone();
-        Callback::from(move |_: MouseEvent| cb.emit(()))
-    };
 
-    let dir_label = if props.sort_desc {
-        "↓ DESC"
-    } else {
-        "↑ ASC"
-    };
-    let current_sort = props.sort.as_str();
     let status_val = props.filter.status.as_str();
     let agent_val = props.filter.agent.as_value();
     let machine_val = props.filter.machine.as_value();
@@ -1337,15 +1329,6 @@ pub fn filter_sort_bar(props: &FilterSortBarProps) -> Html {
                         html! {}
                     }
                 }
-                <span class="filter-label">{"SORT"}</span>
-                <select class="filter-select" onchange={on_sort_change}>
-                    <option value="created" selected={current_sort == "created"}>{"Created"}</option>
-                    <option value="updated" selected={current_sort == "updated"}>{"Updated"}</option>
-                    <option value="title" selected={current_sort == "title"}>{"Title"}</option>
-                    <option value="repository" selected={current_sort == "repository"}>{"Repository"}</option>
-                </select>
-                <button class="btn btn-ghost btn-sm" onclick={on_dir}
-                    title="Toggle sort direction">{dir_label}</button>
             </div>
         </div>
     }
@@ -1517,6 +1500,37 @@ pub fn routine_calendar(props: &CalendarProps) -> Html {
 
 // ─── Table ────────────────────────────────────────────────────────────────────
 
+/// Render a clickable sort column header. Active column shows ▲ / ▼.
+fn sort_th_r(
+    label: &'static str,
+    col: RSort,
+    current: Option<RSort>,
+    desc: bool,
+    on_sort: &Callback<RSort>,
+) -> Html {
+    let active = current == Some(col);
+    let indicator = if active {
+        if desc {
+            " ▼"
+        } else {
+            " ▲"
+        }
+    } else {
+        ""
+    };
+    let cls = if active {
+        "th-sort th-sort-active"
+    } else {
+        "th-sort"
+    };
+    let cb = on_sort.clone();
+    html! {
+        <th class={cls} onclick={Callback::from(move |_: MouseEvent| cb.emit(col))}>
+            { format!("{label}{indicator}") }
+        </th>
+    }
+}
+
 #[derive(Properties, PartialEq)]
 pub struct TableProps {
     pub routines: Vec<Routine>,
@@ -1525,6 +1539,12 @@ pub struct TableProps {
     pub filter_active: bool,
     /// Reference instant used to compute next-fire countdowns.
     pub now: chrono::DateTime<Local>,
+    /// Column the table is currently sorted by (`None` = natural order).
+    pub sort_col: Option<RSort>,
+    /// `true` → descending order.
+    pub sort_desc: bool,
+    /// Fired when a sortable column header is clicked.
+    pub on_sort: Callback<RSort>,
     pub on_edit: Callback<String>,
     pub on_delete: Callback<(String, String)>,
     pub on_toggle: Callback<(String, bool)>,
@@ -1580,14 +1600,14 @@ pub fn routine_table(props: &TableProps) -> Html {
             <table>
                 <thead>
                     <tr>
-                        <th>{"TITLE"}</th>
+                        { sort_th_r("TITLE", RSort::Title, props.sort_col, props.sort_desc, &props.on_sort) }
                         <th>{"SCHEDULE"}</th>
-                        <th>{"NEXT RUN"}</th>
-                        <th>{"AGENT"}</th>
+                        { sort_th_r("NEXT RUN", RSort::NextRun, props.sort_col, props.sort_desc, &props.on_sort) }
+                        { sort_th_r("AGENT", RSort::Agent, props.sort_col, props.sort_desc, &props.on_sort) }
                         <th>{"REPOS"}</th>
                         <th>{"TTL"}</th>
-                        <th>{"ENABLED"}</th>
-                        <th>{"UPDATED"}</th>
+                        { sort_th_r("ENABLED", RSort::Enabled, props.sort_col, props.sort_desc, &props.on_sort) }
+                        { sort_th_r("UPDATED", RSort::Updated, props.sort_col, props.sort_desc, &props.on_sort) }
                         <th></th>
                     </tr>
                 </thead>

--- a/ui/src/routines_tests.rs
+++ b/ui/src/routines_tests.rs
@@ -437,3 +437,127 @@ fn unassigned_routines_count_counts_empty_machine_lists() {
     ];
     assert_eq!(unassigned_routines_count(&routines), 2);
 }
+
+// ── sort_routines ─────────────────────────────────────────────────────────────
+
+fn sorted_ids(routines: Vec<Routine>) -> Vec<String> {
+    routines.into_iter().map(|r| r.id).collect()
+}
+
+#[test]
+fn sort_routines_none_preserves_insertion_order() {
+    let routines = vec![
+        routine("c", "C", "agent", "0 * * * *", &[], &[], true),
+        routine("a", "A", "agent", "0 * * * *", &[], &[], true),
+        routine("b", "B", "agent", "0 * * * *", &[], &[], true),
+    ];
+    let got = sort_routines(routines, None, false, now());
+    assert_eq!(sorted_ids(got), vec!["c", "a", "b"]);
+}
+
+#[test]
+fn sort_routines_title_ascending() {
+    let routines = vec![
+        routine("1", "Zebra", "agent", "0 * * * *", &[], &[], true),
+        routine("2", "apple", "agent", "0 * * * *", &[], &[], true),
+        routine("3", "Mango", "agent", "0 * * * *", &[], &[], true),
+    ];
+    let got = sort_routines(routines, Some(RSort::Title), false, now());
+    assert_eq!(sorted_ids(got), vec!["2", "3", "1"]);
+}
+
+#[test]
+fn sort_routines_title_descending() {
+    let routines = vec![
+        routine("1", "Zebra", "agent", "0 * * * *", &[], &[], true),
+        routine("2", "apple", "agent", "0 * * * *", &[], &[], true),
+        routine("3", "Mango", "agent", "0 * * * *", &[], &[], true),
+    ];
+    let got = sort_routines(routines, Some(RSort::Title), true, now());
+    assert_eq!(sorted_ids(got), vec!["1", "3", "2"]);
+}
+
+#[test]
+fn sort_routines_agent_ascending() {
+    let mut r1 = routine("1", "t", "zeta", "0 * * * *", &[], &[], true);
+    let mut r2 = routine("2", "t", "Alpha", "0 * * * *", &[], &[], true);
+    let mut r3 = routine("3", "t", "beta", "0 * * * *", &[], &[], true);
+    // Use distinct updated_at for stable tiebreak by id
+    r1.updated_at = 10;
+    r2.updated_at = 20;
+    r3.updated_at = 30;
+    let got = sort_routines(vec![r1, r2, r3], Some(RSort::Agent), false, now());
+    assert_eq!(sorted_ids(got), vec!["2", "3", "1"]);
+}
+
+#[test]
+fn sort_routines_enabled_ascending_disabled_first() {
+    let routines = vec![
+        routine("1", "t", "agent", "0 * * * *", &[], &[], true),
+        routine("2", "t", "agent", "0 * * * *", &[], &[], false),
+        routine("3", "t", "agent", "0 * * * *", &[], &[], true),
+    ];
+    let got = sort_routines(routines, Some(RSort::Enabled), false, now());
+    assert_eq!(got[0].id, "2");
+    assert!(!got[0].enabled);
+}
+
+#[test]
+fn sort_routines_enabled_descending_enabled_first() {
+    let routines = vec![
+        routine("1", "t", "agent", "0 * * * *", &[], &[], false),
+        routine("2", "t", "agent", "0 * * * *", &[], &[], true),
+    ];
+    let got = sort_routines(routines, Some(RSort::Enabled), true, now());
+    assert_eq!(got[0].id, "2");
+    assert!(got[0].enabled);
+}
+
+#[test]
+fn sort_routines_updated_ascending() {
+    let mut r1 = routine("1", "t", "agent", "0 * * * *", &[], &[], true);
+    let mut r2 = routine("2", "t", "agent", "0 * * * *", &[], &[], true);
+    let mut r3 = routine("3", "t", "agent", "0 * * * *", &[], &[], true);
+    r1.updated_at = 300;
+    r2.updated_at = 100;
+    r3.updated_at = 200;
+    let got = sort_routines(vec![r1, r2, r3], Some(RSort::Updated), false, now());
+    assert_eq!(sorted_ids(got), vec!["2", "3", "1"]);
+}
+
+#[test]
+fn sort_routines_updated_descending() {
+    let mut r1 = routine("1", "t", "agent", "0 * * * *", &[], &[], true);
+    let mut r2 = routine("2", "t", "agent", "0 * * * *", &[], &[], true);
+    r1.updated_at = 100;
+    r2.updated_at = 200;
+    let got = sort_routines(vec![r1, r2], Some(RSort::Updated), true, now());
+    assert_eq!(sorted_ids(got), vec!["2", "1"]);
+}
+
+#[test]
+fn sort_routines_next_run_enabled_before_disabled() {
+    // enabled routine with "0 * * * *" fires within the hour; disabled gets None
+    let enabled = routine("e", "t", "agent", "0 * * * *", &[], &[], true);
+    let disabled = routine("d", "t", "agent", "0 * * * *", &[], &[], false);
+    let got = sort_routines(
+        vec![disabled.clone(), enabled.clone()],
+        Some(RSort::NextRun),
+        false,
+        now(),
+    );
+    assert_eq!(got[0].id, "e");
+    assert_eq!(got[1].id, "d");
+}
+
+#[test]
+fn sort_routines_next_run_desc_puts_later_fire_first() {
+    // "0 * * * *" fires at :00 of next hour; "0 0 * * *" fires at midnight
+    // now() is 2026-01-01 12:00:00 → "0 * * * *" fires 13:00, "0 0 * * *" fires next 00:00
+    let r1 = routine("hourly", "t", "agent", "0 * * * *", &[], &[], true);
+    let r2 = routine("midnight", "t", "agent", "0 0 * * *", &[], &[], true);
+    // desc: later fire time first
+    let got = sort_routines(vec![r1, r2], Some(RSort::NextRun), true, now());
+    assert_eq!(got[0].id, "midnight");
+    assert_eq!(got[1].id, "hourly");
+}


### PR DESCRIPTION
## Summary

- Replaces the **SORT dropdown + direction-toggle button** in the Routines filter bar with **clickable column headers** (TITLE, NEXT RUN, AGENT, ENABLED, UPDATED), creating UX parity with the already-shipped Cron Jobs table.
- Clicking a column sorts ascending (▲); clicking the same column again reverses to descending (▼); clicking a different column resets to ascending for the new column.
- Adds `sort_routines()` — a pure, host-testable function — and updates the `RSort` enum to reflect actual table columns (Title, NextRun, Agent, Enabled, Updated).
- Removes the old `SetSort` / `ToggleSortDir` actions and `RSort::{Created, Repository}` variants; one `ClickSortCol(RSort)` action replaces both.
- All changes are confined to `ui/src/routines.rs`, `ui/src/routines_tests.rs`, and `CHANGELOG.md` — no backend change.

Closes #679.

## Test plan

- [ ] `cargo test -p ui` — 169 tests pass
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --check -p ui` — clean
- [ ] Only `ui/src/routines.rs`, `ui/src/routines_tests.rs`, `CHANGELOG.md` staged (no `prebuilt.html`)

---

*This pull request was opened by the UI dashboard feature builder (research → issue → PR → merge) routine of moadim. @tupe12334*

🤖 Generated with [Claude Code](https://claude.com/claude-code)