### PR TITLE
feat(cli): add --model to moadim routines create/update/replace

### DIFF
--- a/.changeset/cli-routine-model-flag.md
+++ b/.changeset/cli-routine-model-flag.md
@@ -1,0 +1,13 @@
+---
+"moadim": minor
+---
+
+### Added
+
+- **`--model` on the `moadim routines` CLI.** `create`, `update`, and
+  `replace` gain a `--model <id>` flag, threaded into the same JSON body the
+  REST route already accepts. The `model` field itself landed data/API-only
+  in #742 with a note that other surfaces were a follow-up; this closes the
+  gap for the terminal (the web UI form field remains a separate follow-up).
+  On `update`, `--model ""` clears the override back to the agent's own
+  default, matching the existing REST/MCP semantics.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -75,6 +75,10 @@ enum RoutineCmd {
         /// Agent registry key to launch.
         #[arg(long)]
         agent: String,
+        /// Model ID to run the agent with (e.g. `claude-sonnet-4-6`); omit to use the agent's own
+        /// default.
+        #[arg(long)]
+        model: Option<String>,
         /// Task prompt.
         #[arg(long)]
         prompt: String,
@@ -118,6 +122,9 @@ enum RoutineCmd {
         /// New agent registry key.
         #[arg(long)]
         agent: Option<String>,
+        /// New model ID, or an empty string to clear the override back to the agent's own default.
+        #[arg(long)]
+        model: Option<String>,
         /// New prompt.
         #[arg(long)]
         prompt: Option<String>,
@@ -154,6 +161,10 @@ enum RoutineCmd {
         /// Agent registry key to launch.
         #[arg(long)]
         agent: String,
+        /// Model ID to run the agent with (e.g. `claude-sonnet-4-6`); omit to use the agent's own
+        /// default.
+        #[arg(long)]
+        model: Option<String>,
         /// Task prompt.
         #[arg(long)]
         prompt: String,
@@ -238,6 +249,7 @@ fn dispatch_routine(cmd: RoutineCmd) -> i32 {
             schedule,
             title,
             agent,
+            model,
             prompt,
             repositories,
             machines,
@@ -249,6 +261,7 @@ fn dispatch_routine(cmd: RoutineCmd) -> i32 {
             schedule,
             title,
             agent,
+            model,
             prompt,
             repositories,
             machines,
@@ -267,6 +280,7 @@ fn dispatch_routine(cmd: RoutineCmd) -> i32 {
             schedule,
             title,
             agent,
+            model,
             prompt,
             repositories,
             machines,
@@ -279,6 +293,7 @@ fn dispatch_routine(cmd: RoutineCmd) -> i32 {
             insert_opt(&mut map, "schedule", schedule.map(Value::String));
             insert_opt(&mut map, "title", title.map(Value::String));
             insert_opt(&mut map, "agent", agent.map(Value::String));
+            insert_opt(&mut map, "model", model.map(Value::String));
             insert_opt(&mut map, "prompt", prompt.map(Value::String));
             match insert_json_opt(&mut map, "repositories", repositories) {
                 Ok(()) => {}
@@ -308,6 +323,7 @@ fn dispatch_routine(cmd: RoutineCmd) -> i32 {
             schedule,
             title,
             agent,
+            model,
             prompt,
             repositories,
             machines,
@@ -319,6 +335,7 @@ fn dispatch_routine(cmd: RoutineCmd) -> i32 {
             schedule,
             title,
             agent,
+            model,
             prompt,
             repositories,
             machines,
@@ -351,6 +368,7 @@ fn routine_body(
     schedule: String,
     title: String,
     agent: String,
+    model: Option<String>,
     prompt: String,
     repositories: Option<String>,
     machines: Option<String>,
@@ -363,6 +381,7 @@ fn routine_body(
     map.insert("schedule".to_string(), Value::String(schedule));
     map.insert("title".to_string(), Value::String(title));
     map.insert("agent".to_string(), Value::String(agent));
+    insert_opt(&mut map, "model", model.map(Value::String));
     map.insert("prompt".to_string(), Value::String(prompt));
     insert_json_opt(&mut map, "repositories", repositories)?;
     insert_json_opt(&mut map, "machines", machines)?;

--- a/src/commands_tests.rs
+++ b/src/commands_tests.rs
@@ -210,6 +210,8 @@ fn every_subcommand_succeeds_against_a_2xx_server() {
             "t",
             "--agent",
             "a",
+            "--model",
+            "claude-sonnet-4-6",
             "--prompt",
             "p",
             "--disabled",
@@ -228,6 +230,8 @@ fn every_subcommand_succeeds_against_a_2xx_server() {
             "rid",
             "--title",
             "t2",
+            "--model",
+            "",
             "--repositories",
             "[]",
             "--enabled",
@@ -336,6 +340,7 @@ fn routine_body_serializes_all_fields() {
             "* * * * *".into(),
             "title".into(),
             "agent".into(),
+            Some("claude-sonnet-4-6".into()),
             "prompt".into(),
             Some("[]".into()),
             Some("[\"work\"]".into()),
@@ -348,6 +353,10 @@ fn routine_body_serializes_all_fields() {
     )
     .unwrap();
     assert_eq!(value["title"], Value::String("title".to_string()));
+    assert_eq!(
+        value["model"],
+        Value::String("claude-sonnet-4-6".to_string())
+    );
     assert_eq!(value["repositories"], Value::Array(vec![]));
     assert_eq!(
         value["machines"],
@@ -371,6 +380,7 @@ fn routine_body_rejects_bad_repositories() {
             "* * * * *".into(),
             "t".into(),
             "a".into(),
+            None,
             "p".into(),
             Some("{bad".into()),
             None,
@@ -391,6 +401,7 @@ fn routine_body_rejects_bad_machines() {
             "* * * * *".into(),
             "t".into(),
             "a".into(),
+            None,
             "p".into(),
             None,
             Some("{bad".into()),


### PR DESCRIPTION
## Summary
- `Routine.model` is fully wired end-to-end (`CreateRoutineRequest`/`UpdateRoutineRequest`, persistence, and injected as `--model <id>` on the agent invocation — see #742), but the CLI's `moadim routines create/update/replace` never exposed a flag for it. A terminal user had no way to set or clear a routine's model override; only the raw REST API could.
- Adds `--model <id>` to `create`/`replace` and `--model <id|"">` to `update`, threaded into the same JSON body the REST route already accepts. On `update`, passing `--model ""` clears the override back to the agent's own default, matching the existing REST/MCP blank-value semantics (`normalize_model`).
- The web UI form field remains a separate, already-noted follow-up (per #742's changeset) — this PR is CLI-only.

## Test plan
- [x] `cargo test` — 672 passed, including new/updated cases in `commands_tests.rs` covering `--model` on create/update and the JSON body builder
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% (mirrors the pre-push hook's coverage gate)
- [x] `.changeset/cli-routine-model-flag.md` added (minor bump)

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.