### PR TITLE
test(routines): cover flags.rs create_dir/read/remove error paths

### DIFF
--- a/.changeset/test-flags-io-error-paths.md
+++ b/.changeset/test-flags-io-error-paths.md
@@ -1,0 +1,14 @@
+---
+"moadim": patch
+---
+
+### Tests
+
+- **Covered `routines::flags`'s I/O error paths.** `create_flag`,
+  `list_flags`, and `resolve_flag` each have a filesystem-error branch
+  (a failed `create_dir_all`, `read_to_string`, or `remove_file`) that
+  `cargo llvm-cov` region coverage showed had zero executions. Added three
+  tests exercising each: `create_flag_propagates_create_dir_failure`,
+  `list_flags_skips_entries_it_cant_read_as_text`, and
+  `resolve_flag_propagates_remove_failure`. No behavior change — this locks
+  the existing error handling in against a future regression.

--- a/src/routines/flags_tests.rs
+++ b/src/routines/flags_tests.rs
@@ -114,6 +114,29 @@ fn create_flag_propagates_write_failure() {
 }
 
 #[test]
+fn create_flag_propagates_create_dir_failure() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let _home = TempHome::set();
+    let routines_dir = crate::paths::routines_dir();
+    std::fs::create_dir_all(&routines_dir).unwrap();
+    // Strip write permission so `create_dir_all` inside `create_flag` can't create the
+    // routine's own directory (let alone the `flags/` dir nested under it).
+    let mut perms = std::fs::metadata(&routines_dir).unwrap().permissions();
+    perms.set_mode(0o555);
+    std::fs::set_permissions(&routines_dir, perms).unwrap();
+
+    let result = create_flag("r1", "bug", "broken", FlagScope::General);
+
+    // Restore write permission so the temp-home cleanup can remove everything.
+    let mut perms = std::fs::metadata(&routines_dir).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&routines_dir, perms).unwrap();
+
+    assert!(result.is_err());
+}
+
+#[test]
 fn list_flags_returns_empty_for_missing_dir() {
     let _home = TempHome::set();
     assert!(list_flags("no-such-routine").is_empty());
@@ -163,6 +186,22 @@ fn list_flags_skips_unparsable_filenames() {
 }
 
 #[test]
+fn list_flags_skips_entries_it_cant_read_as_text() {
+    let _home = TempHome::set();
+    let dir = crate::paths::routine_flags_dir("r1");
+    std::fs::create_dir_all(&dir).unwrap();
+    // A directory whose name matches the `{type}-{timestamp}.md` shape: it parses fine, but
+    // `read_to_string` fails on it (it's not a regular file), so it must be skipped rather
+    // than propagating an error out of `list_flags`.
+    std::fs::create_dir(dir.join("bug-999.md")).unwrap();
+    std::fs::write(dir.join("bug-100.md"), "bug\n\nreal\n").unwrap();
+
+    let flags = list_flags("r1");
+    assert_eq!(flags.len(), 1);
+    assert_eq!(flags[0].description, "real");
+}
+
+#[test]
 fn list_flags_defaults_missing_description_to_empty() {
     let _home = TempHome::set();
     let dir = crate::paths::routine_flags_dir("r1");
@@ -192,6 +231,29 @@ fn resolve_flag_missing_file_returns_false() {
     let _home = TempHome::set();
     let resolved = resolve_flag("r1", "bug-123.md").unwrap();
     assert!(!resolved);
+}
+
+#[test]
+fn resolve_flag_propagates_remove_failure() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let _home = TempHome::set();
+    let flag = create_flag("r1", "bug", "broken", FlagScope::General).unwrap();
+    let dir = crate::paths::routine_flags_dir("r1");
+    // Deleting a file requires write permission on its *containing* directory, not the file
+    // itself, so stripping it here forces `remove_file` inside `resolve_flag` to fail.
+    let mut perms = std::fs::metadata(&dir).unwrap().permissions();
+    perms.set_mode(0o555);
+    std::fs::set_permissions(&dir, perms).unwrap();
+
+    let result = resolve_flag("r1", &flag.filename);
+
+    // Restore write permission so the temp-home cleanup can remove everything.
+    let mut perms = std::fs::metadata(&dir).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&dir, perms).unwrap();
+
+    assert!(result.is_err());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Surveyed the ~96 currently-open PRs and open issues first to avoid duplicating in-flight work. `fmt`/`clippy`/`cargo test`/the 100%-line-coverage gate are all already green on `main` (no broken gate to fix), and there was no existing PR touching `routines::flags`'s I/O error paths (PR #889 already covers `parse_filename`'s two malformed-filename branches, which this PR does not touch).

`cargo llvm-cov` region coverage showed three filesystem-error branches in `src/routines/flags.rs` with zero executions:

- `create_flag`'s `create_dir_all(&dir)?` (line 104)
- `list_flags`'s `read_to_string(entry.path()).ok()?` (line 144)
- `resolve_flag`'s `remove_file(&path)?` (line 174)

This adds one test per branch, reusing the same permission-based failure-injection pattern already established in this file's `create_flag_propagates_write_failure` test:

- `create_flag_propagates_create_dir_failure` — strips write permission on `routines_dir()` so `create_dir_all` fails.
- `list_flags_skips_entries_it_cant_read_as_text` — seeds a directory whose name matches the `{type}-{timestamp}.md` shape, so `read_to_string` fails on it and it must be silently skipped.
- `resolve_flag_propagates_remove_failure` — strips write permission on the flags dir so `remove_file` fails.

No behavior change — this locks the existing error handling in against a future regression (e.g. someone swapping a `?` for `.unwrap()`).

Region coverage for `routines/flags.rs` improved from 96.32% to 98.53% (the remaining 2 missed regions are `parse_filename`'s branches, already claimed by open PR #889). Line coverage stays at 100% (excluding `main.rs`, per the repo's gate).

## Checks run locally

- `cargo build`
- `cargo test` (719 passed, up from 716 on `main`)
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (100% line coverage maintained)
- Full `.githooks/pre-push` hook (test-file convention, fmt, clippy, coverage, changeset check) — all passed

Added a changeset (`patch`, package `moadim`) per repo convention.

---

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.

cc @tupe12334 if you'd like to take a look.