### PR TITLE
fix(build): remove duplicate unused_async lint key breaking cargo build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Fixed
 
+- **`cargo build` was broken on `main`.** Two independent PRs (#804 and #805)
+  each added a `unused_async = "deny"` entry under `[lints.clippy]` in
+  `Cargo.toml`, and both merged cleanly since git's line-based merge doesn't
+  understand TOML semantics. The resulting duplicate key made every `cargo`
+  invocation fail immediately with `error: duplicate key` before compiling a
+  single crate. Removed the duplicate entry so the workspace builds again.
 - `docs/moadim.1`'s `.TH` header reported a stale `moadim 0.16.0` even though
   `Cargo.toml` had moved on to 0.18.0 — the hand-maintained man page has no
   build-time link to the crate version, so a release could silently ship a man

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,3 @@ redundant_closure_for_method_calls = "deny"
 # reader having to confirm that `.iter()` isn't secretly `.into_iter()` (which
 # would move). It states "borrow and iterate" at a glance.
 explicit_iter_loop = "deny"
-# Reject `async fn`s (and async closures/blocks) that never `.await` anything
-# internally — needless async propagates up the call stack and pulls in a
-# `Future` state machine for work that's actually synchronous.
-unused_async = "deny"


### PR DESCRIPTION
## Problem

`cargo build` currently fails outright on `main`:

```
error: duplicate key
  --> Cargo.toml:95:1
   |
95 | unused_async = "deny"
   | ^^^^^^^^^^^^
```

PR #804 (`chore(lint): enable clippy::unused_async`) and PR #805
(`ci(lint): enable clippy::unused_async lint`) each independently added
`unused_async = "deny"` under `[lints.clippy]` in `Cargo.toml`. Both PRs
merged cleanly one after the other because git's line-based merge has no
concept of TOML semantics — it happily applied both additive diffs, leaving
two entries for the same key. `cargo` itself refuses to parse a TOML file
with a duplicate key, so every `cargo build`/`test`/`clippy` invocation now
fails before compiling a single crate. This is as close to "the build is
red" as it gets, and it isn't caught by CI because the lint/test workflows
never got a chance to catch it — the duplicate landed via two separately
green PRs that never overlapped in the same CI run.

## Fix

Removed the duplicate `unused_async = "deny"` entry (kept the first
occurrence, along with its explanatory comment). Verified locally:

- `cargo build --workspace` — now succeeds
- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 725/726 pass; the one failure
  (`restart_tests::stop_running_and_wait_succeeds_without_pid_file_when_server_eventually_stops`)
  is a pre-existing timing flake under parallel test load (passes in
  isolation) already tracked by open PR #783 — unrelated to this change.

Added a CHANGELOG entry under `## [Unreleased]` per repo convention.

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.
cc @tupe12334