### PR TITLE
docs: remove stale run.sh references from README, Architecture, and man page

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -26,7 +26,6 @@ Moadim is a Rust daemon that manages scheduled AI-agent routines and exposes the
                ~/.config/moadim/routines/
                ├── <uuid>/routine.toml      (tracked)
                ├── <uuid>/prompt.md         (tracked)
-               ├── <uuid>/run.sh            (generated)
                └── <uuid>/.gitignore        (generated)
 ```
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ install -Dm644 docs/moadim.1 "$HOME/.local/share/man/man1/moadim.1"
 │   └── nightly-triage/
 │       ├── routine.toml       # tracked — schedule, agent, prompt, repositories
 │       ├── prompt.md          # tracked — the rendered prompt handed to the agent
-│       ├── run.sh             # generated — the crontab entry invokes this
 │       └── .gitignore         # generated — excludes *.local.* and *.log
 ├── agents/                    # registered coding agents referenced by routines
 │   └── claude.toml
@@ -152,7 +151,6 @@ git-trackable:
 └── nightly-triage/
     ├── routine.toml   # tracked — schedule, agent, prompt, repositories
     ├── prompt.md      # tracked — the rendered prompt handed to the agent
-    ├── run.sh         # generated — the crontab entry invokes this
     └── .gitignore     # generated — excludes *.local.* and *.log
 ```
 

--- a/docs/moadim.1
+++ b/docs/moadim.1
@@ -86,9 +86,8 @@ Manage routines (alias:
 .BR routine ).
 .TP
 .B schedule trigger <id>
-Trigger a routine by ID (used by the generated
-.B run.sh
-wrappers).
+Trigger a routine by ID (invoked directly from the routine's crontab
+entry).
 .TP
 .B agents
 List available agent keys.


### PR DESCRIPTION
## Why

Per-routine `run.sh` launch scripts were removed from the daemon a while back:

- `src/routine_storage.rs` actively **deletes** any stale `run.sh` left behind by an older daemon version on load.
- `src/sync/routines.rs` documents that the crontab line invokes `moadim schedule trigger <id>` directly — no per-routine script is generated.

Three doc surfaces never got updated to match and still describe `run.sh` as a real, generated file:

- `README.md` — both directory-layout diagrams (the top-level tree and the "Routines" section tree) list a `run.sh # generated — the crontab entry invokes this` entry, directly contradicted a few lines later by the same file's own "Crontab sync" section, which correctly shows the crontab line invoking `moadim schedule trigger '<id>'` with no script involved.
- `Architecture.md` — same stale entry in the "High-level picture" diagram, contradicted by that file's own later "Routines" section, which correctly shows the crontab line running the agent command directly.
- `docs/moadim.1` (the man page) — describes `schedule trigger <id>` as "used by the generated `run.sh` wrappers," which no longer exist.

A contributor or user reading these docs would go looking for a file the daemon actively deletes on sight. This PR removes the three stale mentions so the docs match the current (and already-documented-elsewhere) architecture. Docs-only change — no `src/` or `ui/` files touched, so no changeset/CHANGELOG entry is needed per this repo's own gating rule.

## What changed

- `README.md`: drop the `run.sh` line from both directory-layout code blocks.
- `Architecture.md`: drop the `run.sh` line from the high-level-picture diagram.
- `docs/moadim.1`: reword the `schedule trigger <id>` description to say it's invoked directly from the routine's crontab entry, instead of referencing nonexistent `run.sh` wrappers.

## Test plan

- [x] Grepped the repo for `run.sh` post-change — only remaining references are in `src/` (the legacy-cleanup code path itself, which is accurate) and `CHANGELOG.md` (correctly historical).
- Docs-only diff; no code paths touched, so `cargo build`/`test`/`clippy`/`fmt` are unaffected (verified clean on this branch prior to this change).

---

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.

cc @tupe12334