### PR TITLE
fix(docs): correct stale moadim.1 version + guard against future drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+### Fixed
+
+- `docs/moadim.1`'s `.TH` header reported a stale `moadim 0.16.0` even though
+  `Cargo.toml` had moved on to 0.18.0 — the hand-maintained man page has no
+  build-time link to the crate version, so a release could silently ship a man
+  page reporting the *previous* version. Corrected the version token and added
+  a regression test (`cli::cli_tests::man_page_version_matches_cargo_pkg_version`)
+  that fails when the two drift again. (#556)
+
 ### Added
 
 - **Machine name in health output.** `GET /health` and the MCP `health` tool now

--- a/docs/moadim.1
+++ b/docs/moadim.1
@@ -1,7 +1,7 @@
 .\" Man page for moadim.
 .\" Mirrors the built-in `moadim --help` output (src/cli.rs::print_help).
 .\" View with:  man ./docs/moadim.1   or install into share/man/man1/.
-.TH MOADIM 1 "2026-06-26" "moadim 0.16.0" "Moadim Manual"
+.TH MOADIM 1 "2026-06-30" "moadim 0.18.0" "Moadim Manual"
 .SH NAME
 moadim \- cron/MCP/REST server with a web control panel
 .SH SYNOPSIS

--- a/src/cli_tests.rs
+++ b/src/cli_tests.rs
@@ -898,3 +898,23 @@ fn run_background_errors_when_spawn_detached_fails() {
     assert!(run_background().is_err());
     let _ = std::fs::remove_dir_all(&base);
 }
+
+/// `docs/moadim.1` hand-mirrors the CLI and hardcodes its own version in the `.TH` header
+/// (e.g. `"moadim 0.16.0"`). Nothing previously kept that in lockstep with `Cargo.toml`, so a
+/// release could silently ship a man page reporting the *previous* version (issue #556). Fail
+/// loudly on drift instead.
+#[test]
+fn man_page_version_matches_cargo_pkg_version() {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/docs/moadim.1");
+    let man_page = std::fs::read_to_string(path).expect("docs/moadim.1 should exist");
+    let th_line = man_page
+        .lines()
+        .find(|line| line.starts_with(".TH MOADIM"))
+        .expect("docs/moadim.1 should have a .TH header line");
+    let expected = format!("\"moadim {}\"", env!("CARGO_PKG_VERSION"));
+    assert!(
+        th_line.contains(&expected),
+        "docs/moadim.1 .TH header is stale: expected it to contain {expected:?}, got: {th_line:?}\n\
+         Update the version token in docs/moadim.1 to match Cargo.toml."
+    );
+}


### PR DESCRIPTION
## Why

`docs/moadim.1` hand-mirrors the CLI and hardcodes its own version in the `.TH` header. Nothing kept it in lockstep with `Cargo.toml`, so it had already drifted: the header said `"moadim 0.16.0"` while `Cargo.toml` is `0.18.0` — exactly the silent-failure pattern filed in #556. `man moadim` was reporting the wrong version with zero CI signal.

## What

- Corrected the `.TH` version token in `docs/moadim.1` to match `Cargo.toml` (`0.18.0`).
- Added `cli::cli_tests::man_page_version_matches_cargo_pkg_version`, which reads `docs/moadim.1` and asserts the `.TH` header contains `"moadim {CARGO_PKG_VERSION}"`, so a future version bump without a man-page update fails `cargo test` instead of shipping silently.
- Added a `CHANGELOG.md` entry under `## [Unreleased]`.

This is a focused slice of #556 (the version-drift half); the command/flag-parity half of that issue is left for a follow-up to keep this PR small and reviewable.

## Verification

Ran locally:
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test man_page_version_matches_cargo_pkg_version`
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (skipping the unrelated, already-flaky `stop_running_and_wait_succeeds_without_pid_file_when_server_eventually_stops`, tracked separately in #783) — 100% line coverage, gate passes.

Closes #556 (version-drift portion).

---

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.

cc @tupe12334