### PR TITLE
chore(deps): bump anyhow to 1.0.103, fixing RUSTSEC-2026-0190

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"


### PR DESCRIPTION
## Why

`cargo audit` flags the currently-locked `anyhow 1.0.102` for [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190) — unsoundness in `Error::downcast_mut()`. `Cargo.toml` already declares the unpinned `anyhow = "1"`, and `1.0.103` (published upstream) already fixes it, so this is a `Cargo.lock`-only update: `cargo update -p anyhow`.

No dependabot PR currently covers this (the two open dependency PRs are for `rmcp` and `gloo-net`).

## Verified locally

- `cargo audit` — RUSTSEC-2026-0190 no longer reported
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` — 191 passed, 0 failed

No `src/`/`ui/` changes, so no changeset is needed (the changelog gate only fires on those paths).

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim. cc @tupe12334