### PR TITLE
fix(cron): populate HandlerRegistry from disk at startup

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -103,6 +103,8 @@ pub type HandlerRegistry = Arc<HashSet<String>>;
 
 Both are cloned into `AppState` (REST) and `MoadimMcp` (MCP). Every write acquires the mutex, updates in memory, then flushes to disk before releasing.
 
+`HandlerRegistry` is built once, at startup, by `scan_registry()` scanning `handlers_dir()` and stripping each entry's extension. It is **not** hot-reloaded: a handler script added to the directory after the daemon starts is not reflected until the next restart.
+
 ---
 
 ## Service layer
@@ -319,7 +321,7 @@ main()
   TcpListener::bind(:5784)
   routes::http::run_with_listener_until(store, listener, pending())
     build_app(store)
-      AppState { store, handlers: new_registry() }
+      AppState { store, handlers: scan_registry() }   scan ~/.config/moadim/handlers/ → HandlerRegistry
       StreamableHttpService::new(|| MoadimMcp::new(...))
       Router::new()  ← wire all routes + middleware
     banner::print(addr)          stdout: REST / MCP / UI URLs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Fixed
 
+- `GET /cron-jobs`, `GET /cron-jobs/{id}`, and the equivalent MCP tools always
+  reported `handler_registered: false`, even when the job's handler script
+  genuinely existed on disk. The `HandlerRegistry` backing that field was built
+  with `new_registry()` at startup — an empty set that nothing ever populated
+  from `handlers_dir()`. The daemon now scans `handlers_dir()` at startup
+  (`scan_registry()`), so `handler_registered` reflects reality. The registry
+  stays read-only after startup; a handler script added later requires a
+  restart to be picked up. (#790)
 - `docs/moadim.1`'s `.TH` header reported a stale `moadim 0.16.0` even though
   `Cargo.toml` had moved on to 0.18.0 — the hand-maintained man page has no
   build-time link to the crate version, so a release could silently ship a man

--- a/src/cron_jobs.rs
+++ b/src/cron_jobs.rs
@@ -159,8 +159,36 @@ pub fn new_store() -> CronStore {
 }
 
 /// Create an empty [`HandlerRegistry`].
+#[cfg(test)]
 pub fn new_registry() -> HandlerRegistry {
     Arc::new(HashSet::new())
+}
+
+/// Build a [`HandlerRegistry`] by scanning [`crate::paths::handlers_dir()`] for handler scripts.
+///
+/// Each discovered file's extension is stripped (`file_stem()`) so the registry holds the same
+/// extension-less identifiers stored on a [`CronJob`]'s `handler` field, matching the convention
+/// `crate::sync::resolve_handler_path` uses to resolve a handler name back to a script on disk.
+/// Called once at server startup (see `build_app_with_shutdown`); the registry is read-only
+/// afterward, so a handler script added to the directory later is not reflected until the daemon
+/// restarts.
+pub fn scan_registry() -> HandlerRegistry {
+    let Ok(entries) = std::fs::read_dir(crate::paths::handlers_dir()) else {
+        return Arc::new(HashSet::new());
+    };
+    let handlers = entries
+        .filter_map(Result::ok)
+        // `is_file()` follows symlinks (unlike `file_type()`, which reflects the dir entry
+        // itself), so a handler script reached via a symlink is still discovered.
+        .filter(|entry| entry.path().is_file())
+        .filter_map(|entry| {
+            entry
+                .path()
+                .file_stem()
+                .map(|stem| stem.to_string_lossy().into_owned())
+        })
+        .collect();
+    Arc::new(handlers)
 }
 
 /// Normalize `expr` to 5-field OS cron format for consistent storage.

--- a/src/cron_jobs_tests.rs
+++ b/src/cron_jobs_tests.rs
@@ -1027,3 +1027,33 @@ fn svc_trigger_write_failure_returns_internal() {
     let result = svc_trigger(&store, "j1");
     assert!(matches!(result, Err(AppError::Internal)));
 }
+
+#[test]
+fn scan_registry_strips_extensions_and_skips_directories() {
+    let home = HomeOverrideGuard::new();
+    let handlers_dir = crate::paths::handlers_dir();
+    std::fs::create_dir_all(&handlers_dir).unwrap();
+    std::fs::write(handlers_dir.join("my-handler.sh"), b"#!/bin/sh\n").unwrap();
+    std::fs::write(handlers_dir.join("no-ext"), b"#!/bin/sh\n").unwrap();
+    // A subdirectory must not be reported as a handler identifier.
+    std::fs::create_dir_all(handlers_dir.join("a-subdir")).unwrap();
+
+    let registry = scan_registry();
+
+    assert!(registry.contains("my-handler"));
+    assert!(registry.contains("no-ext"));
+    assert!(!registry.contains("a-subdir"));
+    assert_eq!(registry.len(), 2);
+    drop(home);
+}
+
+#[test]
+fn scan_registry_returns_empty_set_when_handlers_dir_missing() {
+    let _home = HomeOverrideGuard::new();
+    // HomeOverrideGuard only creates the temp home root, not the handlers dir.
+    assert!(!crate::paths::handlers_dir().exists());
+
+    let registry = scan_registry();
+
+    assert!(registry.is_empty());
+}

--- a/src/routes/http.rs
+++ b/src/routes/http.rs
@@ -1,7 +1,7 @@
 //! HTTP server setup: builds the Axum router and starts listening.
 
 use super::mcp::MoadimMcp;
-use crate::cron_jobs::{self, new_registry, AppState, CronStore, ShutdownSignal};
+use crate::cron_jobs::{self, scan_registry, AppState, CronStore, ShutdownSignal};
 use crate::error::AppError;
 use crate::middlewares;
 use crate::routines::{self, RoutineStore};
@@ -256,7 +256,7 @@ pub(crate) fn build_app_with_shutdown(
 
     let app_state = AppState {
         store: store.clone(),
-        handlers: new_registry(),
+        handlers: scan_registry(),
         routines: routines.clone(),
         uptime_start: now_secs(),
         shutdown: shutdown_signal,

--- a/src/routes/http_tests.rs
+++ b/src/routes/http_tests.rs
@@ -572,6 +572,61 @@ async fn router_cron_job_full_lifecycle() {
 }
 
 #[tokio::test]
+async fn router_handler_registered_true_when_handler_script_exists_on_disk() {
+    // Regression test for the empty-registry bug: build the production AppState through the
+    // real startup path (`build_app` -> `build_app_with_shutdown` -> `scan_registry`), not
+    // `new_registry()` directly, so a registry that silently stays empty would be caught here.
+    let _home = TempHome::set();
+    let handlers_dir = crate::paths::handlers_dir();
+    std::fs::create_dir_all(&handlers_dir).unwrap();
+    std::fs::write(handlers_dir.join("real-handler.sh"), b"#!/bin/sh\n").unwrap();
+
+    let store = new_store();
+    let resp = build_app(store.clone(), crate::routines::new_store())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/cron-jobs")
+                .header(CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    r#"{"schedule":"@daily","handler":"real-handler"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let created: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let id = created["id"].as_str().unwrap().to_string();
+    assert_eq!(
+        created["handler_registered"], true,
+        "a job created against a handler script that already exists on disk should be \
+         registered by the startup scan"
+    );
+
+    // A second request rebuilds the app (and re-scans the registry) the same way the real
+    // server does on every request; the result should not depend on which request created it.
+    let resp = build_app(store.clone(), crate::routines::new_store())
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/cron-jobs/{id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let fetched: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(fetched["handler_registered"], true);
+}
+
+#[tokio::test]
 async fn router_create_invalid_cron_returns_400() {
     let resp = build_app(new_store(), crate::routines::new_store())
         .oneshot(


### PR DESCRIPTION
## What

`scan_registry()` reads `handlers_dir()` at startup and builds the `HandlerRegistry` from the (extension-stripped) filenames found there. `build_app_with_shutdown` now calls it instead of `new_registry()` (which just returns an empty `HashSet`).

## Why

`new_registry()` was the only thing production startup (`build_app_with_shutdown`, the only non-test call site) ever called to build `AppState`'s `HandlerRegistry`. Nothing scanned `handlers_dir()` to populate it. Result: `GET /cron-jobs`, `GET /cron-jobs/{id}`, and the equivalent MCP tools reported `handler_registered: false` for *every* job, in *every* real deployment, regardless of whether the handler script genuinely existed on disk — the field was permanently useless as shipped.

## Implementation

- `scan_registry()` reads `handlers_dir()`, keeps only files (`is_file()`, which follows symlinks — unlike `file_type()`, so a handler reached via a symlink is still discovered), and strips each entry's extension via `file_stem()` to match the extension-less `handler` field stored on a `CronJob` (mirroring the convention `sync::resolve_handler_path` uses to go the other way).
- `new_registry()` is now `#[cfg(test)]`-only — production no longer calls it, but it's still useful as an empty-registry baseline across the existing test suite.
- The registry stays read-only after startup (matching the existing `Architecture.md` claim and the `Arc<HashSet<...>>` type, which has no interior mutability) — a handler script added to the directory after the daemon starts is not picked up until the next restart. Documented in `Architecture.md` and the function's doc comment, closing the doc ambiguity raised in #16 item 2.

## Tests

- `cron_jobs::scan_registry_strips_extensions_and_skips_directories` / `scan_registry_returns_empty_set_when_handlers_dir_missing` — unit coverage for the scan logic.
- `routes::http::router_handler_registered_true_when_handler_script_exists_on_disk` — integration test that builds the production `AppState` via the real `build_app()` startup path (not `new_registry()` directly, which is exactly why this bug shipped unnoticed) and asserts `handler_registered: true` for a job whose handler script exists on disk.

## Checks

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test` (single-threaded) — 729 passed
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% line coverage
- `CHANGELOG.md` updated under `[Unreleased]`

Closes #790

---
This pull request was opened by the *Open issues → fix PRs (owned repos + my orgs)* routine of moadim.