### PR TITLE
ci(lint): pass --workspace to the clippy job so it actually lints ui

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,8 +8,11 @@ name: Lint
 #
 # fmt and clippy run as separate jobs so a formatting failure and a lint failure
 # are reported independently. The build relies on the committed `prebuilt.html`
-# (build.rs falls back to it when trunk is absent), so no trunk or wasm target
-# is needed just to type-check and lint the server crate.
+# (build.rs falls back to it when trunk is absent), so no trunk step is needed
+# just to type-check and lint. The clippy job runs `--workspace` so the `ui`
+# member crate is linted too; `ui`'s deps (yew/gloo/web-sys) build fine on the
+# host target for clippy's purposes, so no wasm32 target install is required
+# here either.
 
 on:
   pull_request:
@@ -54,4 +57,11 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Run clippy
-        run: cargo clippy --all-targets -- -D warnings
+        # Match the local pre-push hook exactly: this is a non-virtual
+        # workspace (the root Cargo.toml declares both a [package] and a
+        # [workspace]), so a bare `cargo clippy` only checks the root
+        # `moadim` package and silently skips the `ui` member crate. Without
+        # `--workspace`, `ui/Cargo.toml`'s `[lints.clippy] all = "deny"` was
+        # never enforced here, so a PR could lint-regress the dashboard and
+        # still go fully green.
+        run: cargo clippy --workspace --all-targets -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,9 +51,14 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   bare `cargo clippy`. In this non-virtual workspace (the root `Cargo.toml`
   declares both a `[package]` and `[workspace]`), the bare form only checks
   the root `moadim` package, so the `ui` member crate was never type-checked
-  or linted by the hook. `.github/workflows/lint.yml`'s `clippy` job has the
-  same gap and needs the same `--workspace` flag; tracked as follow-up since
-  this PR's credentials can't push workflow-file changes.
+  or linted by the hook.
+- `.github/workflows/lint.yml`'s `clippy` job now runs `cargo clippy
+  --workspace --all-targets -- -D warnings` too, closing the matching gap in
+  CI: previously the bare `cargo clippy --all-targets` only checked the root
+  `moadim` package, so `ui/Cargo.toml`'s `[lints.clippy] all = "deny"`
+  posture was never enforced on PRs and a dashboard lint regression could
+  merge to `main` fully green, only surfacing via the local hook (if a
+  contributor had it installed) or at release time.
 
 ### Fixed
 
@@ -63,8 +68,9 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   `Routine` by #505, and `cron_jobs::unassigned_count` /
   `routines::unassigned_routines_count` were dead code left over from before
   #771 made the "Unassigned" machine facet a permanent filter option. None of
-  this was caught because `ui` was outside the pre-push clippy gate (see the
-  `--workspace` fix above) and CI's equivalent gate has the same blind spot.
+  this was caught because `ui` was outside the pre-push clippy gate and CI's
+  equivalent gate had the same blind spot (now closed, see `--workspace`
+  fix above).
 
 ## [0.18.0] — 2026-06-30
 


### PR DESCRIPTION
## Summary

`.github/workflows/lint.yml`'s `clippy` job runs `cargo clippy --all-targets -- -D warnings`. This repo's root `Cargo.toml` declares both a `[package]` and a `[workspace]` (a non-virtual workspace), so a bare `cargo clippy` invocation only checks the root `moadim` package by default — it silently skips the `ui` workspace member. That means `ui/Cargo.toml`'s `[lints.clippy] all = "deny"` posture has never actually been enforced in CI: a PR could introduce a clippy violation (or worse, a compile error) in `ui/src/**` and the `clippy` check would still go green.

This exact gap was already fixed in the **local** pre-push hook in a prior PR (#787, "bring the ui crate inside the pre-push clippy gate"), whose CHANGELOG entry explicitly flagged it as an unresolved follow-up:

> `.github/workflows/lint.yml`'s `clippy` job has the same gap and needs the same `--workspace` flag; tracked as follow-up since this PR's credentials can't push workflow-file changes.

This PR is that follow-up: it adds `--workspace` to the CI clippy job, mirroring the hook exactly (`cargo clippy --workspace --all-targets -- -D warnings`), so the `ui` crate's lint posture is finally enforced on every PR instead of only being caught locally (if a contributor has the hook installed) or at release time. Verified locally with `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` — all pass on current stable Rust, and the `ui` crate type-checks fine on the host target (no wasm32 target install needed for clippy's purposes, same as the existing hook).

Also updates `CHANGELOG.md`'s `## [Unreleased]` section to record the fix and resolve the stale "tracked as follow-up" note left by #787.

This is a related, narrower fix than #412 (which additionally wants a dedicated wasm32 build/compile gate for `ui`) — it only closes the specific `--workspace` clippy gap called out as a known follow-up, not the full acceptance criteria of #412.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (locally, matching the new CI invocation)
- [x] `cargo test` passes (1 pre-existing, unrelated flaky restart-timing test under `cargo llvm-cov` is already tracked by a separate open PR)
- [x] `.github/workflows/lint.yml` YAML parses cleanly

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)