### PR TITLE
feat(routines): omit prompts from list_routines by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+### Changed
+
+- **`list_routines` omits routine prompts by default.** The prompt is the
+  largest field on a routine and is rarely needed when scanning a listing, so it
+  bloated `GET /routines` responses and burned MCP context tokens on every call.
+  The `prompt` key is now absent from list entries unless the caller opts in with
+  `include_prompts=true` (a new boolean on the `list_routines` MCP tool and the
+  `GET /routines` query string). `get_routine` / `GET /routines/{id}` are
+  unaffected and always return the prompt; `routine.toml` persistence is
+  unchanged. (#824)
+
 ### Documentation
 
 - **Added `CODE_OF_CONDUCT.md`.** The repo had a `CONTRIBUTING.md` and

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -536,6 +536,15 @@
             "schema": {
               "type": "boolean"
             }
+          },
+          {
+            "name": "include_prompts",
+            "in": "query",
+            "description": "When `true`, include each routine's `prompt` in the response. Defaults to `false`:\nthe prompt (often the largest field) is omitted so listings stay compact. Fetch a\nsingle routine with `svc_get` / `GET /routines/{id}` to always see its prompt.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -1433,7 +1442,6 @@
           "schedule",
           "title",
           "agent",
-          "prompt",
           "enabled",
           "source",
           "created_at",
@@ -1494,7 +1502,7 @@
           },
           "prompt": {
             "type": "string",
-            "description": "The task prompt handed to the agent."
+            "description": "The task prompt handed to the agent.\n\nOmitted from serialized output when empty. A persisted routine always has a\nnon-blank prompt (enforced by `validate_prompt`), so this never affects\n`routine.toml` persistence; it lets list responses drop the prompt by blanking\nit in-memory (see [`RoutineListQuery::include_prompts`] / `svc_list`)."
           },
           "repositories": {
             "type": "array",

--- a/src/routes/mcp.rs
+++ b/src/routes/mcp.rs
@@ -71,6 +71,17 @@ pub(super) struct LocalOnlyParam {
     local_only: Option<bool>,
 }
 
+/// Input for the `list_routines` MCP tool.
+#[derive(Deserialize, JsonSchema)]
+pub(super) struct ListRoutinesParam {
+    /// When `true` (the default), only return routines targeting the current machine.
+    /// Pass `false` to see routines from all machines.
+    local_only: Option<bool>,
+    /// When `true`, include each routine's `prompt` in the response. Defaults to `false`
+    /// so listings stay compact; use `get_routine` to see a single routine's prompt.
+    include_prompts: Option<bool>,
+}
+
 /// Input for the `lock_routines` MCP tool.
 #[derive(Deserialize, JsonSchema)]
 struct LockRoutinesInput {
@@ -281,15 +292,19 @@ impl MoadimMcp {
     ///
     /// When `local_only` is `true` (the default), only routines whose `machines` list includes the
     /// current machine are returned. Pass `false` to see all routines regardless of machine.
+    ///
+    /// Prompts are omitted by default to keep the listing compact; pass `include_prompts=true`
+    /// to include each routine's prompt.
     #[tool(
-        description = "List managed routines (agent-driven jobs). Defaults to routines targeting the current machine only; pass local_only=false to see all machines."
+        description = "List managed routines (agent-driven jobs). Defaults to routines targeting the current machine only; pass local_only=false to see all machines. Prompts are omitted by default; pass include_prompts=true to include them."
     )]
     fn list_routines(
         &self,
-        Parameters(params): Parameters<LocalOnlyParam>,
+        Parameters(params): Parameters<ListRoutinesParam>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         let query = routines::RoutineListQuery {
             local_only: Some(params.local_only.unwrap_or(true)),
+            include_prompts: Some(params.include_prompts.unwrap_or(false)),
             ..Default::default()
         };
         Ok(ok(routines::svc_list(&self.routines, &query)))

--- a/src/routes/mcp_tests.rs
+++ b/src/routes/mcp_tests.rs
@@ -389,7 +389,10 @@ fn list_routines_empty() {
     use rmcp::handler::server::wrapper::Parameters;
     let handler = make_handler();
     let result = handler
-        .list_routines(Parameters(LocalOnlyParam { local_only: None }))
+        .list_routines(Parameters(ListRoutinesParam {
+            local_only: None,
+            include_prompts: None,
+        }))
         .unwrap();
     assert!(!result.is_error.unwrap_or(false));
 }

--- a/src/routines/model.rs
+++ b/src/routines/model.rs
@@ -62,6 +62,10 @@ pub struct RoutineListQuery {
     /// When `true`, only return routines whose `machines` list includes the current machine.
     /// Defaults to `false` (return all routines, preserving backwards compatibility).
     pub local_only: Option<bool>,
+    /// When `true`, include each routine's `prompt` in the response. Defaults to `false`:
+    /// the prompt (often the largest field) is omitted so listings stay compact. Fetch a
+    /// single routine with `svc_get` / `GET /routines/{id}` to always see its prompt.
+    pub include_prompts: Option<bool>,
 }
 
 /// Query parameters for `GET /routines.ics`: optionally scope the feed to one routine.
@@ -88,6 +92,12 @@ pub struct Routine {
     /// Agent registry key (e.g. `"claude"`) resolved from `~/.config/moadim/agents/`.
     pub agent: String,
     /// The task prompt handed to the agent.
+    ///
+    /// Omitted from serialized output when empty. A persisted routine always has a
+    /// non-blank prompt (enforced by `validate_prompt`), so this never affects
+    /// `routine.toml` persistence; it lets list responses drop the prompt by blanking
+    /// it in-memory (see [`RoutineListQuery::include_prompts`] / `svc_list`).
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub prompt: String,
     /// Repositories listed in the prompt as context.
     #[serde(default)]

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -108,7 +108,8 @@ fn validate_agent(agent: &str) -> Result<(), AppError> {
 /// Return the routines matching `query`, filtered and sorted as requested.
 ///
 /// The default query (no repository filter, sort by creation time ascending)
-/// reproduces the previous behaviour. The `repository` filter keeps routines
+/// reproduces the previous behaviour, except each routine's `prompt` is omitted
+/// unless `include_prompts` is `true`. The `repository` filter keeps routines
 /// referencing a matching repository URL; `sort`/`order` control ordering.
 pub fn svc_list(store: &RoutineStore, query: &RoutineListQuery) -> Vec<RoutineResponse> {
     let lock = store.lock_recover();
@@ -148,9 +149,18 @@ pub fn svc_list(store: &RoutineStore, query: &RoutineListQuery) -> Vec<RoutineRe
         routines.reverse();
     }
 
+    // Omit prompts by default: they are the largest field and rarely needed in a listing.
+    // Blanking triggers `skip_serializing_if` on `Routine::prompt`, dropping it from the JSON.
+    let include_prompts = query.include_prompts.unwrap_or(false);
+
     routines
         .into_iter()
-        .map(RoutineResponse::from_routine)
+        .map(|mut routine| {
+            if !include_prompts {
+                routine.prompt.clear();
+            }
+            RoutineResponse::from_routine(routine)
+        })
         .collect()
 }
 

--- a/src/routines/service_tests.rs
+++ b/src/routines/service_tests.rs
@@ -130,7 +130,10 @@ fn svc_list_includes_prompt_when_requested() {
     let list = svc_list(&store, &query);
     assert_eq!(list[0].routine.prompt, "do the thing");
     let json = serde_json::to_value(&list[0]).unwrap();
-    assert_eq!(json.get("prompt").and_then(|v| v.as_str()), Some("do the thing"));
+    assert_eq!(
+        json.get("prompt").and_then(|value| value.as_str()),
+        Some("do the thing")
+    );
 }
 
 /// Build a minimal valid create request; callers tweak the field under test.

--- a/src/routines/service_tests.rs
+++ b/src/routines/service_tests.rs
@@ -104,6 +104,35 @@ fn svc_list_sorts_by_title_case_insensitively() {
     assert_eq!(list[2].routine.id, "cherry");
 }
 
+#[test]
+fn svc_list_omits_prompt_by_default() {
+    let _home = TempHome::set();
+    // Default query leaves the prompt blank, and `skip_serializing_if` drops the field entirely.
+    let store = store_with(vec![make_routine("a", "Alpha", 0, 0)]);
+    let list = svc_list(&store, &RoutineListQuery::default());
+    assert_eq!(list.len(), 1);
+    assert!(list[0].routine.prompt.is_empty());
+    let json = serde_json::to_value(&list[0]).unwrap();
+    assert!(
+        json.get("prompt").is_none(),
+        "prompt should be absent from the serialized listing, got {json}"
+    );
+}
+
+#[test]
+fn svc_list_includes_prompt_when_requested() {
+    let _home = TempHome::set();
+    let store = store_with(vec![make_routine("a", "Alpha", 0, 0)]);
+    let query = RoutineListQuery {
+        include_prompts: Some(true),
+        ..Default::default()
+    };
+    let list = svc_list(&store, &query);
+    assert_eq!(list[0].routine.prompt, "do the thing");
+    let json = serde_json::to_value(&list[0]).unwrap();
+    assert_eq!(json.get("prompt").and_then(|v| v.as_str()), Some("do the thing"));
+}
+
 /// Build a minimal valid create request; callers tweak the field under test.
 fn valid_create_request() -> CreateRoutineRequest {
     CreateRoutineRequest {


### PR DESCRIPTION
Closes #824

## What

`list_routines` (MCP tool and `GET /routines`) no longer returns each routine's `prompt` by default. Callers opt in with a new `include_prompts=true` boolean.

## Why

The prompt is the largest field on a routine and is rarely needed when scanning a listing — it bloated list responses and burned MCP context tokens on every call.

## How

- `RoutineListQuery` gains `include_prompts: Option<bool>` (default `false`), wired through the REST query string and a new `ListRoutinesParam` for the MCP tool.
- `svc_list` blanks each routine's `prompt` in-memory when prompts aren't requested.
- `Routine::prompt` gets `#[serde(skip_serializing_if = "String::is_empty")]`, so a blanked prompt is **truly absent** from the JSON rather than emitted as `""`. Real prompts are always non-blank (`validate_prompt`), so `routine.toml` persistence and `get_routine` are unaffected.
- Regenerated `apis/openapi.json`.

## Tests

- `svc_list_omits_prompt_by_default` — prompt blank + absent from serialized JSON.
- `svc_list_includes_prompt_when_requested` — prompt present when `include_prompts=true`.
- Updated the `list_routines` MCP handler test for the new param struct.
- Full `cargo test` green; `cargo clippy` clean (only the pre-existing trunk/Yew build note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)