### PR TITLE
ci(lint): cancel superseded lint runs on new pushes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,13 @@ on:
   push:
     branches: [main]
 
+# Cancel a stale run when a PR gets a new push, so superseded lint runs don't
+# pile up and burn CI minutes. Scoped per-workflow-per-ref so unrelated PRs
+# (and the push-to-main trigger) never cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   fmt:
     name: rustfmt

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,6 @@ This is a list of todos for consumption, in a pr remove the todo you have implem
 
 - Add a `cargo xtask spellcheck` (or `make spell`) wrapper that installs and runs `typos` so contributors don't need to know the tool name
 - Add a `test + coverage` CI job that mirrors the pre-push hook's final gate (`cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'`) so the 100% coverage contract is enforced in PRs, not just locally
-- Add a `concurrency` group to `lint.yml` (group by workflow + PR ref, `cancel-in-progress: true`) so a new push to a PR cancels the superseded lint run instead of piling up redundant jobs
 - Add a CI step (or weekly scheduled job) that checks whether a newer `crate-ci/typos` release exists than the pinned tag and opens/updates a tracking issue, so the pin gets bumped on a cadence instead of drifting silently
 - Add a day-detail popover to the routines calendar: clicking a day lists each fire time (HH:MM) with its routine, and a "run now" shortcut per routine
 - Link the routines calendar UI to the new `GET /routines.ics` feed: add a "SUBSCRIBE" button that copies the feed URL (the endpoint already supports a per-routine `?routine=<id>` filter)


### PR DESCRIPTION
## Summary
- A new push to a PR currently kicks off a fresh fmt/clippy run while a prior run for the same ref may still be executing, wasting CI minutes on output that's about to be superseded.
- Add a `concurrency` group to `lint.yml`, scoped by `${{ github.workflow }}-${{ github.ref }}`, with `cancel-in-progress: true` so only the latest push's lint run survives.
- Removes the corresponding TODO.md item, which already called this out.

## Test plan
- [x] Workflow YAML is valid GitHub Actions syntax (mirrors the existing `auto-release.yml` concurrency block already in this repo).
- [x] `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` pass locally on this branch (unrelated to this change, confirms HEAD is otherwise clean).
- [ ] Will confirm on the PR's own checks that lint.yml still runs correctly with the new concurrency group.