### PR TITLE
fix(routines): remove dead NotFound arms in svc_update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   (`cli::cli_tests::status_stop_cleanup_json_share_the_same_address`) asserting
   `status --json`, `stop --json`, and `cleanup --json` all surface the same
   `address` value, so the three shapes can't silently drift apart again. (#245)
+- Removed two dead `AppError::NotFound` arms in `svc_update` (`routines/service.rs`):
+  the function already checks the routine's existence once, up front, while
+  holding the store's lock continuously for the rest of the call, so the two
+  later re-fetches could never actually miss. The two tests written to cover
+  those unreachable arms were accidental duplicates of the same first-check
+  path; merged them into one `svc_update_not_found_when_id_missing` test that
+  covers both request shapes against the real, single `NotFound` path.
 
 ### Added
 

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -382,7 +382,11 @@ pub fn svc_update(
     // update leaves the in-memory store untouched (#468).
     let effective_schedule = match req.schedule.as_deref() {
         Some(schedule) => normalize_schedule(schedule),
-        None => lock.get(id).ok_or(AppError::NotFound)?.schedule.clone(),
+        None => lock
+            .get(id)
+            .expect("id existence checked above, and the lock has been held continuously since")
+            .schedule
+            .clone(),
     };
     reject_over_ceiling(
         "ttl_secs",
@@ -394,7 +398,9 @@ pub fn svc_update(
         req.max_runtime_secs,
         max_runtime_ceiling_secs(&effective_schedule),
     )?;
-    let routine = lock.get_mut(id).ok_or(AppError::NotFound)?;
+    let routine = lock
+        .get_mut(id)
+        .expect("id existence checked above, and the lock has been held continuously since");
     if let Some(schedule) = req.schedule {
         routine.schedule = normalize_schedule(&schedule);
     }

--- a/src/routines/service_tests.rs
+++ b/src/routines/service_tests.rs
@@ -1739,40 +1739,26 @@ fn svc_trigger_returns_internal_on_write_failure() {
 }
 
 #[test]
-fn svc_update_not_found_when_no_schedule_and_id_missing() {
+fn svc_update_not_found_when_id_missing() {
     let _home = TempHome::set();
-    // Covers L359 error arm: `lock.get(id).ok_or(AppError::NotFound)?` fires when the
-    // routine does not exist in the store and no new schedule is provided.
+    // `svc_update` looks the id up once (to compute `old_slug`) while holding the store's
+    // lock for the rest of the function, so a missing id can only ever fail at that single,
+    // first lookup — regardless of whether a new schedule is supplied. This one test covers
+    // both request shapes; the later `lock.get`/`lock.get_mut` calls can no longer fail on a
+    // missing id, so they use `.expect(..)` instead of a second/third `NotFound` arm.
     let store = new_store(); // empty store
     with_empty_path(|| {
-        let result = svc_update(
-            &store,
-            "nonexistent-id",
-            UpdateRoutineRequest {
-                schedule: None,
-                ..empty_update_request()
-            },
-        );
-        assert!(matches!(result, Err(AppError::NotFound)));
-    });
-}
-
-#[test]
-fn svc_update_not_found_when_schedule_provided_and_id_missing() {
-    let _home = TempHome::set();
-    // Covers L371 error arm: `lock.get_mut(id).ok_or(AppError::NotFound)?` fires when
-    // the routine does not exist in the store and a new schedule is provided.
-    let store = new_store(); // empty store
-    with_empty_path(|| {
-        let result = svc_update(
-            &store,
-            "nonexistent-id",
-            UpdateRoutineRequest {
-                schedule: Some("@daily".into()),
-                ..empty_update_request()
-            },
-        );
-        assert!(matches!(result, Err(AppError::NotFound)));
+        for schedule in [None, Some("@daily".to_string())] {
+            let result = svc_update(
+                &store,
+                "nonexistent-id",
+                UpdateRoutineRequest {
+                    schedule,
+                    ..empty_update_request()
+                },
+            );
+            assert!(matches!(result, Err(AppError::NotFound)));
+        }
     });
 }
 


### PR DESCRIPTION
## Why

`cargo llvm-cov` region coverage shows two `0`-execution regions inside `svc_update` (`src/routines/service.rs`):

- `lock.get(id).ok_or(AppError::NotFound)?` when computing `effective_schedule`
- `lock.get_mut(id).ok_or(AppError::NotFound)?` for the final mutable fetch

Both are structurally unreachable: `svc_update` already does an existence check (`lock.get(id).ok_or(AppError::NotFound)?`) as its first store access, and holds the *same* `MutexGuard` for the rest of the function with no removal in between — so by the time execution reaches the later fetches, existence is already guaranteed.

Two tests (`svc_update_not_found_when_no_schedule_and_id_missing` / `svc_update_not_found_when_schedule_provided_and_id_missing`) claimed in their comments to cover those two later arms, but both used an empty store, so both actually just tripped the first, real check — they were accidental duplicates, not real coverage of the later arms.

## What changed

- Replaced the two dead `ok_or(AppError::NotFound)?` calls with `.expect(...)` documenting the invariant (existence already checked, lock held continuously).
- Merged the two duplicate tests into one `svc_update_not_found_when_id_missing` that covers both request shapes against the one real `NotFound` path.
- Added a CHANGELOG entry under `## [Unreleased]`.

## Testing

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test` (726 passed)
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (passes)

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.