### PR TITLE
chore(lint): enable clippy::explicit_iter_loop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,3 +74,9 @@ manual_let_else = "deny"
 # wrapping it in a closure that only forwards the receiver
 # (`|e| e.ok()`, `|s| s.to_string()`).
 redundant_closure_for_method_calls = "deny"
+# Prefer `for x in &collection` / `for x in &mut collection` over the explicit
+# `for x in collection.iter()` / `.iter_mut()` form. The reference syntax is
+# shorter, is the idiomatic way to iterate without consuming, and avoids the
+# reader having to confirm that `.iter()` isn't secretly `.into_iter()` (which
+# would move). It states "borrow and iterate" at a glance.
+explicit_iter_loop = "deny"


### PR DESCRIPTION
Enables `clippy::explicit_iter_loop` in `[lints.clippy]` at the `deny` level.

## What this changes

Adds one entry to `Cargo.toml`:

```toml
explicit_iter_loop = "deny"
```

## Why

`clippy::explicit_iter_loop` flags `for x in v.iter()` / `for x in v.iter_mut()` where `for x in &v` / `for x in &mut v` is the idiomatic, shorter form. The reference syntax states "borrow and iterate" at a glance without making the reader verify that `.iter()` isn't secretly `.into_iter()`.

The codebase has **zero current violations** — this PR simply locks in the clean state and prevents the explicit-`.iter()` form from creeping back in.

`cargo clippy` passes with no warnings or errors after this change.

Closes #763

---

*This pull request was opened by the Clippy lint improvements → issue + PR (Rust repos) → Slack routine of moadim. Tagging @tupe12334 for review.*
