### PR TITLE
chore: declare MSRV (rust-version) in Cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   `machine.local.toml`, or hostname — same as `GET /machine`) in a new `machine`
   field, so clients can tell which machine answered without a second request. (#778)
 
+### Changed
+
+- Declared `rust-version = "1.88"` (MSRV) in the root `Cargo.toml` and
+  `ui/Cargo.toml`, matching the floor already required transitively by
+  `darling 0.23`, so `cargo install moadim` on an older stable toolchain now
+  fails with Cargo's clean MSRV message instead of an opaque compile error. (#326)
+
 ## [0.18.0] — 2026-06-30
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ opt-level = "z"
 name = "moadim"
 version = "0.18.0"
 edition = "2021"
+# Floor set by the transitive proc-macro build dependency `darling 0.23`
+# (pulled in via `rmcp-macros` <- `rmcp`), which itself declares
+# `rust-version = "1.88.0"`. Bumping this is a deliberate, CHANGELOG-worthy
+# change — see CONTRIBUTING.md.
+rust-version = "1.88"
 description = "Loop engine for AI agents — cron jobs and routines over REST, MCP, and a built-in web UI"
 license = "MIT"
 repository = "https://github.com/moadim-io/daemon"

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -2,6 +2,8 @@
 name = "ui"
 version = "0.1.0"
 edition = "2021"
+# Kept in lockstep with the workspace root's MSRV (see Cargo.toml).
+rust-version = "1.88"
 
 [[bin]]
 name = "ui"


### PR DESCRIPTION
## Summary

`Cargo.toml` declared no `rust-version` (MSRV), so `cargo install moadim` on an older-but-recent stable toolchain failed with an opaque mid-compile error instead of Cargo's clean "requires rustc X or newer" message.

- Added `rust-version = "1.88"` to `[package]` in the root `Cargo.toml` (the `moadim` server crate) and in `ui/Cargo.toml` (the workspace's wasm UI crate), so both stay in lockstep.

## Why 1.88

CI's `test.yml`/`lint.yml` only install `dtolnay/rust-toolchain@stable` (a floating target, not a pinned version), so there is no fixed CI toolchain to use as the baseline. Instead the floor was determined empirically from the dependency graph via `cargo metadata`:

- The server crate (`moadim`) transitively depends on **`darling 0.23.0`** (a proc-macro dependency pulled in via `rmcp-macros` <- `rmcp`), which itself declares `rust-version = "1.88.0"`. This is the highest MSRV requirement anywhere in the `moadim` package's dependency tree, so 1.88.0 is the real, already-in-effect floor today.
- The `ui` crate's own transitive floor (`indexmap 2.14.0`, `rust-version = "1.85"`) is lower, but it's set to the same `1.88` as the root crate for a single, easy-to-reason-about workspace-wide MSRV.

Verified with `cargo check -p moadim` on the current toolchain (rustc 1.96.0) — builds clean, no regressions from the metadata-only change.

This PR only declares the existing, already-required floor; it does not add a CI job enforcing it (left as straightforward follow-up since the issue's main pain point — opaque failures for `cargo install` users on older toolchains — is what `rust-version` itself fixes).

Closes #326

---
This pull request was opened by the Open issues → fix PRs (owned repos + my orgs) routine of moadim.