### PR TITLE
ci(release): drop RELEASE_PAT, chain lint/test via workflow_call

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -10,10 +10,22 @@ name: Changeset Release
 # `publish.yml`/`release.yml` — this workflow never publishes or tags
 # anything itself, it only prepares the version-bump PR.
 #
-# Uses a `RELEASE_PAT` (a repo-provisioned fine-grained PAT) instead of the
-# default GITHUB_TOKEN: PRs opened with the default token don't trigger other
-# `pull_request` workflows (lint.yml, test.yml, changelog.yml), so the Version
-# Packages PR would merge with zero CI signal otherwise.
+# Uses the default GITHUB_TOKEN — no PAT. A PR opened with the default token
+# doesn't trigger other `pull_request`-triggered workflows (lint.yml, test.yml,
+# changelog.yml) on its own; that's GitHub's anti-recursion loop-guard and it
+# can't be turned off. Instead of routing around it with a repo-provisioned PAT
+# (an extra secret to rotate/scope/lose), this workflow calls lint.yml and
+# test.yml directly as reusable workflows once the Version Packages branch is
+# pushed — the same `workflow_call` escape hatch auto-release.yml already uses
+# to hand off to publish.yml/release.yml around this identical restriction.
+# Those calls target `changeset-release/main` explicitly (the branch name
+# changesets/action always uses for baseBranch "main"), since a workflow_call
+# job otherwise inherits the calling run's ref (the push to `main` that
+# triggered this workflow), not the branch the version step just created.
+#
+# changelog.yml's unreleased-entry check is not called here: it only gates
+# PRs that touch src/ or ui/, and this PR only ever touches package.json,
+# Cargo.toml/Cargo.lock, CHANGELOG.md, and .changeset/*.md.
 
 on:
   push:
@@ -31,11 +43,12 @@ jobs:
   version:
     name: Version Packages PR
     runs-on: ubuntu-latest
+    outputs:
+      pr-number: ${{ steps.changesets.outputs.pullRequestNumber }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -55,10 +68,27 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Create/update Version Packages PR
+        id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: pnpm version-packages
           commit: "chore(release): version packages"
           title: "chore(release): version packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  lint:
+    name: Lint Version Packages PR
+    needs: version
+    if: needs.version.outputs.pr-number != ''
+    uses: ./.github/workflows/lint.yml
+    with:
+      ref: changeset-release/main
+
+  test:
+    name: Test Version Packages PR
+    needs: version
+    if: needs.version.outputs.pr-number != ''
+    uses: ./.github/workflows/test.yml
+    with:
+      ref: changeset-release/main

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,16 @@ on:
   pull_request:
   push:
     branches: [main]
+  workflow_call:
+    inputs:
+      ref:
+        description: >
+          Git ref to check out. Empty (the default) means "use the ref that
+          triggered this run" — set only by changeset-release.yml, which
+          calls this workflow directly to lint a branch (changeset-release/main)
+          other than the one that triggered it.
+        required: false
+        type: string
 
 # Cancel a stale run when a PR gets a new push, so superseded lint runs don't
 # pile up and burn CI minutes. Scoped per-workflow-per-ref so unrelated PRs
@@ -32,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Install Rust (with rustfmt)
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
@@ -47,6 +59,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Install Rust (with clippy)
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,16 @@ on:
   pull_request:
   push:
     branches: [main]
+  workflow_call:
+    inputs:
+      ref:
+        description: >
+          Git ref to check out. Empty (the default) means "use the ref that
+          triggered this run" — set only by changeset-release.yml, which
+          calls this workflow directly to test a branch (changeset-release/main)
+          other than the one that triggered it.
+        required: false
+        type: string
 
 # Cancel a stale run when a PR gets a new push, matching lint.yml's behavior
 # so superseded test runs don't pile up and burn CI minutes.
@@ -40,6 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1


### PR DESCRIPTION
## Summary
- `changeset-release.yml` used a repo `RELEASE_PAT` secret solely to let the bot-opened "Version Packages" PR trigger `lint.yml`/`test.yml` — GitHub's anti-recursion loop-guard blocks a default-`GITHUB_TOKEN`-authored PR from cascading into other `pull_request`-triggered workflows, and that restriction can't be disabled.
- The secret was never actually configured (only `CARGO_REGISTRY_TOKEN` exists on the repo), so `changeset-release.yml` has been failing on every push to `main` with `Input required and not supplied: token` — no Version Packages PR has been opening.
- Instead of provisioning a PAT (a secret someone has to own/rotate), give `lint.yml`/`test.yml` a `workflow_call` trigger with an optional `ref` input, and have `changeset-release.yml` call them directly against `changeset-release/main` right after pushing the version-bump branch. Same escape hatch `auto-release.yml` already uses to hand off to `publish.yml`/`release.yml` around this identical restriction.
- Dropped the `token:` override on `actions/checkout` and the `GITHUB_TOKEN: secrets.RELEASE_PAT` env — both now use the default token, which already has the `contents: write` / `pull-requests: write` permissions this job needs.

## Test plan
- [x] `actionlint` clean on all three edited workflow files
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] After merge: confirm `changeset-release.yml` succeeds on the next push to `main`, opens/updates the Version Packages PR, and the `Lint Version Packages PR` / `Test Version Packages PR` jobs run against `changeset-release/main` with real pass/fail signal