### PR TITLE
docs(cli): fix stale stop_json doc claiming exact status --json parity

### DIFF
--- a/.changeset/fix-stop-json-doc-drift.md
+++ b/.changeset/fix-stop-json-doc-drift.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+### Fixed
+
+- **Corrected the `stop_json` doc comment's stale claim.** It said `stop --json`'s shape matches
+  `status --json` "exactly", but `status --json` later gained `uptime_secs`/`version` fields that
+  `stop --json` never got — the two shapes are a subset relationship (already enforced by
+  `status_and_stop_json_share_a_common_key_set`), not an exact match. Doc-only; no behavior change.

--- a/TODO.md
+++ b/TODO.md
@@ -11,8 +11,6 @@ This is a list of todos for consumption, in a pr remove the todo you have implem
 - Have a commands folder for all the cli commands, we want to work with colocation of files
 - Add a TTL preset row (1h / 1d / 7d / 30d) under the WORKBENCH TTL input in the routine form, mirroring the cron schedule presets
 - Show a humanized retention countdown ("expires in 2d" / "expired") per finished run in the routine LOGS view, derived from the run's finish time and the routine's effective TTL
-- Enrich `moadim status --json` with the server's liveness details from `GET /health` (e.g. `uptime_secs`) so a single call returns running-state + age, not just the local PID
-- Add a `cli_tests` assertion that `status --json` and `stop --json` produce the SAME set of object keys, so the two shapes can't silently drift apart again as fields are added
 - Add a CLI integration test (spawn a real listener on an ephemeral port, point the probe at it) that exercises the `status`/`cleanup`/`stop` network paths end-to-end, lifting `cli.rs` off its ~27% coverage floor toward the repo's 100% line-coverage gate
 - Add a `moadim restart --interactive` (or `-i`) flavor that restarts the daemon in the foreground attached to the terminal instead of detached, mirroring `moadim -i`
 - Have `moadim restart` emit its PID-rotation summary as a `--json` object (`{"old":N|null,"new":M}`) too, mirroring the `status`/`cleanup` `--json` contract

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -390,12 +390,14 @@ pub fn stop(json: bool, quiet: bool) -> anyhow::Result<i32> {
 }
 
 /// Render the `stop` result as a one-line JSON object:
-/// `{"running":bool,"pid":N|null,"address":…}`, matching `status --json`'s shape exactly so both
-/// can be parsed uniformly. `running` is `true` when a running server was asked to shut down, and
-/// `false` when none was reachable. `pid` is the process that was stopped (read from the pid file
-/// before the shutdown request), or `null` when no pid file was present. `address` is the bound
-/// address the request was sent to ([`bind_addr`], honoring the `MOADIM_BIND_ADDR` override) so it
-/// stays identical to `status --json` under a non-default bind.
+/// `{"running":bool,"pid":N|null,"address":…}` — a subset of `status --json`'s shape (which
+/// additionally folds in server-sourced `uptime_secs`/`version`; see
+/// `status_and_stop_json_share_a_common_key_set`), so both can still be parsed uniformly on their
+/// shared fields. `running` is `true` when a running server was asked to shut down, and `false`
+/// when none was reachable. `pid` is the process that was stopped (read from the pid file before
+/// the shutdown request), or `null` when no pid file was present. `address` is the bound address
+/// the request was sent to ([`bind_addr`], honoring the `MOADIM_BIND_ADDR` override) so it stays
+/// identical to `status --json` under a non-default bind.
 fn stop_json(running: bool, pid: Option<u32>) -> String {
     serde_json::json!({
         "running": running,


### PR DESCRIPTION
## Why

`stop_json`'s doc comment claims its shape matches `status --json` "exactly." That was true when written, but `status --json` later gained server-sourced `uptime_secs`/`version` fields (folded in from `GET /health`) that `stop --json` never got — `stop` has no live health probe to source them from. The actual, tested contract is a subset relationship: every key `stop --json` emits also appears in `status --json` (enforced by `status_and_stop_json_share_a_common_key_set` in `cli_tests.rs`), not an exact match.

This PR only corrects the doc comment to describe the real contract, and prunes two `TODO.md` items it turns out are already done:
- "Enrich `moadim status --json` with liveness details from `GET /health`" — already shipped (`uptime_secs`/`version`).
- "Add a `cli_tests` assertion that `status --json`/`stop --json` share the SAME set of keys" — already covered by `status_and_stop_json_share_a_common_key_set` (as a subset check, matching the corrected doc).

No behavior change — doc comment + `TODO.md` only. `cargo fmt`, `cargo clippy -- -D warnings`, and `cargo test` all pass locally.

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.