### PR TITLE
fix(server): add panic-recovery layer so a handler panic returns 500 (#337)

### DIFF
--- a/.changeset/http-panic-recovery-layer.md
+++ b/.changeset/http-panic-recovery-layer.md
@@ -1,0 +1,11 @@
+---
+"moadim": patch
+---
+
+### Fixed
+
+- **A panicking HTTP handler no longer resets the connection with no response.**
+  Added `tower_http::catch_panic::CatchPanicLayer` as the outermost layer of
+  the Axum router, so an unexpected panic inside a handler now yields a plain
+  `500 Internal Server Error` response instead of the client seeing a dropped
+  connection and the server logging nothing (issue #337).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2400,14 +2400,17 @@ dependencies = [
  "bitflags 2.13.0",
  "bytes",
  "futures-core",
+ "futures-util",
  "http 1.4.2",
  "http-body",
+ "http-body-util",
  "percent-encoding",
  "pin-project-lite",
  "tokio",
  "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ toml = "1.1"
 rmcp = { version = "2.0.0", features = ["server", "macros", "transport-io", "transport-streamable-http-server"] }
 schemars = "1"
 tokio = { version = "1", features = ["full"] }
-tower-http = { version = "0.7", features = ["compression-gzip"] }
+tower-http = { version = "0.7", features = ["catch-panic", "compression-gzip"] }
 utoipa = { version = "5", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "9", features = ["axum"] }
 uuid = { version = "1", features = ["v4"] }

--- a/src/routes/http.rs
+++ b/src/routes/http.rs
@@ -19,6 +19,7 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
 use std::sync::{Arc, LazyLock};
+use tower_http::catch_panic::CatchPanicLayer;
 use tower_http::compression::CompressionLayer;
 use utoipa_swagger_ui::SwaggerUi;
 
@@ -408,6 +409,10 @@ pub(crate) fn build_app_with_shutdown(
         // (notably the ~1.1 MB SPA `index.html` and the OpenAPI JSON under `/docs`). A no-op
         // for clients that don't advertise gzip support (issue #399).
         .layer(CompressionLayer::new())
+        // Outermost of all: a panicking handler would otherwise unwind straight through Hyper,
+        // resetting the connection with no response and no logged error (issue #337). Catch it
+        // here and answer with a plain 500 instead.
+        .layer(CatchPanicLayer::new())
         .with_state(app_state)
 }
 

--- a/src/routes/http_tests.rs
+++ b/src/routes/http_tests.rs
@@ -3,10 +3,11 @@
 use axum::{
     body::Body,
     http::{header::CONTENT_TYPE, Request, StatusCode},
-    routing::post,
+    routing::{get, post},
     Router,
 };
 use tower::ServiceExt;
+use tower_http::catch_panic::CatchPanicLayer;
 
 use super::{build_app, echo, health, run_with_listener_until, write_openapi_spec, AppState};
 use crate::utils::time::now_secs;
@@ -1402,4 +1403,26 @@ async fn build_app_restart_route_returns_500_when_spawn_fails() {
         StatusCode::INTERNAL_SERVER_ERROR,
         "restart route should return 500 when spawn_restart fails"
     );
+}
+
+/// `CatchPanicLayer` is what stands between a panicking handler and a reset connection with no
+/// response (issue #337). `build_app`'s production routes never panic deliberately, so exercise
+/// the layer directly on a minimal router wired the same way, confirming it turns a panic into a
+/// plain 500 instead of the request erroring out.
+#[tokio::test]
+async fn catch_panic_layer_turns_a_handler_panic_into_a_500() {
+    async fn boom() -> StatusCode {
+        panic!("intentional test panic")
+    }
+
+    let app = Router::new()
+        .route("/boom", get(boom))
+        .layer(CatchPanicLayer::new());
+
+    let resp = app
+        .oneshot(Request::builder().uri("/boom").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }


### PR DESCRIPTION
## What

Adds `tower_http::catch_panic::CatchPanicLayer` as the outermost layer of the Axum router. Previously, a panicking HTTP handler would unwind straight through Hyper, resetting the connection with **no response and no logged error** — closes #337.

## Why

The router had no panic-recovery layer at all (confirmed by grepping `tower-http`'s enabled Cargo features and the `.layer(...)` chain in `src/routes/http.rs` — only `compression-gzip` was enabled, no `catch-panic`). A client hitting a panicking handler would just see the connection drop, and operators would get no `500` and no log line pointing at the failure — a real observability/robustness gap, not a hypothetical one.

## Change

- `Cargo.toml`: enable the `catch-panic` feature on the already-present `tower-http` dependency (no new dependency).
- `src/routes/http.rs`: add `.layer(CatchPanicLayer::new())` as the outermost layer (after compression), so it wraps every inner layer/handler.
- `src/routes/http_tests.rs`: new test `catch_panic_layer_turns_a_handler_panic_into_a_500` builds a minimal router wired the same way with a deliberately panicking handler and asserts the response is `500` instead of the request erroring out.

## Verification

```
cargo fmt --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test                                   # 687 passed
cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'   # 100.00% lines, gate passes
```

## Changeset

Added `.changeset/http-panic-recovery-layer.md` (patch bump) per the repo's Changesets convention.

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.