### PR TITLE
fix(health): surface missing python3 dependency instead of failing silently

### DIFF
--- a/.changeset/health-python3-dependency.md
+++ b/.changeset/health-python3-dependency.md
@@ -1,0 +1,7 @@
+---
+"moadim": patch
+---
+
+### Added
+
+`GET /health`'s `dependencies` now also reports `python3` (alongside the existing `tmux` flag), and the daemon logs a startup warning when it is missing. The built-in `claude` agent's `setup` step depends on `python3` to pre-seed workspace-trust state; previously a missing `python3` failed that step silently, with the routine still showing a healthy status.

--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ building and installing:
 | `tmux`     | launching routine agents — every scheduled routine starts its agent inside a tmux session. **Without `tmux`, routine runs silently fail to launch.** | `brew install tmux` (macOS) · `apt install tmux` (Debian/Ubuntu) |
 | `crontab`  | scheduling — moadim writes managed routines into the OS crontab so they fire on schedule | preinstalled on macOS; `apt install cron` (Debian/Ubuntu) |
 
-The daemon reports whether `tmux` resolves on its `PATH` in `GET /api/v1/health`
-(under `dependencies`) and logs a warning at startup when it is missing, so a
-misconfigured host is easy to spot.
+The daemon reports whether `tmux` and `python3` resolve on its `PATH` in
+`GET /api/v1/health` (under `dependencies`) and logs a warning at startup when
+either is missing, so a misconfigured host is easy to spot. See the built-in
+`claude` agent's prerequisites below for why `python3` matters.
 
 ## Installation
 
@@ -204,9 +205,11 @@ things on the host beyond the `claude` CLI itself:
 
 - **`python3`** — the agent's `setup` step runs a short `python3` snippet to
   pre-seed per-workbench state in `~/.claude.json` (trust dialog + MCP-server
-  approvals) so the unattended session never blocks on a prompt. If `python3` is
-  not on `PATH`, the setup step fails and the run no-ops — the routine still
-  shows a healthy (green) status, but the agent never actually launches.
+  approvals) so the unattended session never blocks on a prompt. If `python3`
+  is not on `PATH`, the setup step fails and the run no-ops. This is now
+  surfaced (not just silent): the daemon logs a startup warning and
+  `GET /api/v1/health`'s `dependencies.python3` flag reports `false`, though
+  the affected routine's own health dot still shows green.
 - **`tmux`** — every routine run is launched inside a tmux session (named after
   the run's workbench), so a tmux binary must be installed.
 

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -977,9 +977,14 @@
         "type": "object",
         "description": "External-binary dependencies the daemon relies on at runtime, and whether each is resolvable on\nthe daemon's `PATH`. Surfaced in [`HealthResponse`] so the UI/CLI can flag a missing dependency\ninstead of having routine runs silently no-op.",
         "required": [
-          "tmux"
+          "tmux",
+          "python3"
         ],
         "properties": {
+          "python3": {
+            "type": "boolean",
+            "description": "Whether `python3` resolves on the daemon's `PATH`. The built-in `claude` agent's `setup`\nstep runs a `python3` snippet to pre-seed workspace-trust state; when it is missing that\nstep fails silently and the routine still shows a healthy status (issue #404)."
+          },
           "tmux": {
             "type": "boolean",
             "description": "Whether `tmux` (used to launch every routine agent) resolves on the daemon's `PATH`."

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,17 @@ async fn run_server() -> anyhow::Result<()> {
              agent. Install tmux (e.g. `brew install tmux` or `apt install tmux`)."
         );
     }
+    // python3 is a hard dependency of the built-in `claude` agent's `setup` step (workspace-trust
+    // seeding). When it is missing, that step fails and the routine's agent never actually
+    // launches, yet nothing else surfaces the failure — the routine still shows a healthy status
+    // (issue #404). Warn at startup, same as the tmux check above; also surfaced in `GET /health`.
+    if !routines::agent_command_available("python3") {
+        log::warn!(
+            "python3 not found on PATH; the built-in `claude` agent's setup step requires it to \
+             pre-seed workspace-trust state, so routines using that agent will silently fail to \
+             launch. Install python3, or use a different agent."
+        );
+    }
     routines::ensure_default_agents();
     // Rename any prompt.txt sidecars to prompt.md before the crontab resync; otherwise the first
     // cron trigger after upgrade would fail on the launch command's `cp prompt.compiled.md` step.

--- a/src/routes/http.rs
+++ b/src/routes/http.rs
@@ -54,6 +54,10 @@ impl axum::extract::FromRef<AppState> for RoutineStore {
 pub struct DependencyHealth {
     /// Whether `tmux` (used to launch every routine agent) resolves on the daemon's `PATH`.
     pub tmux: bool,
+    /// Whether `python3` resolves on the daemon's `PATH`. The built-in `claude` agent's `setup`
+    /// step runs a `python3` snippet to pre-seed workspace-trust state; when it is missing that
+    /// step fails silently and the routine still shows a healthy status (issue #404).
+    pub python3: bool,
 }
 
 /// Response body for `GET /health`.
@@ -161,6 +165,7 @@ pub async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
         machine: crate::machine::current_machine(),
         dependencies: DependencyHealth {
             tmux: routines::tmux_available(),
+            python3: routines::agent_command_available("python3"),
         },
         version: crate::build_info::VERSION.to_string(),
         git_sha: crate::build_info::GIT_SHA.to_string(),

--- a/src/routes/http_tests.rs
+++ b/src/routes/http_tests.rs
@@ -466,6 +466,11 @@ async fn build_app_serves_health() {
         json["dependencies"]["tmux"].is_boolean(),
         "health payload should carry a boolean dependencies.tmux flag, got: {json}"
     );
+    // Likewise for python3, which the built-in `claude` agent's setup step depends on (#404).
+    assert!(
+        json["dependencies"]["python3"].is_boolean(),
+        "health payload should carry a boolean dependencies.python3 flag, got: {json}"
+    );
     assert_eq!(json["version"], env!("CARGO_PKG_VERSION"));
     // The resolved machine name is surfaced so clients can identify which daemon answered.
     assert!(


### PR DESCRIPTION
## Problem

The built-in `claude` agent's `setup` step runs a `python3` snippet to pre-seed per-workbench workspace-trust state in `~/.claude.json`. When `python3` isn't on `PATH`, that step fails and the agent never actually launches — but nothing surfaces this: the routine's health dot stays green and the run just silently no-ops until the watchdog reaps it. This is `python3`'s half of issue #404 (the doc half was already covered by the existing README prerequisites section).

## Fix

Mirror the existing `tmux` dependency check exactly:

- `GET /api/v1/health`'s `dependencies` object now also reports a `python3: bool` flag alongside the existing `tmux` flag, computed via the already-generalized `agent_command_available("python3")` helper (previously only used for the agent's own `command` binary).
- The daemon logs a startup warning when `python3` is missing, matching the existing `tmux`-missing warning.
- `apis/openapi.json` regenerated (via `cargo test`'s self-syncing `committed_spec_is_current` test) to reflect the new field.
- README's health/prerequisites sections updated to describe the new signal instead of claiming the failure is silent.

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all pass.
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` reports 100% line coverage (the `main.rs` startup-warning branch is excluded from the gate, same as the existing `tmux` one; the `http.rs`/health-endpoint addition is covered by the extended `build_app_serves_health` test).

## Scope check

Surveyed the ~98 currently-open PRs and 100 open issues on this repo before starting — no open PR touches `GET /health`, `DependencyHealth`, or issue #404. Some of #404's other acceptance criteria (a `moadim doctor` command, replacing the python3 dependency outright) are separate, larger follow-ups and intentionally left out of this small PR.

---

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.

cc @tupe12334