### PR TITLE
chore(release): version packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-07-02
+
 ### Removed
 
 - **Removed the cron-job feature.** Moadim scheduled two kinds of things —
@@ -1191,7 +1193,12 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 - Ship the prebuilt UI in the published crate.
 - Rename the binary to `moadim` and add install docs.
 
-[Unreleased]: https://github.com/moadim-io/daemon/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/moadim-io/daemon/compare/v0.19.0...HEAD
+[0.19.0]: https://github.com/moadim-io/daemon/compare/v0.18.0...v0.19.0
+[0.18.0]: https://github.com/moadim-io/daemon/compare/v0.17.1...v0.18.0
+[0.17.1]: https://github.com/moadim-io/daemon/compare/v0.17.0...v0.17.1
+[0.17.0]: https://github.com/moadim-io/daemon/compare/v0.16.0...v0.17.0
+[0.16.0]: https://github.com/moadim-io/daemon/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/moadim-io/daemon/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/moadim-io/daemon/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/moadim-io/daemon/compare/v0.12.0...v0.13.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1622,7 +1622,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ opt-level = "z"
 
 [package]
 name = "moadim"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 # Floor set by the transitive proc-macro build dependency `darling 0.23`
 # (pulled in via `rmcp-macros` <- `rmcp`), which itself declares

--- a/docs/moadim.1
+++ b/docs/moadim.1
@@ -1,7 +1,7 @@
 .\" Man page for moadim.
 .\" Mirrors the built-in `moadim --help` output (src/cli.rs::print_help).
 .\" View with:  man ./docs/moadim.1   or install into share/man/man1/.
-.TH MOADIM 1 "2026-06-30" "moadim 0.18.0" "Moadim Manual"
+.TH MOADIM 1 "2026-07-02" "moadim 0.19.0" "Moadim Manual"
 .SH NAME
 moadim \- routine scheduler with an MCP/REST API and a web control panel
 .SH SYNOPSIS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moadim",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bot workflow (`changeset-release.yml`) is unavailable — its last two runs (#844, #845) failed with `Input required and not supplied: token` (`RELEASE_PAT` secret missing/misconfigured). Cutting this release manually per CONTRIBUTING.md's documented fallback.
- No changeset files exist yet (repo just adopted Changesets at #845), so `pnpm version-packages` would no-op. Bumped versions by hand instead and promoted the hand-written `Unreleased` section (accumulated since v0.18.0, includes the breaking cron-job removal in #842) to a dated `0.19.0` heading.
- `0.18.0` → `0.19.0` (minor): pre-1.0, one breaking change (#842) plus non-breaking fixes/features.
- Also fixed `docs/moadim.1`'s `.TH` version/date (caught by the repo's own regression test) and repaired the CHANGELOG compare-link footer, which had drifted stale at v0.15.0.

## Follow-up needed (separate from this PR)
`RELEASE_PAT` repo secret needs to be re-provisioned/fixed so `changeset-release.yml` can create the standing Version Packages PR automatically going forward.

## Test plan
- [x] `cargo check` passes with bumped `Cargo.lock`
- [x] Full test suite + 100% line coverage gate passes (pre-push hook)
- [x] `docs/moadim.1` version/date regression test passes
- [x] CHANGELOG heading (`0.19.0`) matches `Cargo.toml` version, satisfying `auto-release.yml`'s gate
- [ ] On merge: confirm `auto-release.yml` tags `v0.19.0`, then `publish.yml`/`release.yml` complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)