### PR TITLE
fix(ui): default Routine::prompt so /routines list loads (#849)

### DIFF
--- a/.changeset/fix-ui-routine-prompt-default.md
+++ b/.changeset/fix-ui-routine-prompt-default.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Fix the routines UI failing to load with `missing field \`prompt\`` (#849) by adding `#[serde(default)]` to `Routine::prompt`, matching the server's `GET /routines` response which omits `prompt` by default since #825.

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -48,6 +48,7 @@ pub struct Routine {
     pub schedule: String,
     pub title: String,
     pub agent: String,
+    #[serde(default)]
     pub prompt: String,
     #[serde(default)]
     pub repositories: Vec<Repository>,

--- a/ui/src/routines_tests.rs
+++ b/ui/src/routines_tests.rs
@@ -53,6 +53,23 @@ fn window() -> Duration {
     Duration::seconds(DUE_SOON_WINDOW_SECS)
 }
 
+// ── Deserialization ────────────────────────────────────────────────────────────
+
+/// `GET /routines` omits `prompt` by default (see #825); the UI's hand-mirrored
+/// `Routine` struct must tolerate that or every routines-list fetch fails (#849).
+#[test]
+fn routine_deserializes_without_prompt_field() {
+    let json = r#"{
+        "id": "r1",
+        "schedule": "0 0 * * *",
+        "title": "T",
+        "agent": "a",
+        "enabled": true
+    }"#;
+    let routine: Routine = serde_json::from_str(json).unwrap();
+    assert_eq!(routine.prompt, "");
+}
+
 // ── RoutineStatusFacet codecs ─────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Why

`GET /routines` has omitted `prompt` from each routine's JSON by default since #825 (server-side, `src/routines/service.rs`). The UI's separately hand-mirrored `Routine` struct in `ui/src/routines.rs` never got the matching `#[serde(default)]`, so the wasm client's `.json::<Vec<Routine>>()` call fails to deserialize, and the routines page shows: `Failed to load routines: missing field \`prompt\` at line 1 column 671`. This currently breaks the UI's routines list entirely (#849).

## Fix

Add `#[serde(default)]` to `Routine::prompt`, matching the pattern already used by every other optional-in-JSON field on the struct. Adds a regression test that deserializes a `/routines`-shaped payload without a `prompt` key.

Fixes #849.

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.