### PR TITLE
feat(logging): echo request correlation id as x-request-id header

### DIFF
--- a/.changeset/request-id-correlation.md
+++ b/.changeset/request-id-correlation.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Echo each request's log correlation id back as an `x-request-id` response header (`src/middlewares/logger.rs`), reusing an inbound `x-request-id` when the caller supplies one instead of always minting a fresh counter-based id. Completes the remaining acceptance criterion of issue #354; the shared inbound/outbound log correlation itself already shipped.

--- a/src/middlewares/logger.rs
+++ b/src/middlewares/logger.rs
@@ -1,6 +1,15 @@
-use axum::{extract::Request, middleware::Next, response::Response};
+use axum::{
+    extract::Request,
+    http::{header::HeaderName, HeaderValue},
+    middleware::Next,
+    response::Response,
+};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
+
+/// Response header a request's correlation id is echoed under, reusing an inbound value of the
+/// same name when the caller supplies one instead of always minting a fresh id.
+const REQUEST_ID_HEADER: &str = "x-request-id";
 
 /// The health-check endpoint the web UI polls continuously. Logged at `debug`
 /// (see [`logger`]). This is the fully-qualified request path the middleware
@@ -22,9 +31,19 @@ static REQUEST_COUNTER: AtomicU64 = AtomicU64::new(0);
 ///
 /// Each request is tagged with a short correlation id that prefixes both its
 /// inbound (`<-`) and outbound (`->`) line, so the two can be paired in the log
-/// even when many requests interleave under concurrency.
+/// even when many requests interleave under concurrency. The same id is echoed
+/// back as an `x-request-id` response header; an inbound `x-request-id` (when
+/// present and a valid header value) is reused rather than regenerated, so a
+/// caller-supplied id survives into the daemon's own logs.
 pub async fn logger(req: Request, next: Next) -> Response {
-    let id = REQUEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let inbound_id = req
+        .headers()
+        .get(REQUEST_ID_HEADER)
+        .and_then(|header| header.to_str().ok())
+        .filter(|header| !header.is_empty())
+        .map(str::to_string);
+    let id = inbound_id
+        .unwrap_or_else(|| format!("{:08x}", REQUEST_COUNTER.fetch_add(1, Ordering::Relaxed)));
     let method = req.method().clone();
     let path = req.uri().path().to_string();
     // Health-check polls are noise at info level; keep them at debug.
@@ -33,12 +52,16 @@ pub async fn logger(req: Request, next: Next) -> Response {
     } else {
         log::Level::Info
     };
-    log::log!(level, "[{id:08x}] <- {method} {path}");
+    log::log!(level, "[{id}] <- {method} {path}");
     let start = Instant::now();
-    let res = next.run(req).await;
+    let mut res = next.run(req).await;
     let status = res.status();
     let elapsed = start.elapsed().as_millis();
-    log::log!(level, "[{id:08x}] -> {status} {path} in {elapsed}ms");
+    log::log!(level, "[{id}] -> {status} {path} in {elapsed}ms");
+    if let Ok(value) = HeaderValue::from_str(&id) {
+        res.headers_mut()
+            .insert(HeaderName::from_static(REQUEST_ID_HEADER), value);
+    }
     res
 }
 

--- a/src/middlewares/logger_tests.rs
+++ b/src/middlewares/logger_tests.rs
@@ -66,3 +66,77 @@ async fn logger_passes_404_response_through() {
 
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
+
+#[tokio::test]
+async fn logger_stamps_a_generated_request_id_header() {
+    let app = Router::new()
+        .route("/", get(|| async { "ok" }))
+        .layer(middleware::from_fn(logger));
+
+    let resp = app
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    let id = resp
+        .headers()
+        .get("x-request-id")
+        .expect("x-request-id header set")
+        .to_str()
+        .unwrap();
+    assert_eq!(id.len(), 8, "generated id is an 8-hex-digit counter value");
+}
+
+#[tokio::test]
+async fn logger_reuses_an_inbound_request_id() {
+    let app = Router::new()
+        .route("/", get(|| async { "ok" }))
+        .layer(middleware::from_fn(logger));
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/")
+                .header("x-request-id", "caller-supplied-id")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.headers().get("x-request-id").unwrap(),
+        "caller-supplied-id"
+    );
+}
+
+#[tokio::test]
+async fn logger_gives_concurrent_requests_distinct_generated_ids() {
+    let app = Router::new()
+        .route("/", get(|| async { "ok" }))
+        .layer(middleware::from_fn(logger));
+
+    let resp_a = app
+        .clone()
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let resp_b = app
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    let id_a = resp_a
+        .headers()
+        .get("x-request-id")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    let id_b = resp_b
+        .headers()
+        .get("x-request-id")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert_ne!(id_a, id_b);
+}


### PR DESCRIPTION
## Summary

The HTTP request logger (`src/middlewares/logger.rs`) already tags each request's inbound (`<-`) and outbound (`->`) log lines with a shared correlation id, but never surfaced that id anywhere a caller could see it.

- Echoes the correlation id back as an `x-request-id` response header.
- Reuses an inbound `x-request-id` header when the caller supplies one (falling back to the existing counter-based id otherwise), so a caller-provided id survives into the daemon's own logs.
- Adds 3 new tests: a generated id is stamped, an inbound id is reused verbatim, and concurrent requests get distinct generated ids.

Completes the remaining (optional) acceptance criterion of #354 — the shared log-line correlation itself already shipped.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test logger` — 6/6 passing (3 pre-existing + 3 new)
- [x] `.changeset/request-id-correlation.md` added (patch, no behavior change to existing log format)

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim. cc @tupe12334