### PR TITLE
feat(dx): add make spell wrapper so contributors don't need to know the typos tool name

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,15 +4,7 @@ set -e
 # ── Spell check ─────────────────────────────────────────────────────────────
 # Catch typos in source and prose before they land. Configured by typos.toml
 # at the repo root (generated/vendored files are excluded there).
-# Requires: cargo install typos-cli  (or `brew install typos-cli`)
-if ! command -v typos >/dev/null 2>&1; then
-  echo ""
-  echo "typos is not installed. Run:"
-  echo "  cargo install typos-cli"
-  echo "(or 'brew install typos-cli'), then commit again."
-  exit 1
-fi
-
-echo "Spell-checking with typos..."
-typos
+# `make spell` installs typos-cli if missing, so contributors never need to
+# know the tool's crate/binary name.
+make spell
 echo "Spell check passed."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ By participating in this project you agree to abide by our
 | [Rust stable](https://rustup.rs/) | Build the daemon |
 | [Trunk](https://trunkrs.dev/) | Build the Yew UI (`cargo install trunk`) |
 | `wasm32-unknown-unknown` target | UI target (`rustup target add wasm32-unknown-unknown`) |
-| [`typos`](https://github.com/crate-ci/typos) | Spell check, run by the pre-commit hook (`cargo install typos-cli`) |
+| [`typos`](https://github.com/crate-ci/typos) | Spell check, run by the pre-commit hook (`make spell` installs it automatically) |
 | [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov) + `llvm-tools-preview` | 100% line-coverage gate, enforced by the pre-push hook (`cargo install cargo-llvm-cov && rustup component add llvm-tools-preview`) |
 
 The `wasm32` target and Trunk are only needed when working on the browser UI
@@ -50,8 +50,11 @@ The **pre-commit** hook spell-checks the tree with
 format/lint/coverage gates below. Spell-check the tree on demand with:
 
 ```sh
-typos
+make spell
 ```
+
+`make spell` installs `typos-cli` if it's missing, then runs `typos` against
+the repo root — you don't need to know the crate/binary name to run it.
 
 Generated and vendored files (`prebuilt.html`, lockfiles, `apis/openapi.json`,
 `schemas/`) are excluded in `typos.toml`. To accept a real word that `typos`

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+# Convenience wrappers around tools the pre-commit/pre-push hooks and CI
+# already enforce, so contributors don't need to know a tool's crate/binary
+# name to run the same check locally. Keep in lockstep with .githooks/ and
+# .github/workflows/ — this only wraps the existing gates, it never redefines
+# them.
+
+.PHONY: spell
+
+spell:
+	@command -v typos >/dev/null 2>&1 || cargo install typos-cli
+	typos

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,6 @@
 
 This is a list of todos for consumption, in a pr remove the todo you have implemented and add any new ones you think of.
 
-- Add a `cargo xtask spellcheck` (or `make spell`) wrapper that installs and runs `typos` so contributors don't need to know the tool name
 - Add a `test + coverage` CI job that mirrors the pre-push hook's final gate (`cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'`) so the 100% coverage contract is enforced in PRs, not just locally
 - Add a CI step (or weekly scheduled job) that checks whether a newer `crate-ci/typos` release exists than the pinned tag and opens/updates a tracking issue, so the pin gets bumped on a cadence instead of drifting silently
 - Add a day-detail popover to the routines calendar: clicking a day lists each fire time (HH:MM) with its routine, and a "run now" shortcut per routine


### PR DESCRIPTION
## Problem

`typos` spell-checking is enforced by the pre-commit hook, the Spell check CI workflow, and CONTRIBUTING.md, but there was no project-provided command to run it — contributors had to already know the crate is `typos-cli` and the binary is `typos`.

## Change

- Add a `Makefile` with a `spell` target: installs `typos-cli` if the `typos` binary is missing, then runs `typos` against the repo root (reusing the existing `typos.toml`).
- Point the pre-commit hook's spell-check step and CONTRIBUTING.md at `make spell` instead of the raw `cargo install typos-cli` + `typos` steps.
- Remove the now-implemented TODO item.

Out of scope (per the issue): the `typos` config and the CI gate itself are unchanged.

Closes #483

This pull request was opened by the "Implement my assigned issues without a PR (daemon + landing)" routine of moadim.