### PR TITLE
feat(cli): add moadim restart --json to emit the PID rotation as JSON

### DIFF
--- a/.changeset/restart-json-flag.md
+++ b/.changeset/restart-json-flag.md
@@ -1,0 +1,10 @@
+---
+"moadim": minor
+---
+
+### Added
+
+- **`moadim restart --json`.** Emits the PID-rotation summary as a
+  machine-readable `{"old":N|null,"new":M}` object instead of the
+  human-readable `restarted: pid <old> -> <new>` line, mirroring the
+  `status`/`cleanup`/`stop` `--json` contract.

--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ moadim cleanup         # reap finished, expired routine workbenches now
 moadim cleanup --json  # same, as a machine-readable JSON object
 moadim trigger <id>    # trigger a routine to run now, outside its schedule
 moadim restart         # stop a running server (if any) and start a fresh one
+moadim restart --json  # same, as a machine-readable JSON object
 moadim stop            # ask a running server to stop
 moadim stop --json     # same, as a machine-readable JSON object
 ```
@@ -300,7 +301,7 @@ moadim stop --json     # same, as a machine-readable JSON object
 |--------------------|---------------|-----------|
 | `moadim`           | background    | Spawns a detached server, writes its PID to `~/.config/moadim/moadim.pid`, logs to `~/.config/moadim/daemon.log`, and exits. Refuses to start if one is already running. |
 | `moadim -i`        | interactive   | Runs in the foreground; logs to the terminal; Ctrl-C stops it. |
-| `moadim restart`   | background    | Stops the running server (if any) and spawns a fresh detached instance, so you get a clean process without a separate stop/start. Prints the PID rotation as `restarted: pid <old> -> <new>` (old reads `none` when nothing was running) so scripts/logs can confirm the process actually changed. |
+| `moadim restart`   | background    | Stops the running server (if any) and spawns a fresh detached instance, so you get a clean process without a separate stop/start. Prints the PID rotation as `restarted: pid <old> -> <new>` (old reads `none` when nothing was running) so scripts/logs can confirm the process actually changed. Add `--json` for `{"old":N\|null,"new":M}`. |
 | `moadim stop`      | —             | Sends `POST /shutdown` to the running server for a graceful stop. Add `--json` for `{"running":bool,"pid":N\|null,"address":"127.0.0.1:5784"}` (the `pid` is read before the shutdown request, since a graceful stop clears the pid file). Exits `0` when a running server was asked to shut down, `3` when none was reachable. |
 | `moadim status`    | —             | Prints whether a server is reachable on `127.0.0.1:5784`. Add `--json` for `{"running":bool,"pid":N\|null,"address":"127.0.0.1:5784","uptime_secs":N\|null,"version":S\|null}` — `uptime_secs`/`version` come from the server's `GET /health`, so a single call returns liveness **and** age/version (both `null` when no server answers). Add `--wait[=SECS]` to poll `GET /health` every 200ms until it answers or `SECS` elapse (default 30) instead of checking once, so a launch script can block on startup rather than sleeping blindly. Exits `0` when running, `3` when not (including a `--wait` timeout). |
 | `moadim cleanup`   | —             | Sends `POST /api/v1/routines/cleanup` to the running server and prints how many finished, expired routine workbenches were reaped (the on-demand version of the hourly sweep). Add `--json` for `{"running":bool,"removed":N,"address":"127.0.0.1:5784"}` (matching `status`/`stop --json`'s shape). Exits `0` when running, `3` when not. |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -48,8 +48,12 @@ pub enum Command {
     Foreground,
     /// Spawn the server as a detached background process, then exit (the default, non-interactive).
     Background,
-    /// Stop a running background server (if any) and start a fresh detached instance.
-    Restart,
+    /// Stop a running background server (if any) and start a fresh detached instance. `json`
+    /// requests machine-readable output.
+    Restart {
+        /// Emit machine-readable JSON output instead of human-readable text.
+        json: bool,
+    },
     /// Ask a running background server to stop. `json` requests machine-readable output.
     Stop {
         /// Emit machine-readable JSON output instead of human-readable text.
@@ -108,7 +112,9 @@ pub fn parse(args: impl IntoIterator<Item = String>) -> Command {
     match args.first().map(String::as_str) {
         Some(first) if DATA_COMMANDS.contains(&first) => Command::Data(args),
         Some("machine") => Command::Machine(args[1..].to_vec()),
-        Some("restart") => Command::Restart,
+        Some("restart") => Command::Restart {
+            json: wants_json(&args[1..]),
+        },
         Some("stop") => Command::Stop {
             json: wants_json(&args[1..]),
             quiet: wants_quiet(&args[1..]),
@@ -182,7 +188,7 @@ pub fn print_help() {
          \x20   -b, --background       start the server detached in the background (explicit default)\n\
          \n\
          COMMANDS:\n\
-         \x20   restart                stop a running server (if any) and start a fresh background one\n\
+         \x20   restart [--json]       stop a running server (if any) and start a fresh background one\n\
          \x20   stop [--json] [-q]     stop a running background server (-q/--quiet: no stdout)\n\
          \x20   status [--json] [--wait[=SECS]] show whether a server is running (--wait: poll until\n\
          \x20                          reachable or SECS elapse, default 30, instead of checking once)\n\
@@ -273,28 +279,38 @@ fn foreground_already_running_message(pid: Option<u32>) -> String {
     )
 }
 
-/// Stop a running background server (if any) and start a fresh detached instance.
+/// Stop a running background server (if any) and start a fresh detached instance. With `json`,
+/// emits a single machine-readable object (`{"old":N|null,"new":M}`) instead of the human-readable
+/// lines.
 ///
 /// Unlike [`run_background`], which restarts only as a side effect of being asked to start while
 /// one is already up, this is the explicit "give me a clean process now" command: it stops the
 /// running server when present, otherwise just starts one.
-pub fn restart() -> anyhow::Result<()> {
+pub fn restart(json: bool) -> anyhow::Result<()> {
     let old_pid = if is_running() {
         let pid = read_pid_file();
-        let suffix = pid
-            .map(|process_id| format!(" (pid {process_id})"))
-            .unwrap_or_default();
-        println!("moadim is running{suffix}; stopping it");
+        if !json {
+            let suffix = pid
+                .map(|process_id| format!(" (pid {process_id})"))
+                .unwrap_or_default();
+            println!("moadim is running{suffix}; stopping it");
+        }
         crate::restart::stop_running_and_wait()?;
         pid
     } else {
-        println!("moadim is not running; starting a fresh instance");
+        if !json {
+            println!("moadim is not running; starting a fresh instance");
+        }
         None
     };
     let new_pid = spawn_detached()?;
-    // Headline the rotation so scripts/logs can see the process actually changed.
-    println!("{}", restart_rotation_line(old_pid, new_pid));
-    report_endpoints();
+    if json {
+        println!("{}", restart_json(old_pid, new_pid));
+    } else {
+        // Headline the rotation so scripts/logs can see the process actually changed.
+        println!("{}", restart_rotation_line(old_pid, new_pid));
+        report_endpoints();
+    }
     Ok(())
 }
 
@@ -305,6 +321,17 @@ pub fn restart() -> anyhow::Result<()> {
 fn restart_rotation_line(old: Option<u32>, new: u32) -> String {
     let old = old.map_or_else(|| "none".to_string(), |pid| pid.to_string());
     format!("restarted: pid {old} -> {new}")
+}
+
+/// Render the `restart` result as a one-line JSON object: `{"old":N|null,"new":M}`, mirroring
+/// [`stop_json`]'s shape. `old` is the PID of the server that was stopped (`null` when nothing was
+/// running); `new` is the freshly spawned server's PID.
+fn restart_json(old: Option<u32>, new: u32) -> String {
+    serde_json::json!({
+        "old": old,
+        "new": new,
+    })
+    .to_string()
 }
 
 /// Spawn a detached server process and print where to reach and manage it.

--- a/src/cli_tests.rs
+++ b/src/cli_tests.rs
@@ -340,7 +340,15 @@ fn liveness_exit_code_maps_running_to_codes() {
 
 #[test]
 fn restart_command() {
-    assert_eq!(parse(argv(&["restart"])), Command::Restart);
+    assert_eq!(parse(argv(&["restart"])), Command::Restart { json: false });
+}
+
+#[test]
+fn restart_command_with_json_flag() {
+    assert_eq!(
+        parse(argv(&["restart", "--json"])),
+        Command::Restart { json: true }
+    );
 }
 
 #[test]
@@ -391,6 +399,17 @@ fn restart_rotation_line_reads_none_when_nothing_was_running() {
         restart_rotation_line(None, 456),
         "restarted: pid none -> 456"
     );
+}
+
+#[test]
+fn restart_json_reports_old_and_new_pid() {
+    let value: serde_json::Value = serde_json::from_str(&restart_json(Some(123), 456)).unwrap();
+    assert_eq!(value["old"], serde_json::json!(123));
+    assert_eq!(value["new"], serde_json::json!(456));
+
+    let fresh: serde_json::Value = serde_json::from_str(&restart_json(None, 456)).unwrap();
+    assert!(fresh["old"].is_null());
+    assert_eq!(fresh["new"], serde_json::json!(456));
 }
 
 #[test]
@@ -1035,7 +1054,16 @@ fn restart_starts_fresh_when_none_running() {
     let home = temp_home("restart-fresh");
     let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", home.to_str().unwrap());
     let _addr = EnvGuard::set(BIND_ADDR_ENV, UNREACHABLE_ADDR);
-    restart().unwrap();
+    restart(false).unwrap();
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+#[test]
+fn restart_json_skips_human_text_when_none_running() {
+    let home = temp_home("restart-fresh-json");
+    let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", home.to_str().unwrap());
+    let _addr = EnvGuard::set(BIND_ADDR_ENV, UNREACHABLE_ADDR);
+    restart(true).unwrap();
     let _ = std::fs::remove_dir_all(&home);
 }
 
@@ -1049,7 +1077,21 @@ fn restart_replaces_running_server() {
     let _poll = EnvGuard::set("MOADIM_RESTART_POLL_MS", "10");
     write_pid_file().unwrap();
     server.stop_after(Duration::from_millis(80));
-    restart().unwrap();
+    restart(false).unwrap();
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+#[test]
+fn restart_json_reports_old_pid_when_running() {
+    let server = FakeServer::start(200, String::new());
+    let home = temp_home("restart-running-json");
+    let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", home.to_str().unwrap());
+    let _addr = EnvGuard::set(BIND_ADDR_ENV, &server.addr);
+    let _timeout = EnvGuard::set("MOADIM_RESTART_TIMEOUT_MS", "2000");
+    let _poll = EnvGuard::set("MOADIM_RESTART_POLL_MS", "10");
+    write_pid_file().unwrap();
+    server.stop_after(Duration::from_millis(80));
+    restart(true).unwrap();
     let _ = std::fs::remove_dir_all(&home);
 }
 
@@ -1218,7 +1260,7 @@ fn restart_errors_when_stop_running_times_out() {
     let _addr = EnvGuard::set(BIND_ADDR_ENV, &server.addr);
     let _timeout = EnvGuard::set("MOADIM_RESTART_TIMEOUT_MS", "1");
     let _poll = EnvGuard::set("MOADIM_RESTART_POLL_MS", "1");
-    assert!(restart().is_err());
+    assert!(restart(false).is_err());
     let _ = std::fs::remove_dir_all(&home);
 }
 
@@ -1231,7 +1273,7 @@ fn restart_errors_when_spawn_detached_fails() {
     std::fs::write(base.join(".config/moadim"), "block").unwrap();
     let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", base.to_str().unwrap());
     let _addr = EnvGuard::set(BIND_ADDR_ENV, UNREACHABLE_ADDR);
-    assert!(restart().is_err());
+    assert!(restart(false).is_err());
     let _ = std::fs::remove_dir_all(&base);
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ async fn main() -> anyhow::Result<()> {
         cli::Command::Stop { json, quiet } => std::process::exit(cli::stop(json, quiet)?),
         cli::Command::Trigger { id } => std::process::exit(cli::trigger(id)?),
         cli::Command::Background => cli::run_background(),
-        cli::Command::Restart => cli::restart(),
+        cli::Command::Restart { json } => cli::restart(json),
         cli::Command::Install => service::install(),
         cli::Command::Uninstall => uninstall(),
         cli::Command::Data(args) => std::process::exit(commands::run(args)),


### PR DESCRIPTION
## Why

`status`, `cleanup`, and `stop` all have a `--json` flag for machine-readable
output; `restart` was the one lifecycle command still human-text-only. It's
called out explicitly in `TODO.md`:

> Have `moadim restart` emit its PID-rotation summary as a `--json` object
> (`{"old":N|null,"new":M}`) too, mirroring the `status`/`cleanup` `--json`
> contract

so scripts driving a restart can parse the old/new PID instead of scraping
`restarted: pid <old> -> <new>`.

(Note: `TODO.md` also lists a `restart --interactive` flavor — that's a
different flag and already covered by open PR #813; this PR only adds
`--json`.)

## What

- `Command::Restart` now carries a `json: bool`, parsed via the same
  `wants_json` helper `stop`/`status`/`cleanup` already use.
- `restart(json)` prints `{"old":N|null,"new":M}` and skips the
  human-readable lines (and `report_endpoints()`) when `json` is set,
  otherwise unchanged.
- Updated `--help` usage and the README command table/usage block.
- Added a changeset.

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D
  warnings`, `cargo test` all pass locally.
- `cargo llvm-cov` shows `cli.rs` at 100% line coverage; the only repo-wide
  gaps are pre-existing (`main.rs`, `routines/service.rs`,
  `routines/flags.rs`) and unrelated to this change.

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.