### PR TITLE
feat(ui): quick-trigger ▶ RUN button in Overview Upcoming Runs (#753)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Added
 
+- **UI overview: "▶ RUN" quick-trigger button in the Upcoming Runs table.**
+  Each row in the UPCOMING RUNS table on the Overview page now carries a
+  `▶ RUN` button that fires the job's trigger endpoint
+  (`POST /api/v1/routines/{id}/trigger` or `/api/v1/cron-jobs/{id}/trigger`)
+  without leaving the page. A toast confirms success or surfaces the error.
+  Implements the "quick actions" best practice from CI/CD operations dashboards
+  (Cronitor, Temporal, GitHub Actions) where operators can fire jobs directly
+  from the at-a-glance view.
+
 - **iCal feed: carriage returns in routine titles/prompts no longer corrupt content lines.**
   `escape_text` now normalises both bare `\r` and CRLF sequences to an escaped newline (`\n`)
   before emitting them into a `TEXT` property value, satisfying RFC 5545 §3.3.11 which forbids

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -369,7 +369,7 @@ pub fn shell() -> Html {
     let switch = {
         let on_toast = on_toast.clone();
         Callback::from(move |route: Route| match route {
-            Route::Home => html! { <OverviewPage /> },
+            Route::Home => html! { <OverviewPage on_toast={on_toast.clone()} /> },
             Route::CronJobs => html! { <CronJobsPage on_toast={on_toast.clone()} /> },
             Route::Routines => html! { <RoutinesPage on_toast={on_toast.clone()} /> },
             Route::Heatmap => html! { <HeatmapPage /> },

--- a/ui/src/overview.rs
+++ b/ui/src/overview.rs
@@ -22,7 +22,7 @@ use yew_router::prelude::*;
 use crate::cron_jobs::CronJob;
 use crate::routines::Routine;
 use crate::schedule::{fires_within, fmt_until, fmt_when, next_fire_after};
-use crate::Route;
+use crate::{Route, ToastKind};
 
 /// "Due soon" / "soon" window: an enabled entity whose next fire lands within
 /// this many seconds is operationally urgent. Mirrors the per-page cron stats.
@@ -54,6 +54,8 @@ pub(crate) enum Kind {
 pub(crate) struct SchedSource {
     /// Cron job or routine.
     pub kind: Kind,
+    /// API id used to trigger the entity (cron-job id UUID, routine UUID).
+    pub id: String,
     /// Display name: the cron-job id or the routine title.
     pub label: String,
     /// Raw cron expression used to compute the next fire.
@@ -144,6 +146,8 @@ pub(crate) struct AttentionItem {
 pub(crate) struct UpcomingRun {
     /// Cron job or routine.
     pub kind: Kind,
+    /// API id passed to the trigger endpoint.
+    pub id: String,
     /// Display name.
     pub label: String,
     /// Human schedule description, when present.
@@ -227,6 +231,7 @@ pub(crate) fn upcoming_runs(sources: &[SchedSource], now: DateTime<Local>) -> Ve
         .filter_map(|s| {
             next_fire_after(&s.schedule, now).map(|at| UpcomingRun {
                 kind: s.kind,
+                id: s.id.clone(),
                 label: s.label.clone(),
                 human: s.human.clone(),
                 at,
@@ -255,6 +260,7 @@ fn targets_no_machine(machines: &[String]) -> bool {
 fn from_cron(job: &CronJob) -> SchedSource {
     SchedSource {
         kind: Kind::Cron,
+        id: job.id.clone(),
         label: job.id.clone(),
         schedule: job.schedule.clone(),
         human: job.schedule_description.clone(),
@@ -268,6 +274,7 @@ fn from_cron(job: &CronJob) -> SchedSource {
 fn from_routine(routine: &Routine) -> SchedSource {
     SchedSource {
         kind: Kind::Routine,
+        id: routine.id.clone(),
         label: routine.title.clone(),
         schedule: routine.schedule.clone(),
         human: routine.schedule_description.clone(),
@@ -284,6 +291,30 @@ fn sources_of(crons: &[CronJob], routines: &[Routine]) -> Vec<SchedSource> {
         .map(from_cron)
         .chain(routines.iter().map(from_routine))
         .collect()
+}
+
+async fn api_trigger_cron(id: &str) -> Result<(), String> {
+    let resp = Request::post(&format!("/api/v1/cron-jobs/{id}/trigger"))
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    if resp.ok() {
+        Ok(())
+    } else {
+        Err(format!("HTTP {}", resp.status()))
+    }
+}
+
+async fn api_trigger_routine(id: &str) -> Result<(), String> {
+    let resp = Request::post(&format!("/api/v1/routines/{id}/trigger"))
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    if resp.ok() {
+        Ok(())
+    } else {
+        Err(format!("HTTP {}", resp.status()))
+    }
 }
 
 pub(crate) async fn fetch_crons() -> Result<Vec<CronJob>, String> {
@@ -316,8 +347,13 @@ struct Data {
     error: Option<String>,
 }
 
+#[derive(Properties, PartialEq)]
+pub struct OverviewPageProps {
+    pub on_toast: Callback<(String, ToastKind)>,
+}
+
 #[function_component(OverviewPage)]
-pub fn overview_page() -> Html {
+pub fn overview_page(props: &OverviewPageProps) -> Html {
     let data = use_state(|| Data {
         loading: true,
         ..Data::default()
@@ -372,6 +408,23 @@ pub fn overview_page() -> Html {
         });
     }
 
+    let on_trigger = {
+        let on_toast = props.on_toast.clone();
+        Callback::from(move |(kind, id): (Kind, String)| {
+            let on_toast = on_toast.clone();
+            spawn_local(async move {
+                let result = match kind {
+                    Kind::Cron => api_trigger_cron(&id).await,
+                    Kind::Routine => api_trigger_routine(&id).await,
+                };
+                match result {
+                    Ok(()) => on_toast.emit(("Triggered".into(), ToastKind::Ok)),
+                    Err(e) => on_toast.emit((format!("Trigger failed: {e}"), ToastKind::Err)),
+                }
+            });
+        })
+    };
+
     let now_val = *now;
     let sources = sources_of(&data.crons, &data.routines);
     let kpis = compute_kpis(&sources, now_val);
@@ -406,6 +459,7 @@ pub fn overview_page() -> Html {
                 now={now_val}
                 loading={data.loading}
                 error={data.error.clone()}
+                on_trigger={on_trigger}
             />
         </main>
     }
@@ -514,6 +568,7 @@ struct UpcomingTableProps {
     now: DateTime<Local>,
     loading: bool,
     error: Option<String>,
+    on_trigger: Callback<(Kind, String)>,
 }
 
 #[function_component(UpcomingTable)]
@@ -558,6 +613,7 @@ fn upcoming_table(props: &UpcomingTableProps) -> Html {
                         <th>{"NAME"}</th>
                         <th>{"SCHEDULE"}</th>
                         <th>{"NEXT RUN"}</th>
+                        <th></th>
                     </tr>
                 </thead>
                 <tbody>
@@ -567,6 +623,12 @@ fn upcoming_table(props: &UpcomingTableProps) -> Html {
                             Kind::Routine => ("ROUTINE", "kind-badge routine", Route::Routines),
                         };
                         let until_cls = if run.soon { "cell-next-until soon" } else { "cell-next-until" };
+                        let kind = run.kind;
+                        let id = run.id.clone();
+                        let on_trigger = props.on_trigger.clone();
+                        let onclick = Callback::from(move |_: MouseEvent| {
+                            on_trigger.emit((kind, id.clone()));
+                        });
                         html! {
                             <tr key={i.to_string()}>
                                 <td><span class={badge_cls}>{badge}</span></td>
@@ -583,6 +645,15 @@ fn upcoming_table(props: &UpcomingTableProps) -> Html {
                                 <td class="cell-next">
                                     <div class="cell-next-when">{fmt_when(now, run.at)}</div>
                                     <div class={until_cls}>{fmt_until(now, run.at)}</div>
+                                </td>
+                                <td class="cell-act">
+                                    <button
+                                        class="btn btn-sm btn-ghost run-now-btn"
+                                        title="Trigger now"
+                                        {onclick}
+                                    >
+                                        {"▶ RUN"}
+                                    </button>
                                 </td>
                             </tr>
                         }

--- a/ui/src/overview_tests.rs
+++ b/ui/src/overview_tests.rs
@@ -18,6 +18,7 @@ fn at_ten() -> DateTime<Local> {
 fn src(kind: Kind, label: &str, schedule: &str, enabled: bool) -> SchedSource {
     SchedSource {
         kind,
+        id: label.into(),
         label: label.into(),
         schedule: schedule.into(),
         human: None,
@@ -121,6 +122,7 @@ fn from_cron_maps_label_and_schedule() {
     .expect("valid cron job json");
     let source = from_cron(&job);
     assert_eq!(source.kind, Kind::Cron);
+    assert_eq!(source.id, "backup");
     assert_eq!(source.label, "backup");
     assert_eq!(source.schedule, "*/5 * * * *");
     assert_eq!(source.human.as_deref(), Some("Every 5 minutes"));
@@ -140,6 +142,7 @@ fn from_routine_uses_title_as_label() {
     .expect("valid routine json");
     let source = from_routine(&routine);
     assert_eq!(source.kind, Kind::Routine);
+    assert_eq!(source.id, "r1");
     assert_eq!(source.label, "Nightly sweep");
     assert_eq!(source.schedule, "0 0 * * *");
     assert!(!source.enabled);
@@ -310,6 +313,33 @@ fn from_routine_carries_agent_registration_and_machines() {
     let s = from_routine(&routine);
     assert_eq!(s.agent_registered, Some(false));
     assert!(!s.machines_empty);
+}
+
+#[test]
+fn upcoming_run_carries_cron_id() {
+    let source = src(Kind::Cron, "daily-backup", "*/5 * * * *", true);
+    let runs = upcoming_runs(&[source], at_ten());
+    assert_eq!(runs[0].id, "daily-backup");
+    assert_eq!(runs[0].label, "daily-backup");
+}
+
+#[test]
+fn upcoming_run_routine_id_differs_from_label() {
+    let routine: Routine = serde_json::from_value(serde_json::json!({
+        "id": "abc-uuid-123",
+        "schedule": "*/5 * * * *",
+        "title": "My Routine",
+        "agent": "claude",
+        "prompt": "do something",
+        "enabled": true
+    }))
+    .expect("valid routine json");
+    let source = from_routine(&routine);
+    assert_eq!(source.id, "abc-uuid-123");
+    assert_eq!(source.label, "My Routine");
+    let runs = upcoming_runs(&[source], at_ten());
+    assert_eq!(runs[0].id, "abc-uuid-123");
+    assert_eq!(runs[0].label, "My Routine");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Each row in the UPCOMING RUNS table on the Overview page now carries a **▶ RUN** button that fires the job's trigger endpoint without leaving the page.
- `SchedSource` gains an `id` field (routine UUID or cron-job id), threaded through `UpcomingRun` so the trigger endpoint is known at render time.
- `OverviewPage` now accepts `on_toast` (same pattern as `CronJobsPage`/`RoutinesPage`) and spawns `POST /api/v1/routines/{id}/trigger` or `POST /api/v1/cron-jobs/{id}/trigger` on click.
- Shell now passes `on_toast` to `OverviewPage`.
- Two new host tests: `upcoming_run_carries_cron_id` and `upcoming_run_routine_id_differs_from_label`.

No backend changes — both trigger endpoints already exist.

Closes #753.

## Best-practice rationale

Operations dashboards in leading tools (Cronitor, GitHub Actions, Temporal) treat the overview as an **action surface**, not just a read-only status page. The defining pattern: manual trigger must be one click from the overview — switching tabs to fire a job adds friction at exactly the moment an operator is under pressure. This implements the "quick actions" principle from CI/CD monitoring best practices.

## Test plan

- [ ] Run `cargo test --package ui` — all 239 tests pass
- [ ] Run `cargo clippy --package ui --all-targets -- -D warnings` — clean
- [ ] Run `cargo fmt --package ui --check` — clean
- [ ] Diff touches only `CHANGELOG.md` and `ui/` files

_This pull request was opened by the **UI dashboard feature builder (research → issue → PR → merge)** routine of moadim. /cc @tupe12334_

🤖 Generated with [Claude Code](https://claude.com/claude-code)