### PR TITLE
docs: add CODE_OF_CONDUCT.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Documentation
 
+- **Added `CODE_OF_CONDUCT.md`.** The repo had a `CONTRIBUTING.md` and
+  `SECURITY.md` but no documented standard of conduct or enforcement contact,
+  leaving GitHub's community-standards profile incomplete. Added a Contributor
+  Covenant v2.1 code of conduct with a real reporting contact, and linked it
+  from `CONTRIBUTING.md`. (#423)
 - The README's **Bind address** section now warns that the REST API and MCP
   endpoint are unauthenticated, so `MOADIM_BIND_ADDR` should stay on a loopback
   address: binding to a routable interface (a LAN IP or `0.0.0.0`) exposes

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,135 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces (issues, pull
+requests, discussions, and other project communication channels), and also
+applies when an individual is officially representing the project in public
+spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer, [@tupe12334](https://github.com/tupe12334),
+by email at **61761153+tupe12334@users.noreply.github.com**. All complaints
+will be reviewed and investigated promptly and fairly.
+
+(Security vulnerabilities have a separate, private reporting path — see
+[`SECURITY.md`](SECURITY.md). Use this Code of Conduct contact for behavioral
+concerns, not security reports.)
+
+All maintainers are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Project maintainers will follow these Community Impact Guidelines in
+determining the consequences for any action they deem in violation of this
+Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from project maintainers, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,8 @@
 # Contributing
 
+By participating in this project you agree to abide by our
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
 ## Prerequisites
 
 | Tool | Purpose |

--- a/typos.toml
+++ b/typos.toml
@@ -15,3 +15,7 @@ extend-exclude = [
 [default.extend-words]
 # Intentional spelling used in the codebase; keep it as-is.
 unparseable = "unparseable"
+
+[default.extend-identifiers]
+# Maintainer's GitHub handle, used as a contact/mention target in docs.
+tupe12334 = "tupe12334"


### PR DESCRIPTION
## Why

The repo ships `CONTRIBUTING.md` and `SECURITY.md` but has no `CODE_OF_CONDUCT.md`
(none at the repo root or under `.github/`), so GitHub's community-standards
checklist flags the profile as incomplete and there is no documented standard
of conduct or enforcement contact for a project that already accepts outside
contributions.

Closes #423.

## What

- Added `CODE_OF_CONDUCT.md` based on the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html),
  with a real enforcement/reporting contact (the maintainer's GitHub handle and
  noreply email) — no placeholder text left behind. Clarified that security
  reports should still go through the separate private process in
  `SECURITY.md`, not this contact.
- Linked the Code of Conduct from `CONTRIBUTING.md` so it's discoverable.
- Added the maintainer's GitHub handle to `typos.toml`'s
  `default.extend-identifiers` so the new doc passes the spell-check gate
  (`tupe12334` was otherwise flagged as a likely misspelling of `tuple`/`type`).
- Added a `CHANGELOG.md` entry under `## [Unreleased]` / `### Documentation`.

This is a low-risk, self-contained docs addition with no code impact, and is
not a duplicate of any of the many open PRs from this routine — none of them
touch `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, or `typos.toml`'s identifier
allowlist. I cross-checked it against the full list of ~50 currently-open PRs
from this routine before picking it.

I also investigated `cargo fmt --check`, `cargo clippy --workspace --all-targets`,
and `cargo test`/`cargo llvm-cov` on current `main` HEAD: fmt and clippy are
clean, but `cargo test`/`llvm-cov` reproducibly fail
`restart::restart_tests::stop_running_and_wait_succeeds_without_pid_file_when_server_eventually_stops`
on tight timing margins — that exact flake is already fixed by open PR #783,
so it isn't a fresh target. I also tried a CI hardening fix (adding explicit
least-privilege `permissions:` blocks to 4 workflow files missing them, per
issue #452), but this environment's push credentials lack the GitHub `workflow`
OAuth scope needed to push changes to `.github/workflows/*` (confirmed by a
`refusing to allow an OAuth App to create or update workflow ...` rejection,
and corroborated by a comment already in `CHANGELOG.md` noting an earlier PR
hit the same constraint), so that fix isn't pushable from here and a
docs-only target was chosen instead.

## Verification

- `typos` (full repo) → clean
- `cargo fmt --check` → clean
- No Rust/UI source touched, so `cargo clippy`/`cargo test` are unaffected by
  this change

---

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.

cc @tupe12334