### PR TITLE
chore(lint): enable clippy::unused_async lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Changed
 
+- Enabled the `clippy::unused_async` lint. It flags `async fn`s (and async
+  closures/blocks) that never `.await` anything internally, which needlessly
+  propagate async-ness up the call stack and pull in a `Future` state machine
+  for work that's actually synchronous. Zero existing violations, so this only
+  guards against the pattern creeping in going forward. No behavior change.
+  (#803)
 - **Gzip-compressed HTTP responses.** The Axum router now negotiates
   `Accept-Encoding` and gzip-compresses response bodies via a `tower-http`
   `CompressionLayer`, cutting the ~1.1 MB SPA payload (and the OpenAPI JSON

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,3 +86,7 @@ redundant_closure_for_method_calls = "deny"
 # reader having to confirm that `.iter()` isn't secretly `.into_iter()` (which
 # would move). It states "borrow and iterate" at a glance.
 explicit_iter_loop = "deny"
+# Reject `async fn`s (and async closures/blocks) that never `.await` anything
+# internally — needless async propagates up the call stack and pulls in a
+# `Future` state machine for work that's actually synchronous.
+unused_async = "deny"


### PR DESCRIPTION
## What

Adds `unused_async = "deny"` to the `[lints.clippy]` table in the root `Cargo.toml`.

## Why

`clippy::unused_async` flags `async fn`s (and async closures/blocks) that never `.await` anything internally. A function marked `async` but with no actual await point doesn't need to be async — it needlessly propagates async-ness up the call stack to every caller and pulls in a `Future` state machine for work that's actually synchronous. It's also a signal-to-noise issue: seeing `async` implies "this yields/awaits," and when it doesn't, it's misleading.

This codebase is built heavily on `axum`/`tokio`, so it's a good fit. A `cargo clippy` run scoped to this lint reports **zero violations**, so this is a no-risk addition that guards against the pattern creeping in going forward.

Closes #803.

## Verify

```
cargo fmt --check                                    # pass
cargo clippy --workspace --all-targets -- -D warnings # pass, zero violations
cargo test                                            # 726 passed
```

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.

cc @tupe12334