### PR TITLE
feat(routines): move prompt out of routine.toml into prompts/prompt.pure.md + prompt.compiled.md

### DIFF
--- a/.changeset/routine-prompt-files-subfolder.md
+++ b/.changeset/routine-prompt-files-subfolder.md
@@ -1,0 +1,15 @@
+---
+"moadim": patch
+---
+
+### Changed
+
+- **A routine's prompt no longer lives inside `routine.toml`.** The raw prompt
+  is now stored in its own file, `prompts/prompt.pure.md`, and the composed
+  prompt (repositories preamble + raw prompt) moved from the top-level
+  `prompt.md` to `prompts/prompt.compiled.md` — both inside the routine's
+  directory. Embedding a long, often multi-line prompt as an escaped TOML
+  string made `routine.toml` awkward to diff and edit; giving the raw prompt
+  its own markdown file finishes the split the daemon already started for the
+  composed prompt. Existing installs are migrated automatically on the next
+  startup.

--- a/Architecture.md
+++ b/Architecture.md
@@ -24,9 +24,10 @@ Moadim is a Rust daemon that manages scheduled AI-agent routines and exposes the
                                │ read+write on every mutation
                                ▼
                ~/.config/moadim/routines/
-               ├── <uuid>/routine.toml      (tracked)
-               ├── <uuid>/prompt.md         (tracked)
-               └── <uuid>/.gitignore        (generated)
+               ├── <uuid>/routine.toml                  (tracked)
+               ├── <uuid>/prompts/prompt.pure.md         (tracked)
+               ├── <uuid>/prompts/prompt.compiled.md     (tracked)
+               └── <uuid>/.gitignore                    (generated)
 ```
 
 ---
@@ -43,7 +44,7 @@ src/
 ├── global_lock.rs       lock sentinel that halts all routine scheduling/triggers
 ├── openapi.rs           utoipa ApiDoc definition served at /docs/openapi.json
 ├── restart.rs           replaces an already-running daemon with a fresh process
-├── routine_storage.rs   routine.toml + prompt.md persistence
+├── routine_storage.rs   routine.toml + prompts/ (pure/compiled) persistence
 │
 ├── routes/
 │   ├── http.rs          Axum router assembly + run_with_listener_until
@@ -126,14 +127,14 @@ and a `title`. Routines have their own store (`RoutineStore`), REST endpoints
 (`/routines`), MCP tools (`create_routine`, …), and crontab block.
 
 When a routine fires there is **no moadim process in the loop and no clone step**. At create/update
-time moadim composes `prompt.md` (a repositories-as-context preamble + the prompt) into
-`~/.config/moadim/routines/<id>/`, then writes a single self-contained shell command into a dedicated
-crontab block:
+time moadim writes the raw prompt to `prompts/prompt.pure.md` and composes `prompts/prompt.compiled.md`
+(a repositories-as-context preamble + the prompt) into `~/.config/moadim/routines/<id>/`, then writes a
+single self-contained shell command into a dedicated crontab block:
 
 ```
 # BEGIN MOADIM-ROUTINES
 # Managed by moadim — routines (agent tmux sessions)
-<sched> TS=$(date +\%s); WB=…/workbenches/<slug>-$TS; mkdir -p $WB; cp …/prompt.md $WB/; \
+<sched> TS=$(date +\%s); WB=…/workbenches/<slug>-$TS; mkdir -p $WB; cp …/prompts/prompt.compiled.md $WB/prompt.md; \
   tmux new-session -d -s moadim-<slug>-$TS -c $WB '<agent-cmd>'; \
   tmux pipe-pane -o -t … "cat >> $WB/agent.log"   # moadim-routine:<id>
 # END MOADIM-ROUTINES
@@ -168,7 +169,8 @@ The resolved values are baked into the crontab line at sync time, so editing an 
 re-syncing routines that use it. Routines with no matching agent config are skipped (with a warning).
 
 Modules: `src/routines/` (model + service + command builder + handlers), `src/routine_storage.rs`
-(`routine.toml` + `prompt.md` persistence), `src/sync/routines.rs` (the `MOADIM-ROUTINES` block).
+(`routine.toml` + `prompts/prompt.pure.md` + `prompts/prompt.compiled.md` persistence),
+`src/sync/routines.rs` (the `MOADIM-ROUTINES` block).
 Reverse sync (crontab → store) is not implemented for routines.
 
 ## Error handling (`src/error.rs`)
@@ -215,10 +217,11 @@ The prebuilt is stored at the package root — not under `ui/` — because `ui/`
 
 ```
 main()
-  routine_storage::migrate_prompt_files() / migrate_routine_dirs()   pre-load-time healing
+  routine_storage::migrate_prompt_files() / migrate_prompts_to_subfolder() / migrate_routine_dirs()
+                                          pre-load-time healing
   routine_storage::load_store()          scan ~/.config/moadim/routines/ → RoutineStore
   routines::ensure_default_routines()    seed missing built-in default routines
-  routine_storage::repersist_routines()  heal any dirs missing a prompt.md sidecar
+  routine_storage::repersist_routines()  heal any dirs missing a prompts/ sidecar
   sync::routines::sync_routines_to_crontab()   re-sync the MOADIM-ROUTINES crontab block
   TcpListener::bind(:5784)
   cli::write_pid_file()

--- a/README.md
+++ b/README.md
@@ -105,8 +105,10 @@ install -Dm644 docs/moadim.1 "$HOME/.local/share/man/man1/moadim.1"
 ~/.config/moadim/
 ├── routines/                  # scheduled AI-agent tasks (see ## Routines)
 │   └── nightly-triage/
-│       ├── routine.toml       # tracked — schedule, agent, prompt, repositories
-│       ├── prompt.md          # tracked — the rendered prompt handed to the agent
+│       ├── routine.toml       # tracked — schedule, agent, repositories
+│       ├── prompts/
+│       │   ├── prompt.pure.md      # tracked — the raw, user-authored prompt
+│       │   └── prompt.compiled.md  # tracked — the rendered prompt handed to the agent
 │       └── .gitignore         # generated — excludes *.local.* and *.log
 ├── agents/                    # registered coding agents referenced by routines
 │   └── claude.toml
@@ -149,8 +151,10 @@ git-trackable:
 ```
 ~/.config/moadim/routines/
 └── nightly-triage/
-    ├── routine.toml   # tracked — schedule, agent, prompt, repositories
-    ├── prompt.md      # tracked — the rendered prompt handed to the agent
+    ├── routine.toml   # tracked — schedule, agent, repositories
+    ├── prompts/
+    │   ├── prompt.pure.md      # tracked — the raw, user-authored prompt
+    │   └── prompt.compiled.md  # tracked — the rendered prompt handed to the agent
     └── .gitignore     # generated — excludes *.local.* and *.log
 ```
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -14,7 +14,7 @@ unattended in a throwaway workbench, locally, with no cloud dependency.
 | **Agent-agnostic** (swap CLI)    | ✅ claude/codex/hermes| n/a                   | ✅ any                | ❌ Claude only          | ❌ usually 1 vendor  |
 | **Per-run isolation** (workbench)| ✅ throwaway + reaped | ❌                    | ✅ fresh runner       | ⚠️ varies               | ⚠️ varies            |
 | **Unattended auth** pre-seed     | ✅ (claude trust/MCP) | n/a                   | ⚠️ secrets/tokens     | ✅                      | ⚠️ varies            |
-| Config **git-trackable**         | ✅ TOML + prompt.md   | ⚠️ crontab file       | ✅ YAML in repo       | ⚠️ varies               | ⚠️ varies            |
+| Config **git-trackable**         | ✅ TOML + prompt files| ⚠️ crontab file       | ✅ YAML in repo       | ⚠️ varies               | ⚠️ varies            |
 | **3 interfaces, one port**       | ✅ UI + REST + MCP    | ❌ CLI only           | ❌ web/API            | ⚠️ CLI/web              | ⚠️ varies            |
 | **MCP** native (agents self-schedule) | ✅               | ❌                    | ❌                    | ⚠️                      | ⚠️                   |
 | Calendar feed (`.ics`)           | ✅                    | ❌                    | ❌                    | ❌                      | ❌                   |

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,20 +111,24 @@ async fn run_server() -> anyhow::Result<()> {
     }
     routines::ensure_default_agents();
     // Rename any prompt.txt sidecars to prompt.md before the crontab resync; otherwise the first
-    // cron trigger after upgrade would fail on the launch command's `cp prompt.md` step.
+    // cron trigger after upgrade would fail on the launch command's `cp prompt.compiled.md` step.
     routine_storage::migrate_prompt_files();
+    // Move each routine's prompt file(s) into its prompts/ subfolder, and extract the raw prompt
+    // out of routine.toml into prompts/prompt.pure.md. Must run before migrate_routine_dirs and
+    // load_store, which both read the prompt from the new sidecar location.
+    routine_storage::migrate_prompts_to_subfolder();
     // Move legacy UUID-named routine dirs to the current slug-based layout before loading, so the
-    // store reflects the canonical dirs the crontab sync and the launch command's `cp prompt.md`
-    // both target.
+    // store reflects the canonical dirs the crontab sync and the launch command's
+    // `cp prompt.compiled.md` both target.
     routine_storage::migrate_routine_dirs();
     let routines = routine_storage::load_store();
     // Seed any missing built-in default routines (e.g. the daily moadim cargo update check) so a
     // fresh install ships with them, and a default deleted while stopped is restored. Existing
     // routines are never overwritten. Must run before the crontab sync so the defaults schedule.
     routines::ensure_default_routines(&routines);
-    // Re-persist so every routine has its routine.toml + prompt.md sidecar in the slug dir (and any
+    // Re-persist so every routine has its routine.toml + prompts/ sidecars in the slug dir (and any
     // stale legacy run.sh is removed), healing dirs left without a prompt (otherwise the launch
-    // command's `cp prompt.md` fails and the agent launches with an empty prompt).
+    // command's `cp prompt.compiled.md` fails and the agent launches with an empty prompt).
     routine_storage::repersist_routines(&routines);
     // Re-sync routines to the crontab on startup; otherwise a block that went stale (e.g. emptied
     // by an earlier run before agent configs existed) would never be regenerated until the next

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -82,10 +82,23 @@ pub fn routine_toml_path(id: &str) -> PathBuf {
     routine_dir(id).join("routine.toml")
 }
 
-/// Returns the path to `{routines_dir}/{id}/prompt.md`.
+/// Returns the path to `{routines_dir}/{id}/prompts/`.
 #[must_use]
-pub fn routine_prompt_path(id: &str) -> PathBuf {
-    routine_dir(id).join("prompt.md")
+pub fn routine_prompts_dir(id: &str) -> PathBuf {
+    routine_dir(id).join("prompts")
+}
+
+/// Returns the path to `{routines_dir}/{id}/prompts/prompt.pure.md`, the raw user-authored prompt.
+#[must_use]
+pub fn routine_pure_prompt_path(id: &str) -> PathBuf {
+    routine_prompts_dir(id).join("prompt.pure.md")
+}
+
+/// Returns the path to `{routines_dir}/{id}/prompts/prompt.compiled.md`, the composed prompt
+/// (repositories preamble + pure prompt) that the launch command copies into the workbench.
+#[must_use]
+pub fn routine_compiled_prompt_path(id: &str) -> PathBuf {
+    routine_prompts_dir(id).join("prompt.compiled.md")
 }
 
 /// Returns the path to `{routines_dir}/{id}/.gitignore`.

--- a/src/paths/mod_tests.rs
+++ b/src/paths/mod_tests.rs
@@ -43,10 +43,30 @@ fn routine_toml_path_filename() {
 }
 
 #[test]
-fn routine_prompt_path_filename() {
-    let path = routine_prompt_path("abc");
-    assert_eq!(path.file_name().unwrap().to_str().unwrap(), "prompt.md");
-    assert!(path.to_string_lossy().contains("abc"));
+fn routine_prompts_dir_filename() {
+    let path = routine_prompts_dir("abc");
+    assert_eq!(path.file_name().unwrap().to_str().unwrap(), "prompts");
+    assert_eq!(path.parent().unwrap(), routine_dir("abc"));
+}
+
+#[test]
+fn routine_pure_prompt_path_filename() {
+    let path = routine_pure_prompt_path("abc");
+    assert_eq!(
+        path.file_name().unwrap().to_str().unwrap(),
+        "prompt.pure.md"
+    );
+    assert_eq!(path.parent().unwrap(), routine_prompts_dir("abc"));
+}
+
+#[test]
+fn routine_compiled_prompt_path_filename() {
+    let path = routine_compiled_prompt_path("abc");
+    assert_eq!(
+        path.file_name().unwrap().to_str().unwrap(),
+        "prompt.compiled.md"
+    );
+    assert_eq!(path.parent().unwrap(), routine_prompts_dir("abc"));
 }
 
 #[test]

--- a/src/routes/mcp.rs
+++ b/src/routes/mcp.rs
@@ -292,8 +292,8 @@ impl MoadimMcp {
         Ok(ok(routines::available_agents()))
     }
 
-    /// Raise a new flag against a routine, refreshing its `prompt.md` so the next run's "Open
-    /// flags" section includes it.
+    /// Raise a new flag against a routine, refreshing its `prompt.compiled.md` so the next run's
+    /// "Open flags" section includes it.
     #[tool(
         description = "Flag something unclear about a routine mid-run — a gap, bug, edge case, or question the agent hit with no other channel to surface it (the run happens unattended inside tmux). `type` is free text (common examples: \"bug\", \"gap\", \"edge_case\", \"question\", \"blocker\"); `scope` is \"general\" (committed, shared via git) or \"local\" (gitignored, machine-local). Unresolved flags are shown back to the agent in the routine's prompt on its next run."
     )]
@@ -326,8 +326,8 @@ impl MoadimMcp {
         })
     }
 
-    /// Resolve (delete) a flag by filename, refreshing `prompt.md` so it stops appearing in the
-    /// next run's prompt.
+    /// Resolve (delete) a flag by filename, refreshing `prompt.compiled.md` so it stops appearing
+    /// in the next run's prompt.
     #[tool(
         description = "Resolve a routine flag by filename (as returned by create_flag/list_flags), removing it"
     )]

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -1,4 +1,5 @@
-//! TOML-backed persistence for routines, plus the composed `prompt.md` sidecar file.
+//! TOML-backed persistence for routines, plus the `prompts/prompt.pure.md` (raw) and
+//! `prompts/prompt.compiled.md` (composed) sidecar files.
 
 use crate::utils::lock::LockRecover;
 use std::collections::HashMap;
@@ -7,8 +8,9 @@ use std::sync::{Arc, Mutex};
 use serde::{Deserialize, Serialize};
 
 use crate::paths::{
-    routine_dir, routine_gitignore_path, routine_prompt_path, routine_scheduled_state_path,
-    routine_script_path, routine_state_path, routine_toml_path, routines_dir,
+    routine_compiled_prompt_path, routine_dir, routine_gitignore_path, routine_prompts_dir,
+    routine_pure_prompt_path, routine_scheduled_state_path, routine_script_path,
+    routine_state_path, routine_toml_path, routines_dir,
 };
 use crate::routines::{compose_prompt, slugify, Repository, Routine, RoutineStore};
 use crate::utils::atomic::atomic_write;
@@ -28,6 +30,13 @@ struct RoutineToml {
     #[serde(default)]
     model: Option<String>,
     /// Task prompt.
+    ///
+    /// **Read-only / legacy.** The prompt now lives in the `prompts/prompt.pure.md` sidecar so it
+    /// is diff/edit-friendly markdown instead of an escaped TOML string. This field is still parsed
+    /// so routines written by older daemons keep their prompt (the value migrates into the sidecar
+    /// via [`migrate_prompts_to_subfolder`] on the next startup), but it is never written back —
+    /// `skip_serializing` keeps it out of every freshly written `routine.toml`.
+    #[serde(default, skip_serializing)]
     prompt: Option<String>,
     /// Context repositories.
     #[serde(default)]
@@ -112,6 +121,15 @@ fn read_scheduled_state(dir_name: &str) -> Option<u64> {
         .last_scheduled_trigger_at
 }
 
+/// Read a routine's raw prompt from its `prompts/prompt.pure.md` sidecar, falling back to the
+/// legacy `routine.toml` `prompt` field for a dir that has not been migrated yet.
+fn read_pure_prompt(dir_name: &str, legacy: Option<String>) -> String {
+    std::fs::read_to_string(routine_pure_prompt_path(dir_name))
+        .ok()
+        .or(legacy)
+        .unwrap_or_default()
+}
+
 /// Load a routine from `{routines_dir}/{dir_name}/routine.toml`.
 ///
 /// `dir_name` is the slug (title-derived folder name). The routine's UUID `id` is read from
@@ -125,13 +143,14 @@ fn load_routine_from_dir(dir_name: &str) -> Option<Routine> {
     let id = toml.id.unwrap_or_else(|| dir_name.to_string());
     let last_manual_trigger_at = read_runtime_state(dir_name).or(toml.last_manual_trigger_at);
     let last_scheduled_trigger_at = read_scheduled_state(dir_name);
+    let prompt = read_pure_prompt(dir_name, toml.prompt);
     Some(Routine {
         id,
         schedule: toml.schedule?,
         title,
         agent: toml.agent?,
         model: toml.model,
-        prompt: toml.prompt.unwrap_or_default(),
+        prompt,
         repositories: toml.repositories,
         machines: toml.machines,
         enabled: toml.enabled.unwrap_or(true),
@@ -146,8 +165,9 @@ fn load_routine_from_dir(dir_name: &str) -> Option<Routine> {
     })
 }
 
-/// Write `routine` to disk: `routine.toml` (tracked config), the composed `prompt.md`, the
-/// gitignored `state.local.toml` runtime sidecar, and `.gitignore` if absent.
+/// Write `routine` to disk: `routine.toml` (tracked config), the `prompts/prompt.pure.md` (raw) and
+/// `prompts/prompt.compiled.md` (composed) sidecars, the gitignored `state.local.toml` runtime
+/// sidecar, and `.gitignore` if absent.
 ///
 /// The folder is named after the slugified title (`slugify(&routine.title)`). The UUID `id` is
 /// stored inside `routine.toml` so it survives a rename. Daemon-written runtime state
@@ -157,6 +177,7 @@ pub fn write_routine(routine: &Routine) -> std::io::Result<()> {
     let slug = slugify(&routine.title);
     let dir = routine_dir(&slug);
     std::fs::create_dir_all(&dir)?;
+    std::fs::create_dir_all(routine_prompts_dir(&slug))?;
 
     let gitignore = routine_gitignore_path(&slug);
     if !gitignore.exists() {
@@ -174,7 +195,8 @@ pub fn write_routine(routine: &Routine) -> std::io::Result<()> {
         title: Some(routine.title.clone()),
         agent: Some(routine.agent.clone()),
         model: routine.model.clone(),
-        prompt: Some(routine.prompt.clone()),
+        // Never written; the raw prompt now lives in the `prompts/prompt.pure.md` sidecar below.
+        prompt: None,
         repositories: routine.repositories.clone(),
         machines: routine.machines.clone(),
         enabled: Some(routine.enabled),
@@ -195,8 +217,9 @@ pub fn write_routine(routine: &Routine) -> std::io::Result<()> {
     // there is no continuously-running reverse crontab sync re-reading these files; reverse sync
     // is implemented but not wired up — see issue #218.)
     atomic_write(&routine_toml_path(&slug), text.as_bytes())?;
+    atomic_write(&routine_pure_prompt_path(&slug), routine.prompt.as_bytes())?;
     atomic_write(
-        &routine_prompt_path(&slug),
+        &routine_compiled_prompt_path(&slug),
         compose_prompt(routine).as_bytes(),
     )?;
     write_runtime_state(&slug, routine.last_manual_trigger_at)?;
@@ -270,12 +293,72 @@ pub(crate) fn migrate_prompt_files_from_dir(dir: &std::path::Path) {
     }
 }
 
+/// Move each routine's prompt file(s) into its `prompts/` subfolder, and extract the raw prompt out
+/// of `routine.toml` into `prompts/prompt.pure.md`.
+///
+/// Call once at startup, after [`migrate_prompt_files`] (which renames `prompt.txt` to `prompt.md`)
+/// and before [`migrate_routine_dirs`] / `load_store`. Older daemons wrote a single top-level
+/// `prompt.md` (the composed prompt) and kept the raw prompt inside `routine.toml`'s `prompt` field;
+/// this daemon reads the raw prompt from `prompts/prompt.pure.md` and the composed prompt from
+/// `prompts/prompt.compiled.md`, so an un-migrated dir would launch with an empty prompt.
+pub fn migrate_prompts_to_subfolder() {
+    migrate_prompts_to_subfolder_from_dir(&routines_dir());
+}
+
+/// Inner variant of [`migrate_prompts_to_subfolder`] that scans `dir` instead of [`routines_dir`].
+///
+/// Extracted so tests can drive the migration against a controlled scratch directory, including the
+/// `read_dir` error-return branch and the per-entry rename/write-failure branches.
+pub(crate) fn migrate_prompts_to_subfolder_from_dir(dir: &std::path::Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if !entry.file_type().is_ok_and(|ft| ft.is_dir()) {
+            continue;
+        }
+        let prompts_dir = entry.path().join("prompts");
+        if let Err(err) = std::fs::create_dir_all(&prompts_dir) {
+            log::warn!(
+                "migrate_prompts_to_subfolder: failed to create {}: {err}",
+                prompts_dir.display()
+            );
+            continue;
+        }
+
+        let old_compiled = entry.path().join("prompt.md");
+        let new_compiled = prompts_dir.join("prompt.compiled.md");
+        if old_compiled.exists() && !new_compiled.exists() {
+            if let Err(err) = std::fs::rename(&old_compiled, &new_compiled) {
+                log::warn!(
+                    "migrate_prompts_to_subfolder: failed to rename {}: {err}",
+                    old_compiled.display()
+                );
+            }
+        }
+
+        let pure = prompts_dir.join("prompt.pure.md");
+        if !pure.exists() {
+            let legacy_prompt = read_routine_toml(&entry.path().join("routine.toml"))
+                .and_then(|toml| toml.prompt)
+                .unwrap_or_default();
+            if let Err(err) = std::fs::write(&pure, legacy_prompt.as_bytes()) {
+                log::warn!(
+                    "migrate_prompts_to_subfolder: failed to write {}: {err}",
+                    pure.display()
+                );
+            }
+        }
+    }
+}
+
 /// Migrate legacy UUID-named routine directories to the current slug-based layout.
 ///
 /// Early daemon versions stored each routine under `{routines_dir}/{id}/` (the UUID). The current
 /// layout uses `{routines_dir}/{slugify(title)}/`. After an upgrade the legacy dir still holds the
-/// real `routine.toml` + `prompt.md`, while the crontab sync creates a *fresh* slug dir containing
-/// only `run.sh` — so the cron `cp prompt.md` reads an empty dir and the agent launches task-less.
+/// real `routine.toml` + `prompts/prompt.compiled.md`, while the crontab sync creates a *fresh* slug
+/// dir containing only `run.sh` — so the cron `cp prompt.compiled.md` reads an empty dir and the
+/// agent launches task-less.
 ///
 /// For every on-disk routine whose directory name does not already equal its slug, this re-persists
 /// it into the slug dir (preserving any `run.sh` already there) and removes the stale legacy dir.
@@ -318,13 +401,14 @@ pub(crate) fn migrate_routine_dirs_from_dir(dir: &std::path::Path) {
     }
 }
 
-/// Re-persist every loaded routine to disk, recreating `routine.toml`, `prompt.md`, and `.gitignore`
-/// in its canonical slug directory.
+/// Re-persist every loaded routine to disk, recreating `routine.toml`, `prompts/prompt.pure.md`,
+/// `prompts/prompt.compiled.md`, and `.gitignore` in its canonical slug directory.
 ///
-/// Nothing else rewrites the prompt sidecar on startup, so a slug dir missing its `prompt.md` (e.g.
-/// after the UUID→slug migration, or if the sidecar was lost) would fail the launch command's
-/// `cp prompt.md`. Re-persisting from the in-memory store heals those dirs (and removes any stale
-/// legacy `run.sh`). Idempotent; safe to call on every startup after [`load_store`].
+/// Nothing else rewrites the prompt sidecars on startup, so a slug dir missing its
+/// `prompts/prompt.compiled.md` (e.g. after the UUID→slug migration, or if the sidecar was lost)
+/// would fail the launch command's `cp prompt.compiled.md`. Re-persisting from the in-memory store
+/// heals those dirs (and removes any stale legacy `run.sh`). Idempotent; safe to call on every
+/// startup after [`load_store`].
 pub fn repersist_routines(store: &RoutineStore) {
     let routines: Vec<Routine> = store.lock_recover().values().cloned().collect();
     for routine in &routines {

--- a/src/routine_storage_tests.rs
+++ b/src/routine_storage_tests.rs
@@ -56,8 +56,18 @@ fn write_then_load_round_trips() {
         write_routine(&routine).unwrap();
 
         assert!(crate::paths::routine_toml_path(&slug).exists());
-        assert!(crate::paths::routine_prompt_path(&slug).exists());
+        assert!(crate::paths::routine_pure_prompt_path(&slug).exists());
+        assert!(crate::paths::routine_compiled_prompt_path(&slug).exists());
         assert!(crate::paths::routine_gitignore_path(&slug).exists());
+        let toml_text = std::fs::read_to_string(crate::paths::routine_toml_path(&slug)).unwrap();
+        assert!(
+            !toml_text.contains("prompt"),
+            "routine.toml must not carry the prompt: {toml_text}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(crate::paths::routine_pure_prompt_path(&slug)).unwrap(),
+            "task"
+        );
 
         let loaded = load_routine_from_dir(&slug).unwrap();
         assert_eq!(loaded.id, id);
@@ -101,7 +111,8 @@ fn prompt_file_contains_composed_prompt() {
         let title = "Rs Prompt Routine";
         let slug = slugify(title);
         write_routine(&make_routine("rs-prompt-id", title)).unwrap();
-        let prompt = std::fs::read_to_string(crate::paths::routine_prompt_path(&slug)).unwrap();
+        let prompt =
+            std::fs::read_to_string(crate::paths::routine_compiled_prompt_path(&slug)).unwrap();
         assert!(prompt.contains("# Workbench"));
         assert!(prompt.contains("https://example.com/r.git (branch main)"));
         assert!(prompt.contains("task"));
@@ -110,9 +121,9 @@ fn prompt_file_contains_composed_prompt() {
 
 #[test]
 fn write_routine_persists_composed_prompt_sidecar_with_repos() {
-    // Focused coverage for the `atomic_write(routine_prompt_path, compose_prompt(..))`
+    // Focused coverage for the `atomic_write(routine_compiled_prompt_path, compose_prompt(..))`
     // call in `write_routine`: a routine with a non-empty prompt AND repositories runs
-    // `compose_prompt` fully, and the composed body lands in prompt.md on disk.
+    // `compose_prompt` fully, and the composed body lands in prompts/prompt.compiled.md on disk.
     with_override_home(|_home| {
         let id = "rs-prompt-sidecar-id";
         let title = "Rs Prompt Sidecar Routine";
@@ -132,19 +143,23 @@ fn write_routine_persists_composed_prompt_sidecar_with_repos() {
 
         write_routine(&routine).unwrap();
 
-        let written = std::fs::read_to_string(crate::paths::routine_prompt_path(&slug)).unwrap();
+        let written =
+            std::fs::read_to_string(crate::paths::routine_compiled_prompt_path(&slug)).unwrap();
         assert_eq!(written, compose_prompt(&routine));
         assert!(written.contains("https://example.com/a.git (branch dev)"));
         assert!(written.contains("https://example.com/b.git\n"));
         assert!(written.contains("line one\nline two"));
+
+        let pure = std::fs::read_to_string(crate::paths::routine_pure_prompt_path(&slug)).unwrap();
+        assert_eq!(pure, "line one\nline two");
     });
 }
 
 #[test]
 fn write_routine_errors_when_prompt_sidecar_write_fails() {
-    // Covers the error-propagation (`?`) on the prompt `atomic_write` in `write_routine`:
+    // Covers the error-propagation (`?`) on the pure-prompt `atomic_write` in `write_routine`:
     // the routine dir, gitignore, and `routine.toml` all write successfully, but a
-    // non-empty directory occupies the `prompt.md` path, so the atomic rename over it
+    // non-empty directory occupies the `prompt.pure.md` path, so the atomic rename over it
     // fails and `write_routine` returns that error.
     with_override_home(|_home| {
         let id = "rs-prompt-write-fail-id";
@@ -152,8 +167,8 @@ fn write_routine_errors_when_prompt_sidecar_write_fails() {
         let slug = slugify(title);
         let dir = crate::paths::routine_dir(&slug);
         std::fs::create_dir_all(&dir).unwrap();
-        // Block prompt.md with a *non-empty* directory so the atomic rename over it fails.
-        let prompt_dir = crate::paths::routine_prompt_path(&slug);
+        // Block prompt.pure.md with a *non-empty* directory so the atomic rename over it fails.
+        let prompt_dir = crate::paths::routine_pure_prompt_path(&slug);
         std::fs::create_dir_all(&prompt_dir).unwrap();
         std::fs::write(prompt_dir.join("occupant"), "keep me non-empty").unwrap();
 
@@ -162,6 +177,35 @@ fn write_routine_errors_when_prompt_sidecar_write_fails() {
 
         // routine.toml was written successfully before the prompt step failed.
         assert!(crate::paths::routine_toml_path(&slug).exists());
+        assert!(
+            prompt_dir.is_dir(),
+            "the blocking prompt dir is left in place"
+        );
+    });
+}
+
+#[test]
+fn write_routine_errors_when_compiled_prompt_sidecar_write_fails() {
+    // Covers the error-propagation (`?`) on the compiled-prompt `atomic_write` in `write_routine`:
+    // routine.toml and the pure-prompt sidecar both write successfully, but a non-empty directory
+    // occupies the `prompt.compiled.md` path, so the atomic rename over it fails.
+    with_override_home(|_home| {
+        let id = "rs-compiled-prompt-write-fail-id";
+        let title = "Rs Compiled Prompt Write Fail Routine";
+        let slug = slugify(title);
+        let dir = crate::paths::routine_dir(&slug);
+        std::fs::create_dir_all(&dir).unwrap();
+        // Block prompt.compiled.md with a *non-empty* directory so the atomic rename over it fails.
+        let prompt_dir = crate::paths::routine_compiled_prompt_path(&slug);
+        std::fs::create_dir_all(&prompt_dir).unwrap();
+        std::fs::write(prompt_dir.join("occupant"), "keep me non-empty").unwrap();
+
+        let err = write_routine(&make_routine(id, title)).unwrap_err();
+        let _ = err;
+
+        // routine.toml and the pure prompt were both written successfully before this step failed.
+        assert!(crate::paths::routine_toml_path(&slug).exists());
+        assert!(crate::paths::routine_pure_prompt_path(&slug).exists());
         assert!(
             prompt_dir.is_dir(),
             "the blocking prompt dir is left in place"
@@ -477,12 +521,14 @@ fn migrate_routine_dirs_moves_legacy_uuid_dir_to_slug() {
 
         migrate_routine_dirs();
 
-        // Legacy dir removed; canonical slug dir now holds toml + prompt.
+        // Legacy dir removed; canonical slug dir now holds toml + prompt sidecars, with the
+        // legacy toml `prompt` field carried over into the new prompts/prompt.pure.md sidecar.
         assert!(!legacy_dir.exists(), "legacy UUID dir should be removed");
         assert!(crate::paths::routine_toml_path(&slug).exists());
-        assert!(crate::paths::routine_prompt_path(&slug).exists());
+        assert!(crate::paths::routine_compiled_prompt_path(&slug).exists());
         let loaded = load_routine_from_dir(&slug).unwrap();
         assert_eq!(loaded.id, id, "UUID id preserved across the dir migration");
+        assert_eq!(loaded.prompt, "task");
     });
 }
 
@@ -493,9 +539,9 @@ fn repersist_routines_recreates_missing_prompt_sidecar() {
         let title = "Rs Repersist Routine";
         let slug = slugify(title);
         write_routine(&make_routine(id, title)).unwrap();
-        // Simulate the sync-only state: prompt.md gone, only run.sh-style dir remains.
-        std::fs::remove_file(crate::paths::routine_prompt_path(&slug)).unwrap();
-        assert!(!crate::paths::routine_prompt_path(&slug).exists());
+        // Simulate the sync-only state: prompt.compiled.md gone, only run.sh-style dir remains.
+        std::fs::remove_file(crate::paths::routine_compiled_prompt_path(&slug)).unwrap();
+        assert!(!crate::paths::routine_compiled_prompt_path(&slug).exists());
 
         let mut map = HashMap::new();
         map.insert(id.to_string(), make_routine(id, title));
@@ -503,7 +549,7 @@ fn repersist_routines_recreates_missing_prompt_sidecar() {
         repersist_routines(&store);
 
         assert!(
-            crate::paths::routine_prompt_path(&slug).exists(),
+            crate::paths::routine_compiled_prompt_path(&slug).exists(),
             "repersist should recreate the prompt sidecar"
         );
     });
@@ -609,6 +655,192 @@ fn migrate_prompt_files_public_wrapper_runs() {
     // override home (no routines dir yet, so it returns without doing anything).
     with_override_home(|_home| {
         migrate_prompt_files();
+    });
+}
+
+#[test]
+fn migrate_prompts_to_subfolder_from_dir_missing_dir_returns() {
+    // The scan directory does not exist, so `read_dir` errors and the function returns early.
+    let missing = scratch_dir("prompts-subfolder-missing");
+    migrate_prompts_to_subfolder_from_dir(&missing);
+    assert!(!missing.exists());
+}
+
+#[test]
+fn migrate_prompts_to_subfolder_from_dir_migrates_legacy_layout() {
+    let dir = scratch_dir("prompts-subfolder-migrate");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    // A plain file in the scan dir exercises the non-directory `continue` branch.
+    std::fs::write(dir.join("loose.txt"), "ignore me").unwrap();
+
+    // A legacy routine dir: top-level prompt.md (composed) + routine.toml carrying the raw
+    // prompt in its (legacy) `prompt` field, no `prompts/` subfolder yet.
+    let legacy = dir.join("legacy-routine");
+    std::fs::create_dir_all(&legacy).unwrap();
+    std::fs::write(legacy.join("prompt.md"), "old composed body").unwrap();
+    std::fs::write(
+        legacy.join("routine.toml"),
+        "title = \"Legacy\"\nschedule = \"@daily\"\nagent = \"claude\"\nprompt = \"raw prompt\"\n",
+    )
+    .unwrap();
+
+    migrate_prompts_to_subfolder_from_dir(&dir);
+
+    assert!(
+        !legacy.join("prompt.md").exists(),
+        "top-level prompt.md should be moved"
+    );
+    assert_eq!(
+        std::fs::read_to_string(legacy.join("prompts").join("prompt.compiled.md")).unwrap(),
+        "old composed body"
+    );
+    assert_eq!(
+        std::fs::read_to_string(legacy.join("prompts").join("prompt.pure.md")).unwrap(),
+        "raw prompt"
+    );
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[test]
+fn migrate_prompts_to_subfolder_from_dir_skips_already_migrated() {
+    // A dir already in the new layout (both prompts/ files present, no top-level prompt.md) is
+    // left untouched: the `!new_compiled.exists()` and `!pure.exists()` guards both short-circuit.
+    let dir = scratch_dir("prompts-subfolder-skip");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let routine = dir.join("already-migrated");
+    let prompts = routine.join("prompts");
+    std::fs::create_dir_all(&prompts).unwrap();
+    std::fs::write(prompts.join("prompt.compiled.md"), "compiled").unwrap();
+    std::fs::write(prompts.join("prompt.pure.md"), "pure").unwrap();
+    std::fs::write(
+        routine.join("routine.toml"),
+        "title = \"Already\"\nschedule = \"@daily\"\nagent = \"claude\"\n",
+    )
+    .unwrap();
+
+    migrate_prompts_to_subfolder_from_dir(&dir);
+
+    assert_eq!(
+        std::fs::read_to_string(prompts.join("prompt.compiled.md")).unwrap(),
+        "compiled"
+    );
+    assert_eq!(
+        std::fs::read_to_string(prompts.join("prompt.pure.md")).unwrap(),
+        "pure"
+    );
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[test]
+fn migrate_prompts_to_subfolder_from_dir_defaults_missing_legacy_prompt_to_empty() {
+    // A routine dir with no prompts/ subfolder and no legacy `prompt` field in routine.toml (nor
+    // any routine.toml at all) still gets an (empty) prompt.pure.md written.
+    let dir = scratch_dir("prompts-subfolder-no-legacy");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let routine = dir.join("no-legacy-prompt");
+    std::fs::create_dir_all(&routine).unwrap();
+
+    migrate_prompts_to_subfolder_from_dir(&dir);
+
+    assert_eq!(
+        std::fs::read_to_string(routine.join("prompts").join("prompt.pure.md")).unwrap(),
+        ""
+    );
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn migrate_prompts_to_subfolder_from_dir_logs_on_create_dir_failure() {
+    // A regular FILE occupies the `prompts` path, so `create_dir_all(prompts_dir)` fails and the
+    // entry is skipped entirely (logged, `continue`).
+    let dir = scratch_dir("prompts-subfolder-create-fail");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let routine = dir.join("blocked-routine");
+    std::fs::create_dir_all(&routine).unwrap();
+    std::fs::write(routine.join("prompts"), "i block the prompts dir").unwrap();
+
+    migrate_prompts_to_subfolder_from_dir(&dir);
+
+    assert!(
+        routine.join("prompts").is_file(),
+        "the blocking file is left in place"
+    );
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn migrate_prompts_to_subfolder_from_dir_logs_on_rename_failure() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // prompts/ already exists (writable), but the routine dir itself is read-only, so removing
+    // the top-level prompt.md as part of the rename fails.
+    let dir = scratch_dir("prompts-subfolder-rename-fail");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let routine = dir.join("rename-fail-routine");
+    std::fs::create_dir_all(routine.join("prompts")).unwrap();
+    std::fs::write(routine.join("prompt.md"), "old composed body").unwrap();
+    std::fs::write(routine.join("prompts").join("prompt.pure.md"), "pure").unwrap();
+    std::fs::set_permissions(&routine, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+    migrate_prompts_to_subfolder_from_dir(&dir);
+
+    std::fs::set_permissions(&routine, std::fs::Permissions::from_mode(0o755)).unwrap();
+    assert!(
+        routine.join("prompt.md").exists(),
+        "the rename could not happen, so the old file remains"
+    );
+    assert!(!routine.join("prompts").join("prompt.compiled.md").exists());
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn migrate_prompts_to_subfolder_from_dir_logs_on_pure_write_failure() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // prompts/ exists but is read-only, so writing the extracted prompt.pure.md fails.
+    let dir = scratch_dir("prompts-subfolder-write-fail");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let routine = dir.join("write-fail-routine");
+    let prompts = routine.join("prompts");
+    std::fs::create_dir_all(&prompts).unwrap();
+    std::fs::write(
+        routine.join("routine.toml"),
+        "title = \"Write Fail\"\nschedule = \"@daily\"\nagent = \"claude\"\nprompt = \"raw\"\n",
+    )
+    .unwrap();
+    std::fs::set_permissions(&prompts, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+    migrate_prompts_to_subfolder_from_dir(&dir);
+
+    std::fs::set_permissions(&prompts, std::fs::Permissions::from_mode(0o755)).unwrap();
+    assert!(
+        !prompts.join("prompt.pure.md").exists(),
+        "the write could not happen"
+    );
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[test]
+fn migrate_prompts_to_subfolder_public_wrapper_runs() {
+    // Exercises the public wrapper, which simply delegates to the inner variant scanning an empty
+    // override home (no routines dir yet, so it returns without doing anything).
+    with_override_home(|_home| {
+        migrate_prompts_to_subfolder();
     });
 }
 

--- a/src/routines/command.rs
+++ b/src/routines/command.rs
@@ -1,6 +1,6 @@
 //! Prompt composition, slug/shell helpers, and the single-line tmux launch command builder.
 
-use crate::paths::{routine_prompt_path, routine_scheduled_state_path};
+use crate::paths::{routine_compiled_prompt_path, routine_scheduled_state_path};
 
 use super::agents::AgentCommand;
 use super::flags::{list_flags, FlagScope};
@@ -36,8 +36,8 @@ pub(crate) fn slugify(title: &str) -> String {
     }
 }
 
-/// Compose the `prompt.md` body: a repositories-as-context preamble, the prompt, and — when the
-/// routine has any — an "Open flags" section listing gaps/bugs/edge cases the agent raised on a
+/// Compose the `prompt.compiled.md` body: a repositories-as-context preamble, the prompt, and — when
+/// the routine has any — an "Open flags" section listing gaps/bugs/edge cases the agent raised on a
 /// previous run (see [`super::flags`]) that no one has resolved yet.
 ///
 /// When the routine lists no repositories the preamble omits the "clone any you need:" sentence
@@ -314,7 +314,9 @@ pub(crate) fn system_prompt_stmts(
 /// command is `;`-joined (no newlines) so it fits one crontab line.
 pub(crate) fn build_routine_command(routine: &Routine, agent: &AgentCommand) -> String {
     let slug = slugify(&routine.title);
-    let prompt_path = routine_prompt_path(&slug).to_string_lossy().into_owned();
+    let prompt_path = routine_compiled_prompt_path(&slug)
+        .to_string_lossy()
+        .into_owned();
     let scheduled_state_path = routine_scheduled_state_path(&slug)
         .to_string_lossy()
         .into_owned();

--- a/src/routines/defaults/mod.rs
+++ b/src/routines/defaults/mod.rs
@@ -137,7 +137,7 @@ fn reconcile(spec: &DefaultRoutine, cur: &Routine, now: u64) -> Option<Routine> 
 /// For each [`DEFAULT_ROUTINES`] entry: if a routine with the same slug is already in `store`, it is
 /// refreshed via [`reconcile`] (daemon-owned content updated, the user's `enabled` toggle preserved)
 /// and only rewritten when it drifted; otherwise a fresh enabled routine is created. Persists each
-/// affected routine (`routine.toml` + `prompt.md` + `.gitignore`) and inserts it into `store` so the
+/// affected routine (`routine.toml` + `prompts/` sidecars + `.gitignore`) and inserts it into `store` so the
 /// subsequent crontab sync schedules it. Best-effort: a write failure is logged and skipped rather
 /// than aborting startup. Call once at startup after [`crate::routine_storage::load_store`] and
 /// before the crontab sync.

--- a/src/routines/defaults/the_1_percent.rs
+++ b/src/routines/defaults/the_1_percent.rs
@@ -65,7 +65,7 @@ Good improvement examples:
 ```bash
 git -C ~/.config/moadim checkout -b 1pct/$(date +%Y%m%d-%H%M)
 # Edit/add/delete files under ~/.config/moadim/routines/ as needed.
-# Only touch routine.toml files. Do NOT modify moadim daemon config.
+# Only touch routine.toml / prompts/prompt.pure.md files. Do NOT modify moadim daemon config.
 git -C ~/.config/moadim add -A
 git -C ~/.config/moadim commit -m \"routines: <concise description>\"
 git -C ~/.config/moadim push -u origin HEAD

--- a/src/routines/defaults/token_trim.rs
+++ b/src/routines/defaults/token_trim.rs
@@ -70,7 +70,7 @@ calls, same outputs, same decision logic. When in doubt, keep the instruction.
 
 ```bash
 git -C ~/.config/moadim checkout -b token-trim/$(date +%Y%m%d-%H%M)
-# Edit the relevant routine.toml / prompt.md file(s) under ~/.config/moadim/routines/.
+# Edit the relevant <slug>/prompts/prompt.pure.md file(s) under ~/.config/moadim/routines/.
 # Only touch routine prompt files. Do NOT modify moadim daemon config.
 git -C ~/.config/moadim add -A
 git -C ~/.config/moadim commit -m \"routines: trim token cost in <routine-name>\"

--- a/src/routines/mod_tests.rs
+++ b/src/routines/mod_tests.rs
@@ -561,7 +561,7 @@ fn svc_create_update_delete_lifecycle() {
     let id = created.routine.id.clone();
     // folder is slug of the title, not the UUID
     assert!(crate::paths::routine_toml_path("cov-routine").exists());
-    assert!(crate::paths::routine_prompt_path("cov-routine").exists());
+    assert!(crate::paths::routine_compiled_prompt_path("cov-routine").exists());
 
     let updated = svc_update(
         &store,

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -178,7 +178,7 @@ pub fn svc_get(store: &RoutineStore, id: &str) -> Result<RoutineResponse, AppErr
 /// Reject a prompt that is empty or whitespace-only with `400 Bad Request`.
 ///
 /// The prompt is the one field that defines what a routine actually does. A blank
-/// prompt still produces a valid `prompt.md` (just the moadim preamble + repo list),
+/// prompt still produces a valid `prompt.compiled.md` (just the moadim preamble + repo list),
 /// so the routine fires on every cron tick and launches an agent with no task —
 /// silently burning scheduled runs and the user's agent/API budget (issue #224).
 /// Shared by the create and update paths so the REST and MCP surfaces reject it
@@ -228,7 +228,7 @@ fn validate_title(title: &str) -> Result<(), AppError> {
 /// Reject `repositories` entries whose URL (or set branch) is empty/whitespace-only, and return a
 /// normalized copy with surrounding whitespace trimmed.
 ///
-/// `repository` is a free-form string rendered verbatim into the agent's `prompt.md` preamble by
+/// `repository` is a free-form string rendered verbatim into the agent's `prompt.compiled.md` preamble by
 /// `compose_prompt` (see #241), so a blank or padded entry yields a broken `- ` clone bullet. An
 /// empty list is valid — this only guards the contents of non-empty entries. Mirrors the
 /// `validate_cron` / `validate_agent` boundary checks for the other routine fields (#224/#226).
@@ -295,7 +295,7 @@ fn normalize_model(model: Option<String>) -> Option<String> {
     })
 }
 
-/// Validate `req`, assign a UUID, persist (routine.toml + prompt.md), and sync the crontab.
+/// Validate `req`, assign a UUID, persist (routine.toml + prompts/ sidecars), and sync the crontab.
 pub fn svc_create(
     store: &RoutineStore,
     req: CreateRoutineRequest,
@@ -629,7 +629,8 @@ fn routine_and_slug(store: &RoutineStore, id: &str) -> Result<(Routine, String),
 
 /// Raise a new flag against routine `id`. `flag_type` and `description` must be non-blank;
 /// `scope` is `"general"` (committed) or `"local"` (gitignored). Refreshes the routine's
-/// `prompt.md` afterward so the next run's "Open flags" section (see `compose_prompt`) includes it.
+/// `prompts/prompt.compiled.md` afterward so the next run's "Open flags" section (see
+/// `compose_prompt`) includes it.
 pub fn svc_create_flag(
     store: &RoutineStore,
     id: &str,
@@ -656,7 +657,8 @@ pub fn svc_list_flags(store: &RoutineStore, id: &str) -> Result<Vec<Flag>, AppEr
 /// Resolve (delete) the flag named `filename` under routine `id`.
 ///
 /// `NotFound` when the routine does not exist, `filename` is unsafe, or names no existing flag.
-/// Refreshes `prompt.md` afterward so a resolved flag stops appearing in the next run's prompt.
+/// Refreshes `prompts/prompt.compiled.md` afterward so a resolved flag stops appearing in the next
+/// run's prompt.
 pub fn svc_resolve_flag(store: &RoutineStore, id: &str, filename: &str) -> Result<(), AppError> {
     let (routine, slug) = routine_and_slug(store, id)?;
     let resolved = flags::resolve_flag(&slug, filename).map_err(|_| AppError::Internal)?;

--- a/src/routines/service_tests.rs
+++ b/src/routines/service_tests.rs
@@ -2021,9 +2021,10 @@ fn svc_create_flag_persists_and_refreshes_prompt() {
     assert_eq!(flag.flag_type, "bug");
     assert_eq!(flag.description, "broken thing");
 
-    // prompt.md is refreshed with the new open flag so the next run sees it.
+    // prompt.compiled.md is refreshed with the new open flag so the next run sees it.
     let slug = slugify(title);
-    let prompt = std::fs::read_to_string(crate::paths::routine_prompt_path(&slug)).unwrap();
+    let prompt =
+        std::fs::read_to_string(crate::paths::routine_compiled_prompt_path(&slug)).unwrap();
     assert!(prompt.contains("Open flags"));
     assert!(prompt.contains("broken thing"));
 }
@@ -2086,6 +2087,7 @@ fn svc_resolve_flag_deletes_and_refreshes_prompt() {
 
     assert!(svc_list_flags(&store, &id).unwrap().is_empty());
     let slug = slugify(title);
-    let prompt = std::fs::read_to_string(crate::paths::routine_prompt_path(&slug)).unwrap();
+    let prompt =
+        std::fs::read_to_string(crate::paths::routine_compiled_prompt_path(&slug)).unwrap();
     assert!(!prompt.contains("Open flags"));
 }


### PR DESCRIPTION
## What & why

A routine's raw prompt lived inside `routine.toml`'s `prompt` field — an escaped, multi-line TOML string that's awkward to diff and edit. The daemon already wrote a *derived* composed prompt to a sidecar file (`prompt.md`); this PR finishes that split so the raw prompt gets the same treatment.

- `routine.toml` no longer carries a `prompt` field.
- The raw prompt now lives in `<routine>/prompts/prompt.pure.md`.
- The composed prompt (repo preamble + raw prompt) moves from the top-level `prompt.md` to `<routine>/prompts/prompt.compiled.md`.
- A new one-shot startup migration (`migrate_prompts_to_subfolder`) heals existing installs: moves the legacy top-level `prompt.md` into `prompts/prompt.compiled.md`, and extracts the legacy `routine.toml` `prompt` field into `prompts/prompt.pure.md`.

This is a storage-layer-only change — the in-memory `Routine.prompt` field and every CLI/HTTP/MCP-facing API shape are unchanged, so `create_routine`/`update_routine`/`get_routine`/CLI flags/UI needed no changes.

Fixes #861

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test` (618 passed)
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (100% line coverage)
- [x] New tests cover the migration's happy path, idempotent re-run, `read_dir` error branch, and per-entry create-dir/rename/write failure branches
- [x] Docs updated (`README.md`, `Architecture.md`, `docs/comparison.md`)
- [x] Changeset added (`.changeset/routine-prompt-files-subfolder.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)