### PR TITLE
ci: adopt Swatinem/rust-cache to cache target/ across test and clippy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,14 +54,12 @@ jobs:
           toolchain: stable
           components: clippy
 
-      - name: Cache cargo registry (registry only, not target)
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Cache cargo registry and target/
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+          # Scoped so the `clippy` job's --all-targets target/ artifacts
+          # don't clobber the `test` job's cache entry.
+          shared-key: clippy
 
       - name: Run clippy
         # Match the local pre-push hook exactly: this is a non-virtual

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,14 +40,13 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Cache cargo registry (registry only, not target)
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Cache cargo registry and target/
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+          # Scoped so the `test` and `clippy` jobs' target/ artifacts (built
+          # with different flags: plain build vs --all-targets clippy) don't
+          # clobber each other's cache entry.
+          shared-key: test
 
       - name: Run tests
         run: cargo test


### PR DESCRIPTION
## Summary

`test.yml` and `lint.yml` only cached `~/.cargo/registry` and `~/.cargo/git`,
never `target/`, so both the `test` and `clippy` jobs recompiled the entire
dependency graph from scratch on every push/PR — the slowest part of a Rust
build, repeated on every run.

Replaces the manual `actions/cache` step in both jobs with
`Swatinem/rust-cache`, which caches `target/` alongside the cargo dirs, keys
on `Cargo.lock` **and** the rustc version (so a toolchain bump can't serve a
stale cache), and prunes stale/unused artifacts automatically.

Closes #393

## Changes

- `.github/workflows/test.yml` — `actions/cache` → `Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1`, `shared-key: test`
- `.github/workflows/lint.yml` (clippy job) — same, `shared-key: clippy`
- Distinct `shared-key` per job so `cargo test`'s plain build and `cargo clippy --workspace --all-targets`'s build don't clobber each other's cache entry
- Pinned to a commit SHA with a trailing version comment, consistent with the existing supply-chain hardening on the other actions in these workflows
- No change to what is built, tested, or linted — the `fmt` job is untouched since it doesn't compile anything

## Test plan

- [x] `actionlint .github/workflows/test.yml .github/workflows/lint.yml` — no findings
- [x] YAML parses cleanly
- [x] Diff confirms only the caching step changed in each job — `cargo test` / `cargo clippy --workspace --all-targets -- -D warnings` commands are untouched
- [ ] First run on this PR will be a cold cache (expected); a follow-up run confirms deps aren't recompiled on an unchanged `Cargo.lock`

---

This pull request was opened by the Open issues → fix PRs (owned repos + my orgs) routine of moadim.