### PR TITLE
chore: release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+## [0.18.0] — 2026-06-30
+
 ### Added
 
 - **Optional `tags` for routines.** Routines can now carry a free-form list of

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ opt-level = "z"
 
 [package]
 name = "moadim"
-version = "0.17.1"
+version = "0.18.0"
 edition = "2021"
 description = "Loop engine for AI agents — cron jobs and routines over REST, MCP, and a built-in web UI"
 license = "MIT"


### PR DESCRIPTION
Bump version to 0.18.0 and promote CHANGELOG [Unreleased] → [0.18.0].

### Added
- Optional `tags` for routines (#502)