### PR TITLE
fix(routines): resolve tmux via more than the bare PATH lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,17 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ### Fixed
 
+- **The daemon never killed hung routine tmux sessions when launched via
+  launchd/systemd.** Those managers start `moadim --interactive` with a
+  minimal `PATH` (e.g. macOS launchd's `/usr/bin:/bin:/usr/sbin:/sbin`) that
+  hides a Homebrew- or npm-installed `tmux`. The daemon's own cleanup/watchdog
+  sweep shelled out to `tmux` directly (no login shell), so every
+  liveness/kill probe silently failed and read as "session already dead" —
+  a hung run's workbench got TTL-reaped while its real tmux session and agent
+  process kept running, untracked, forever. `resolve_tmux_bin` now also
+  searches common install locations (Homebrew, `/usr/local/bin`,
+  `~/.local/bin`) when `tmux` isn't on `PATH`, and the generated launchd
+  plist now sets a real `PATH` via `EnvironmentVariables`.
 - **`cargo build` was broken on `main`.** Two independent PRs (#804 and #805)
   each added a `unused_async = "deny"` entry under `[lints.clippy]` in
   `Cargo.toml`, and both merged cleanly since git's line-based merge doesn't

--- a/src/routines/cleanup/session.rs
+++ b/src/routines/cleanup/session.rs
@@ -9,6 +9,12 @@ use std::path::Path;
 /// The `tmux` executable, overridable via `MOADIM_TMUX_BIN`. In test builds, when no override is
 /// set, this resolves to a non-existent path so tmux probes/kills are harmless no-ops and tests
 /// never touch the real tmux server. Mirrors the `MOADIM_CRONTAB_BIN` seam (#211).
+///
+/// Outside tests, resolves via [`super::super::command::resolve_tmux_bin`] rather than the bare
+/// `"tmux"` name: launchd/systemd start the daemon with a minimal `PATH` that hides a Homebrew- or
+/// npm-installed `tmux`, which used to make every probe here silently fail (read as "session
+/// dead") — TTL-reaping a hung run's workbench while its tmux session and agent process kept
+/// running, untracked, forever.
 pub(super) fn tmux_bin() -> String {
     if let Ok(bin) = std::env::var("MOADIM_TMUX_BIN") {
         return bin;
@@ -16,7 +22,7 @@ pub(super) fn tmux_bin() -> String {
     #[cfg(test)]
     let fallback = "/nonexistent/moadim-test-tmux-guard".to_string();
     #[cfg(not(test))]
-    let fallback = "tmux".to_string();
+    let fallback = super::super::command::resolve_tmux_bin();
     fallback
 }
 

--- a/src/routines/command.rs
+++ b/src/routines/command.rs
@@ -102,6 +102,49 @@ pub(crate) fn tmux_available() -> bool {
         .is_some_and(|path| tmux_available_in(&path))
 }
 
+/// Common install locations to probe for `tmux` when it is not on `path` at all.
+///
+/// Split out so [`resolve_tmux_bin_from`] can be exercised in tests against fake, temp-dir-anchored
+/// fallback lists instead of these real absolute paths (which may or may not hold a real `tmux` on
+/// the machine running the tests).
+fn tmux_fallback_dirs(home: &str) -> Vec<String> {
+    vec![
+        "/opt/homebrew/bin".to_string(),
+        "/usr/local/bin".to_string(),
+        format!("{home}/.local/bin"),
+    ]
+}
+
+/// Best-effort absolute path to `tmux`: first dir on `path` holding it, else the first of
+/// `fallback_dirs` holding it, else the bare `"tmux"` name.
+///
+/// Injectable variant of [`resolve_tmux_bin`] for tests. Mirrors the fallback list [`cron_path`]
+/// bakes into crontab lines: launchd/systemd start the daemon with a minimal `PATH`
+/// (`/usr/bin:/bin:/usr/sbin:/sbin`) that hides a Homebrew- or npm-installed `tmux`, so the
+/// daemon's own tmux probes (`routines::cleanup::session`) would otherwise always fail to find it
+/// — every liveness check then reads as "not running", so a hung run's workbench gets TTL-reaped
+/// while the real tmux session and agent process are never killed and become permanently
+/// untracked. Returning the bare `"tmux"` name when it cannot be found anywhere leaves the
+/// caller's `Command::new` failing exactly as before.
+fn resolve_tmux_bin_from(path: &str, fallback_dirs: &[String]) -> String {
+    if let Some(dir) = bin_dir_in(path, "tmux") {
+        return format!("{dir}/tmux");
+    }
+    for dir in fallback_dirs {
+        if std::path::Path::new(dir).join("tmux").is_file() {
+            return format!("{dir}/tmux");
+        }
+    }
+    "tmux".to_string()
+}
+
+/// Live-`PATH`/`HOME` variant of [`resolve_tmux_bin_from`]; see its docs for why this exists.
+pub(crate) fn resolve_tmux_bin() -> String {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+    let path = std::env::var("PATH").unwrap_or_default();
+    resolve_tmux_bin_from(&path, &tmux_fallback_dirs(&home))
+}
+
 /// A short `PATH` for cron, since cron's default (`/usr/bin:/bin`) hides homebrew/npm-installed
 /// tools like `tmux` and the agent binary.
 ///

--- a/src/routines/command_tests.rs
+++ b/src/routines/command_tests.rs
@@ -239,6 +239,101 @@ fn tmux_available_false_when_path_unset() {
 }
 
 #[test]
+fn resolve_tmux_bin_from_prefers_path_over_fallbacks() {
+    // tmux present on `path` -> returned immediately, fallback_dirs never consulted (Some-arm of
+    // `bin_dir_in`, early return before the fallback loop).
+    let dir =
+        std::env::temp_dir().join(format!("moadim-resolve-tmux-path-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("tmux"), "#!/bin/sh\n").unwrap();
+
+    let dir_str = dir.to_string_lossy().into_owned();
+    let resolved = resolve_tmux_bin_from(&dir_str, &["/definitely/not/here".to_string()]);
+    assert_eq!(resolved, format!("{dir_str}/tmux"));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn resolve_tmux_bin_from_falls_back_to_first_matching_fallback_dir() {
+    // Not on `path`, but present in the second fallback dir -> the `for` loop's `is_file()` Some
+    // (true) arm returns from there, having skipped the first (missing) dir.
+    let base =
+        std::env::temp_dir().join(format!("moadim-resolve-tmux-fb-{}", uuid::Uuid::new_v4()));
+    let missing = base.join("missing");
+    let present = base.join("present");
+    std::fs::create_dir_all(&present).unwrap();
+    std::fs::write(present.join("tmux"), "#!/bin/sh\n").unwrap();
+
+    let resolved = resolve_tmux_bin_from(
+        "",
+        &[
+            missing.to_string_lossy().into_owned(),
+            present.to_string_lossy().into_owned(),
+        ],
+    );
+    assert_eq!(resolved, format!("{}/tmux", present.to_string_lossy()));
+
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[test]
+fn resolve_tmux_bin_from_returns_bare_name_when_nowhere_found() {
+    // Neither `path` nor any fallback dir holds `tmux` -> the loop runs to completion and the
+    // final bare `"tmux"` fallback is returned.
+    let resolved = resolve_tmux_bin_from("", &["/definitely/not/here".to_string()]);
+    assert_eq!(resolved, "tmux");
+}
+
+#[test]
+fn tmux_fallback_dirs_are_anchored_under_home() {
+    let dirs = tmux_fallback_dirs("/home/u");
+    assert!(dirs.contains(&"/opt/homebrew/bin".to_string()));
+    assert!(dirs.contains(&"/usr/local/bin".to_string()));
+    assert!(dirs.contains(&"/home/u/.local/bin".to_string()));
+}
+
+#[test]
+fn resolve_tmux_bin_reads_live_path_and_home() {
+    // End-to-end live-env wrapper: with a fake tmux on PATH it resolves through the same
+    // `bin_dir_in` Some-arm as `resolve_tmux_bin_from`, proving the live `PATH`/`HOME` plumbing
+    // reaches it.
+    let dir =
+        std::env::temp_dir().join(format!("moadim-resolve-tmux-live-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("tmux"), "#!/bin/sh\n").unwrap();
+
+    let dir_str = dir.to_string_lossy().into_owned();
+    with_path(&dir, || {
+        assert_eq!(resolve_tmux_bin(), format!("{dir_str}/tmux"));
+    });
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn resolve_tmux_bin_falls_back_to_root_home_when_home_unset() {
+    // With HOME removed, `std::env::var("HOME").unwrap_or_else(|_| "/root".to_string())` takes its
+    // fallback arm — mirrors `cron_path_falls_back_to_root_home_when_home_unset` for the identical
+    // pattern here. `home` is computed unconditionally before the PATH/fallback-dir search, so this
+    // covers the closure regardless of whether a real `tmux` is on the test machine's live PATH.
+    let saved = std::env::var_os("HOME");
+    // SAFETY: single-threaded test harness; restored immediately below.
+    unsafe {
+        std::env::remove_var("HOME");
+    }
+
+    let _ = resolve_tmux_bin();
+
+    unsafe {
+        match saved {
+            Some(prev) => std::env::set_var("HOME", prev),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+}
+
+#[test]
 fn bin_dir_returns_none_when_path_unset() {
     // With PATH removed entirely, `std::env::var("PATH").ok()?` short-circuits to None.
     let saved = std::env::var_os("PATH");

--- a/src/service/macos.rs
+++ b/src/service/macos.rs
@@ -49,11 +49,29 @@ pub(super) fn plist_path_from_home(home: Option<PathBuf>) -> anyhow::Result<Path
         .join(format!("{LAUNCHD_LABEL}.plist")))
 }
 
+/// `PATH` to give the launchd agent, in place of launchd's own minimal default
+/// (`/usr/bin:/bin:/usr/sbin:/sbin`).
+///
+/// That default hides Homebrew/cargo-installed tools — notably `tmux`, which the daemon's own
+/// background sweep shells out to directly (`routines::cleanup::session`) to probe/kill hung
+/// routine sessions. With no `tmux` on `PATH`, every probe silently failed ("session not found"),
+/// so a hung run's workbench got TTL-reaped while its tmux session and agent process kept running,
+/// untracked, forever. `resolve_tmux_bin` now also searches these locations directly as a second
+/// line of defense, but giving the process a real `PATH` fixes this for every other subprocess the
+/// daemon shells out to as well.
+fn agent_path(home: &Path) -> String {
+    format!(
+        "/opt/homebrew/bin:/usr/local/bin:{home}/.cargo/bin:{home}/.local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+        home = home.display(),
+    )
+}
+
 /// Render the launchd property list for the moadim user agent.
 ///
 /// `exe` is the absolute path to the `moadim` binary; `log` is where launchd writes its stdout and
-/// stderr. The agent runs `moadim --interactive` so launchd supervises it directly.
-pub(super) fn render_plist(exe: &Path, log: &Path) -> String {
+/// stderr; `home` derives the `PATH` (see [`agent_path`]). The agent runs `moadim --interactive` so
+/// launchd supervises it directly.
+pub(super) fn render_plist(exe: &Path, log: &Path, home: &Path) -> String {
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -74,24 +92,30 @@ pub(super) fn render_plist(exe: &Path, log: &Path) -> String {
   <string>{log}</string>
   <key>StandardErrorPath</key>
   <string>{log}</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>{path}</string>
+  </dict>
 </dict>
 </plist>
 "#,
         label = LAUNCHD_LABEL,
         exe = xml_escape(&exe.display().to_string()),
         log = xml_escape(&log.display().to_string()),
+        path = xml_escape(&agent_path(home)),
     )
 }
 
-/// Render the plist for `exe`/`log` and write it (creating parent dirs) to `plist`.
-pub(super) fn write_plist(plist: &Path, exe: &Path, log: &Path) -> anyhow::Result<()> {
+/// Render the plist for `exe`/`log`/`home` and write it (creating parent dirs) to `plist`.
+pub(super) fn write_plist(plist: &Path, exe: &Path, log: &Path, home: &Path) -> anyhow::Result<()> {
     if let Some(dir) = plist.parent() {
         std::fs::create_dir_all(dir)?;
     }
     if let Some(dir) = log.parent() {
         std::fs::create_dir_all(dir)?;
     }
-    std::fs::write(plist, render_plist(exe, log))?;
+    std::fs::write(plist, render_plist(exe, log, home))?;
     Ok(())
 }
 
@@ -116,8 +140,10 @@ fn report_installed(plist: &Path, log: &Path) {
 pub fn install() -> anyhow::Result<()> {
     let exe = moadim_exe().expect("current executable path is always available");
     let log = daemon_log();
+    let home =
+        crate::paths::home().expect("home directory must be known to install the launchd agent");
     let plist = plist_path().expect("home directory must be known to install the launchd agent");
-    write_plist(&plist, &exe, &log)?;
+    write_plist(&plist, &exe, &log, &home)?;
     reload_agent(&plist)?;
     report_installed(&plist, &log);
     request_automation_permission();

--- a/src/service/mod_tests.rs
+++ b/src/service/mod_tests.rs
@@ -8,6 +8,7 @@ fn plist_carries_label_program_args_and_supervision_keys() {
     let plist = render_plist(
         std::path::Path::new("/opt/moadim/bin/moadim"),
         std::path::Path::new("/Users/u/.config/moadim/daemon.log"),
+        std::path::Path::new("/Users/u"),
     );
     assert!(plist.contains("<string>io.moadim.daemon</string>"));
     assert!(plist.contains("<string>/opt/moadim/bin/moadim</string>"));
@@ -15,6 +16,8 @@ fn plist_carries_label_program_args_and_supervision_keys() {
     assert!(plist.contains("<key>RunAtLoad</key>"));
     assert!(plist.contains("<key>KeepAlive</key>"));
     assert!(plist.contains("/Users/u/.config/moadim/daemon.log"));
+    assert!(plist.contains("<key>EnvironmentVariables</key>"));
+    assert!(plist.contains("/opt/homebrew/bin:/usr/local/bin:/Users/u/.cargo/bin"));
 }
 
 #[cfg(target_os = "macos")]
@@ -23,6 +26,7 @@ fn plist_escapes_xml_metacharacters_in_paths() {
     let plist = render_plist(
         std::path::Path::new("/tmp/a&b<c>"),
         std::path::Path::new("/tmp/log"),
+        std::path::Path::new("/tmp/home"),
     );
     assert!(plist.contains("/tmp/a&amp;b&lt;c&gt;"));
     assert!(!plist.contains("a&b<c>"));
@@ -161,7 +165,7 @@ fn write_plist_skips_dir_creation_when_paths_have_no_parent() {
     // path ("") skips create_dir_all for both the plist and the log. The trailing write then fails,
     // which is expected — only the no-parent branches need exercising.
     let no_parent = std::path::Path::new("");
-    assert!(write_plist(no_parent, no_parent, no_parent).is_err());
+    assert!(write_plist(no_parent, no_parent, no_parent, no_parent).is_err());
 }
 
 #[cfg(target_os = "macos")]
@@ -175,7 +179,13 @@ fn write_plist_errors_when_plist_dir_creation_blocked() {
     std::fs::write(base.join("LaunchAgents"), "block").unwrap();
     let plist = base.join("LaunchAgents/io.moadim.daemon.plist");
     let log = base.join("daemon.log");
-    assert!(write_plist(&plist, std::path::Path::new("/usr/local/bin/moadim"), &log).is_err());
+    assert!(write_plist(
+        &plist,
+        std::path::Path::new("/usr/local/bin/moadim"),
+        &log,
+        &base
+    )
+    .is_err());
     let _ = std::fs::remove_dir_all(&base);
 }
 
@@ -193,7 +203,13 @@ fn write_plist_errors_when_log_dir_creation_blocked() {
     let plist = launch_agents.join("io.moadim.daemon.plist");
     // Give a log path whose parent is the blocked non-directory.
     let log = log_parent.join("daemon.log");
-    assert!(write_plist(&plist, std::path::Path::new("/usr/local/bin/moadim"), &log).is_err());
+    assert!(write_plist(
+        &plist,
+        std::path::Path::new("/usr/local/bin/moadim"),
+        &log,
+        &base
+    )
+    .is_err());
     let _ = std::fs::remove_dir_all(&base);
 }
 


### PR DESCRIPTION
## Summary
- `resolve_tmux_bin()` (`src/routines/command.rs`) resolves `tmux`'s absolute path via the live `PATH` first, then falls back to common install locations (`/opt/homebrew/bin`, `/usr/local/bin`, `~/.local/bin`) — used by the daemon's own tmux probes (`routines/cleanup/session.rs`) instead of the bare `"tmux"` name.
- The generated launchd plist (`src/service/macos.rs`) now sets a real `PATH` via `EnvironmentVariables`, fixing any other subprocess the daemon shells out to under launchd's restricted default PATH.

## Why
launchd/systemd start the daemon with a minimal `PATH` (macOS launchd's default is `/usr/bin:/bin:/usr/sbin:/sbin`) that hides a Homebrew- or npm-installed `tmux`. The daemon's own cleanup/watchdog sweep shells out to `tmux` directly (no login shell), so every liveness/kill probe silently failed and was read as "session already dead". `reap_dir` still TTL-reaped the workbench *directory* once the routine's TTL elapsed (that only needs `is_alive() == false`, not a successful kill), so a hung run's tmux session and its `claude` agent process kept running, permanently untracked, forever — new routine launches were unaffected since they go through a login shell (`sh -lc`) that sources `~/.profile`.

Observed in the wild: 25+ orphaned `moadim-*` tmux sessions with no matching workbench directory, some 3+ hours past their routine's max runtime, on a launchd-managed install. `daemon.log` showed the hourly TTL reap running fine but zero session kills since the daemon's last launchd restart.

Fixes #843

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (734 passed)
- [x] `cargo llvm-cov --fail-under-lines 100` (100% line coverage)
- [x] Deployed the fix to a live launchd-managed daemon: `GET /health` now reports `"tmux": true` with no `tmux not found on PATH` startup warning, and cleaned up the 26 orphaned sessions it had already produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)