### PR TITLE
fix(release): sync docs/moadim.1's version on every release too

### DIFF
--- a/scripts/release/version-and-sync.mjs
+++ b/scripts/release/version-and-sync.mjs
@@ -20,6 +20,7 @@ const CHANGESET_DIR = path.join(ROOT, ".changeset");
 const CHANGELOG_PATH = path.join(ROOT, "CHANGELOG.md");
 const PACKAGE_JSON_PATH = path.join(ROOT, "package.json");
 const CARGO_TOML_PATH = path.join(ROOT, "Cargo.toml");
+const MAN_PAGE_PATH = path.join(ROOT, "docs", "moadim.1");
 const REPO_URL = "https://github.com/moadim-io/daemon";
 
 function readPendingChangesets() {
@@ -47,6 +48,22 @@ function bumpCargoToml(version) {
     throw new Error(`Could not find a "version" line in ${CARGO_TOML_PATH}`);
   }
   writeFileSync(CARGO_TOML_PATH, next);
+}
+
+// docs/moadim.1 hand-mirrors the CLI and hardcodes its own version in the
+// .TH header (see the `man_page_version_matches_cargo_pkg_version` test in
+// src/cli_tests.rs, which fails the build if this drifts from Cargo.toml).
+function bumpManPage(version) {
+  const manPage = readFileSync(MAN_PAGE_PATH, "utf8");
+  let replaced = false;
+  const next = manPage.replace(/^(\.TH MOADIM 1 "[^"]*" ")moadim [^"]*(")/m, (_, pre, post) => {
+    replaced = true;
+    return `${pre}moadim ${version}${post}`;
+  });
+  if (!replaced) {
+    throw new Error(`Could not find a .TH header line in ${MAN_PAGE_PATH}`);
+  }
+  writeFileSync(MAN_PAGE_PATH, next);
 }
 
 function todayIso() {
@@ -127,10 +144,11 @@ function main() {
 
   updateChangelog(version, combinedBody);
   bumpCargoToml(version);
+  bumpManPage(version);
 
   execSync("cargo check -q", { cwd: ROOT, stdio: "inherit" });
 
-  console.log(`Synced Cargo.toml, Cargo.lock, and CHANGELOG.md to ${version}.`);
+  console.log(`Synced Cargo.toml, Cargo.lock, CHANGELOG.md, and docs/moadim.1 to ${version}.`);
 }
 
 main();


### PR DESCRIPTION
## Summary
- `cut-release.yml`'s first real run (0.19.0 → 0.19.1) failed `cargo test`: `man_page_version_matches_cargo_pkg_version` caught that `docs/moadim.1`'s `.TH` header still said `0.19.0` after the bump.
- `version-and-sync.mjs` already syncs `Cargo.toml`/`Cargo.lock`/`CHANGELOG.md` but never touched `docs/moadim.1`, whose version is hand-hardcoded and only ever got fixed by a human noticing (see #848, a standalone "sync moadim.1" PR). This would have failed *every* future automated release the same way.
- Adds a `bumpManPage` step (same regex-substitution shape as the existing `bumpCargoToml`) to keep it in sync going forward.

## Test plan
- [x] Dry-ran the regex against the real `docs/moadim.1` in a Node one-liner — correctly rewrites only the version token, leaves the date and other `.TH` fields untouched
- [x] `node --check scripts/release/version-and-sync.mjs`
- [x] pre-push hooks green (this file isn't in `src/`/`ui/`, no changeset required)
- [ ] After merge: re-run `gh workflow run cut-release.yml`, confirm `cargo test` passes this time and the release completes