### PR TITLE
chore(release): bump version to 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-06-26
+
 ### Changed
 
 - **`defaults` module split.** `src/routines/defaults.rs` is now a module (`defaults/`); each

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ opt-level = "z"
 
 [package]
 name = "moadim"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Loop engine for AI agents — cron jobs and routines over REST, MCP, and a built-in web UI"
 license = "MIT"

--- a/docs/moadim.1
+++ b/docs/moadim.1
@@ -1,7 +1,7 @@
 .\" Man page for moadim.
 .\" Mirrors the built-in `moadim --help` output (src/cli.rs::print_help).
 .\" View with:  man ./docs/moadim.1   or install into share/man/man1/.
-.TH MOADIM 1 "2026-06-22" "moadim 0.15.0" "Moadim Manual"
+.TH MOADIM 1 "2026-06-26" "moadim 0.16.0" "Moadim Manual"
 .SH NAME
 moadim \- cron/MCP/REST server with a web control panel
 .SH SYNOPSIS


### PR DESCRIPTION
## Summary

- Bumps `Cargo.toml` version from `0.15.0` → `0.16.0`
- Updates `Cargo.lock` to match
- Promotes `[Unreleased]` section in `CHANGELOG.md` to `[0.16.0] - 2026-06-26`
- Updates `docs/moadim.1` date and version string

Merging this PR triggers `auto-release.yml`, which pushes the `v0.16.0` tag and runs the crates.io publish + GitHub Release workflows automatically.

## Test plan

- [ ] CI passes (lint, test, spellcheck)
- [ ] Auto-release workflow fires on merge and creates `v0.16.0` tag + GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)