### PR TITLE
chore(lint): enable clippy::wildcard_imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,11 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Changed
 
+- Enabled the `clippy::wildcard_imports` lint. It flags `use some::module::*;`
+  glob imports, which obscure where a name comes from at the call site, can
+  silently change behavior when the globbed module gains a new item, and
+  defeat "go to definition" tooling. Zero existing violations, so this only
+  guards against the pattern creeping in going forward. No behavior change.
 - Enabled the `clippy::unused_async` lint. It flags `async fn`s (and async
   closures/blocks) that never `.await` anything internally, which needlessly
   propagate async-ness up the call stack and pull in a `Future` state machine

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,3 +89,8 @@ redundant_closure_for_method_calls = "deny"
 # reader having to confirm that `.iter()` isn't secretly `.into_iter()` (which
 # would move). It states "borrow and iterate" at a glance.
 explicit_iter_loop = "deny"
+# Reject `use some::module::*;` glob imports. Explicit imports make it clear
+# at the call site which module a name comes from, avoid silent breakage or
+# ambiguity when the globbed module adds a new item, and keep `rust-analyzer`
+# "go to definition" unambiguous.
+wildcard_imports = "deny"


### PR DESCRIPTION
## Why

The `[lints.clippy]` table in `Cargo.toml` already denies several targeted
pedantic lints (`unused_async`, `map_unwrap_or`, `semicolon_if_nothing_returned`,
`manual_let_else`, `redundant_closure_for_method_calls`, `explicit_iter_loop`,
`uninlined_format_args`, `min_ident_chars`, `dbg_macro`), but `clippy::wildcard_imports`
was not yet enabled. Glob imports (`use some::module::*;`) hide where a name
comes from at the call site, can silently change behavior when the globbed
module later gains a new item that happens to shadow something, and defeat
"go to definition" tooling — the same class of maintainability problem the
existing lint entries already guard against.

## What

- Added `wildcard_imports = "deny"` to `[lints.clippy]` in `Cargo.toml`.
- Added a `## [Unreleased]` / `### Changed` CHANGELOG entry, matching the
  style of the existing `clippy::unused_async` entry.

No source changes were needed — `cargo clippy --workspace --all-targets -- -D clippy::wildcard_imports`
reports zero existing violations across both the `moadim` and `ui` crates, so
this purely guards against the pattern creeping in going forward.

## Verification

Ran locally on this branch before pushing:
- `cargo fmt --check` — passes
- `cargo clippy --workspace --all-targets -- -D warnings` — passes
- `cargo test` — 725/726 pass; the one failure
  (`restart::restart_tests::stop_running_and_wait_succeeds_without_pid_file_when_server_eventually_stops`)
  also fails identically on a clean `main` checkout with no changes applied, so
  it's a pre-existing environment-flaky test unrelated to this change.

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.