### PR TITLE
fix(docs): fix broken intra-doc link to private crate::sync::crontab_bin

### DIFF
--- a/.changeset/fix-doc-broken-intra-link.md
+++ b/.changeset/fix-doc-broken-intra-link.md
@@ -1,0 +1,13 @@
+---
+"moadim": patch
+---
+
+### Fixed
+
+- **`cargo doc` no longer fails on `main`.** The doc comment on `sh_bin()` in
+  `src/routines/service.rs` used an intra-doc link
+  (`` [`crate::sync::crontab_bin`] ``) to a private, unexported function,
+  which rustdoc can never resolve even with `--document-private-items`. This
+  tripped `#![deny(warnings)]` and broke the `cargo doc` CI check (and any
+  local `cargo doc` / `cargo install moadim` doc build) on every PR
+  regardless of what it touched. Replaced the broken link with plain text.

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -589,8 +589,8 @@ pub fn svc_trigger_scheduled(store: &RoutineStore, id: &str) -> Result<Routine, 
 ///
 /// In **test builds**, when no `MOADIM_SH_BIN` shim is configured this never falls back to the
 /// real `sh`: it returns a path that cannot exist, so the spawn fails harmlessly instead of
-/// launching a real agent process. This closes the same structural gap `crontab_bin()`
-/// ([`crate::sync::crontab_bin`]) closes for crontab I/O (issue #175) — a test that forgets to
+/// launching a real agent process. This closes the same structural gap `crontab_bin()` in
+/// `crate::sync` closes for crontab I/O (issue #175) — a test that forgets to
 /// clear `PATH` or shim this binary still cannot execute a real command on the developer's
 /// machine (issue #217). Tests that need a working spawn set `MOADIM_SH_BIN` to a shim.
 fn sh_bin() -> String {


### PR DESCRIPTION
## Why

`cargo doc` currently fails on `main`. The doc comment on `sh_bin()` in
`src/routines/service.rs` links to `[`crate::sync::crontab_bin`]`, but
`crontab_bin()` in `src/sync/mod.rs` is a bare private `fn` — rustdoc can
never resolve that intra-doc link, even with `--document-private-items`.
Because the crate denies warnings (`#![deny(warnings)]`), this turns into
a hard build failure:

```
error: unresolved link to `crate::sync::crontab_bin`
   --> src/routines/service.rs:593:8
error: could not document `moadim`
```

This is a standing break, unrelated to any in-flight PR's own diff — it
fails `.github/workflows/doc.yml`'s `cargo doc --workspace --no-deps
--document-private-items` (with `RUSTDOCFLAGS=-D warnings`) on every
open and new PR regardless of what that PR touches, and also breaks a
local `cargo doc --open` / the docs shipped with `cargo install moadim`.

Filed as issue #894, which recommended dropping the intra-doc link
syntax (lower risk than making `crontab_bin` `pub(crate)`, since its
privacy looks intentional).

## What

Replaced the broken `[`crate::sync::crontab_bin`]` intra-doc link with
plain text (`` `crontab_bin()` in `crate::sync` ``) in the doc comment
on `sh_bin()`.

## Verification

- `cargo fmt --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items` — now passes (previously failed with the error above), matching the exact CI command in `doc.yml`

Added a changeset (`patch`) per repo convention.

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.

cc @tupe12334