### PR TITLE
fix(cli): ensure .gitignore patterns present on every start (#770)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+### Fixed
+
+- `~/.config/moadim/.gitignore` required patterns (`*.pid`, `*.log`,
+  `*.local.*`) are now ensured on every daemon start instead of only when
+  the file is absent, so a manually edited or newly required entry is
+  restored automatically. (#770)
+
 ## [0.17.0] — 2026-06-29
 
 ### Added

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -474,15 +474,32 @@ pub fn write_pid_file() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Write a `.gitignore` into the config dir so generated runtime files (`*.pid`, `*.log`) and
-/// per-machine state (`*.local.*`, e.g. `machine.local.toml`) stay out of version control when users
-/// track `~/.config/moadim` in a dotfiles repo shared across machines.
-/// Best-effort: failure to write it is not fatal to starting the daemon.
+/// Ensure the config dir `.gitignore` contains all required patterns on every start.
+///
+/// Reads the existing file (if any), appends any missing patterns, and writes back only when
+/// something changed. Preserves user-added entries. Best-effort: failure is not fatal.
 fn ensure_config_gitignore() {
+    const REQUIRED: &[&str] = &["*.pid", "*.log", "*.local.*"];
     let gitignore = crate::paths::config_gitignore_path();
-    if !gitignore.exists() {
-        let _ = std::fs::write(&gitignore, "*.pid\n*.log\n*.local.*\n");
+    let existing = std::fs::read_to_string(&gitignore).unwrap_or_default();
+    let lines: Vec<&str> = existing.lines().collect();
+    let missing: Vec<&str> = REQUIRED
+        .iter()
+        .copied()
+        .filter(|p| !lines.iter().any(|l| l.trim() == *p))
+        .collect();
+    if missing.is_empty() {
+        return;
     }
+    let mut content = existing.clone();
+    if !content.is_empty() && !content.ends_with('\n') {
+        content.push('\n');
+    }
+    for pattern in &missing {
+        content.push_str(pattern);
+        content.push('\n');
+    }
+    let _ = std::fs::write(&gitignore, &content);
 }
 
 /// Remove the pid file. Best-effort: a missing file is not an error.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -486,7 +486,7 @@ fn ensure_config_gitignore() {
     let missing: Vec<&str> = REQUIRED
         .iter()
         .copied()
-        .filter(|p| !lines.iter().any(|l| l.trim() == *p))
+        .filter(|pat| !lines.iter().any(|line| line.trim() == *pat))
         .collect();
     if missing.is_empty() {
         return;

--- a/src/cli_tests.rs
+++ b/src/cli_tests.rs
@@ -669,14 +669,24 @@ fn pid_file_write_read_clear_roundtrip() {
     let gitignore = crate::paths::config_gitignore_path();
     assert!(gitignore.exists());
     let content = std::fs::read_to_string(&gitignore).unwrap();
-    assert!(content.contains("*.local.*"), "gitignore must cover *.local.*");
+    assert!(
+        content.contains("*.local.*"),
+        "gitignore must cover *.local.*"
+    );
     // Manually remove one pattern; a second write must restore it without
     // duplicating the patterns already present.
     std::fs::write(&gitignore, "*.pid\n*.log\n").unwrap();
     write_pid_file().unwrap();
     let content = std::fs::read_to_string(&gitignore).unwrap();
-    assert!(content.contains("*.local.*"), "missing pattern must be re-added");
-    assert_eq!(content.matches("*.pid").count(), 1, "existing patterns must not duplicate");
+    assert!(
+        content.contains("*.local.*"),
+        "missing pattern must be re-added"
+    );
+    assert_eq!(
+        content.matches("*.pid").count(),
+        1,
+        "existing patterns must not duplicate"
+    );
     clear_pid_file();
     assert!(read_pid_file().is_none());
     // A garbage pid file parses to None rather than panicking.

--- a/src/cli_tests.rs
+++ b/src/cli_tests.rs
@@ -687,6 +687,22 @@ fn pid_file_write_read_clear_roundtrip() {
         1,
         "existing patterns must not duplicate"
     );
+    // Write a file with all patterns but no trailing newline; the next write
+    // must insert the newline separator before appending (line 495 branch).
+    std::fs::write(&gitignore, "*.pid\n*.log").unwrap();
+    write_pid_file().unwrap();
+    let content = std::fs::read_to_string(&gitignore).unwrap();
+    assert!(
+        content.contains("*.local.*"),
+        "must append after no-trailing-newline content"
+    );
+    // All patterns present → early return (line 492 branch). Call twice; second is a no-op.
+    write_pid_file().unwrap();
+    assert_eq!(
+        std::fs::read_to_string(&gitignore).unwrap(),
+        content,
+        "no-op write must not change file"
+    );
     clear_pid_file();
     assert!(read_pid_file().is_none());
     // A garbage pid file parses to None rather than panicking.

--- a/src/cli_tests.rs
+++ b/src/cli_tests.rs
@@ -666,9 +666,17 @@ fn pid_file_write_read_clear_roundtrip() {
     let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", home.to_str().unwrap());
     write_pid_file().unwrap();
     assert_eq!(read_pid_file(), Some(std::process::id()));
-    assert!(crate::paths::config_gitignore_path().exists());
-    // A second write hits the "gitignore already exists, skip" branch.
+    let gitignore = crate::paths::config_gitignore_path();
+    assert!(gitignore.exists());
+    let content = std::fs::read_to_string(&gitignore).unwrap();
+    assert!(content.contains("*.local.*"), "gitignore must cover *.local.*");
+    // Manually remove one pattern; a second write must restore it without
+    // duplicating the patterns already present.
+    std::fs::write(&gitignore, "*.pid\n*.log\n").unwrap();
     write_pid_file().unwrap();
+    let content = std::fs::read_to_string(&gitignore).unwrap();
+    assert!(content.contains("*.local.*"), "missing pattern must be re-added");
+    assert_eq!(content.matches("*.pid").count(), 1, "existing patterns must not duplicate");
     clear_pid_file();
     assert!(read_pid_file().is_none());
     // A garbage pid file parses to None rather than panicking.


### PR DESCRIPTION
Closes #770

## What

`ensure_config_gitignore()` used to bail out the moment `~/.config/moadim/.gitignore` existed, even if a required pattern was missing. Now it reads the file on every daemon start and appends only the entries that are absent.

## Why

A user who manually edits the gitignore, or whose install predates a newly required pattern, would silently have incomplete coverage. The repair should be automatic.

## Changes

- `src/cli.rs` — rewritten `ensure_config_gitignore`: read → diff → append missing; no-op when complete
- `src/cli_tests.rs` — extended `pid_file_write_read_clear_roundtrip` to cover:
  - repair after a pattern is stripped
  - no trailing-newline edge case
  - early-return no-op when all patterns are present

## Test plan
- [ ] `cargo test` — 719 tests pass
- [ ] `cargo llvm-cov` — 100% line coverage maintained