### PR TITLE
ci: fix lint/test concurrency-group collision under workflow_call

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,9 +31,15 @@ on:
 
 # Cancel a stale run when a PR gets a new push, so superseded lint runs don't
 # pile up and burn CI minutes. Scoped per-workflow-per-ref so unrelated PRs
-# (and the push-to-main trigger) never cancel each other.
+# (and the push-to-main trigger) never cancel each other. Uses a literal
+# "lint" prefix rather than ${{ github.workflow }}: when called via
+# workflow_call (see cut-release.yml), github.workflow resolves to the
+# CALLER's name, so lint and test would otherwise share one group with each
+# other (and with the caller) and race-cancel one another. inputs.ref falls
+# back to github.ref for the normal pull_request/push triggers, where
+# inputs.ref is unset.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: lint-${{ inputs.ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,9 +39,12 @@ on:
         type: string
 
 # Cancel a stale run when a PR gets a new push, matching lint.yml's behavior
-# so superseded test runs don't pile up and burn CI minutes.
+# so superseded test runs don't pile up and burn CI minutes. Literal "test"
+# prefix, not ${{ github.workflow }} — see lint.yml's comment: workflow_call
+# callers (cut-release.yml) would otherwise collide lint and test onto the
+# same concurrency group and race-cancel each other.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: test-${{ inputs.ref || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- The first `cut-release.yml` run (#857) cancelled its own `Test version bump` job within 1 second of starting.
- Root cause: `github.workflow` resolves to the *calling* workflow's name inside a `workflow_call` invocation, not the called workflow's own name. `lint.yml` and `test.yml` both keyed their concurrency group as `${{ github.workflow }}-${{ github.ref }}`, so when `cut-release.yml` calls them side by side they both land on the identical group `Cut Release-refs/heads/main` and race to cancel each other.
- Fix: key each workflow's group off a literal prefix (`lint-`/`test-`) instead, falling back `inputs.ref || github.ref` so normal `pull_request`/`push` triggers (where `inputs.ref` is unset) behave exactly as before.

No harm from the original collision — `land` correctly no-ops when a `needs` job is cancelled, so `main` was never touched.

## Test plan
- [x] `actionlint` clean
- [x] pre-push hooks green
- [ ] After merge: re-run `gh workflow run cut-release.yml`, confirm `lint`/`test` both complete (no more spurious cancellation) and `land` fast-forwards `main`