### PR TITLE
chore: release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+## [0.17.0] — 2026-06-29
+
 ### Added
 
 - Machine name badge in the header: the resolved `@ <name>` is shown as a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ opt-level = "z"
 
 [package]
 name = "moadim"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "Loop engine for AI agents — cron jobs and routines over REST, MCP, and a built-in web UI"
 license = "MIT"


### PR DESCRIPTION
Bumps version to `0.17.0` and promotes the `[Unreleased]` changelog section.

The auto-release workflow will tag `v0.17.0` and publish to crates.io once this merges to `main`.

## What's in this release

- Machine name badge in the UI header with rename dialog (#766)
- All previously unreleased features from `[Unreleased]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)