### PR TITLE
chore(lint): enable clippy::unused_async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,9 @@ min_ident_chars = "deny"
 uninlined_format_args = "deny"
 # Reject leftover `dbg!` debugging macros so they never ship to production.
 dbg_macro = "deny"
+# Reject `async fn`s that never `.await` anything — they don't need to be
+# async, and being async needlessly propagates async-ness to callers.
+unused_async = "deny"
 # Prefer `map_or`/`map_or_else`/`is_ok_and` over `.map(f).unwrap_or(_)`.
 map_unwrap_or = "deny"
 # Require a trailing `;` on the last statement of a `()`-returning block so


### PR DESCRIPTION
## Summary
- Enables `clippy::unused_async` (deny) in the root `Cargo.toml`'s `[lints.clippy]` table, matching the repo's existing pattern of denying individual pedantic/style lints with an explanatory comment.
- This lint flags `async fn`s that never `.await` anything internally — needless async that only propagates async-ness to callers without doing any actual yielding.
- No violations currently exist in this codebase, so no code changes beyond the lint declaration were needed.

Closes #803

## Test plan
- [x] `cargo clippy --workspace --all-targets` — clean, no new warnings
- [x] `cargo build --workspace` — succeeds
- [x] `cargo test --workspace` — 235 passed, 0 failed

This pull request was opened by the Clippy lint improvements → issue + PR (Rust repos) → Slack routine of moadim.

cc @tupe12334