### PR TITLE
fix(api): clarify PUT /routines and /cron-jobs as PATCH alias, not full replace

### DIFF
--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -145,7 +145,8 @@
         "tags": [
           "crate::cron_jobs"
         ],
-        "summary": "`PUT /cron-jobs/{id}` — fully replace a cron job (behaves identically to PATCH).",
+        "summary": "`PUT /cron-jobs/{id}` — partial-update alias for PATCH.",
+        "description": "Despite the HTTP convention, this endpoint does **not** perform a full replacement: it\ndelegates to the same PATCH handler, so omitted fields are retained rather than reset to\ntheir defaults. Clients that need idempotent full-resource replacement must supply every\nfield explicitly; the response shape is identical to PATCH.",
         "operationId": "replace",
         "parameters": [
           {
@@ -764,7 +765,8 @@
         "tags": [
           "crate::routines"
         ],
-        "summary": "`PUT /routines/{id}` — fully replace a routine (behaves identically to PATCH).",
+        "summary": "`PUT /routines/{id}` — partial-update alias for PATCH.",
+        "description": "Despite the HTTP convention, this endpoint does **not** perform a full replacement: it\ndelegates to the same PATCH handler, so omitted fields are retained rather than reset to\ntheir defaults. Clients that need idempotent full-resource replacement must supply every\nfield explicitly; the response shape is identical to PATCH.",
         "operationId": "replace",
         "parameters": [
           {

--- a/src/cron_jobs.rs
+++ b/src/cron_jobs.rs
@@ -438,7 +438,12 @@ pub async fn update(
     Ok(Json(svc_update(&state.store, &state.handlers, &id, body)?))
 }
 
-/// `PUT /cron-jobs/{id}` — fully replace a cron job (behaves identically to PATCH).
+/// `PUT /cron-jobs/{id}` — partial-update alias for PATCH.
+///
+/// Despite the HTTP convention, this endpoint does **not** perform a full replacement: it
+/// delegates to the same PATCH handler, so omitted fields are retained rather than reset to
+/// their defaults. Clients that need idempotent full-resource replacement must supply every
+/// field explicitly; the response shape is identical to PATCH.
 #[utoipa::path(put, path = "/cron-jobs/{id}",
     params(("id" = String, Path, description = "Cron job UUID")),
     request_body = UpdateRequest,

--- a/src/routines/handlers.rs
+++ b/src/routines/handlers.rs
@@ -144,7 +144,12 @@ pub async fn update(
     Ok(Json(svc_update(&store, &id, body)?))
 }
 
-/// `PUT /routines/{id}` — fully replace a routine (behaves identically to PATCH).
+/// `PUT /routines/{id}` — partial-update alias for PATCH.
+///
+/// Despite the HTTP convention, this endpoint does **not** perform a full replacement: it
+/// delegates to the same PATCH handler, so omitted fields are retained rather than reset to
+/// their defaults. Clients that need idempotent full-resource replacement must supply every
+/// field explicitly; the response shape is identical to PATCH.
 #[utoipa::path(put, path = "/routines/{id}",
     params(("id" = String, Path, description = "Routine UUID")),
     request_body = UpdateRoutineRequest,


### PR DESCRIPTION
## Summary

Both `PUT /routines/{id}` and `PUT /cron-jobs/{id}` handlers had self-contradictory doc comments that claimed to "fully replace" while also admitting they "behave identically to PATCH". This is misleading: a PUT with omitted optional fields silently retains the old values rather than resetting them to defaults, which violates the HTTP/REST client expectation for `PUT`.

### Changes

- `src/routines/handlers.rs`: Replace the self-contradictory "fully replace … behaves identically to PATCH" wording with an accurate description: this is a **partial-update alias for PATCH**; omitted fields are retained, not reset.
- `src/cron_jobs.rs`: Same fix for the cron-job handler.
- `apis/openapi.json`: Regenerated to match the updated operation descriptions (no schema changes, only description text).

This takes **direction 2** from the issue: document the alias honestly rather than implementing true replacement. True full-replace semantics would require a distinct request type with required (non-`Option`) fields, which is a larger breaking change.

Closes #242

---

*This pull request was opened by the **Implement my assigned issues without a PR (daemon + landing)** routine of moadim. Tagging @tupe12334 for review.*