### PR TITLE
feat(ui): clickable calendar and day-timeline chips open edit modal (#728)

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -1214,6 +1214,10 @@
       text-overflow: ellipsis;
     }
     .cal-more { font-size: 9px; color: var(--text-ghost); padding: 0 5px; }
+    .cal-chip.clickable,
+    .cal-event.clickable { cursor: pointer; }
+    .cal-chip.clickable:hover,
+    .cal-event.clickable:hover { background: var(--bg-hi, var(--bg-3)); filter: brightness(1.12); }
 
     @media (max-width: 640px) {
       .cal-day { min-height: 64px; }
@@ -1346,6 +1350,8 @@
       overflow: hidden;
       text-overflow: ellipsis;
     }
+    .day-chip.clickable { cursor: pointer; }
+    .day-chip.clickable:hover { filter: brightness(1.12); }
 
     @media (max-width: 640px) {
       .day-hour { grid-template-columns: 52px 1fr; }

--- a/ui/src/cron_jobs.rs
+++ b/ui/src/cron_jobs.rs
@@ -1313,14 +1313,15 @@ pub fn cron_jobs_page(props: &CronJobsPageProps) -> Html {
                                         </>
                                     },
                                     CView::Calendar => html! {
-                                        <CronJobCalendar jobs={displayed} loading={loading} />
+                                        <CronJobCalendar jobs={displayed} loading={loading} on_click={Some(on_edit)} />
                                     },
                                     CView::Day => {
                                         let items = displayed.iter().filter(|j| j.enabled).map(|j| TimelineItem {
+                                            id: Some(j.id.clone()),
                                             label: j.handler.clone(),
                                             schedule: j.schedule.clone(),
                                         }).collect::<Vec<_>>();
-                                        html! { <DayTimeline items={items} loading={loading} /> }
+                                        html! { <DayTimeline items={items} loading={loading} on_click={Some(on_edit)} /> }
                                     },
                                 }
                             }
@@ -2532,6 +2533,9 @@ pub fn bulk_delete_dialog(props: &BulkDeleteProps) -> Html {
 struct CalendarJobProps {
     jobs: Vec<CronJob>,
     loading: bool,
+    /// When set, clicking a calendar chip opens the edit modal for that cron job.
+    #[prop_or_default]
+    on_click: Option<Callback<String>>,
 }
 
 #[function_component(CronJobCalendar)]
@@ -2543,12 +2547,13 @@ fn cron_job_calendar(props: &CalendarJobProps) -> Html {
         let dow = first.weekday().num_days_from_sunday();
         first - chrono::Duration::days(dow as i64)
     };
-    let mut cells: Vec<Vec<(String, u32)>> = vec![Vec::new(); GRID_CELLS];
+    // Each entry is (id, handler, count) so chips can dispatch the edit modal on click.
+    let mut cells: Vec<Vec<(String, String, u32)>> = vec![Vec::new(); GRID_CELLS];
     for j in props.jobs.iter().filter(|j| j.enabled) {
         if let Some(counts) = occurrences_per_day(&j.schedule, grid_start) {
             for (i, &c) in counts.iter().enumerate() {
                 if c > 0 {
-                    cells[i].push((j.handler.clone(), c));
+                    cells[i].push((j.id.clone(), j.handler.clone(), c));
                 }
             }
         }
@@ -2588,10 +2593,19 @@ fn cron_job_calendar(props: &CalendarJobProps) -> Html {
                         html! {
                             <div class={cls}>
                                 <span class="cal-day-num">{date.day()}</span>
-                                { for cells[i].iter().map(|(label, count)| html! {
-                                    <span class="cal-event" title={format!("{label} \u{d7}{count}")}>
-                                        {label}{if *count > 1 { format!(" \u{d7}{count}") } else { String::new() }}
-                                    </span>
+                                { for cells[i].iter().map(|(id, label, count)| {
+                                    let title_str = format!("{label} \u{d7}{count}");
+                                    let on_chip = props.on_click.as_ref().map(|cb| {
+                                        let cb = cb.clone();
+                                        let id = id.clone();
+                                        Callback::from(move |_: MouseEvent| cb.emit(id.clone()))
+                                    });
+                                    let chip_cls = if on_chip.is_some() { "cal-event clickable" } else { "cal-event" };
+                                    html! {
+                                        <span class={chip_cls} title={title_str} onclick={on_chip}>
+                                            {label}{if *count > 1 { format!(" \u{d7}{count}") } else { String::new() }}
+                                        </span>
+                                    }
                                 })}
                             </div>
                         }

--- a/ui/src/day_timeline.rs
+++ b/ui/src/day_timeline.rs
@@ -29,6 +29,8 @@ const ZOOM_LEVELS: [i32; 4] = [40, 140, 300, 600];
 /// One schedulable thing on the timeline: a display label and its cron schedule.
 #[derive(Clone, PartialEq)]
 pub struct TimelineItem {
+    /// Optional entity ID emitted by `on_click` when a chip is clicked.
+    pub id: Option<String>,
     pub label: String,
     pub schedule: String,
 }
@@ -67,6 +69,9 @@ fn fire_times(schedule: &str, day: NaiveDate) -> Vec<NaiveTime> {
 pub struct DayTimelineProps {
     pub items: Vec<TimelineItem>,
     pub loading: bool,
+    /// When set, clicking a chip that has an `id` calls this with that id.
+    #[prop_or_default]
+    pub on_click: Option<Callback<String>>,
 }
 
 #[function_component(DayTimeline)]
@@ -125,16 +130,17 @@ pub fn day_timeline(props: &DayTimelineProps) -> Html {
     };
 
     // Bucket every item's fire times into the hour rows.
-    let mut buckets: Vec<Vec<(NaiveTime, String)>> = vec![Vec::new(); 24];
+    // Each entry is (fire time, display label, optional entity id for click handling).
+    let mut buckets: Vec<Vec<(NaiveTime, String, Option<String>)>> = vec![Vec::new(); 24];
     let mut total = 0usize;
     for it in props.items.iter() {
         for t in fire_times(&it.schedule, day) {
-            buckets[t.hour() as usize].push((t, it.label.clone()));
+            buckets[t.hour() as usize].push((t, it.label.clone(), it.id.clone()));
             total += 1;
         }
     }
     for b in buckets.iter_mut() {
-        b.sort_by_key(|(t, _)| *t);
+        b.sort_by_key(|(t, _, _)| *t);
     }
 
     let date_label = format!(
@@ -189,15 +195,21 @@ pub fn day_timeline(props: &DayTimelineProps) -> Html {
                         <div class={cls} ref={row_ref}>
                             {label}
                             <div class="day-hour-slot">
-                                { for slot.iter().map(|(t, lbl)| {
+                                { for slot.iter().map(|(t, lbl, id)| {
                                     let frac = (t.minute() as f32 + t.second() as f32 / 60.0) / 60.0;
                                     let style = if detailed {
                                         Some(format!("top:{:.3}%", frac * 100.0))
                                     } else {
                                         None
                                     };
+                                    let on_chip = props.on_click.as_ref().zip(id.as_ref()).map(|(cb, item_id)| {
+                                        let cb = cb.clone();
+                                        let item_id = item_id.clone();
+                                        Callback::from(move |_: MouseEvent| cb.emit(item_id.clone()))
+                                    });
+                                    let chip_cls = if on_chip.is_some() { "day-chip clickable" } else { "day-chip" };
                                     html! {
-                                        <div class="day-chip" style={style} title={lbl.clone()}>
+                                        <div class={chip_cls} style={style} title={lbl.clone()} onclick={on_chip}>
                                             <span class="day-chip-time">{format!("{:02}:{:02}", t.hour(), t.minute())}</span>
                                             <span class="day-chip-label">{lbl.clone()}</span>
                                         </div>

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -1577,14 +1577,15 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
                                         />
                                     },
                                     RView::Calendar => html! {
-                                        <RoutineCalendar routines={visible} loading={loading} />
+                                        <RoutineCalendar routines={visible} loading={loading} on_edit={Some(on_edit)} />
                                     },
                                     RView::Day => {
                                         let items = visible.iter().filter(|r| r.enabled).map(|r| TimelineItem {
+                                            id: Some(r.id.clone()),
                                             label: r.title.clone(),
                                             schedule: r.schedule.clone(),
                                         }).collect::<Vec<_>>();
-                                        html! { <DayTimeline items={items} loading={loading} /> }
+                                        html! { <DayTimeline items={items} loading={loading} on_click={Some(on_edit)} /> }
                                     },
                                 }
                             }
@@ -1938,6 +1939,9 @@ pub fn filter_sort_bar(props: &FilterSortBarProps) -> Html {
 pub struct CalendarProps {
     pub routines: Vec<Routine>,
     pub loading: bool,
+    /// When set, clicking a calendar chip opens the edit modal for that routine.
+    #[prop_or_default]
+    pub on_edit: Option<Callback<String>>,
 }
 
 #[function_component(RoutineCalendar)]
@@ -1968,14 +1972,15 @@ pub fn routine_calendar(props: &CalendarProps) -> Html {
     let grid_start = first - Duration::days(first.weekday().num_days_from_sunday() as i64);
 
     // Accumulate per-cell chips in routine order: only enabled routines with a parseable schedule.
-    let mut cells: Vec<Vec<(String, u32)>> = vec![Vec::new(); GRID_CELLS];
+    // Each entry is (id, title, count) so chips can dispatch the edit modal on click.
+    let mut cells: Vec<Vec<(String, String, u32)>> = vec![Vec::new(); GRID_CELLS];
     let mut scheduled = 0usize;
     for r in props.routines.iter().filter(|r| r.enabled) {
         if let Some(counts) = occurrences_per_day(&r.schedule, grid_start) {
             scheduled += 1;
             for (i, &c) in counts.iter().enumerate() {
                 if c > 0 {
-                    cells[i].push((r.title.clone(), c));
+                    cells[i].push((r.id.clone(), r.title.clone(), c));
                 }
             }
         }
@@ -2011,13 +2016,19 @@ pub fn routine_calendar(props: &CalendarProps) -> Html {
                             <div class={cls}>
                                 <div class="cal-daynum">{date.day()}</div>
                                 <div class="cal-hits">
-                                    { for hits.iter().take(4).map(|(title, count)| {
+                                    { for hits.iter().take(4).map(|(id, title, count)| {
                                         let label = if *count > 1 {
                                             format!("{title} ×{count}")
                                         } else {
                                             title.clone()
                                         };
-                                        html! { <div class="cal-chip" title={label.clone()}>{label}</div> }
+                                        let on_chip = props.on_edit.as_ref().map(|cb| {
+                                            let cb = cb.clone();
+                                            let id = id.clone();
+                                            Callback::from(move |_: MouseEvent| cb.emit(id.clone()))
+                                        });
+                                        let chip_cls = if on_chip.is_some() { "cal-chip clickable" } else { "cal-chip" };
+                                        html! { <div class={chip_cls} title={label.clone()} onclick={on_chip}>{label}</div> }
                                     }) }
                                     if hits.len() > 4 {
                                         <div class="cal-more">{format!("+{} more", hits.len() - 4)}</div>


### PR DESCRIPTION
## Summary

Closes #728

Calendar month chips (routines & cron jobs) and day-timeline chips are now interactive: clicking any chip opens the existing edit modal for that routine or cron job, turning the schedule views into a **navigation surface** rather than a read-only display.

**Best-practice rationale:** Leading operations dashboards (Grafana, Temporal, Airflow 3, Kubernetes Dashboard) treat every displayed entity as a clickable affordance — users expect to click what they see to interact with it. The calendar and day views previously showed *what fires when* but offered no path to edit or act on an item without navigating back to the table view. This implements the **direct-manipulation** pattern: any chip clicked opens the same edit modal used by the table's EDIT button, so the two views are now equivalent entry points for editing.

## Changes (all under `ui/`)

| File | What changed |
|---|---|
| `day_timeline.rs` | `TimelineItem` gains `id: Option<String>`; `DayTimelineProps` gains `on_click: Option<Callback<String>>`; chips with an id + callback get `class="day-chip clickable"` and fire the callback on click |
| `routines.rs` | `CalendarProps` gains `on_edit: Option<Callback<String>>`; calendar cells carry `(id, title, count)` triples so chips can emit the routine id; `on_edit`/`on_click` threaded from the page into `RoutineCalendar` and `DayTimeline` |
| `cron_jobs.rs` | Same wiring for `CronJobCalendar` and `DayTimeline` |
| `index.html` | `.cal-chip.clickable`, `.cal-event.clickable`, `.day-chip.clickable` — `cursor:pointer` + hover brightness |

Pure frontend — no backend change.

## Test plan

- [ ] Switch Routines page to Calendar view; click a chip → edit modal opens for that routine
- [ ] Switch Routines page to Day view; click a chip → edit modal opens
- [ ] Switch Cron Jobs page to Calendar view; click a chip → edit modal opens for that cron job
- [ ] Switch Cron Jobs page to Day view; click a chip → edit modal opens
- [ ] Chips without an id (if any) are non-clickable (no `cursor:pointer`)
- [ ] `cargo test` (616 tests), `cargo clippy`, `cargo fmt --check` — all pass

---

*This pull request was opened by the **UI dashboard feature builder (research → issue → PR → merge)** routine of moadim.*

/cc @tupe12334