### PR TITLE
docs(routines): stop advertising PUT /routines/{id} as a full replace

### DIFF
--- a/.changeset/docs-put-routines-patch-alias.md
+++ b/.changeset/docs-put-routines-patch-alias.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Clarify in doc comments and the OpenAPI spec that `PUT /routines/{id}` is a partial-merge alias for `PATCH`, not a full RFC 7231 replace (#872).

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -483,7 +483,8 @@
         "tags": [
           "crate::routines"
         ],
-        "summary": "`PUT /routines/{id}` — fully replace a routine (behaves identically to PATCH).",
+        "summary": "`PUT /routines/{id}` — alias for `PATCH`: a partial-merge update, not a full replace.",
+        "description": "Fields omitted from the body are retained from the existing record, exactly as with `PATCH`.\nA client expecting RFC 7231 full-resource-replacement semantics (omitted fields reset to\ndefault) should not rely on this route for that; use `PATCH` and set every field explicitly.",
         "operationId": "replace",
         "parameters": [
           {

--- a/src/routines/handlers.rs
+++ b/src/routines/handlers.rs
@@ -158,7 +158,11 @@ pub async fn update(
     Ok(Json(svc_update(&store, &id, body)?))
 }
 
-/// `PUT /routines/{id}` — fully replace a routine (behaves identically to PATCH).
+/// `PUT /routines/{id}` — alias for `PATCH`: a partial-merge update, not a full replace.
+///
+/// Fields omitted from the body are retained from the existing record, exactly as with `PATCH`.
+/// A client expecting RFC 7231 full-resource-replacement semantics (omitted fields reset to
+/// default) should not rely on this route for that; use `PATCH` and set every field explicitly.
 #[utoipa::path(put, path = "/routines/{id}",
     params(("id" = String, Path, description = "Routine UUID")),
     request_body = UpdateRoutineRequest,


### PR DESCRIPTION
## Summary

`PUT /routines/{id}` delegates directly to the `PATCH` handler (`replace` calls `update`) and shares its all-`Option` request body (`UpdateRoutineRequest`), so a field omitted from a `PUT` body is silently retained from the existing record instead of being reset — partial-merge (PATCH) semantics, not full replacement. The doc comment and OpenAPI summary claimed "fully replace ... behaves identically to PATCH", which is self-contradictory and misleading to API clients that expect RFC 7231 replace semantics from `PUT`.

Per the issue, there were two coherent fixes: make `PUT` a true replace, or document it as the `PATCH` alias it already is. This PR takes the documentation-only route — a true replace would require a new non-`Option` request type and would be a breaking behavior change for any client currently relying on `PUT`'s partial-merge behavior. Documenting reality is the safe, non-breaking fix.

## Changes

- `src/routines/handlers.rs`: rewrote the `replace` handler's rustdoc to state it's a `PATCH` alias (partial merge), not a full replace, and to warn clients wanting real replace semantics to use `PATCH` explicitly.
- `apis/openapi.json`: regenerated via `cargo test openapi` so the committed spec matches the new doc comment.

Note: the only `PUT` route matching this pattern in the current codebase is `/routines/{id}` — the `/cron-jobs/{id}` route mentioned in the original issue no longer exists (cron jobs were merged into the routines model in a later refactor).

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (100.00% line coverage, 648 tests passed)

Closes #242

---
This pull request was opened by the "Implement my assigned issues without a PR (daemon + landing)" routine of moadim.