### PR TITLE
fix(macos): request automation permission during install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+### Fixed
+
+- **macOS: TCC "administer your computer" dialog no longer appears during background runs.**
+  `moadim install` now proactively sends a harmless Apple Event to System Events so macOS
+  prompts for the Automation permission once, while the user is at the terminal. After clicking
+  OK the grant is remembered permanently; the background daemon never triggers the dialog again.
+  A hint line is printed before the prompt so users know what to expect. Closes #730.
+
 ### Added
 
 - **Local-machine filter for routines and cron jobs.** A new `GET /api/v1/machine` endpoint

--- a/src/service/macos.rs
+++ b/src/service/macos.rs
@@ -135,7 +135,10 @@ fn request_automation_permission() {
 granting it here prevents background interruptions"
     );
     let _ = std::process::Command::new("osascript")
-        .args(["-e", "tell application \"System Events\" to get name of every process"])
+        .args([
+            "-e",
+            "tell application \"System Events\" to get name of every process",
+        ])
         .output();
 }
 

--- a/src/service/macos.rs
+++ b/src/service/macos.rs
@@ -120,7 +120,23 @@ pub fn install() -> anyhow::Result<()> {
     write_plist(&plist, &exe, &log)?;
     reload_agent(&plist)?;
     report_installed(&plist, &log);
+    request_automation_permission();
     Ok(())
+}
+
+/// Trigger the macOS TCC "administer your computer" prompt now, while the user is present at the
+/// terminal, so the background daemon never has to ask for it mid-run.
+///
+/// Sends a harmless Apple Event to System Events (list running process names). If permission is
+/// already granted this is a no-op; if not, the dialog appears once here and is remembered forever.
+fn request_automation_permission() {
+    println!(
+        "  hint    if macOS asks \"moadim would like to administer your computer\", click OK — \
+granting it here prevents background interruptions"
+    );
+    let _ = std::process::Command::new("osascript")
+        .args(["-e", "tell application \"System Events\" to get name of every process"])
+        .output();
 }
 
 /// Unload the LaunchAgent (if loaded) and delete its plist.


### PR DESCRIPTION
## Summary

- During `moadim install`, call `osascript` with a harmless System Events query to trigger the TCC permission dialog while the user is present at the terminal
- Print a hint before the dialog appears so the user knows what it is and why to allow it
- If already granted, the `osascript` call is a no-op — no visible effect on reinstalls

Closes #730

## Test plan

- [ ] Run `moadim install` on macOS — verify hint line prints and TCC dialog appears
- [ ] Click OK — verify `moadim install` completes successfully
- [ ] Restart the daemon — verify no further "administer your computer" dialogs appear during background agent runs
- [ ] Run `moadim install` again (reinstall) — verify no dialog (already granted)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)