### PR TITLE
feat(ui): group-by dimension for the Routines table (#733)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Added
 
+- **UI: group-by dimension for the Routines table.** A **GROUP BY** selector in the section
+  toolbar lets operators partition the flat routine list into labelled sections by **Agent**,
+  **Machine**, or **Status** (Enabled / Disabled), with a **None** option to restore the flat
+  view. The selector only appears in Table view (hidden for Calendar and Day) and composes with
+  the existing faceted filter and column-sort controls. Closes #733.
+
 - **UI: clone/duplicate a routine.** A ⧉ duplicate button on each routine row opens the
   create-routine form pre-filled with all fields from the source routine (schedule, agent, prompt,
   repositories, machines, TTL, enabled state). The title is automatically prefixed with

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -625,6 +625,96 @@ impl RDir {
     }
 }
 
+// ─── Group-by ────────────────────────────────────────────────────────────────
+
+/// Dimension used to partition the Routines table into labelled sections.
+/// Orthogonal to faceted filtering and column sorting — composes with both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RGroupBy {
+    #[default]
+    None,
+    /// Group by the routine's agent (claude, codex, …).
+    Agent,
+    /// Group by target machine; routines with no machine share an `(unassigned)` section.
+    Machine,
+    /// Group by enabled/disabled status.
+    Status,
+}
+
+impl RGroupBy {
+    /// Stable token stored as the `<select>` option value.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            RGroupBy::None => "none",
+            RGroupBy::Agent => "agent",
+            RGroupBy::Machine => "machine",
+            RGroupBy::Status => "status",
+        }
+    }
+
+    /// Parse a token back to a variant, defaulting to `None` for unknown values.
+    #[must_use]
+    pub fn from_str(s: &str) -> Self {
+        match s {
+            "agent" => RGroupBy::Agent,
+            "machine" => RGroupBy::Machine,
+            "status" => RGroupBy::Status,
+            _ => RGroupBy::None,
+        }
+    }
+
+    /// Short human label shown in the selector dropdown.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            RGroupBy::None => "None",
+            RGroupBy::Agent => "Agent",
+            RGroupBy::Machine => "Machine",
+            RGroupBy::Status => "Status",
+        }
+    }
+}
+
+/// Group key for a single routine under the given dimension.
+#[must_use]
+pub fn routine_group_key(r: &Routine, by: RGroupBy) -> String {
+    match by {
+        RGroupBy::None => String::new(),
+        RGroupBy::Agent => r.agent.clone(),
+        RGroupBy::Machine => r
+            .machines
+            .first()
+            .cloned()
+            .unwrap_or_else(|| "(unassigned)".to_string()),
+        RGroupBy::Status => {
+            if r.enabled {
+                "Enabled".to_string()
+            } else {
+                "Disabled".to_string()
+            }
+        }
+    }
+}
+
+/// Partition `routines` into `(group_label, routines_in_group)` pairs sorted
+/// alphabetically by label. Within each group the input order is preserved.
+/// When `by` is `None`, returns a single pair with an empty label.
+#[must_use]
+pub fn group_routines(routines: &[Routine], by: RGroupBy) -> Vec<(String, Vec<Routine>)> {
+    use std::collections::BTreeMap;
+    if by == RGroupBy::None {
+        return vec![(String::new(), routines.to_vec())];
+    }
+    let mut map: BTreeMap<String, Vec<Routine>> = BTreeMap::new();
+    for r in routines {
+        map.entry(routine_group_key(r, by))
+            .or_default()
+            .push(r.clone());
+    }
+    map.into_iter().collect()
+}
+
 /// Return `routines` sorted by `col` in `dir` order. When `col` is `None` the
 /// server/insertion order is preserved. Ties break by id for a stable sort.
 #[must_use]
@@ -689,6 +779,8 @@ pub struct RState {
     pub sort_dir: RDir,
     /// IDs of currently selected routines (multiselect for bulk actions).
     pub selected: BTreeSet<String>,
+    /// Active group-by dimension; `None` renders a flat list.
+    pub group_by: RGroupBy,
     /// Most recently fetched global lock status; `None` until the first fetch completes.
     pub lock_status: Option<LockStatus>,
     /// This machine's resolved name from the daemon, used to default the machine facet.
@@ -707,6 +799,7 @@ impl Default for RState {
             sort_col: None,
             sort_dir: RDir::default(),
             selected: BTreeSet::new(),
+            group_by: RGroupBy::default(),
             lock_status: None,
             current_machine: None,
         }
@@ -733,6 +826,7 @@ pub enum RAction {
     SetAgentFacet(AgentFacet),
     SetMachineFacet(RoutineMachineFacet),
     ClearFilters,
+    SetGroupBy(RGroupBy),
     SortByCol(RCol),
     Upsert(Box<Routine>),
     Remove(String),
@@ -787,6 +881,7 @@ impl Reducible for RState {
             RAction::SetAgentFacet(ag) => s.filter.agent = ag,
             RAction::SetMachineFacet(m) => s.filter.machine = m,
             RAction::ClearFilters => s.filter = RoutineFilter::default(),
+            RAction::SetGroupBy(by) => s.group_by = by,
             RAction::SortByCol(col) => {
                 if s.sort_col == Some(col) {
                     s.sort_dir = s.sort_dir.flip();
@@ -1017,6 +1112,10 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
     let on_set_view = {
         let state = state.clone();
         Callback::from(move |view: RView| state.dispatch(RAction::SetView(view)))
+    };
+    let on_set_group_by = {
+        let state = state.clone();
+        Callback::from(move |by: RGroupBy| state.dispatch(RAction::SetGroupBy(by)))
     };
     let on_set_query = {
         let state = state.clone();
@@ -1353,6 +1452,7 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
     let sort_col = state.sort_col;
     let sort_dir = state.sort_dir;
     let selected = state.selected.clone();
+    let group_by = state.group_by;
 
     // Faceted filter + sort applied client-side.
     let now_val = *now;
@@ -1419,6 +1519,12 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
                                         updated_at_ms={*updated_at}
                                         on_change={on_set_interval}
                                     />
+                                    if view == RView::Table {
+                                        <RoutineGroupBySelector
+                                            group_by={group_by}
+                                            on_change={on_set_group_by}
+                                        />
+                                    }
                                     <ViewToggle view={view} on_set_view={on_set_view} />
                                     <button class="btn btn-ghost btn-sm" onclick={on_cleanup}
                                         title="Reap finished, expired run workbenches now">{"CLEANUP NOW"}</button>
@@ -1459,6 +1565,7 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
                                             on_select_all={on_select_all}
                                             sort_col={sort_col}
                                             sort_dir={sort_dir}
+                                            group_by={group_by}
                                             on_sort={on_col_sort}
                                             on_edit={on_edit}
                                             on_clone={on_clone}
@@ -1655,6 +1762,45 @@ pub fn view_toggle(props: &ViewToggleProps) -> Html {
             { mk(RView::Table, "LIST") }
             { mk(RView::Calendar, "CALENDAR") }
             { mk(RView::Day, "DAY") }
+        </div>
+    }
+}
+
+// ─── Group-by selector ────────────────────────────────────────────────────────
+
+#[derive(Properties, PartialEq)]
+pub struct GroupBySelectorProps {
+    pub group_by: RGroupBy,
+    pub on_change: Callback<RGroupBy>,
+}
+
+/// Drop-down that lets the operator choose how to partition the Routines table.
+/// Placed in the section toolbar next to the view toggle; hidden for Calendar/Day views.
+#[function_component(RoutineGroupBySelector)]
+pub fn routine_group_by_selector(props: &GroupBySelectorProps) -> Html {
+    let on_change = props.on_change.clone();
+    let on_select = Callback::from(move |e: Event| {
+        let select: HtmlSelectElement = e.target_unchecked_into();
+        on_change.emit(RGroupBy::from_str(&select.value()));
+    });
+    let cur = props.group_by.as_str();
+    html! {
+        <div class="group-by-ctrl">
+            <label class="filter-label" for="routine-group-by-select">{"GROUP BY"}</label>
+            <select
+                id="routine-group-by-select"
+                class="filter-select"
+                aria-label="Group routines by"
+                onchange={on_select}
+            >
+                { for [RGroupBy::None, RGroupBy::Agent, RGroupBy::Machine, RGroupBy::Status].iter()
+                    .map(|&by| html! {
+                        <option value={by.as_str()} selected={cur == by.as_str()}>
+                            { by.label() }
+                        </option>
+                    })
+                }
+            </select>
         </div>
     }
 }
@@ -1950,6 +2096,8 @@ pub struct TableProps {
     pub sort_col: Option<RCol>,
     /// Direction of the active column sort.
     pub sort_dir: RDir,
+    /// Active group-by dimension; `None` renders a flat list.
+    pub group_by: RGroupBy,
     /// Fired when the user clicks a sortable column header.
     pub on_sort: Callback<RCol>,
     pub on_edit: Callback<String>,
@@ -2041,20 +2189,36 @@ pub fn routine_table(props: &TableProps) -> Html {
                     </tr>
                 </thead>
                 <tbody>
-                    { for props.routines.iter().map(|r| html! {
-                        <RoutineRow
-                            key={r.id.clone()}
-                            routine={r.clone()}
-                            now={props.now}
-                            selected={props.selected.contains(&r.id)}
-                            on_select={props.on_select.clone()}
-                            on_edit={props.on_edit.clone()}
-                            on_clone={props.on_clone.clone()}
-                            on_delete={props.on_delete.clone()}
-                            on_toggle={props.on_toggle.clone()}
-                            on_trigger={props.on_trigger.clone()}
-                            on_logs={props.on_logs.clone()}
-                        />
+                    { for group_routines(&props.routines, props.group_by).into_iter().map(|(label, group)| {
+                        let count = group.len();
+                        let grouped = props.group_by != RGroupBy::None;
+                        html! {
+                            <>
+                                if grouped {
+                                    <tr class="group-hd" key={format!("ghd-{label}")}>
+                                        <td colspan="12">
+                                            <span class="group-label">{label.clone()}</span>
+                                            <span class="group-count">{format!("({count})")}</span>
+                                        </td>
+                                    </tr>
+                                }
+                                { for group.into_iter().map(|r| html! {
+                                    <RoutineRow
+                                        key={r.id.clone()}
+                                        routine={r.clone()}
+                                        now={props.now}
+                                        selected={props.selected.contains(&r.id)}
+                                        on_select={props.on_select.clone()}
+                                        on_edit={props.on_edit.clone()}
+                                        on_clone={props.on_clone.clone()}
+                                        on_delete={props.on_delete.clone()}
+                                        on_toggle={props.on_toggle.clone()}
+                                        on_trigger={props.on_trigger.clone()}
+                                        on_logs={props.on_logs.clone()}
+                                    />
+                                }) }
+                            </>
+                        }
                     }) }
                 </tbody>
             </table>

--- a/ui/src/routines_tests.rs
+++ b/ui/src/routines_tests.rs
@@ -811,6 +811,142 @@ fn sort_by_health_descending_puts_healthy_first() {
     assert_eq!(sorted[1].id, "dormant");
 }
 
+// ── RGroupBy codec ────────────────────────────────────────────────────────────
+
+#[test]
+fn r_group_by_as_str_roundtrips() {
+    for by in [
+        RGroupBy::None,
+        RGroupBy::Agent,
+        RGroupBy::Machine,
+        RGroupBy::Status,
+    ] {
+        assert_eq!(RGroupBy::from_str(by.as_str()), by);
+    }
+}
+
+#[test]
+fn r_group_by_default_is_none() {
+    assert_eq!(RGroupBy::default(), RGroupBy::None);
+}
+
+#[test]
+fn r_group_by_unknown_token_decodes_to_none() {
+    assert_eq!(RGroupBy::from_str("bogus"), RGroupBy::None);
+    assert_eq!(RGroupBy::from_str(""), RGroupBy::None);
+}
+
+// ── routine_group_key ─────────────────────────────────────────────────────────
+
+#[test]
+fn routine_group_key_agent_returns_agent_field() {
+    let r = routine("id1", "t", "claude", "0 * * * *", &["m1"], &[], true);
+    assert_eq!(routine_group_key(&r, RGroupBy::Agent), "claude");
+}
+
+#[test]
+fn routine_group_key_machine_returns_first_machine() {
+    let r = routine("id1", "t", "claude", "0 * * * *", &["alpha", "beta"], &[], true);
+    assert_eq!(routine_group_key(&r, RGroupBy::Machine), "alpha");
+}
+
+#[test]
+fn routine_group_key_machine_returns_unassigned_when_no_machines() {
+    let r = routine("id1", "t", "claude", "0 * * * *", &[], &[], true);
+    assert_eq!(routine_group_key(&r, RGroupBy::Machine), "(unassigned)");
+}
+
+#[test]
+fn routine_group_key_status_enabled() {
+    let r = routine("id1", "t", "claude", "0 * * * *", &[], &[], true);
+    assert_eq!(routine_group_key(&r, RGroupBy::Status), "Enabled");
+}
+
+#[test]
+fn routine_group_key_status_disabled() {
+    let r = routine("id1", "t", "claude", "0 * * * *", &[], &[], false);
+    assert_eq!(routine_group_key(&r, RGroupBy::Status), "Disabled");
+}
+
+#[test]
+fn routine_group_key_none_returns_empty_string() {
+    let r = routine("id1", "t", "claude", "0 * * * *", &[], &[], true);
+    assert_eq!(routine_group_key(&r, RGroupBy::None), "");
+}
+
+// ── group_routines ────────────────────────────────────────────────────────────
+
+#[test]
+fn group_routines_none_returns_single_group_with_all_routines() {
+    let rs = vec![
+        routine("a", "t", "claude", "0 * * * *", &[], &[], true),
+        routine("b", "t", "codex", "0 * * * *", &[], &[], false),
+    ];
+    let groups = group_routines(&rs, RGroupBy::None);
+    assert_eq!(groups.len(), 1);
+    assert_eq!(groups[0].0, "");
+    assert_eq!(groups[0].1.len(), 2);
+}
+
+#[test]
+fn group_routines_by_agent_creates_one_group_per_agent() {
+    let rs = vec![
+        routine("a", "t", "claude", "0 * * * *", &[], &[], true),
+        routine("b", "t", "codex", "0 * * * *", &[], &[], true),
+        routine("c", "t", "claude", "0 * * * *", &[], &[], true),
+    ];
+    let groups = group_routines(&rs, RGroupBy::Agent);
+    // BTreeMap → alphabetical: claude, codex
+    assert_eq!(groups.len(), 2);
+    assert_eq!(groups[0].0, "claude");
+    assert_eq!(groups[0].1.len(), 2);
+    assert_eq!(groups[1].0, "codex");
+    assert_eq!(groups[1].1.len(), 1);
+}
+
+#[test]
+fn group_routines_by_agent_preserves_input_order_within_group() {
+    let rs = vec![
+        routine("first", "t", "claude", "0 * * * *", &[], &[], true),
+        routine("second", "t", "claude", "0 * * * *", &[], &[], true),
+    ];
+    let groups = group_routines(&rs, RGroupBy::Agent);
+    assert_eq!(groups[0].1[0].id, "first");
+    assert_eq!(groups[0].1[1].id, "second");
+}
+
+#[test]
+fn group_routines_by_machine_separates_unassigned() {
+    let rs = vec![
+        routine("a", "t", "claude", "0 * * * *", &["worker-1"], &[], true),
+        routine("b", "t", "claude", "0 * * * *", &[], &[], true),
+        routine("c", "t", "claude", "0 * * * *", &["worker-1"], &[], true),
+    ];
+    let groups = group_routines(&rs, RGroupBy::Machine);
+    // alphabetical: "(unassigned)" sorts before "worker-1"
+    assert_eq!(groups.len(), 2);
+    assert_eq!(groups[0].0, "(unassigned)");
+    assert_eq!(groups[0].1.len(), 1);
+    assert_eq!(groups[1].0, "worker-1");
+    assert_eq!(groups[1].1.len(), 2);
+}
+
+#[test]
+fn group_routines_by_status_splits_enabled_and_disabled() {
+    let rs = vec![
+        routine("a", "t", "claude", "0 * * * *", &[], &[], true),
+        routine("b", "t", "claude", "0 * * * *", &[], &[], false),
+        routine("c", "t", "claude", "0 * * * *", &[], &[], true),
+    ];
+    let groups = group_routines(&rs, RGroupBy::Status);
+    // alphabetical: "Disabled" before "Enabled"
+    assert_eq!(groups.len(), 2);
+    assert_eq!(groups[0].0, "Disabled");
+    assert_eq!(groups[0].1.len(), 1);
+    assert_eq!(groups[1].0, "Enabled");
+    assert_eq!(groups[1].1.len(), 2);
+}
+
 // ── sort by RCol::LastFire ────────────────────────────────────────────────────
 
 fn routine_with_last_fire(id: &str, manual: Option<u64>, scheduled: Option<u64>) -> Routine {

--- a/ui/src/routines_tests.rs
+++ b/ui/src/routines_tests.rs
@@ -846,7 +846,15 @@ fn routine_group_key_agent_returns_agent_field() {
 
 #[test]
 fn routine_group_key_machine_returns_first_machine() {
-    let r = routine("id1", "t", "claude", "0 * * * *", &["alpha", "beta"], &[], true);
+    let r = routine(
+        "id1",
+        "t",
+        "claude",
+        "0 * * * *",
+        &["alpha", "beta"],
+        &[],
+        true,
+    );
     assert_eq!(routine_group_key(&r, RGroupBy::Machine), "alpha");
 }
 


### PR DESCRIPTION
## Summary

Closes #733

Adds a **GROUP BY** selector to the Routines table toolbar, giving operators the ability to partition the flat routine list into labelled sections. Mirrors the equivalent feature already present in the Cron Jobs table (added in #716).

- **Agent** — one section per agent name (claude, codex, …)  
- **Machine** — one section per target machine; unassigned routines collect under `(unassigned)`  
- **Status** — "Enabled" / "Disabled" sections  
- **None** — restores the flat, unpartitioned list (default)

The selector only appears in Table view (hidden for Calendar and Day). Grouping composes with the existing faceted filter and column-sort controls.

## New public items (`ui/src/routines.rs`)

| Symbol | Kind | Description |
|---|---|---|
| `RGroupBy` | enum | None / Agent / Machine / Status |
| `routine_group_key(r, by)` | fn | Maps a routine to its group label |
| `group_routines(routines, by)` | fn | Partitions into sorted `(label, rows)` pairs |
| `RoutineGroupBySelector` | component | `<select>` control placed in section-acts |
| `SetGroupBy(RGroupBy)` | action | Reducer arm; stored in `RState::group_by` |

## Test plan

- 14 new host-side unit tests in `routines_tests.rs` covering:
  - `RGroupBy` codec roundtrips
  - `routine_group_key` for each dimension
  - `group_routines` — flat fallback, per-agent grouping, order preservation, machine + unassigned split, status split

---

*This pull request was opened by the UI dashboard feature builder (research → issue → PR → merge) routine of moadim.*

/cc @tupe12334