### PR TITLE
fix(ui): bring the ui crate inside the pre-push clippy gate

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -48,10 +48,11 @@ cargo fmt --check
 
 # ── 3. Lint ───────────────────────────────────────────────────────────────────
 # Match the CI clippy gate (.github/workflows/lint.yml) exactly: lint every
-# target (tests, examples, benches), and treat warnings as errors. Bare
-# `cargo clippy` skips test code and only warns, so it can pass here yet fail
-# CI — keep the two in lockstep so a green local push stays green in CI.
-cargo clippy --all-targets -- -D warnings
+# target (tests, examples, benches) across the whole workspace (including the
+# `ui` member crate), and treat warnings as errors. Bare `cargo clippy` skips
+# test code and only lints the root package, so it can pass here yet fail CI —
+# keep the two in lockstep so a green local push stays green in CI.
+cargo clippy --workspace --all-targets -- -D warnings
 
 # ── 4. Coverage ───────────────────────────────────────────────────────────────
 # Requires: cargo install cargo-llvm-cov && rustup component add llvm-tools-preview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,24 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   `ui/Cargo.toml`, matching the floor already required transitively by
   `darling 0.23`, so `cargo install moadim` on an older stable toolchain now
   fails with Cargo's clean MSRV message instead of an opaque compile error. (#326)
+- The local pre-push hook now runs `cargo clippy --workspace` instead of a
+  bare `cargo clippy`. In this non-virtual workspace (the root `Cargo.toml`
+  declares both a `[package]` and `[workspace]`), the bare form only checks
+  the root `moadim` package, so the `ui` member crate was never type-checked
+  or linted by the hook. `.github/workflows/lint.yml`'s `clippy` job has the
+  same gap and needs the same `--workspace` flag; tracked as follow-up since
+  this PR's credentials can't push workflow-file changes.
+
+### Fixed
+
+- Fixed the `ui` crate, which had silently stopped compiling: three test
+  fixtures (`command_palette_tests.rs`, `routines_tests.rs`,
+  `schedule_heatmap_tests.rs`) were missing the `tags` field added to
+  `Routine` by #505, and `cron_jobs::unassigned_count` /
+  `routines::unassigned_routines_count` were dead code left over from before
+  #771 made the "Unassigned" machine facet a permanent filter option. None of
+  this was caught because `ui` was outside the pre-push clippy gate (see the
+  `--workspace` fix above) and CI's equivalent gate has the same blind spot.
 
 ## [0.18.0] — 2026-06-30
 

--- a/ui/src/command_palette_tests.rs
+++ b/ui/src/command_palette_tests.rs
@@ -36,6 +36,7 @@ fn routine(id: &str, title: &str, agent: &str, schedule: &str, human: Option<&st
         last_manual_trigger_at: None,
         last_scheduled_trigger_at: None,
         ttl_secs: None,
+        tags: vec![],
         agent_registered: false,
         file_path: String::new(),
         schedule_description: human.map(Into::into),

--- a/ui/src/cron_jobs.rs
+++ b/ui/src/cron_jobs.rs
@@ -245,13 +245,6 @@ pub fn distinct_machines(jobs: &[CronJob]) -> Vec<String> {
     set.into_iter().collect()
 }
 
-/// Count of dormant jobs (no machine assigned) — surfaced as the "Unassigned"
-/// machine-facet option only when at least one such job exists.
-#[must_use]
-pub fn unassigned_count(jobs: &[CronJob]) -> usize {
-    jobs.iter().filter(|j| j.machines.is_empty()).count()
-}
-
 // ─── Column sort ──────────────────────────────────────────────────────────────
 //
 // Client-side sort applied to the filtered job list before rendering.

--- a/ui/src/cron_jobs_tests.rs
+++ b/ui/src/cron_jobs_tests.rs
@@ -291,16 +291,6 @@ fn distinct_machines_are_sorted_and_deduped() {
     assert_eq!(distinct_machines(&jobs), vec!["m1", "m2", "m3"]);
 }
 
-#[test]
-fn unassigned_count_tallies_dormant_jobs() {
-    let jobs = vec![
-        job("a", "h", "0 * * * *", &["m1"], true),
-        job("b", "h", "0 * * * *", &[], true),
-        job("c", "h", "0 * * * *", &[], false),
-    ];
-    assert_eq!(unassigned_count(&jobs), 2);
-}
-
 // ── Sort ──────────────────────────────────────────────────────────────────────
 
 #[test]

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -566,12 +566,6 @@ pub fn distinct_machines_r(routines: &[Routine]) -> Vec<String> {
     set.into_iter().collect()
 }
 
-/// Count of routines with no machine assigned.
-#[must_use]
-pub fn unassigned_routines_count(routines: &[Routine]) -> usize {
-    routines.iter().filter(|r| r.machines.is_empty()).count()
-}
-
 // ─── State ────────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/ui/src/routines_tests.rs
+++ b/ui/src/routines_tests.rs
@@ -36,6 +36,7 @@ fn routine(
         last_manual_trigger_at: None,
         last_scheduled_trigger_at: None,
         ttl_secs: None,
+        tags: vec![],
         agent_registered: false,
         file_path: String::new(),
         schedule_description: None,
@@ -427,16 +428,6 @@ fn distinct_machines_r_returns_sorted_unique_machines() {
     ];
     let machines = distinct_machines_r(&routines);
     assert_eq!(machines, vec!["m1", "m2", "m3"]);
-}
-
-#[test]
-fn unassigned_routines_count_counts_empty_machine_lists() {
-    let routines = vec![
-        routine("a", "t", "claude", "0 * * * *", &[], &[], true),
-        routine("b", "t", "claude", "0 * * * *", &["m1"], &[], true),
-        routine("c", "t", "claude", "0 * * * *", &[], &[], false),
-    ];
-    assert_eq!(unassigned_routines_count(&routines), 2);
 }
 
 // ── Bulk selection reducer actions ────────────────────────────────────────────

--- a/ui/src/schedule_heatmap_tests.rs
+++ b/ui/src/schedule_heatmap_tests.rs
@@ -248,6 +248,7 @@ fn routine(schedule: &str, enabled: bool) -> Routine {
         last_manual_trigger_at: None,
         last_scheduled_trigger_at: None,
         ttl_secs: None,
+        tags: vec![],
         agent_registered: false,
         file_path: String::new(),
         schedule_description: None,


### PR DESCRIPTION
## Why

`cargo clippy --all-targets` (no `-p`/`--workspace`) only lints the **root** `moadim` package in this non-virtual workspace (root `Cargo.toml` has both `[package]` and `[workspace] members = ["ui"]`). Neither the pre-push hook nor CI's `lint.yml` ever type-checked or linted the `ui` member crate.

As a result `ui` had quietly broken and nobody noticed:
- Three test fixtures (`command_palette_tests.rs`, `routines_tests.rs`, `schedule_heatmap_tests.rs`) construct `Routine` literals missing the `tags` field added by #505 — `cargo clippy -p ui --all-targets` fails to even compile.
- `cron_jobs::unassigned_count` and `routines::unassigned_routines_count` are dead code: leftovers from before #771 made the "Unassigned" machine facet a permanent filter option instead of one gated on a nonzero count.

## What

- Add the missing `tags: vec![]` field to the three test fixtures.
- Remove the two dead helper functions and their now-orphaned unit tests.
- Switch the pre-push hook's clippy invocation to `cargo clippy --workspace --all-targets -- -D warnings` so this can't silently regress again locally.
- Add a CHANGELOG entry (touches `ui/`, so the `unreleased-entry` check requires one).

**Not included:** `.github/workflows/lint.yml`'s `clippy` job has the identical `--workspace` gap, but this session's GitHub token lacks the `workflow` OAuth scope needed to push changes to files under `.github/workflows/`. A maintainer (or a follow-up PR from a token with that scope) should apply the same one-line `--workspace` fix there.

## Testing

- `cargo fmt --check --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test` (722 passed, 1 skipped — pre-existing unrelated flake under `cargo llvm-cov`, see #783)
- `cargo test -p ui` — 235 passed

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.

cc @tupe12334