### PR TITLE
chore(ci): bump crate-ci/typos action from v1.47.2 to v1.48.0

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -33,4 +33,4 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Spell check with typos
-        uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89 # v1.47.2
+        uses: crate-ci/typos@bee27e3a4fd1ea2111cf90ab89cd076c870fce14 # v1.48.0


### PR DESCRIPTION
## Why

`spellcheck.yml` pins `crate-ci/typos` to `v1.47.2` (2026-06-04). Upstream has
since shipped `v1.48.0` (2026-06-30, dictionary-only update per the release
notes), and Homebrew's `typos-cli` formula is already on `1.48.0`, so the
pinned SHA in this repo is one release behind.

## Change

Bumps the pinned commit SHA + version comment on `spellcheck.yml`'s single
`crate-ci/typos` step, verified against the tag's resolved commit via the
GitHub API (`v1.48.0` → `bee27e3a4fd1ea2111cf90ab89cd076c870fce14`).

## Verified locally

- Upgraded local `typos-cli` from `1.42.3` to `1.48.0` via `brew upgrade` and
  ran `typos` against the full repo — zero findings, so the newer dictionary
  introduces no new false positives here.
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `actionlint .github/workflows/spellcheck.yml`
- YAML syntax check (`python3 -c "import yaml; yaml.safe_load(...)"`)

No `src/`/`ui/` changes, so no changeset is needed (the changelog gate only
fires on those paths).

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim. cc @tupe12334