### PR TITLE
test(cli): lock status/stop/cleanup --json address contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   page reporting the *previous* version. Corrected the version token and added
   a regression test (`cli::cli_tests::man_page_version_matches_cargo_pkg_version`)
   that fails when the two drift again. (#556)
+- Locked the `--json` machine-readable contract with a regression test
+  (`cli::cli_tests::status_stop_cleanup_json_share_the_same_address`) asserting
+  `status --json`, `stop --json`, and `cleanup --json` all surface the same
+  `address` value, so the three shapes can't silently drift apart again. (#245)
 
 ### Added
 

--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,6 @@ This is a list of todos for consumption, in a pr remove the todo you have implem
 - Add a TTL preset row (1h / 1d / 7d / 30d) under the WORKBENCH TTL input in the routine form, mirroring the cron schedule presets
 - Show a humanized retention countdown ("expires in 2d" / "expired") per finished run in the routine LOGS view, derived from the run's finish time and the routine's effective TTL
 - Enrich `moadim status --json` with the server's liveness details from `GET /health` (e.g. `uptime_secs`) so a single call returns running-state + age, not just the local PID
-- Have `moadim cleanup --json` include the bound `address` field too (`{"running":bool,"removed":N,"address":…}`), so every `--json` command surfaces the endpoint it talked to, matching `status`/`stop`
 - Add a `cli_tests` assertion that `status --json` and `stop --json` produce the SAME set of object keys, so the two shapes can't silently drift apart again as fields are added
 - Add a CLI integration test (spawn a real listener on an ephemeral port, point the probe at it) that exercises the `status`/`cleanup`/`stop` network paths end-to-end, lifting `cli.rs` off its ~27% coverage floor toward the repo's 100% line-coverage gate
 - Add a `moadim status --wait[=SECS]` flag that polls `GET /health` until the server is reachable (or the timeout elapses), exiting 0 on success and the existing exit-3 on timeout, so scripts can block on startup instead of sleeping

--- a/src/cli_tests.rs
+++ b/src/cli_tests.rs
@@ -536,6 +536,35 @@ fn cleanup_json_address_reflects_bind_override() {
     assert_eq!(value["address"], serde_json::json!("127.0.0.1:6000"));
 }
 
+/// Lock the machine-readable contract across all three `--json` commands: `status`, `stop`, and
+/// `cleanup` must each surface `address`, and — since they all describe the same bound endpoint —
+/// the value must be identical across all three, so the shapes can't silently drift apart again.
+#[test]
+fn status_stop_cleanup_json_share_the_same_address() {
+    let _addr = EnvGuard::set(BIND_ADDR_ENV, "127.0.0.1:6000");
+    let status: serde_json::Value =
+        serde_json::from_str(&status_json(true, Some(7), None)).unwrap();
+    let stop: serde_json::Value = serde_json::from_str(&stop_json(true, Some(7))).unwrap();
+    let cleanup: serde_json::Value = serde_json::from_str(&cleanup_json(2, true)).unwrap();
+
+    let expected = serde_json::json!("127.0.0.1:6000");
+    assert!(
+        status["address"].is_string(),
+        "status --json must include address"
+    );
+    assert!(
+        stop["address"].is_string(),
+        "stop --json must include address"
+    );
+    assert!(
+        cleanup["address"].is_string(),
+        "cleanup --json must include address"
+    );
+    assert_eq!(status["address"], expected);
+    assert_eq!(stop["address"], expected);
+    assert_eq!(cleanup["address"], expected);
+}
+
 #[test]
 fn print_help_and_version_emit_without_panicking() {
     print_help();


### PR DESCRIPTION
## Context

Issue #245 asked for `cleanup --json` to include the bound `address` field, matching `status --json`/`stop --json`. That part had already landed on `main` via commit fb31bf9 (#355) — `cleanup_json` already emits `{"running":bool,"removed":N,"address":…}` in both branches, and its doc comment / the `print_help` `--json` note already reflect that shape.

There's also a stale, now-conflicting open PR (#257) from an earlier run that duplicates that already-merged change against an older base — flagging it as superseded separately; no action taken on it in this PR.

The one acceptance criterion from #245 that was still outstanding on `main`:

> A `cli_tests` assertion locks the contract: `address` is present in `status --json`, `stop --json`, and `cleanup --json` (and ideally that the three share the same `address` value), so the shapes can't drift again.

## Changes

- Added `status_stop_cleanup_json_share_the_same_address` to `src/cli_tests.rs`, asserting all three `--json` builders emit a string `address` and that the value is identical across `status`, `stop`, and `cleanup`.
- Removed the now-implemented TODO.md line for the `cleanup --json` address field (repo convention).
- Added a CHANGELOG entry under `## [Unreleased]`.

## Checks

All run locally and passing before push:
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (100.00% lines)
- `typos`

This pull request was opened by the Implement my assigned issues without a PR (daemon + landing) routine of moadim.

Closes #245