### PR TITLE
ci: add cargo-deny gate for advisories, licenses & sources

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,0 +1,52 @@
+name: Cargo deny
+
+# Gate every PR (and pushes to main) on `cargo-deny`, checking the dependency
+# tree for known RustSec advisories, disallowed/duplicate licenses, banned
+# crates, and untrusted registry sources (issue #339). Without this, a
+# vulnerable or incompatibly-licensed dependency only surfaces via Dependabot
+# after it's already merged, not before.
+#
+# The action is pinned to a tagged release (not `@main`) so the gate is
+# reproducible, matching this repo's other workflows. The weekly scheduled
+# run keeps the gate exercised against `main` so newly published advisories
+# surface on their own cadence, not inside an unrelated PR.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    # Mondays at 06:00 UTC — keep the advisory-database gate current against main.
+    - cron: "0 6 * * 1"
+
+# Restrict the default GITHUB_TOKEN to read-only; this workflow only needs to
+# check out the repo and read the dependency tree.
+permissions:
+  contents: read
+
+# Cancel a stale run when a PR gets a new push, matching lint.yml's behavior
+# so superseded cargo-deny runs don't pile up and burn CI minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cargo-deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+    # Prevent a new advisory alone from failing an in-flight PR that made no
+    # dependency change — only the scheduled run and pushes to main hard-fail
+    # on advisories; PRs still see the result annotated on the job.
+    continue-on-error: ${{ matrix.checks == 'advisories' && github.event_name == 'pull_request' }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: cargo-deny ${{ matrix.checks }}
+        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
+        with:
+          command: check ${{ matrix.checks }}

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,42 @@
+# cargo-deny configuration (see .github/workflows/cargo-deny.yml).
+# Docs: https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+all-features = false
+no-default-features = false
+
+[advisories]
+ignore = []
+
+[licenses]
+# Every license currently in the dependency tree (`cargo deny check licenses`
+# lists any newly introduced license that isn't covered here).
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Zlib",
+]
+confidence-threshold = 0.8
+
+[licenses.private]
+ignore = false
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+workspace-default-features = "allow"
+external-default-features = "allow"
+deny = []
+# rand 0.10 and the wasm component tooling pull a newer getrandom/wit-bindgen
+# than the rest of the tree; both major versions are maintained upstream, so
+# this is noise rather than a real duplication problem worth failing CI over.
+skip = ["getrandom", "wit-bindgen"]
+
+[sources]
+unknown-registry = "warn"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
## Why

No dependency-vulnerability or license-compliance check runs on PRs today (#339). A RustSec advisory in a transitive dependency, or a newly-introduced incompatibly-licensed crate, only surfaces after Dependabot notices it post-merge — every other repo lint/format/test gate is enforced pre-merge, this one wasn't.

## What

- `.github/workflows/cargo-deny.yml`: a `cargo-deny` job (advisories, bans, licenses, sources) on PRs, pushes to `main`, and a weekly schedule — matching this repo's existing gates (pinned action SHA, minimal `contents: read` permissions, `cancel-in-progress` concurrency group). A new advisory alone won't hard-fail an in-flight PR that made no dependency change (`continue-on-error` on the `advisories` matrix leg for `pull_request` events only); pushes to `main` and the scheduled run still hard-fail so a new RustSec advisory gets noticed promptly.
- `deny.toml`: allow-lists every license currently in the dependency tree (MIT, Apache-2.0, BSD-3-Clause, MPL-2.0, Unicode-3.0, Zlib) and skips `getrandom`/`wit-bindgen` in duplicate-version detection — both have two actively-maintained major versions pulled in via unrelated dependency chains (rand 0.10 vs. the wasm component tooling), not a real duplication problem worth failing CI over.

## Verified locally

- `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` all still pass (untouched by this change)

CI-only change — no `src/` or `ui/` files touched, so no changeset is required per this repo's own changelog gate.

Closes #339.

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.

cc @tupe12334