### PR TITLE
docs: remove stale prompt field row from routines table in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,6 @@ git-trackable:
 | `schedule`     | string | yes      | Cron expression (`min hour dom month dow` or `@daily`, …), evaluated in the host's local timezone — **not** UTC. |
 | `title`        | string | yes      | Human name; slugified to name the run workbench and tmux session.                            |
 | `agent`        | string | yes      | Agent registry key (e.g. `claude`), resolved from `~/.config/moadim/agents/<agent>.toml`.    |
-| `prompt`       | string | yes      | The task prompt handed to the agent.                                                          |
 | `repositories` | list   | no       | Git repos listed in the prompt as context. Moadim does **not** clone them — the agent does.   |
 | `enabled`      | bool   | no       | Defaults to `true`. Set `false` to pause without deleting.                                    |
 | `ttl_secs`     | int    | no       | How long a finished run's workbench is retained before auto-cleanup. Caps the cron-derived retention lower — it can only shorten, never extend it. `None` uses the cron-derived value. |


### PR DESCRIPTION
PR #865 moved routine prompts out of `routine.toml` into `prompts/prompt.pure.md` and `prompts/prompt.compiled.md`, and correctly updated the two tree diagrams in the "Routines" section of README.md to reflect that (`routine.toml` is now annotated as tracking `schedule, agent, repositories`, with prompt content moved to the `prompts/` sidecar files).

However, the field table just below those diagrams still had a stale `prompt` row, contradicting both diagrams above it and the `RoutineToml.prompt` doc comment in `src/routine_storage.rs`, which explicitly documents the field as "Read-only / legacy" and `skip_serializing` (never written back to `routine.toml`).

This PR removes that stale table row so the docs are internally consistent. No other content was touched.

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.
cc @tupe12334