### PR TITLE
ci(release): verify CHANGELOG.md version matches Cargo.toml before tagging

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -7,6 +7,10 @@ name: Auto Release
 # Flow on every push to `main` that touches `Cargo.toml`:
 #   1. detect  — read the package version; release only if no `v<version>` tag
 #                exists yet (idempotent: dependency-only edits don't release).
+#                Also verifies CHANGELOG.md's topmost dated `## [x.y.z]`
+#                heading matches that version, per CONTRIBUTING.md's release
+#                checklist, so a forgotten "promote Unreleased" step fails fast
+#                here instead of tagging/publishing a release with stale notes.
 #   2. tag     — create and push `v<version>`.
 #   3. publish — call publish.yml (crates.io) directly via `workflow_call`.
 #   4. release — call release.yml (GitHub Release) directly via `workflow_call`.
@@ -54,6 +58,17 @@ jobs:
             echo "New version $VERSION — will tag and release."
             echo "release=true" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Verify CHANGELOG.md's topmost dated heading matches the version
+        if: steps.v.outputs.release == 'true'
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          HEADING=$(grep -m1 -E '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | sed -E 's/^## \[([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/')
+          if [ "$HEADING" != "$VERSION" ]; then
+            echo "::error::CHANGELOG.md's topmost dated heading is [$HEADING] but Cargo.toml's version is $VERSION. Promote '## [Unreleased]' to '## [$VERSION] - $(date +%Y-%m-%d)' before releasing."
+            exit 1
+          fi
+          echo "CHANGELOG.md heading matches Cargo.toml version ($VERSION)."
 
   tag:
     name: Push tag

--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,6 @@ This is a list of todos for consumption, in a pr remove the todo you have implem
 - Add a day-detail popover to the routines calendar: clicking a day lists each fire time (HH:MM) with its routine, and a "run now" shortcut per routine
 - Link the routines calendar UI to the new `GET /routines.ics` feed: add a "SUBSCRIBE" button that copies the feed URL (the endpoint already supports a per-routine `?routine=<id>` filter)
 - Auto-stamp the release version/date into CHANGELOG.md from the `chore(release)` step so the `## [Unreleased]` section rolls over on tag
-- Add a CI check that the topmost `## [x.y.z]` heading in CHANGELOG.md matches `Cargo.toml`'s version on tag pushes, so a release tag can't ship with a stale changelog version
 - Have a commands folder for all the cli commands, we want to work with colocation of files
 - Dismiss any open UI modal/dialog (edit, delete-confirm, shutdown-confirm) with the Esc key
 - Add a TTL preset row (1h / 1d / 7d / 30d) under the WORKBENCH TTL input in the routine form, mirroring the cron schedule presets


### PR DESCRIPTION
## Summary

- `publish.yml` already verifies the pushed tag matches `Cargo.toml`'s version, and `release.yml` extracts release notes from CHANGELOG.md's `## [x.y.z]` section for that version — but nothing verified that CHANGELOG.md's topmost dated heading had actually been promoted from `## [Unreleased]` before `auto-release.yml` creates and pushes the release tag.
- Today, a forgotten "promote Unreleased" step still tags the release and publishes to crates.io; the only failure is `release.yml` not finding a matching changelog section, by which point the tag already exists and the crate is already public. CONTRIBUTING.md documents this exact requirement ("`Cargo.toml`'s version must match the topmost changelog heading") but nothing enforced it.
- Adds a step to the `detect` job in `.github/workflows/auto-release.yml` that compares CHANGELOG.md's topmost dated heading against `Cargo.toml`'s version and fails fast — before `tag`/`publish`/`release` run — closing this gap. Verified `actionlint` passes and manually exercised the comparison logic against both the matching (current) state and a synthetic mismatch.
- Removes the now-implemented item from `TODO.md`, per the repo's convention.
- Pure CI change (no `src/`/`ui/` touched), so no CHANGELOG.md entry is required per CONTRIBUTING.md's changelog gate.

## Test plan

- [x] `actionlint .github/workflows/auto-release.yml` passes
- [x] Manually validated the version-comparison shell logic against the current repo state (match) and a synthetic stale-changelog scenario (correctly detected mismatch)
- [x] `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` all pass on this branch (unaffected by this change, confirmed clean before and after)

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.

@tupe12334