### PR TITLE
fix(ui): fluid sizing for modals, filter bar, nav, and heatmap

### DIFF
--- a/.changeset/ui-responsive-adjustable-sizing.md
+++ b/.changeset/ui-responsive-adjustable-sizing.md
@@ -1,0 +1,11 @@
+---
+"moadim": patch
+---
+
+### Changed
+
+- Made the web UI's fixed-pixel dimensions fluid: command palette, modals,
+  confirm dialog, filter input, and calendar/day nav widths now use
+  `clamp()` instead of a single fixed width, and the schedule heatmap
+  shrinks its cell/label sizing under 640px instead of relying only on
+  horizontal scroll.

--- a/ui/index.html
+++ b/ui/index.html
@@ -244,8 +244,7 @@
     .cmdk {
       align-self: flex-start;
       margin-top: 11vh;
-      width: 560px;
-      max-width: 92vw;
+      width: clamp(280px, 90vw, 560px);
       background: var(--bg-2);
       border: 1px solid var(--border-hi);
       box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
@@ -720,8 +719,7 @@
     .modal {
       background: var(--bg-2);
       border: 1px solid var(--border-hi);
-      width: 540px;
-      max-width: 92vw;
+      width: clamp(280px, 90vw, 540px);
       max-height: 88vh;
       overflow-y: auto;
       transform: translateY(10px);
@@ -861,8 +859,7 @@
       background: var(--bg-2);
       border: 1px solid var(--red);
       padding: 22px;
-      width: 350px;
-      max-width: 92vw;
+      width: clamp(240px, 90vw, 350px);
       transform: translateY(8px);
       transition: transform 0.15s;
     }
@@ -1124,7 +1121,7 @@
       font-family: var(--mono);
       font-size: 12px;
       padding: 6px 10px;
-      min-width: 240px;
+      min-width: clamp(140px, 40vw, 240px);
       outline: none;
       transition: border-color 0.12s;
     }
@@ -1203,7 +1200,7 @@
       font-size: 12px;
       letter-spacing: 0.14em;
       color: var(--text-hi);
-      min-width: 150px;
+      min-width: clamp(90px, 30vw, 150px);
       text-align: center;
     }
     .cal-nav .btn-ghost { margin-left: auto; }
@@ -1284,7 +1281,7 @@
       font-size: 12px;
       letter-spacing: 0.14em;
       color: var(--text-hi);
-      min-width: 180px;
+      min-width: clamp(110px, 35vw, 180px);
       text-align: center;
     }
     .day-nav .btn-ghost { margin-left: auto; }
@@ -1546,6 +1543,11 @@
       width: 100%;
       min-width: 720px;
       table-layout: fixed;
+    }
+    @media (max-width: 640px) {
+      table.heatmap { min-width: 480px; }
+      .hm-daylabel { width: 40px; }
+      .hm-cell { height: 16px; font-size: 8px; }
     }
     table.heatmap th, table.heatmap td { padding: 0; }
     .hm-corner, .hm-hcol {


### PR DESCRIPTION
## Summary
- Fixes #886 (starter pass, not full close — see remaining scope below)
- Swap several fixed px widths in `ui/index.html` to `clamp()` so they scale fluidly with viewport instead of jumping at a single `max-width: 92vw` cutoff: command palette, modal, confirm dialog, filter input, calendar month label, day nav label.
- Add a `max-width: 640px` breakpoint for the schedule heatmap that shrinks cell height/font and the day-label column, so narrow screens get a readable compact table instead of only horizontal scroll.

## Remaining scope (tracked in #886)
- Routines table itself still relies on horizontal scroll on narrow viewports — no compact/stacked layout yet.
- No user-adjustable (resizable) panels — this PR only makes existing fixed sizes fluid, not draggable/resizable.

## Test plan
- [x] `cargo build --target wasm32-unknown-unknown` in `ui/` succeeds
- [ ] Manually check modal/palette/heatmap at a few viewport widths (browser devtools) after merge