### PR TITLE
fix(http): remove redundant Arc clones in build_app_with_shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,13 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
   posture was never enforced on PRs and a dashboard lint regression could
   merge to `main` fully green, only surfacing via the local hook (if a
   contributor had it installed) or at release time.
+- `build_app_with_shutdown` cloned `store` and `routines` into `app_state`,
+  then cloned them *again* from the original bindings for the MCP service
+  closure — `clippy::redundant_clone` flags the second pair as dead clones
+  since the originals are never read afterward. Reordered to clone once
+  (for the MCP closure) before moving the originals into `app_state`,
+  dropping two unnecessary `Arc` clone+drop pairs per router build. No
+  behavior change.
 
 ### Fixed
 

--- a/src/routes/http.rs
+++ b/src/routes/http.rs
@@ -254,17 +254,22 @@ pub(crate) fn build_app_with_shutdown(
         session::local::LocalSessionManager, StreamableHttpServerConfig, StreamableHttpService,
     };
 
+    // Clone before moving `store`/`routines` into `app_state` below — each is needed by both the
+    // REST router (via `app_state`) and the MCP service closure, so exactly one clone per value is
+    // required. Cloning from `app_state` afterward (as this used to do) produced an extra,
+    // immediately-dropped clone of each `Arc` per call.
+    let mcp_store = store.clone();
+    let mcp_routines = routines.clone();
+
     let app_state = AppState {
-        store: store.clone(),
+        store,
         handlers: new_registry(),
-        routines: routines.clone(),
+        routines,
         uptime_start: now_secs(),
         shutdown: shutdown_signal,
     };
 
-    let mcp_store = store.clone();
     let mcp_handlers = app_state.handlers.clone();
-    let mcp_routines = routines.clone();
     let uptime_start = app_state.uptime_start;
     let mcp_shutdown = app_state.shutdown.clone();
     let mcp_service = StreamableHttpService::new(


### PR DESCRIPTION
## Summary

`build_app_with_shutdown` cloned `store` and `routines` into `app_state`, then
cloned them **again** from the original bindings to feed the MCP service
closure — but the originals are never read after that first clone. Running
`cargo clippy --workspace --all-targets -- -W clippy::redundant_clone` flags
both as dead clones (`this value is dropped without further use`).

Reordered the code to clone once for the MCP closure *before* moving the
originals into `app_state`, so each `Arc` is cloned exactly once instead of
twice. This drops two unnecessary clone+drop pairs per router build (called
once at daemon startup, so no measurable perf impact — this is a correctness
cleanup, not a performance fix). No behavior change; verified with
`cargo build`, `cargo test`, `cargo clippy --workspace --all-targets -- -D
warnings`, and `cargo fmt --check`, all green.

This is a small, standalone fix — it does not enable `clippy::redundant_clone`
workspace-wide (there are ~20 more hits in `ui/` and test files that are
mostly required by Yew's `move` closures or otherwise low-value to chase), so
it doesn't overlap any of the existing `chore(lint): enable clippy::*` PRs.

## Test plan
- [x] `cargo build`
- [x] `cargo test` (726 passed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (100% lines, unchanged)
- [x] Confirmed `clippy::redundant_clone` no longer flags `src/routes/http.rs`

---

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.

cc @tupe12334