### PR TITLE
ci: add concurrency groups to cancel superseded PR/push runs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,6 +12,12 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
+# Cancel a stale run when a PR gets a new push, matching lint.yml's behavior
+# so superseded changelog checks don't pile up and burn CI minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   changelog:
     name: unreleased-entry

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -19,6 +19,12 @@ on:
     # Mondays at 06:00 UTC — keep the spell-check gate current against main.
     - cron: "0 6 * * 1"
 
+# Cancel a stale run when a PR gets a new push, matching lint.yml's behavior
+# so superseded spell-check runs don't pile up and burn CI minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   typos:
     name: typos

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,12 @@ on:
   push:
     branches: [main]
 
+# Cancel a stale run when a PR gets a new push, matching lint.yml's behavior
+# so superseded test runs don't pile up and burn CI minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: cargo test


### PR DESCRIPTION
## Summary

None of the CI workflows in this repo declared a top-level `concurrency:` block (except `auto-release.yml`, which already has its own), so pushing multiple commits to the same PR/branch in quick succession left stale, superseded lint/test runs still executing instead of being cancelled — wasting CI minutes and runners (#432).

This adds the `${{ github.workflow }}-${{ github.ref }}` / `cancel-in-progress: true` concurrency group — the same pattern already used by `lint.yml` and `doc.yml` — to the remaining workflows that trigger on `pull_request` and/or `push`:

- `changelog.yml` — triggers on `pull_request` only
- `spellcheck.yml` — triggers on `pull_request`, `push` to `main`, and a weekly `schedule`
- `test.yml` — triggers on `pull_request` and `push` to `main`

**Skipped intentionally:**

- `auto-release.yml` — already has its own concurrency group (`group: auto-release`, `cancel-in-progress: false`).
- `publish.yml` and `release.yml` — these only trigger on a `v*` tag push or `workflow_call` from the release pipeline, not on PR/branch pushes. Cancelling an in-flight `cargo publish` or GitHub Release run mid-way would be unsafe (partial publish / partial release), so no concurrency group was added and `cancel-in-progress` is deliberately avoided here.

Validated all edited files with `python3 -c "import yaml; yaml.safe_load(...)"` and `actionlint` (both clean). No unrelated workflow content was touched.

Closes #432

---
This pull request was opened by the Open issues → fix PRs (owned repos + my orgs) routine of moadim.