### PR TITLE
feat(ui): group-by dimension for the Cron Jobs table (#714)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Added
 
+- **Group-by dimension for the Cron Jobs table.** A new **GROUP BY** selector in the
+  Cron Jobs toolbar lets operators partition the flat job list into labelled sections
+  by **Handler**, **Machine**, or **Status** (enabled/disabled). Within each group the
+  active column sort still applies; groups are ordered alphabetically for a stable
+  layout. `None` (the default) preserves the existing flat-list behaviour. Backed by
+  a pure `group_jobs()` / `group_key()` function covered by 16 new host-only tests.
+  Follows the first-class grouping pattern in Airflow's DAG list, GitHub Actions
+  workflow runs, and Temporal namespace views — orthogonal to filtering so operators
+  can filter *and* group simultaneously. Pure frontend — no backend change.
+  Closes #714.
 - **Dedicated LAST FIRE column in the Routines table.** The most-recent trigger
   timestamp is now shown in its own **LAST FIRE** column directly beside NEXT RUN,
   matching the side-by-side "last run / next run" pattern standard in Airflow, Temporal,

--- a/ui/index.html
+++ b/ui/index.html
@@ -1057,6 +1057,33 @@
       white-space: nowrap;
     }
 
+    /* ── Group-by selector ── */
+    .group-by-ctrl { display: flex; align-items: center; gap: 6px; }
+
+    /* ── Table group header rows ── */
+    tr.group-hd td {
+      padding: 5px 10px;
+      background: var(--bg-3);
+      border-top: 1px solid var(--border);
+      border-bottom: 1px solid var(--border);
+    }
+    tr.group-hd:first-child td { border-top: none; }
+    .group-label {
+      font-family: var(--mono);
+      font-size: 10px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--text-hi);
+      font-weight: 600;
+    }
+    .group-count {
+      margin-left: 6px;
+      font-family: var(--mono);
+      font-size: 10px;
+      letter-spacing: 0.06em;
+      color: var(--text-dim);
+    }
+
     /* ── Calendar ── */
     .cal-wrap {
       border: 1px solid var(--border);

--- a/ui/src/cron_jobs.rs
+++ b/ui/src/cron_jobs.rs
@@ -334,6 +334,102 @@ pub fn sort_jobs(
     jobs
 }
 
+// ─── Group-by ─────────────────────────────────────────────────────────────────
+//
+// Orthogonal to filtering and sorting: operators can group the flat job list
+// into labelled sections so jobs of the same handler, machine, or status stay
+// visually together. Best-practice (Airflow DAG list, GitHub Actions workflow
+// runs, Temporal namespace view): grouping is a first-class navigation primitive
+// for large job fleets; it composes with faceted filtering and column sorting.
+
+/// Dimension used to group the cron-jobs table into labelled sections.
+/// `None` (the default) keeps the existing flat list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum GroupBy {
+    #[default]
+    None,
+    /// Group by handler name (e.g. `git-sync`, `backup`, `deploy`).
+    Handler,
+    /// Group by target machine; jobs with no machine share an `(unassigned)` section.
+    Machine,
+    /// Group by enabled/disabled status.
+    Status,
+}
+
+impl GroupBy {
+    /// Stable token stored as the `<select>` option value.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            GroupBy::None => "none",
+            GroupBy::Handler => "handler",
+            GroupBy::Machine => "machine",
+            GroupBy::Status => "status",
+        }
+    }
+
+    /// Parse a token back to a variant, defaulting to `None` for unknown values.
+    #[must_use]
+    pub fn from_str(s: &str) -> Self {
+        match s {
+            "handler" => GroupBy::Handler,
+            "machine" => GroupBy::Machine,
+            "status" => GroupBy::Status,
+            _ => GroupBy::None,
+        }
+    }
+
+    /// Short human label shown in the selector dropdown.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            GroupBy::None => "None",
+            GroupBy::Handler => "Handler",
+            GroupBy::Machine => "Machine",
+            GroupBy::Status => "Status",
+        }
+    }
+}
+
+/// Group key for a single job under the given dimension. A job always belongs
+/// to exactly one group (first machine for `Machine`, or `"(unassigned)"`).
+#[must_use]
+pub fn group_key(job: &CronJob, by: GroupBy) -> String {
+    match by {
+        GroupBy::None => String::new(),
+        GroupBy::Handler => job.handler.clone(),
+        GroupBy::Machine => job
+            .machines
+            .first()
+            .cloned()
+            .unwrap_or_else(|| "(unassigned)".to_string()),
+        GroupBy::Status => {
+            if job.enabled {
+                "Enabled".to_string()
+            } else {
+                "Disabled".to_string()
+            }
+        }
+    }
+}
+
+/// Partition `jobs` into `(group_label, jobs_in_group)` pairs sorted
+/// alphabetically by label. Within each group the input order is preserved
+/// (callers sort before grouping so column sorts apply within groups).
+/// When `by` is `None`, returns a single pair with an empty label.
+#[must_use]
+pub fn group_jobs(jobs: &[CronJob], by: GroupBy) -> Vec<(String, Vec<CronJob>)> {
+    use std::collections::BTreeMap;
+    if by == GroupBy::None {
+        return vec![(String::new(), jobs.to_vec())];
+    }
+    let mut map: BTreeMap<String, Vec<CronJob>> = BTreeMap::new();
+    for job in jobs {
+        map.entry(group_key(job, by)).or_default().push(job.clone());
+    }
+    map.into_iter().collect()
+}
+
 // ─── API layer ────────────────────────────────────────────────────────────────
 
 async fn api_list() -> Result<Vec<CronJob>, String> {
@@ -462,6 +558,8 @@ pub struct CState {
     pub sort_col: Option<SortCol>,
     /// Direction of the active column sort.
     pub sort_dir: SortDir,
+    /// Active group-by dimension (`None` = flat list, the default).
+    pub group_by: GroupBy,
 }
 
 impl Default for CState {
@@ -477,6 +575,7 @@ impl Default for CState {
             filter: JobFilter::default(),
             sort_col: None,
             sort_dir: SortDir::default(),
+            group_by: GroupBy::None,
         }
     }
 }
@@ -511,6 +610,8 @@ pub enum CAction {
     ClearFilters,
     /// Sort by `col`; re-clicking the active column reverses direction.
     SetSort(SortCol),
+    /// Change the group-by dimension for the table view.
+    SetGroupBy(GroupBy),
 }
 
 impl Reducible for CState {
@@ -617,6 +718,7 @@ impl Reducible for CState {
                     s.sort_dir = SortDir::Asc;
                 }
             }
+            CAction::SetGroupBy(by) => s.group_by = by,
         }
         s.into()
     }
@@ -1062,6 +1164,11 @@ pub fn cron_jobs_page(props: &CronJobsPageProps) -> Html {
         Callback::from(move |col: SortCol| state.dispatch(CAction::SetSort(col)))
     };
 
+    let on_set_group_by = {
+        let state = state.clone();
+        Callback::from(move |by: GroupBy| state.dispatch(CAction::SetGroupBy(by)))
+    };
+
     let jobs = state.jobs.clone();
     let loading = state.loading;
     let now_val = *now;
@@ -1072,6 +1179,7 @@ pub fn cron_jobs_page(props: &CronJobsPageProps) -> Html {
     let filter = state.filter.clone();
     let sort_col = state.sort_col;
     let sort_dir = state.sort_dir;
+    let group_by = state.group_by;
 
     // Faceted view of the list: filter first, then sort. The KPI tiles and
     // result count stay over the filtered set (unaffected by sort order).
@@ -1121,6 +1229,12 @@ pub fn cron_jobs_page(props: &CronJobsPageProps) -> Html {
                                         updated_at_ms={*updated_at}
                                         on_change={on_set_interval}
                                     />
+                                    if view == CView::Table {
+                                        <GroupBySelector
+                                            group_by={group_by}
+                                            on_change={on_set_group_by}
+                                        />
+                                    }
                                     <CronViewToggle view={view} on_set_view={on_set_view} />
                                     <button class="btn btn-primary btn-sm" onclick={on_new}>{"+ NEW JOB"}</button>
                                 </div>
@@ -1156,6 +1270,7 @@ pub fn cron_jobs_page(props: &CronJobsPageProps) -> Html {
                                                 filter_active={filter_active}
                                                 sort_col={sort_col}
                                                 sort_dir={sort_dir}
+                                                group_by={group_by}
                                                 on_sort={on_sort}
                                                 on_edit={on_edit}
                                                 on_delete={on_ask_delete}
@@ -1244,6 +1359,46 @@ pub fn cron_view_toggle(props: &CronViewToggleProps) -> Html {
             { mk(CView::Table, "LIST") }
             { mk(CView::Calendar, "CALENDAR") }
             { mk(CView::Day, "DAY") }
+        </div>
+    }
+}
+
+// ─── Group-by selector ────────────────────────────────────────────────────────
+
+#[derive(Properties, PartialEq)]
+pub struct GroupBySelectorProps {
+    pub group_by: GroupBy,
+    pub on_change: Callback<GroupBy>,
+}
+
+/// Drop-down that lets the operator choose how to group the job table.
+/// Placed in the section toolbar next to the view toggle; hidden for
+/// Calendar/Day views (callers only render it in table view).
+#[function_component(GroupBySelector)]
+pub fn group_by_selector(props: &GroupBySelectorProps) -> Html {
+    let on_change = props.on_change.clone();
+    let on_select = Callback::from(move |e: Event| {
+        let select: web_sys::HtmlSelectElement = e.target_unchecked_into();
+        on_change.emit(GroupBy::from_str(&select.value()));
+    });
+    let cur = props.group_by.as_str();
+    html! {
+        <div class="group-by-ctrl">
+            <label class="filter-label" for="group-by-select">{"GROUP BY"}</label>
+            <select
+                id="group-by-select"
+                class="filter-select"
+                aria-label="Group jobs by"
+                onchange={on_select}
+            >
+                { for [GroupBy::None, GroupBy::Handler, GroupBy::Machine, GroupBy::Status].iter()
+                    .map(|&by| html! {
+                        <option value={by.as_str()} selected={cur == by.as_str()}>
+                            { by.label() }
+                        </option>
+                    })
+                }
+            </select>
         </div>
     }
 }
@@ -1474,6 +1629,8 @@ pub struct JobTableProps {
     pub sort_col: Option<SortCol>,
     /// Direction of the active column sort.
     pub sort_dir: SortDir,
+    /// Active group-by dimension; `None` renders a flat list.
+    pub group_by: GroupBy,
     /// Fired when the user clicks a sortable column header.
     pub on_sort: Callback<SortCol>,
     pub on_edit: Callback<String>,
@@ -1532,6 +1689,9 @@ pub fn job_table(props: &JobTableProps) -> Html {
         Callback::from(move |_: MouseEvent| cb.emit(()))
     };
 
+    let groups = group_jobs(&props.jobs, props.group_by);
+    let grouped = props.group_by != GroupBy::None;
+
     html! {
         <div class="table-wrap">
             <table>
@@ -1558,19 +1718,34 @@ pub fn job_table(props: &JobTableProps) -> Html {
                     </tr>
                 </thead>
                 <tbody>
-                    { for props.jobs.iter().map(|job| html! {
-                        <JobRow
-                            key={job.id.clone()}
-                            job={job.clone()}
-                            now={props.now}
-                            selected={props.selected.contains(&job.id)}
-                            on_edit={props.on_edit.clone()}
-                            on_delete={props.on_delete.clone()}
-                            on_toggle={props.on_toggle.clone()}
-                            on_trigger={props.on_trigger.clone()}
-                            on_logs={props.on_logs.clone()}
-                            on_select={props.on_select.clone()}
-                        />
+                    { for groups.into_iter().map(|(label, group_jobs)| {
+                        let count = group_jobs.len();
+                        html! {
+                            <>
+                                if grouped {
+                                    <tr class="group-hd" key={format!("ghd-{label}")}>
+                                        <td colspan="9">
+                                            <span class="group-label">{label.clone()}</span>
+                                            <span class="group-count">{format!("({count})")}</span>
+                                        </td>
+                                    </tr>
+                                }
+                                { for group_jobs.into_iter().map(|job| html! {
+                                    <JobRow
+                                        key={job.id.clone()}
+                                        job={job.clone()}
+                                        now={props.now}
+                                        selected={props.selected.contains(&job.id)}
+                                        on_edit={props.on_edit.clone()}
+                                        on_delete={props.on_delete.clone()}
+                                        on_toggle={props.on_toggle.clone()}
+                                        on_trigger={props.on_trigger.clone()}
+                                        on_logs={props.on_logs.clone()}
+                                        on_select={props.on_select.clone()}
+                                    />
+                                }) }
+                            </>
+                        }
                     }) }
                 </tbody>
             </table>

--- a/ui/src/cron_jobs_tests.rs
+++ b/ui/src/cron_jobs_tests.rs
@@ -477,3 +477,159 @@ fn sort_jobs_stable_tiebreak_by_id() {
     assert_eq!(out[0].id, "alpha");
     assert_eq!(out[1].id, "beta");
 }
+
+// ── GroupBy codec ─────────────────────────────────────────────────────────────
+
+#[test]
+fn group_by_as_str_roundtrips() {
+    for by in [
+        GroupBy::None,
+        GroupBy::Handler,
+        GroupBy::Machine,
+        GroupBy::Status,
+    ] {
+        assert_eq!(GroupBy::from_str(by.as_str()), by);
+    }
+}
+
+#[test]
+fn group_by_default_is_none() {
+    assert_eq!(GroupBy::default(), GroupBy::None);
+}
+
+#[test]
+fn group_by_unknown_token_decodes_to_none() {
+    assert_eq!(GroupBy::from_str("bogus"), GroupBy::None);
+    assert_eq!(GroupBy::from_str(""), GroupBy::None);
+}
+
+// ── group_key ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn group_key_handler_returns_handler_field() {
+    let j = job("id1", "git-sync", "0 * * * *", &["m1"], true);
+    assert_eq!(group_key(&j, GroupBy::Handler), "git-sync");
+}
+
+#[test]
+fn group_key_machine_returns_first_machine() {
+    let j = job("id1", "h", "0 * * * *", &["alpha", "beta"], true);
+    assert_eq!(group_key(&j, GroupBy::Machine), "alpha");
+}
+
+#[test]
+fn group_key_machine_returns_unassigned_when_no_machines() {
+    let j = job("id1", "h", "0 * * * *", &[], true);
+    assert_eq!(group_key(&j, GroupBy::Machine), "(unassigned)");
+}
+
+#[test]
+fn group_key_status_enabled() {
+    let j = job("id1", "h", "0 * * * *", &[], true);
+    assert_eq!(group_key(&j, GroupBy::Status), "Enabled");
+}
+
+#[test]
+fn group_key_status_disabled() {
+    let j = job("id1", "h", "0 * * * *", &[], false);
+    assert_eq!(group_key(&j, GroupBy::Status), "Disabled");
+}
+
+#[test]
+fn group_key_none_returns_empty_string() {
+    let j = job("id1", "h", "0 * * * *", &[], true);
+    assert_eq!(group_key(&j, GroupBy::None), "");
+}
+
+// ── group_jobs ────────────────────────────────────────────────────────────────
+
+#[test]
+fn group_jobs_none_returns_single_group_with_all_jobs() {
+    let jobs = vec![
+        job("a", "handler-a", "0 * * * *", &[], true),
+        job("b", "handler-b", "0 * * * *", &[], false),
+    ];
+    let groups = group_jobs(&jobs, GroupBy::None);
+    assert_eq!(groups.len(), 1);
+    assert_eq!(groups[0].0, "");
+    assert_eq!(groups[0].1.len(), 2);
+}
+
+#[test]
+fn group_jobs_by_handler_creates_one_group_per_handler() {
+    let jobs = vec![
+        job("a", "backup", "0 * * * *", &[], true),
+        job("b", "git-sync", "0 * * * *", &[], true),
+        job("c", "backup", "0 * * * *", &[], true),
+    ];
+    let groups = group_jobs(&jobs, GroupBy::Handler);
+    // BTreeMap → alphabetical: backup, git-sync
+    assert_eq!(groups.len(), 2);
+    assert_eq!(groups[0].0, "backup");
+    assert_eq!(groups[0].1.len(), 2);
+    assert_eq!(groups[1].0, "git-sync");
+    assert_eq!(groups[1].1.len(), 1);
+}
+
+#[test]
+fn group_jobs_by_handler_preserves_input_order_within_group() {
+    let jobs = vec![
+        job("first", "backup", "0 * * * *", &[], true),
+        job("second", "backup", "0 * * * *", &[], true),
+    ];
+    let groups = group_jobs(&jobs, GroupBy::Handler);
+    assert_eq!(groups[0].1[0].id, "first");
+    assert_eq!(groups[0].1[1].id, "second");
+}
+
+#[test]
+fn group_jobs_by_machine_separates_unassigned() {
+    let jobs = vec![
+        job("a", "h", "0 * * * *", &["worker-1"], true),
+        job("b", "h", "0 * * * *", &[], true),
+        job("c", "h", "0 * * * *", &["worker-1"], true),
+    ];
+    let groups = group_jobs(&jobs, GroupBy::Machine);
+    // alphabetical: "(unassigned)" sorts before "worker-1"
+    assert_eq!(groups.len(), 2);
+    assert_eq!(groups[0].0, "(unassigned)");
+    assert_eq!(groups[0].1.len(), 1);
+    assert_eq!(groups[1].0, "worker-1");
+    assert_eq!(groups[1].1.len(), 2);
+}
+
+#[test]
+fn group_jobs_by_status_splits_enabled_and_disabled() {
+    let jobs = vec![
+        job("a", "h", "0 * * * *", &[], true),
+        job("b", "h", "0 * * * *", &[], false),
+        job("c", "h", "0 * * * *", &[], true),
+    ];
+    let groups = group_jobs(&jobs, GroupBy::Status);
+    // alphabetical: "Disabled" before "Enabled"
+    assert_eq!(groups.len(), 2);
+    assert_eq!(groups[0].0, "Disabled");
+    assert_eq!(groups[0].1.len(), 1);
+    assert_eq!(groups[1].0, "Enabled");
+    assert_eq!(groups[1].1.len(), 2);
+}
+
+#[test]
+fn group_jobs_empty_input_returns_empty_for_grouped_dimensions() {
+    for by in [GroupBy::Handler, GroupBy::Machine, GroupBy::Status] {
+        let groups = group_jobs(&[], by);
+        assert!(groups.is_empty(), "expected empty for {by:?}");
+    }
+}
+
+#[test]
+fn group_jobs_groups_sorted_alphabetically() {
+    let jobs = vec![
+        job("a", "zebra", "0 * * * *", &[], true),
+        job("b", "alpha", "0 * * * *", &[], true),
+        job("c", "middle", "0 * * * *", &[], true),
+    ];
+    let groups = group_jobs(&jobs, GroupBy::Handler);
+    let labels: Vec<&str> = groups.iter().map(|(l, _)| l.as_str()).collect();
+    assert_eq!(labels, ["alpha", "middle", "zebra"]);
+}


### PR DESCRIPTION
## Summary

- Adds a **GROUP BY** selector to the Cron Jobs table toolbar with four dimensions: **None** (flat list, the default), **Handler**, **Machine**, and **Status**
- Backed by `GroupBy` enum, `group_key()`, `group_jobs()` — pure host-testable functions covered by 16 new unit tests
- Group header rows (`tr.group-hd`) render a label + count between sections; groups are sorted alphabetically for a stable layout
- Column sort still applies within each group; GROUP BY composes with the existing status/machine facets and free-text search
- `GroupBySelector` component placed in the table toolbar, hidden for Calendar/Day views
- CSS for `.group-hd`, `.group-label`, `.group-count`, `.group-by-ctrl` added to `index.html`
- No backend change — uses the `handler`, `machines`, and `enabled` fields already in the `CronJob` struct

Closes #714

## Test plan

- [x] `cargo test -p ui` — 204 tests pass (16 new group-by tests)
- [x] `cargo clippy -p ui --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p ui --check` — no diff
- [ ] In the UI: GROUP BY selector appears in toolbar between AUTO and LIST/CALENDAR/DAY; selecting Handler groups jobs by handler type with count badges; selecting None restores flat list; combined with search/status/machine filters works correctly

---
*This pull request was opened by the **UI dashboard feature builder (research → issue → PR → merge)** routine of moadim.*

@tupe12334