### PR TITLE
chore(lint): enable clippy::match_same_arms

### DIFF
--- a/.changeset/clippy-match-same-arms.md
+++ b/.changeset/clippy-match-same-arms.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Enable `clippy::match_same_arms` and merge the two duplicate-body arms it flagged in `cli::parse` (issue #719): the bare `None` arm into the `Background` arm, and the redundant explicit `-h`/`--help`/`help` arm that the trailing wildcard already covered.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,3 +94,7 @@ explicit_iter_loop = "deny"
 # ambiguity when the globbed module adds a new item, and keep `rust-analyzer`
 # "go to definition" unambiguous.
 wildcard_imports = "deny"
+# Reject `match` arms with identical bodies — either the arm is dead code
+# already covered by another pattern, or the duplication is an unintentional
+# bug where the bodies were meant to differ.
+match_same_arms = "deny"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -103,7 +103,6 @@ pub(crate) const DATA_COMMANDS: &[&str] = &["routines", "schedule", "agents", "e
 pub fn parse(args: impl IntoIterator<Item = String>) -> Command {
     let args: Vec<String> = args.into_iter().collect();
     match args.first().map(String::as_str) {
-        None => Command::Background,
         Some(first) if DATA_COMMANDS.contains(&first) => Command::Data(args),
         Some("machine") => Command::Machine(args[1..].to_vec()),
         Some("restart") => Command::Restart,
@@ -126,10 +125,9 @@ pub fn parse(args: impl IntoIterator<Item = String>) -> Command {
         },
         Some("install") => Command::Install,
         Some("uninstall") => Command::Uninstall,
-        Some("-h" | "--help" | "help") => Command::Help,
         Some("-V" | "--version" | "version") => Command::Version,
         Some("-i" | "--interactive" | "-f" | "--foreground") => Command::Foreground,
-        Some("-b" | "--background" | "-d" | "--detach" | "--daemon") => Command::Background,
+        None | Some("-b" | "--background" | "-d" | "--detach" | "--daemon") => Command::Background,
         Some(_) => Command::Help,
     }
 }


### PR DESCRIPTION
## Why

`clippy::match_same_arms` (pedantic) flags `match` arms with identical bodies — either dead code already covered elsewhere, or an unintentional duplication masking a logic bug. Closes #719.

## What

- Enabled `match_same_arms = "deny"` in `[lints.clippy]`.
- Fixed the two existing violations in `cli::parse`:
  - Merged the bare `None` arm into the `-b`/`--background`/... arm (both produce `Command::Background`).
  - Dropped the explicit `-h`/`--help`/`help` arm — the trailing `Some(_) => Command::Help` wildcard already covers it.
- No behavior change: `cli_tests.rs` already exercises `-h`/`--help`/`help`/no-args and continues to pass.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (599 passed)

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim. @tupe12334