### PR TITLE
feat(ui): add permanent "None" machine filter option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+### Changed
+
+- Machine filter in Routines and Cron Jobs views now always shows a **None** option
+  (routines/jobs with no machine assigned), replacing the previously conditional
+  "Unassigned" entry that only appeared when such items existed.
+
 ## [0.17.0] — 2026-06-29
 
 ### Added

--- a/ui/src/cron_jobs.rs
+++ b/ui/src/cron_jobs.rs
@@ -1218,7 +1218,6 @@ pub fn cron_jobs_page(props: &CronJobsPageProps) -> Html {
             machine_options.sort();
         }
     }
-    let has_unassigned = unassigned_count(&jobs) > 0;
     let filter_active = filter.is_active();
 
     let edit_job = match &modal {
@@ -1271,7 +1270,6 @@ pub fn cron_jobs_page(props: &CronJobsPageProps) -> Html {
                             <CronFilterBar
                                 filter={filter.clone()}
                                 machines={machine_options}
-                                has_unassigned={has_unassigned}
                                 shown={shown}
                                 total={total_jobs}
                                 search_ref={search_ref.clone()}
@@ -1512,8 +1510,6 @@ pub struct CronFilterBarProps {
     pub filter: JobFilter,
     /// Distinct machines across all jobs, for the machine-facet options.
     pub machines: Vec<String>,
-    /// Whether at least one dormant (no-machine) job exists.
-    pub has_unassigned: bool,
     /// Count after filtering / total loaded — rendered as "Showing N of M".
     pub shown: usize,
     pub total: usize,
@@ -1578,16 +1574,8 @@ pub fn cron_filter_bar(props: &CronFilterBarProps) -> Html {
                 <span class="filter-label">{"MACHINE"}</span>
                 <select class="filter-select" aria-label="Machine filter" onchange={on_machine_change}>
                     <option value={MACHINE_ANY} selected={machine_val == MACHINE_ANY}>{"Any"}</option>
-                    {
-                        if props.has_unassigned {
-                            html! {
-                                <option value={MACHINE_UNASSIGNED}
-                                    selected={machine_val == MACHINE_UNASSIGNED}>{"Unassigned"}</option>
-                            }
-                        } else {
-                            html! {}
-                        }
-                    }
+                    <option value={MACHINE_UNASSIGNED}
+                        selected={machine_val == MACHINE_UNASSIGNED}>{"None"}</option>
                     { for props.machines.iter().map(|m| html! {
                         <option value={m.clone()} selected={machine_val == *m}>{m.clone()}</option>
                     }) }

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -1468,7 +1468,6 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
             machine_options.sort();
         }
     }
-    let has_unassigned = unassigned_routines_count(&routines) > 0;
     let filter_active = filter.is_active();
     let visible = {
         let filtered = filter_routines(&routines, &filter, now_val, window);
@@ -1535,7 +1534,6 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
                                 filter={filter.clone()}
                                 agents={agent_options}
                                 machines={machine_options}
-                                has_unassigned={has_unassigned}
                                 shown={shown}
                                 total={total_routines}
                                 search_ref={search_ref.clone()}
@@ -1815,8 +1813,6 @@ pub struct FilterSortBarProps {
     pub agents: Vec<String>,
     /// Distinct machine ids across all routines, for the machine-facet options.
     pub machines: Vec<String>,
-    /// Whether at least one dormant (no-machine) routine exists.
-    pub has_unassigned: bool,
     /// Count after filtering / total loaded — rendered as "Showing N of M".
     pub shown: usize,
     pub total: usize,
@@ -1899,16 +1895,8 @@ pub fn filter_sort_bar(props: &FilterSortBarProps) -> Html {
                 <span class="filter-label">{"MACHINE"}</span>
                 <select class="filter-select" aria-label="Machine filter" onchange={on_machine_change}>
                     <option value={RMACHINE_ANY} selected={machine_val == RMACHINE_ANY}>{"Any"}</option>
-                    {
-                        if props.has_unassigned {
-                            html! {
-                                <option value={RMACHINE_UNASSIGNED}
-                                    selected={machine_val == RMACHINE_UNASSIGNED}>{"Unassigned"}</option>
-                            }
-                        } else {
-                            html! {}
-                        }
-                    }
+                    <option value={RMACHINE_UNASSIGNED}
+                        selected={machine_val == RMACHINE_UNASSIGNED}>{"None"}</option>
                     { for props.machines.iter().map(|m| html! {
                         <option value={m.clone()} selected={machine_val == *m}>{m.clone()}</option>
                     }) }


### PR DESCRIPTION
Closes #769

## Summary

- Machine filter dropdown in Routines and Cron Jobs views now always shows a **None** option
- Selecting **None** shows only routines/jobs with no machine assigned (empty `machines` list)
- Previously this was a conditional "Unassigned" entry hidden when no such items existed
- Drops unused `has_unassigned` prop from `FilterSortBar` / `CronFilterBar`

## Test plan

- [ ] Open Routines view — machine filter shows Any / None / <machine list>
- [ ] Select **None** — only routines with empty machines list appear
- [ ] Deselect — all routines return
- [ ] Same behaviour on Cron Jobs view
- [ ] `cargo test -p ui` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)