### PR TITLE
chore(deps): bump tower-http from 0.6.11 to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,9 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   `CompressionLayer`, cutting the ~1.1 MB SPA payload (and the OpenAPI JSON
   under `/docs`) several-fold on every load/refresh for clients that
   advertise gzip support. A no-op for clients that don't. (#399)
+- Bumped `tower-http` from `0.6.11` to `0.7.0`. No source changes needed —
+  the only feature used (`compression-gzip`'s `CompressionLayer`) is
+  API-compatible across the bump.
 - Declared `rust-version = "1.88"` (MSRV) in the root `Cargo.toml` and
   `ui/Cargo.toml`, matching the floor already required transitively by
   `darling 0.23`, so `cargo install moadim` on an older stable toolchain now

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2546,9 +2546,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.11"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
  "async-compression",
  "bitflags 2.13.0",
@@ -2556,6 +2556,7 @@ dependencies = [
  "futures-core",
  "http 1.4.2",
  "http-body",
+ "percent-encoding",
  "pin-project-lite",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ toml = "1.1"
 rmcp = { version = "1.7.0", features = ["server", "macros", "transport-io", "transport-streamable-http-server"] }
 schemars = "1"
 tokio = { version = "1", features = ["full"] }
-tower-http = { version = "0.6", features = ["compression-gzip"] }
+tower-http = { version = "0.7", features = ["compression-gzip"] }
 utoipa = { version = "5", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "9", features = ["axum"] }
 uuid = { version = "1", features = ["v4"] }


### PR DESCRIPTION
## Why

`tower-http` is pinned to `0.6` in `Cargo.toml`, but `0.7.0` has been out for a
while (verified via `cargo outdated`). Keeping direct dependencies current
avoids missing upstream fixes and reduces future upgrade friction (e.g. when a
later dependency requires `tower-http >= 0.7`).

## What

- Bumped `tower-http` from `0.6.11` to `0.7.0` in `Cargo.toml`/`Cargo.lock`.
- The only feature this repo uses is `compression-gzip`'s `CompressionLayer`
  (`src/routes/http.rs`), and that API is unchanged across the bump — no
  source changes were required.
- Added a `CHANGELOG.md` entry under `## [Unreleased]` / `### Changed`.

## Verification

Ran locally on the bumped branch:
- `cargo build --workspace` — clean
- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 961 tests pass
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% line coverage maintained

`prebuilt.html` is intentionally left untouched here — it's already tracked
by a separate open PR (#809) and regenerates non-deterministically on every
local build, so bundling it into this diff would just add unrelated noise.

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.

cc @tupe12334