### PR TITLE
chore(lint): enable clippy::unnecessary_debug_formatting

### DIFF
--- a/.changeset/clippy-unnecessary-debug-formatting.md
+++ b/.changeset/clippy-unnecessary-debug-formatting.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Enable `clippy::unnecessary_debug_formatting` and fix the three flagged `log::warn!` call sites (`routine_storage::migrate_prompt_files_from_dir`, `routines::agents::ensure_default_agents_in`) that Debug-formatted (`{path:?}`) a `Path`/`PathBuf` in a user-facing log line instead of using `.display()`, matching every other path already printed this way in the codebase.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,3 +112,9 @@ match_same_arms = "deny"
 # renaming the type requires zero edits inside the `impl` block, and it's
 # the idiomatic way to say "same type as the one being implemented".
 use_self = "deny"
+# Reject `{:?}` (Debug) formatting of a `Path`/`PathBuf` in user-facing output
+# (log lines, error messages). Debug-formats a path with surrounding quotes and
+# escaped separators/backslashes, which reads oddly and diverges from every
+# other path already printed via `.display()` in this codebase. `Path::display`
+# is the correct, consistent way to show a filesystem path to a human.
+unnecessary_debug_formatting = "deny"

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -256,7 +256,10 @@ pub(crate) fn migrate_prompt_files_from_dir(dir: &std::path::Path) {
         let new = entry.path().join("prompt.md");
         if old.exists() && !new.exists() {
             if let Err(err) = std::fs::rename(&old, &new) {
-                log::warn!("migrate_prompt_files: failed to rename {old:?}: {err}");
+                log::warn!(
+                    "migrate_prompt_files: failed to rename {}: {err}",
+                    old.display()
+                );
             }
         }
     }

--- a/src/routines/agents/mod.rs
+++ b/src/routines/agents/mod.rs
@@ -154,7 +154,10 @@ pub fn ensure_default_agents() {
 /// Write missing built-in agent configs into `dir`. See [`ensure_default_agents`].
 pub(crate) fn ensure_default_agents_in(dir: &Path) {
     if let Err(err) = std::fs::create_dir_all(dir) {
-        log::warn!("ensure_default_agents: failed to create {dir:?}: {err}");
+        log::warn!(
+            "ensure_default_agents: failed to create {}: {err}",
+            dir.display()
+        );
         return;
     }
     for (name, contents) in DEFAULT_AGENT_CONFIGS {
@@ -163,7 +166,10 @@ pub(crate) fn ensure_default_agents_in(dir: &Path) {
             continue;
         }
         if let Err(err) = std::fs::write(&path, contents) {
-            log::warn!("ensure_default_agents: failed to write {path:?}: {err}");
+            log::warn!(
+                "ensure_default_agents: failed to write {}: {err}",
+                path.display()
+            );
         }
     }
 }


### PR DESCRIPTION
## Why

`log::warn!` in two places Debug-formatted a `Path`/`PathBuf` (`{path:?}`) instead of using `.display()`. Debug-formatting a path wraps it in quotes and escapes separators/backslashes, which reads oddly and is inconsistent with every other path already printed via `.display()` elsewhere in this codebase (`service/macos.rs`, `service/linux.rs`, `cli.rs`, `build/ui.rs`, ...). It's also the exact case `clippy::unnecessary_debug_formatting` exists to catch, and this repo already ratchets up its clippy lint set one lint at a time (see `map_unwrap_or`, `match_same_arms`, `use_self`, `unwrap_used` in `Cargo.toml`'s `[lints.clippy]`), each added with a fix for whatever it flagged.

## What

- Add `unnecessary_debug_formatting = "deny"` to `[lints.clippy]` in `Cargo.toml`, with a comment explaining the rationale (matching the style of the existing entries).
- Fix the three flagged call sites:
  - `routine_storage::migrate_prompt_files_from_dir` (failed-rename warning)
  - `routines::agents::ensure_default_agents_in` (failed-mkdir and failed-write warnings)

All three now use `.display()`, mirroring the rest of the codebase. Purely mechanical — no behavior change, no test assertions depend on the exact log string.

## Checks

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean (new lint included)
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% line coverage maintained (641 tests passing)
- `typos` — clean on changed files

Verified against the current 117 open PRs and 100 open issues first — no open PR or issue proposes this lint or touches these two functions.

---

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.