### PR TITLE
fix(ui): default missing prompt field when deserializing routines

### DIFF
--- a/.changeset/routines-ui-missing-prompt-field.md
+++ b/.changeset/routines-ui-missing-prompt-field.md
@@ -1,0 +1,11 @@
+---
+"moadim": patch
+---
+
+### Fixed
+
+- **The routines page failed to load with "missing field `prompt`".** PR #825
+  made `GET /routines` omit the `prompt` field from each routine's JSON by
+  default, but the UI's separately-mirrored `Routine` struct never got a
+  matching `#[serde(default)]` on that field, so the wasm client's
+  deserialization broke on every list fetch.

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -48,6 +48,7 @@ pub struct Routine {
     pub schedule: String,
     pub title: String,
     pub agent: String,
+    #[serde(default)]
     pub prompt: String,
     #[serde(default)]
     pub repositories: Vec<Repository>,


### PR DESCRIPTION
## Summary
- `Routine::prompt` in `ui/src/routines.rs` had no `#[serde(default)]`, unlike its sibling fields, so the wasm client failed to deserialize `GET /routines` responses once #825 made the server omit `prompt` by default.
- Adds `#[serde(default)]` to match the rest of the struct.

Fixes #849

## Test plan
- [x] `cargo check --target wasm32-unknown-unknown` on `ui/` passes
- [x] `cargo llvm-cov` — 100% line coverage maintained
- [x] pre-push hooks (fmt, clippy, coverage, changeset) all green