### PR TITLE
test(routine_storage): fix gitignore-write-error test to hit its own branch

### DIFF
--- a/.changeset/fix-gitignore-write-error-test.md
+++ b/.changeset/fix-gitignore-write-error-test.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Fix `write_routine_fails_on_gitignore_write_error` to actually exercise the `.gitignore` write-failure branch it claims to cover, instead of accidentally failing one line earlier on the `prompts/` subdir creation.

--- a/src/routine_storage_tests.rs
+++ b/src/routine_storage_tests.rs
@@ -1085,14 +1085,20 @@ fn load_routine_from_dir_missing_agent_returns_none() {
 #[test]
 fn write_routine_fails_on_gitignore_write_error() {
     use std::os::unix::fs::PermissionsExt as _;
-    // Covers L155: `std::fs::write(&gitignore, ..)? ` — the dir exists but is read-only
-    // (and `.gitignore` is absent), so writing it fails and the error is propagated.
+    // Covers L202: `std::fs::write(&gitignore, ..)? ` — the dir (and its `prompts/`
+    // subdir) already exist but the dir is read-only, and `.gitignore` is absent, so
+    // writing it fails and the error is propagated.
+    //
+    // The `prompts/` subdir must be pre-created: `write_routine` calls
+    // `create_dir_all(routine_prompts_dir(&slug))` *before* the `.gitignore` write, and
+    // creating a not-yet-existing subdir under a read-only parent fails first, which
+    // would exercise that branch instead of the intended gitignore-write branch below.
     with_override_home(|_home| {
         let title = "Rs Gitignore Fail Routine";
         let slug = slugify(title);
         let dir = crate::paths::routine_dir(&slug);
-        // Create dir without a .gitignore, then lock it.
-        std::fs::create_dir_all(&dir).unwrap();
+        // Create dir and prompts/ without a .gitignore, then lock the dir.
+        std::fs::create_dir_all(crate::paths::routine_prompts_dir(&slug)).unwrap();
         std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o555)).unwrap();
 
         let result = write_routine(&make_routine("rs-gitignore-fail-id", title));


### PR DESCRIPTION
## What

`write_routine_fails_on_gitignore_write_error` in `src/routine_storage_tests.rs` was meant to cover the `std::fs::write(&gitignore, ..)?` failure branch in `write_routine` (`src/routine_storage.rs`, the `.gitignore` write). Its comment even said so ("Covers L155").

## Why

The test only created the routine dir itself before chmod'ing it read-only (`0o555`). But `write_routine` also does `create_dir_all(routine_prompts_dir(&slug))` *before* the `.gitignore` write, and that call needs to create a brand-new `prompts/` subdir — which fails first on a read-only parent. So the test's `assert!(result.is_err())` was passing for the wrong reason: it was exercising the `prompts/` dir-creation failure, not the `.gitignore`-write failure it claimed to cover. Verified this concretely: `cargo llvm-cov` region coverage for `routine_storage.rs` showed the `.gitignore` write line (now L202, coverage count 0) as never executed even with this test present and passing.

## Fix

Pre-create the `prompts/` subdir (via `create_dir_all(routine_prompts_dir(&slug))`) before locking the dir, so `write_routine`'s own `create_dir_all` calls are no-ops and execution actually reaches the `.gitignore` write, which then fails as intended. Confirmed with `cargo llvm-cov`: `routine_storage.rs` missed-regions count drops from 1 to 0 after this change, and all 719 tests still pass.

## Checks run locally
- `cargo fmt --check`: pass
- `cargo clippy --workspace --all-targets -- -D warnings`: pass
- `cargo test`: 719 passed
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main.rs'`: 100% line coverage, and the targeted region gap in `routine_storage.rs` is now closed

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs routine of moadim.