### PR TITLE
chore: release v0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+## [0.17.1] — 2026-06-29
+
 ### Changed
 
 - Machine filter in Routines and Cron Jobs views now always shows a **None** option

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ opt-level = "z"
 
 [package]
 name = "moadim"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 description = "Loop engine for AI agents — cron jobs and routines over REST, MCP, and a built-in web UI"
 license = "MIT"


### PR DESCRIPTION
Bumps version `0.17.0` → `0.17.1` and promotes the CHANGELOG.

On merge, `auto-release.yml` will push the `v0.17.1` tag and trigger the crates.io publish.

## Changes since 0.17.0

- Machine filter in Routines and Cron Jobs views now always shows a **None** option for routines/jobs with no machine assigned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)