### PR TITLE
chore(lint): enable clippy::use_self

### DIFF
--- a/.changeset/clippy-use-self.md
+++ b/.changeset/clippy-use-self.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Enable `clippy::use_self` (issue #724) and replace the flagged `Type::Variant` spellings with `Self::Variant` inside their own `impl`/`match` blocks across `src/error.rs`, `src/machine/mod.rs`, `src/routines/agents/mod.rs`, `src/routines/flags.rs`, `src/sync/mod.rs`, and their test modules — purely mechanical, no behavior change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,3 +107,8 @@ wildcard_imports = "deny"
 # already covered by another pattern, or the duplication is an unintentional
 # bug where the bodies were meant to differ.
 match_same_arms = "deny"
+# Prefer `Self`/`Self::Variant` over spelling out the concrete type name
+# inside its own `impl` block. `Self` always tracks the current type, so
+# renaming the type requires zero edits inside the `impl` block, and it's
+# the idiomatic way to say "same type as the one being implemented".
+use_self = "deny"

--- a/src/cli_tests.rs
+++ b/src/cli_tests.rs
@@ -373,13 +373,13 @@ struct EnvGuard {
 
 impl EnvGuard {
     /// Set `name` to `value`, remembering the prior value for restoration.
-    fn set(name: &'static str, value: &str) -> EnvGuard {
+    fn set(name: &'static str, value: &str) -> Self {
         let previous = std::env::var_os(name);
         // SAFETY: tests in this crate run single-threaded per binary.
         unsafe {
             std::env::set_var(name, value);
         }
-        EnvGuard { name, previous }
+        Self { name, previous }
     }
 }
 
@@ -418,7 +418,7 @@ struct FakeServer {
 
 impl FakeServer {
     /// Start a server on an ephemeral port answering with `status` and `body` while alive.
-    fn start(status: u16, body: String) -> FakeServer {
+    fn start(status: u16, body: String) -> Self {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
         let addr = listener.local_addr().expect("local addr").to_string();
         listener.set_nonblocking(true).expect("set nonblocking");
@@ -447,7 +447,7 @@ impl FakeServer {
                 }
             }
         });
-        FakeServer {
+        Self {
             addr,
             alive,
             stop,

--- a/src/commands_tests.rs
+++ b/src/commands_tests.rs
@@ -32,13 +32,13 @@ struct EnvGuard {
 
 impl EnvGuard {
     /// Set `name` to `value`, remembering the prior value for restoration.
-    fn set(name: &'static str, value: &str) -> EnvGuard {
+    fn set(name: &'static str, value: &str) -> Self {
         let previous = std::env::var_os(name);
         // SAFETY: tests in this crate run single-threaded per binary.
         unsafe {
             std::env::set_var(name, value);
         }
-        EnvGuard { name, previous }
+        Self { name, previous }
     }
 }
 
@@ -66,7 +66,7 @@ struct FakeServer {
 
 impl FakeServer {
     /// Start a server on an ephemeral port answering every connection with `status` and `body`.
-    fn start(status: u16, body: &str) -> FakeServer {
+    fn start(status: u16, body: &str) -> Self {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
         let addr = listener.local_addr().expect("local addr").to_string();
         listener.set_nonblocking(true).expect("set nonblocking");
@@ -91,7 +91,7 @@ impl FakeServer {
                 }
             }
         });
-        FakeServer {
+        Self {
             addr,
             stop,
             handle: Some(handle),

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,11 +25,11 @@ pub enum AppError {
 impl fmt::Display for AppError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            AppError::Internal => write!(f, "internal server error"),
-            AppError::BadRequest(msg) => write!(f, "bad request: {msg}"),
-            AppError::NotFound => write!(f, "not found"),
-            AppError::Conflict(msg) => write!(f, "conflict: {msg}"),
-            AppError::Locked(msg) => write!(f, "locked: {msg}"),
+            Self::Internal => write!(f, "internal server error"),
+            Self::BadRequest(msg) => write!(f, "bad request: {msg}"),
+            Self::NotFound => write!(f, "not found"),
+            Self::Conflict(msg) => write!(f, "conflict: {msg}"),
+            Self::Locked(msg) => write!(f, "locked: {msg}"),
         }
     }
 }
@@ -37,11 +37,11 @@ impl fmt::Display for AppError {
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         let status = match &self {
-            AppError::Internal => StatusCode::INTERNAL_SERVER_ERROR,
-            AppError::BadRequest(_) => StatusCode::BAD_REQUEST,
-            AppError::NotFound => StatusCode::NOT_FOUND,
-            AppError::Conflict(_) => StatusCode::CONFLICT,
-            AppError::Locked(_) => StatusCode::LOCKED,
+            Self::Internal => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::BadRequest(_) => StatusCode::BAD_REQUEST,
+            Self::NotFound => StatusCode::NOT_FOUND,
+            Self::Conflict(_) => StatusCode::CONFLICT,
+            Self::Locked(_) => StatusCode::LOCKED,
         };
         (
             status,

--- a/src/global_lock_tests.rs
+++ b/src/global_lock_tests.rs
@@ -12,7 +12,7 @@ impl TempHome {
         unsafe {
             std::env::set_var("MOADIM_HOME_OVERRIDE", &dir);
         }
-        TempHome(dir)
+        Self(dir)
     }
 }
 

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -43,10 +43,10 @@ impl MachineSource {
     /// Short human label used in CLI output.
     pub fn label(self) -> &'static str {
         match self {
-            MachineSource::Env => "MOADIM_MACHINE env",
-            MachineSource::File => "machine.local.toml",
-            MachineSource::Generated => "auto-generated (first run)",
-            MachineSource::Hostname => "system hostname",
+            Self::Env => "MOADIM_MACHINE env",
+            Self::File => "machine.local.toml",
+            Self::Generated => "auto-generated (first run)",
+            Self::Hostname => "system hostname",
         }
     }
 }

--- a/src/machine/mod_tests.rs
+++ b/src/machine/mod_tests.rs
@@ -11,19 +11,19 @@ struct EnvGuard {
 
 impl EnvGuard {
     /// Set `name` to `value`, remembering the prior value for restoration.
-    fn set(name: &'static str, value: &str) -> EnvGuard {
+    fn set(name: &'static str, value: &str) -> Self {
         let previous = std::env::var_os(name);
         // SAFETY: single-threaded test execution.
         unsafe { std::env::set_var(name, value) }
-        EnvGuard { name, previous }
+        Self { name, previous }
     }
 
     /// Ensure `name` is unset for the duration of the guard.
-    fn unset(name: &'static str) -> EnvGuard {
+    fn unset(name: &'static str) -> Self {
         let previous = std::env::var_os(name);
         // SAFETY: single-threaded test execution.
         unsafe { std::env::remove_var(name) }
-        EnvGuard { name, previous }
+        Self { name, previous }
     }
 }
 

--- a/src/restart_tests.rs
+++ b/src/restart_tests.rs
@@ -22,13 +22,13 @@ struct EnvGuard {
 }
 
 impl EnvGuard {
-    fn set(name: &'static str, value: &str) -> EnvGuard {
+    fn set(name: &'static str, value: &str) -> Self {
         let previous = std::env::var_os(name);
         // SAFETY: single-threaded test execution.
         unsafe {
             std::env::set_var(name, value);
         }
-        EnvGuard { name, previous }
+        Self { name, previous }
     }
 }
 
@@ -60,7 +60,7 @@ struct FakeServer {
 }
 
 impl FakeServer {
-    fn start() -> FakeServer {
+    fn start() -> Self {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
         let addr = listener.local_addr().expect("local addr").to_string();
         listener.set_nonblocking(true).expect("set nonblocking");
@@ -86,7 +86,7 @@ impl FakeServer {
                 }
             }
         });
-        FakeServer {
+        Self {
             addr,
             alive,
             stop,

--- a/src/routes/http_tests.rs
+++ b/src/routes/http_tests.rs
@@ -65,14 +65,14 @@ impl Drop for SucceedingCronShim {
 struct TempHome;
 
 impl TempHome {
-    fn set() -> TempHome {
+    fn set() -> Self {
         let dir = std::env::temp_dir().join(format!("moadim-httptest-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&dir).expect("create temp home");
         // SAFETY: single-threaded test execution.
         unsafe {
             std::env::set_var("MOADIM_HOME_OVERRIDE", &dir);
         }
-        TempHome
+        Self
     }
 }
 

--- a/src/routes/mcp_tests.rs
+++ b/src/routes/mcp_tests.rs
@@ -20,14 +20,14 @@ fn test_shutdown() -> crate::routes::http::ShutdownSignal {
 struct TempHome;
 
 impl TempHome {
-    fn set() -> TempHome {
+    fn set() -> Self {
         let dir = std::env::temp_dir().join(format!("moadim-mcptest-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&dir).expect("create temp home");
         // SAFETY: single-threaded test execution.
         unsafe {
             std::env::set_var("MOADIM_HOME_OVERRIDE", &dir);
         }
-        TempHome
+        Self
     }
 }
 

--- a/src/routines/agents/mod.rs
+++ b/src/routines/agents/mod.rs
@@ -68,9 +68,9 @@ pub enum AgentLoadError {
 impl std::fmt::Display for AgentLoadError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            AgentLoadError::Missing => write!(f, "agent config not found"),
-            AgentLoadError::Unreadable(err) => write!(f, "unreadable agent config: {err}"),
-            AgentLoadError::Parse(err) => write!(f, "malformed agent TOML: {err}"),
+            Self::Missing => write!(f, "agent config not found"),
+            Self::Unreadable(err) => write!(f, "unreadable agent config: {err}"),
+            Self::Parse(err) => write!(f, "malformed agent TOML: {err}"),
         }
     }
 }

--- a/src/routines/flags.rs
+++ b/src/routines/flags.rs
@@ -35,8 +35,8 @@ impl FlagScope {
     /// The filename suffix (including the leading `.`) this scope's flag files carry.
     fn suffix(self) -> &'static str {
         match self {
-            FlagScope::General => ".md",
-            FlagScope::Local => ".local.md",
+            Self::General => ".md",
+            Self::Local => ".local.md",
         }
     }
 }

--- a/src/routines/flags_tests.rs
+++ b/src/routines/flags_tests.rs
@@ -8,14 +8,14 @@ use super::*;
 struct TempHome(std::path::PathBuf);
 
 impl TempHome {
-    fn set() -> TempHome {
+    fn set() -> Self {
         let dir = std::env::temp_dir().join(format!("moadim-flagstest-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&dir).expect("create temp home");
         // SAFETY: single-threaded test execution.
         unsafe {
             std::env::set_var("MOADIM_HOME_OVERRIDE", &dir);
         }
-        TempHome(dir)
+        Self(dir)
     }
 }
 

--- a/src/routines/handlers_tests.rs
+++ b/src/routines/handlers_tests.rs
@@ -17,7 +17,7 @@ impl TempHome {
         unsafe {
             std::env::set_var("MOADIM_HOME_OVERRIDE", &dir);
         }
-        TempHome(dir)
+        Self(dir)
     }
 }
 

--- a/src/routines/service_tests.rs
+++ b/src/routines/service_tests.rs
@@ -14,14 +14,14 @@ use std::sync::{Arc, Mutex};
 struct TempHome(std::path::PathBuf);
 
 impl TempHome {
-    fn set() -> TempHome {
+    fn set() -> Self {
         let dir = std::env::temp_dir().join(format!("moadim-svctest-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&dir).expect("create temp home");
         // SAFETY: single-threaded test execution.
         unsafe {
             std::env::set_var("MOADIM_HOME_OVERRIDE", &dir);
         }
-        TempHome(dir)
+        Self(dir)
     }
 }
 

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -33,15 +33,15 @@ pub enum SyncError {
 impl std::fmt::Display for SyncError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            SyncError::CrontabCommand(msg) => write!(f, "crontab: {msg}"),
-            SyncError::Io(err) => write!(f, "io: {err}"),
+            Self::CrontabCommand(msg) => write!(f, "crontab: {msg}"),
+            Self::Io(err) => write!(f, "io: {err}"),
         }
     }
 }
 
 impl From<std::io::Error> for SyncError {
     fn from(err: std::io::Error) -> Self {
-        SyncError::Io(err)
+        Self::Io(err)
     }
 }
 


### PR DESCRIPTION
## Summary

Enables `clippy::use_self` (pedantic group) at `deny` level in the workspace `[lints.clippy]` table and fixes the violations it flags.

- Adds one entry to `Cargo.toml` with an explanatory comment.
- Mechanically replaces `Type::Variant` with `Self::Variant` inside each type's own `impl`/`match` blocks in `src/error.rs`, `src/machine/mod.rs`, `src/routines/agents/mod.rs`, `src/routines/flags.rs`, `src/sync/mod.rs`, and their test modules (`applied via `cargo clippy --fix`, no behavior change).
- `cargo build`, `cargo test` (641 passed), `cargo clippy --all-targets -- -D warnings`, and `cargo fmt --check` are all green on this branch.

## What the lint catches

`clippy::use_self` flags places inside an `impl` block where the concrete type name is spelled out when `Self` could be used instead:

```rust
// before
impl AppError {
    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
        match self {
            AppError::Internal => write!(f, "internal server error"),
            ...
        }
    }
}

// after
impl AppError {
    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
        match self {
            Self::Internal => write!(f, "internal server error"),
            ...
        }
    }
}
```

## Why

`Self` always tracks the current type, so renaming the type requires zero edits inside its own `impl` block, keeps type-rename diffs small and reviewable, and is the idiomatic way to say "same type as the one being implemented."

This lint is in `clippy::pedantic` and is therefore not covered by the existing `all = "deny"` entry; it must be opted in explicitly — matching this repo's established pattern of incrementally adopting pedantic lints (see #759, #755).

Closes #724

---

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim. Tag @tupe12334 if you'd like a human look.