### PR TITLE
perf(http): gzip-compress HTTP responses (#399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Changed
 
+- **Gzip-compressed HTTP responses.** The Axum router now negotiates
+  `Accept-Encoding` and gzip-compresses response bodies via a `tower-http`
+  `CompressionLayer`, cutting the ~1.1 MB SPA payload (and the OpenAPI JSON
+  under `/docs`) several-fold on every load/refresh for clients that
+  advertise gzip support. A no-op for clients that don't. (#399)
 - Declared `rust-version = "1.88"` (MSRV) in the root `Cargo.toml` and
   `ui/Cargo.toml`, matching the floor already required transitively by
   `darling 0.23`, so `cargo install moadim` on an older stable toolchain now

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +324,23 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "console_error_panic_hook"
@@ -629,6 +658,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
+ "crc32fast",
  "miniz_oxide",
  "zlib-rs",
 ]
@@ -1611,6 +1641,7 @@ dependencies = [
  "tokio",
  "toml",
  "tower",
+ "tower-http",
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",
@@ -2511,6 +2542,25 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "async-compression",
+ "bitflags 2.13.0",
+ "bytes",
+ "futures-core",
+ "http 1.4.2",
+ "http-body",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ toml = "1.1"
 rmcp = { version = "1.7.0", features = ["server", "macros", "transport-io", "transport-streamable-http-server"] }
 schemars = "1"
 tokio = { version = "1", features = ["full"] }
+tower-http = { version = "0.6", features = ["compression-gzip"] }
 utoipa = { version = "5", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "9", features = ["axum"] }
 uuid = { version = "1", features = ["v4"] }

--- a/src/routes/http.rs
+++ b/src/routes/http.rs
@@ -15,6 +15,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use tower_http::compression::CompressionLayer;
 use utoipa_swagger_ui::SwaggerUi;
 
 /// External-binary dependencies the daemon relies on at runtime, and whether each is resolvable on
@@ -347,6 +348,10 @@ pub(crate) fn build_app_with_shutdown(
         ))
         .layer(middleware::from_fn(middlewares::fs_location::fs_location))
         .layer(middleware::from_fn(middlewares::logger::logger))
+        // Outermost layer: negotiates `Accept-Encoding` and gzip-compresses response bodies
+        // (notably the ~1.1 MB SPA `index.html` and the OpenAPI JSON under `/docs`). A no-op
+        // for clients that don't advertise gzip support (issue #399).
+        .layer(CompressionLayer::new())
         .with_state(app_state)
 }
 

--- a/src/routes/http_tests.rs
+++ b/src/routes/http_tests.rs
@@ -214,6 +214,45 @@ async fn build_app_serves_root() {
 }
 
 #[tokio::test]
+async fn build_app_compresses_root_with_gzip() {
+    // Issue #399: the ~1.1 MB SPA body should be gzip-compressed when the client advertises
+    // support for it.
+    let app = build_app(new_store(), crate::routines::new_store());
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/")
+                .header(axum::http::header::ACCEPT_ENCODING, "gzip")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers()
+            .get(axum::http::header::CONTENT_ENCODING)
+            .unwrap(),
+        "gzip"
+    );
+}
+
+#[tokio::test]
+async fn build_app_serves_root_uncompressed_without_accept_encoding() {
+    // A client that doesn't advertise gzip support must still get the full identity body.
+    let app = build_app(new_store(), crate::routines::new_store());
+    let resp = app
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(resp
+        .headers()
+        .get(axum::http::header::CONTENT_ENCODING)
+        .is_none());
+}
+
+#[tokio::test]
 async fn build_app_sets_security_headers_on_ui_and_api() {
     // The whole router carries the security headers (issue #406): assert on a representative
     // UI response (the SPA at `/`) and a representative API response (`/api/v1/health`).


### PR DESCRIPTION
## Summary

The web UI is a single self-contained `index.html` (Yew SPA + base64-inlined wasm bundle, ~1.1 MB). The Axum router applied no HTTP response compression, so every UI load/refresh — and the OpenAPI JSON under `/docs` — shipped uncompressed over the wire.

- Added `tower-http` (`compression-gzip` feature) and a `CompressionLayer::new()` as the outermost router layer, so it negotiates `Accept-Encoding` and gzip-compresses response bodies for clients that advertise support, while remaining a no-op (full identity body) for clients that don't.
- Added two tests: one asserting `Content-Encoding: gzip` is returned for a `GET /` request with `Accept-Encoding: gzip`, and one asserting the identity (uncompressed) response is unchanged when the header is absent.

Verified locally: `cargo build`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` all pass (one pre-existing, unrelated flaky test — `restart_tests::stop_running_and_wait_succeeds_without_pid_file_when_server_eventually_stops` — also fails identically on a clean `main` checkout; see open PR #783 tracking that flake).

Closes #399.

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.