### PR TITLE
fix(routines): capture launch-wrapper failures in $WB/launch.log

### DIFF
--- a/.changeset/redirect-launch-wrapper-to-launch-log.md
+++ b/.changeset/redirect-launch-wrapper-to-launch-log.md
@@ -1,0 +1,7 @@
+---
+"moadim": patch
+---
+
+### Fixed
+
+- **A failed routine launch left no trace anywhere.** The generated crontab line ran the prompt copy, the agent's `setup` step, and the `tmux` launch with no output redirection, so a failure in any of them (a `setup` error, `tmux new-session` failing, `PATH` not resolving `tmux`) went to cron's mail spool — silently discarded on the headless hosts this daemon targets, leaving no log to read next to the run's other artifacts. Everything after the workbench is created now runs inside a `{ … } >> "$WB/launch.log" 2>&1` group, so these failures are captured in the run's own workbench alongside `agent.log`. (#375)

--- a/Architecture.md
+++ b/Architecture.md
@@ -134,9 +134,10 @@ single self-contained shell command into a dedicated crontab block:
 ```
 # BEGIN MOADIM-ROUTINES
 # Managed by moadim — routines (agent tmux sessions)
-<sched> TS=$(date +\%s); WB=…/workbenches/<slug>-$TS; mkdir -p $WB; cp …/prompts/prompt.compiled.md $WB/prompt.md; \
-  tmux new-session -d -s moadim-<slug>-$TS -c $WB '<agent-cmd>'; \
-  tmux pipe-pane -o -t … "cat >> $WB/agent.log"   # moadim-routine:<id>
+<sched> TS=$(date +\%s); WB=…/workbenches/<slug>-$TS; mkdir -p $WB; \
+  { cp …/prompts/prompt.compiled.md $WB/prompt.md; \
+    tmux new-session -d -s moadim-<slug>-$TS -c $WB '<agent-cmd>'; \
+    tmux pipe-pane -o -t … "cat >> $WB/agent.log"; } >> $WB/launch.log 2>&1   # moadim-routine:<id>
 # END MOADIM-ROUTINES
 ```
 
@@ -146,6 +147,14 @@ output via `pipe-pane`. The prompt reaches the agent as a process **argument** (
 placeholder expands to `"$(cat prompt.md)"`), so there is no keystroke-injection readiness race. The
 agent decides whether to clone the listed repositories. `POST /routines/{id}/trigger` runs the
 identical command via `sh -c`.
+
+Everything after the `mkdir` runs inside a `{ … } >> $WB/launch.log 2>&1` group, so a failure in the
+prompt copy, the agent's `setup` step, or the `tmux` launch itself is captured next to the run's other
+artifacts instead of going to cron's mail spool (silently discarded on the headless hosts this daemon
+targets). `agent.log` remains the agent's own output (via `pipe-pane`); `launch.log` is the wrapper's
+diagnostics for the steps that get the session running in the first place. Only the `PATH` export and
+the `mkdir` itself precede the redirect — a failure that early means `$WB` may not exist yet, so
+there's nowhere to write a launch log to.
 
 `GET /routines.ics` returns an iCalendar (RFC 5545) feed of every enabled routine's upcoming fire
 times (next 30 days, capped per routine), evaluated in the host local timezone and emitted as UTC

--- a/src/routines/command.rs
+++ b/src/routines/command.rs
@@ -387,12 +387,20 @@ pub(crate) fn build_routine_command(routine: &Routine, agent: &AgentCommand) -> 
         r#"SESS="moadim-$SLUG-$TS""#.to_string(),
         r#"mkdir -p "$WB""#.to_string(),
     ];
-    stmts.extend(system_prompt_stmts(
+
+    // Everything from here on runs with stdout/stderr redirected into the workbench itself, so a
+    // failure in the setup step or the tmux launch leaves a readable trace instead of being handed
+    // to cron's mail spool (silently discarded on the headless hosts this daemon targets — see
+    // #375). `$WB` already exists (created by the `mkdir` above), so the redirect target is valid.
+    // The `cp`/disclosure guards below still `tee` their own abort reason into `agent.log`
+    // explicitly; under this wrapper that message also lands in `launch.log`, which is harmless.
+    let mut inner_stmts = Vec::new();
+    inner_stmts.extend(system_prompt_stmts(
         &crate::paths::user_prompt_path().to_string_lossy(),
         &routine.title,
         &agent.instructions_file,
     ));
-    stmts.extend([
+    inner_stmts.extend([
         // Fail-fast if the routine's source prompt is missing. The statements are `;`-joined, so a
         // bare `cp` failure would be ignored and the agent would launch with an empty
         // `"$(cat prompt.md)"` argument — a blank, task-less session. Abort instead, recording the
@@ -404,13 +412,17 @@ pub(crate) fn build_routine_command(routine: &Routine, agent: &AgentCommand) -> 
     ]);
     if let Some(setup) = &agent.setup {
         // Inserted verbatim so the agent author controls quoting; `$WB`/`$SESS` are in scope.
-        stmts.push(setup.clone());
+        inner_stmts.push(setup.clone());
     }
-    stmts.push(format!(
+    inner_stmts.push(format!(
         r#"tmux new-session -d -s "$SESS" -c "$WB" {}"#,
         shell_quote(&invocation)
     ));
-    stmts.push(r#"tmux pipe-pane -o -t "$SESS" "cat >> \"$WB\"/agent.log""#.to_string());
+    inner_stmts.push(r#"tmux pipe-pane -o -t "$SESS" "cat >> \"$WB\"/agent.log""#.to_string());
+    stmts.push(format!(
+        r#"{{ {} ; }} >> "$WB/launch.log" 2>&1"#,
+        inner_stmts.join("; ")
+    ));
     stmts.join("; ")
 }
 

--- a/src/routines/mod_tests.rs
+++ b/src/routines/mod_tests.rs
@@ -333,6 +333,45 @@ fn build_routine_command_inserts_setup_before_launch() {
 }
 
 #[test]
+fn build_routine_command_redirects_launch_wrapper_to_launch_log() {
+    // Setup/tmux failures must not be silently mailed by cron on a headless host (#375): everything
+    // from the prompt copy through `tmux pipe-pane` runs inside a `{ … } >> "$WB/launch.log" 2>&1`
+    // group, so a failure anywhere in that wrapper leaves a readable trace in the workbench.
+    let routine = make_routine("rid");
+    let agent = AgentCommand {
+        command: "claude".to_string(),
+        args: vec!["{prompt}".to_string()],
+        instructions_file: "CLAUDE.md".to_string(),
+        setup: Some("seed-trust \"$WB\"".to_string()),
+    };
+    let cmd = build_routine_command(&routine, &agent);
+    assert!(
+        cmd.contains(r#"} >> "$WB/launch.log" 2>&1"#),
+        "expected the setup/launch wrapper to redirect into launch.log in: {cmd}"
+    );
+
+    // The redirect group opens after `mkdir -p "$WB"` (so $WB exists before anything tries to
+    // write into it) and closes after the final `tmux pipe-pane` statement.
+    let mkdir_at = cmd.find(r#"mkdir -p "$WB""#).expect("mkdir present");
+    let group_open_at = cmd[mkdir_at..].find('{').map(|off| mkdir_at + off).unwrap();
+    let setup_at = cmd.find("seed-trust").expect("setup present");
+    let pipe_pane_at = cmd.find("tmux pipe-pane").expect("pipe-pane present");
+    let redirect_at = cmd.find(r#"} >> "$WB/launch.log""#).unwrap();
+    assert!(
+        mkdir_at < group_open_at,
+        "mkdir must run before the redirected group opens"
+    );
+    assert!(
+        group_open_at < setup_at,
+        "setup must run inside the redirected group"
+    );
+    assert!(
+        pipe_pane_at < redirect_at,
+        "pipe-pane must run inside the redirected group"
+    );
+}
+
+#[test]
 fn ensure_default_agents_writes_parsable_configs() {
     let dir = std::env::temp_dir().join("moadim-agents-defaults-test");
     let _ = std::fs::remove_dir_all(&dir);


### PR DESCRIPTION
## What

The crontab line for a routine ran the prompt copy, the agent's `setup` step, and the `tmux` launch with **no output redirection**. A failure in any of them (a bad `setup` step, `tmux new-session` failing, `PATH` not resolving `tmux`) went to cron's mail spool — silently discarded on the headless hosts this daemon targets, leaving no log to read next to the run's other artifacts.

## Fix

Everything after `mkdir -p "$WB"` now runs inside a `{ … } >> "$WB/launch.log" 2>&1` group, so a failure in the prompt copy, `setup`, or the `tmux` launch is captured in the run's own workbench alongside `agent.log`. `PATH` export and `mkdir` itself stay outside the group, since a failure that early means `$WB` may not exist yet to write into.

Verified the new command shape manually against real `sh`/`tmux`:
- a deliberately failing statement inside the group lands in `launch.log`
- a normal launch (long-running session) produces an empty-of-errors `launch.log` and `agent.log` still captures the agent's own output via `pipe-pane` as before

## Checks

- `cargo build`, `cargo test` (720 passed), `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` — all clean
- `cargo llvm-cov`: `routines/command.rs` is 100% covered (the repo-wide 99.74% total reflects pre-existing gaps elsewhere, tracked separately in #150)
- Added `.changeset/redirect-launch-wrapper-to-launch-log.md` per CONTRIBUTING.md
- Updated `Architecture.md`'s crontab-line illustration and added a paragraph explaining `launch.log` vs `agent.log`
- Added `build_routine_command_redirects_launch_wrapper_to_launch_log` asserting the redirect wraps setup/tmux and closes after `pipe-pane`

Closes #375

---
This pull request was opened by the Open issues → fix PRs (owned repos + my orgs) routine of moadim.
