### PR TITLE
ci(publish): adopt crates.io Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,9 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # required for crates.io Trusted Publishing (OIDC)
+      contents: read
     env:
       TAG: ${{ inputs.tag || github.ref_name }}
     steps:
@@ -70,5 +73,11 @@ jobs:
             exit 1
           fi
 
+      - name: Authenticate with crates.io (Trusted Publishing)
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+        id: auth
+
       - name: Publish
-        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --allow-dirty
+        run: cargo publish --allow-dirty
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,6 +169,9 @@ detects the new version, pushes the `vx.y.z` tag, then publishes to crates.io
 must not already exist, and `Cargo.toml`'s version must match the topmost
 changelog heading. Pushing a `v*` tag by hand still works as a fallback.
 
+`publish.yml` authenticates to crates.io via [Trusted Publishing](https://crates.io/docs/trusted-publishing)
+(OIDC) — no `CARGO_REGISTRY_TOKEN` secret involved.
+
 ## Code conventions
 
 - New REST routes go in `src/routes/http.rs`; register them in the router


### PR DESCRIPTION
## Summary

Replaces the long-lived `CARGO_REGISTRY_TOKEN` secret in `publish.yml` with crates.io [Trusted Publishing](https://crates.io/docs/trusted-publishing) (OIDC):

- Adds `permissions: id-token: write` (plus `contents: read`) to the `publish` job.
- Adds a step using `rust-lang/crates-io-auth-action@v1.0.5` (pinned by SHA, matching this repo's existing action-pinning convention) to mint a short-lived token via OIDC.
- `cargo publish` now uses that short-lived token via `CARGO_REGISTRY_TOKEN` env (set from the action's output) instead of `--token ${{ secrets.CARGO_REGISTRY_TOKEN }}`.
- Adds a short note to `CONTRIBUTING.md` documenting that publishing now relies on Trusted Publishing.

## Not done here (needs a human with crates.io dashboard access)

- Configuring Trusted Publishing for the `moadim` crate on crates.io (crate Settings → Trusted Publishing → add `moadim-io/daemon` + `publish.yml`) — this is an external, one-time dashboard step this PR cannot perform.
- Deleting the `CARGO_REGISTRY_TOKEN` repo secret — should happen only after a release verifies the new flow works end-to-end.

Closes #488

## Test plan

- [x] YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish.yml'))"`)
- [x] `actionlint .github/workflows/publish.yml` clean
- [ ] Verify end-to-end on the next real release, once Trusted Publishing is configured on crates.io for this crate

This pull request was opened by the Open issues → fix PRs (owned repos + my orgs) routine of moadim.

cc @tupe12334