### PR TITLE
feat(ui): clickable chips in calendar and day-timeline views (#740)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Added
 
+- Calendar and day-timeline chips are now clickable: clicking any chip in the
+  Routines calendar/day view or the Cron Jobs calendar/day view opens the edit
+  modal for that entity directly, without switching to the table view first.
+  `TimelineItem` gains an `id` field; `DayTimeline` gains an optional
+  `on_click: Option<Callback<String>>` prop; both calendar components gain an
+  optional `on_edit: Option<Callback<String>>` prop.
+
 - A `fmt + clippy` CI workflow (`.github/workflows/lint.yml`) that mirrors the
   pre-push hook (`cargo fmt --check`, `cargo clippy -- -D warnings`) on every PR
   and push to `main`, so style/lint regressions are caught in review without

--- a/ui/index.html
+++ b/ui/index.html
@@ -1214,6 +1214,8 @@
       text-overflow: ellipsis;
     }
     .cal-more { font-size: 9px; color: var(--text-ghost); padding: 0 5px; }
+    .cal-chip.link { cursor: pointer; }
+    .cal-chip.link:hover { opacity: 0.75; }
 
     @media (max-width: 640px) {
       .cal-day { min-height: 64px; }
@@ -1346,6 +1348,10 @@
       overflow: hidden;
       text-overflow: ellipsis;
     }
+    .day-chip.link { cursor: pointer; }
+    .day-chip.link:hover { opacity: 0.75; }
+    .cal-event.link { cursor: pointer; }
+    .cal-event.link:hover { opacity: 0.75; }
 
     @media (max-width: 640px) {
       .day-hour { grid-template-columns: 52px 1fr; }

--- a/ui/src/cron_jobs.rs
+++ b/ui/src/cron_jobs.rs
@@ -1313,14 +1313,15 @@ pub fn cron_jobs_page(props: &CronJobsPageProps) -> Html {
                                         </>
                                     },
                                     CView::Calendar => html! {
-                                        <CronJobCalendar jobs={displayed} loading={loading} />
+                                        <CronJobCalendar jobs={displayed} loading={loading} on_edit={Some(on_edit.clone())} />
                                     },
                                     CView::Day => {
                                         let items = displayed.iter().filter(|j| j.enabled).map(|j| TimelineItem {
                                             label: j.handler.clone(),
                                             schedule: j.schedule.clone(),
+                                            id: j.id.clone(),
                                         }).collect::<Vec<_>>();
-                                        html! { <DayTimeline items={items} loading={loading} /> }
+                                        html! { <DayTimeline items={items} loading={loading} on_click={Some(on_edit.clone())} /> }
                                     },
                                 }
                             }
@@ -2532,6 +2533,9 @@ pub fn bulk_delete_dialog(props: &BulkDeleteProps) -> Html {
 struct CalendarJobProps {
     jobs: Vec<CronJob>,
     loading: bool,
+    /// When set, each calendar chip is clickable and emits the cron-job id on click.
+    #[prop_or_default]
+    on_edit: Option<Callback<String>>,
 }
 
 #[function_component(CronJobCalendar)]
@@ -2543,12 +2547,13 @@ fn cron_job_calendar(props: &CalendarJobProps) -> Html {
         let dow = first.weekday().num_days_from_sunday();
         first - chrono::Duration::days(dow as i64)
     };
-    let mut cells: Vec<Vec<(String, u32)>> = vec![Vec::new(); GRID_CELLS];
+    // Each cell entry carries (handler, id, count) so chips can open the edit modal on click.
+    let mut cells: Vec<Vec<(String, String, u32)>> = vec![Vec::new(); GRID_CELLS];
     for j in props.jobs.iter().filter(|j| j.enabled) {
         if let Some(counts) = occurrences_per_day(&j.schedule, grid_start) {
             for (i, &c) in counts.iter().enumerate() {
                 if c > 0 {
-                    cells[i].push((j.handler.clone(), c));
+                    cells[i].push((j.handler.clone(), j.id.clone(), c));
                 }
             }
         }
@@ -2588,10 +2593,22 @@ fn cron_job_calendar(props: &CalendarJobProps) -> Html {
                         html! {
                             <div class={cls}>
                                 <span class="cal-day-num">{date.day()}</span>
-                                { for cells[i].iter().map(|(label, count)| html! {
-                                    <span class="cal-event" title={format!("{label} \u{d7}{count}")}>
-                                        {label}{if *count > 1 { format!(" \u{d7}{count}") } else { String::new() }}
-                                    </span>
+                                { for cells[i].iter().map(|(label, id, count)| {
+                                    let onclick = props.on_edit.as_ref().map(|cb| {
+                                        let cb = cb.clone();
+                                        let entity_id = id.clone();
+                                        Callback::from(move |_: MouseEvent| cb.emit(entity_id.clone()))
+                                    });
+                                    let chip_cls = if onclick.is_some() {
+                                        "cal-event link"
+                                    } else {
+                                        "cal-event"
+                                    };
+                                    html! {
+                                        <span class={chip_cls} title={format!("{label} \u{d7}{count}")} onclick={onclick}>
+                                            {label}{if *count > 1 { format!(" \u{d7}{count}") } else { String::new() }}
+                                        </span>
+                                    }
                                 })}
                             </div>
                         }

--- a/ui/src/day_timeline.rs
+++ b/ui/src/day_timeline.rs
@@ -26,11 +26,14 @@ const MONTHS: [&str; 12] = [
 /// read sub-hour timing instead of a single wrapped bucket.
 const ZOOM_LEVELS: [i32; 4] = [40, 140, 300, 600];
 
-/// One schedulable thing on the timeline: a display label and its cron schedule.
+/// One schedulable thing on the timeline: a display label, its cron schedule, and entity id.
+/// The `id` is passed back through `on_click` so the caller can open the edit modal.
 #[derive(Clone, PartialEq)]
 pub struct TimelineItem {
     pub label: String,
     pub schedule: String,
+    /// Entity id (routine id or cron-job id) emitted by `on_click`.
+    pub id: String,
 }
 
 /// All fire times for `schedule` that fall on `day`, in chronological order.
@@ -67,6 +70,9 @@ fn fire_times(schedule: &str, day: NaiveDate) -> Vec<NaiveTime> {
 pub struct DayTimelineProps {
     pub items: Vec<TimelineItem>,
     pub loading: bool,
+    /// When set, each chip becomes clickable and emits the entity id on click.
+    #[prop_or_default]
+    pub on_click: Option<Callback<String>>,
 }
 
 #[function_component(DayTimeline)]
@@ -124,17 +130,17 @@ pub fn day_timeline(props: &DayTimelineProps) -> Html {
         usize::MAX
     };
 
-    // Bucket every item's fire times into the hour rows.
-    let mut buckets: Vec<Vec<(NaiveTime, String)>> = vec![Vec::new(); 24];
+    // Bucket every item's fire times into the hour rows; carry the id for click callbacks.
+    let mut buckets: Vec<Vec<(NaiveTime, String, String)>> = vec![Vec::new(); 24];
     let mut total = 0usize;
     for it in props.items.iter() {
         for t in fire_times(&it.schedule, day) {
-            buckets[t.hour() as usize].push((t, it.label.clone()));
+            buckets[t.hour() as usize].push((t, it.label.clone(), it.id.clone()));
             total += 1;
         }
     }
     for b in buckets.iter_mut() {
-        b.sort_by_key(|(t, _)| *t);
+        b.sort_by_key(|(t, _, _)| *t);
     }
 
     let date_label = format!(
@@ -189,15 +195,25 @@ pub fn day_timeline(props: &DayTimelineProps) -> Html {
                         <div class={cls} ref={row_ref}>
                             {label}
                             <div class="day-hour-slot">
-                                { for slot.iter().map(|(t, lbl)| {
+                                { for slot.iter().map(|(t, lbl, id)| {
                                     let frac = (t.minute() as f32 + t.second() as f32 / 60.0) / 60.0;
                                     let style = if detailed {
                                         Some(format!("top:{:.3}%", frac * 100.0))
                                     } else {
                                         None
                                     };
+                                    let onclick = props.on_click.as_ref().map(|cb| {
+                                        let cb = cb.clone();
+                                        let entity_id = id.clone();
+                                        Callback::from(move |_: MouseEvent| cb.emit(entity_id.clone()))
+                                    });
+                                    let chip_cls = if onclick.is_some() {
+                                        "day-chip link"
+                                    } else {
+                                        "day-chip"
+                                    };
                                     html! {
-                                        <div class="day-chip" style={style} title={lbl.clone()}>
+                                        <div class={chip_cls} style={style} title={lbl.clone()} onclick={onclick}>
                                             <span class="day-chip-time">{format!("{:02}:{:02}", t.hour(), t.minute())}</span>
                                             <span class="day-chip-label">{lbl.clone()}</span>
                                         </div>

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -1577,14 +1577,15 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
                                         />
                                     },
                                     RView::Calendar => html! {
-                                        <RoutineCalendar routines={visible} loading={loading} />
+                                        <RoutineCalendar routines={visible} loading={loading} on_edit={Some(on_edit.clone())} />
                                     },
                                     RView::Day => {
                                         let items = visible.iter().filter(|r| r.enabled).map(|r| TimelineItem {
                                             label: r.title.clone(),
                                             schedule: r.schedule.clone(),
+                                            id: r.id.clone(),
                                         }).collect::<Vec<_>>();
-                                        html! { <DayTimeline items={items} loading={loading} /> }
+                                        html! { <DayTimeline items={items} loading={loading} on_click={Some(on_edit.clone())} /> }
                                     },
                                 }
                             }
@@ -1938,6 +1939,9 @@ pub fn filter_sort_bar(props: &FilterSortBarProps) -> Html {
 pub struct CalendarProps {
     pub routines: Vec<Routine>,
     pub loading: bool,
+    /// When set, each calendar chip is clickable and emits the routine id on click.
+    #[prop_or_default]
+    pub on_edit: Option<Callback<String>>,
 }
 
 #[function_component(RoutineCalendar)]
@@ -1968,14 +1972,15 @@ pub fn routine_calendar(props: &CalendarProps) -> Html {
     let grid_start = first - Duration::days(first.weekday().num_days_from_sunday() as i64);
 
     // Accumulate per-cell chips in routine order: only enabled routines with a parseable schedule.
-    let mut cells: Vec<Vec<(String, u32)>> = vec![Vec::new(); GRID_CELLS];
+    // Each cell entry carries (title, id, count) so chips can open the edit modal on click.
+    let mut cells: Vec<Vec<(String, String, u32)>> = vec![Vec::new(); GRID_CELLS];
     let mut scheduled = 0usize;
     for r in props.routines.iter().filter(|r| r.enabled) {
         if let Some(counts) = occurrences_per_day(&r.schedule, grid_start) {
             scheduled += 1;
             for (i, &c) in counts.iter().enumerate() {
                 if c > 0 {
-                    cells[i].push((r.title.clone(), c));
+                    cells[i].push((r.title.clone(), r.id.clone(), c));
                 }
             }
         }
@@ -2011,13 +2016,23 @@ pub fn routine_calendar(props: &CalendarProps) -> Html {
                             <div class={cls}>
                                 <div class="cal-daynum">{date.day()}</div>
                                 <div class="cal-hits">
-                                    { for hits.iter().take(4).map(|(title, count)| {
+                                    { for hits.iter().take(4).map(|(title, id, count)| {
                                         let label = if *count > 1 {
                                             format!("{title} ×{count}")
                                         } else {
                                             title.clone()
                                         };
-                                        html! { <div class="cal-chip" title={label.clone()}>{label}</div> }
+                                        let onclick = props.on_edit.as_ref().map(|cb| {
+                                            let cb = cb.clone();
+                                            let entity_id = id.clone();
+                                            Callback::from(move |_: MouseEvent| cb.emit(entity_id.clone()))
+                                        });
+                                        let chip_cls = if onclick.is_some() {
+                                            "cal-chip link"
+                                        } else {
+                                            "cal-chip"
+                                        };
+                                        html! { <div class={chip_cls} title={label.clone()} onclick={onclick}>{label}</div> }
                                     }) }
                                     if hits.len() > 4 {
                                         <div class="cal-more">{format!("+{} more", hits.len() - 4)}</div>


### PR DESCRIPTION
## Summary

- Calendar and day-timeline chips are now clickable in **both** the Routines and Cron Jobs pages
- Clicking a chip opens the edit modal for that entity directly — no need to switch back to the table
- `TimelineItem` gains `id: String`; `DayTimeline` gains `on_click: Option<Callback<String>>`; both calendar components gain `on_edit: Option<Callback<String>>`
- CSS adds `cursor: pointer` + hover opacity for `.cal-chip.link`, `.day-chip.link`, `.cal-event.link`

## Best-practice rationale

Every major scheduling/operations UI (Google Calendar, Temporal, Cronitor, GitHub Actions, Buildkite, Airflow) treats calendar and timeline items as first-class interactive targets. Inert chips break the universal UX contract that "a visual token in a schedule view is a navigable pointer." This change closes that gap.

## Scope

Frontend-only (`ui/src/day_timeline.rs`, `ui/src/routines.rs`, `ui/src/cron_jobs.rs`, `ui/index.html`). No backend changes.

## Test plan
- [ ] Switch Routines to Calendar view — click a chip → edit modal opens for that routine
- [ ] Switch Routines to Day view — click a chip → edit modal opens for that routine
- [ ] Switch Cron Jobs to Calendar view — click a chip → edit modal opens for that job
- [ ] Switch Cron Jobs to Day view — click a chip → edit modal opens for that job
- [ ] Chips without `on_edit`/`on_click` (future callers that omit the prop) render as inert divs/spans

Closes #740.

---

*This pull request was opened by the UI dashboard feature builder (research → issue → PR → merge) routine of moadim.*

/cc @tupe12334