### PR TITLE
fix(sync): serialize the crontab read-modify-write across concurrent syncs

### DIFF
--- a/.changeset/crontab-sync-lock.md
+++ b/.changeset/crontab-sync-lock.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Serialize the crontab read-modify-write across concurrent syncs so overlapping `crontab -l` → edit → `crontab -` round trips can no longer interleave and clobber each other's writes.

--- a/src/sync/routines.rs
+++ b/src/sync/routines.rs
@@ -21,9 +21,25 @@
 //! API keys, …): the daemon's trigger path spawns the agent under `sh -lc`, which sources
 //! `~/.profile`. Reverse sync is not implemented — routines are managed only through the API.
 
+use std::sync::{Mutex, OnceLock};
+
 use crate::routines::{load_agent_command, shell_quote, Routine, RoutineStore};
 use crate::sync::{read_crontab, replace_block_with, to_os_schedule, write_crontab, SyncError};
 use crate::utils::lock::LockRecover;
+
+/// Process-wide lock serializing the crontab read-modify-write sequence.
+///
+/// `sync_routines_to_crontab` is invoked from many concurrent request handlers (REST, MCP) on a
+/// multi-threaded runtime. Each call does an unsynchronized `crontab -l` -> edit -> `crontab -`
+/// round trip; two calls whose round trips overlap can interleave, and the later `crontab -` wins
+/// outright — no merge, no error (issue #365). Taken as the very first thing in
+/// `sync_routines_to_crontab`, before the (separate) `RoutineStore` lock, so lock order is always
+/// crontab-lock -> store-lock and this can never deadlock against a caller that only takes the
+/// store lock.
+fn crontab_sync_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
 
 /// Delimiter marking the start of the moadim routines crontab block.
 pub(crate) const BLOCK_BEGIN: &str = "# BEGIN MOADIM-ROUTINES";
@@ -150,6 +166,7 @@ pub(crate) const ROUTINE_LINE_MARKER: &str = "# moadim-routine:";
 /// loaded fine but holds only disabled/unmanaged routines is *not* empty, so legitimately clearing
 /// the last routine still works.
 pub fn sync_routines_to_crontab(store: &RoutineStore) -> Result<(), SyncError> {
+    let _crontab_guard = crontab_sync_lock().lock_recover();
     let current = read_crontab()?;
     if store.lock_recover().is_empty() && current.contains(ROUTINE_LINE_MARKER) {
         log::warn!(

--- a/src/sync/routines_sync_tests.rs
+++ b/src/sync/routines_sync_tests.rs
@@ -126,6 +126,14 @@ struct CronShim {
 
 impl CronShim {
     fn new(initial: &str) -> Self {
+        Self::new_with_write_delay(initial, 0)
+    }
+
+    /// Like [`Self::new`], but the shim sleeps `delay_ms` milliseconds between receiving a
+    /// `crontab -` write on stdin and installing it, widening the window for concurrency
+    /// regression tests that must observe two `sync_routines_to_crontab` calls overlapping (or
+    /// not) in wall-clock time.
+    fn new_with_write_delay(initial: &str, delay_ms: u64) -> Self {
         use std::os::unix::fs::PermissionsExt;
 
         let base = std::env::temp_dir().join(format!("moadim-rcronshim-{}", uuid::Uuid::new_v4()));
@@ -134,10 +142,11 @@ impl CronShim {
         std::fs::write(&store_file, initial).unwrap();
         let store_display = store_file.to_string_lossy().into_owned();
         let script_path = base.join("crontab-shim.sh");
+        let delay_secs = delay_ms as f64 / 1000.0;
         std::fs::write(
             &script_path,
             format!(
-                "#!/bin/sh\nSTORE=\"{store_display}\"\nif [ \"$1\" = \"-l\" ]; then cat \"$STORE\"; elif [ \"$1\" = \"-\" ]; then cat > \"$STORE\"; fi\n"
+                "#!/bin/sh\nSTORE=\"{store_display}\"\nif [ \"$1\" = \"-l\" ]; then cat \"$STORE\"; elif [ \"$1\" = \"-\" ]; then cat > \"$STORE.tmp\"; sleep {delay_secs}; mv \"$STORE.tmp\" \"$STORE\"; fi\n"
             ),
         )
         .unwrap();
@@ -344,4 +353,62 @@ fn build_block_empty_when_globally_locked() {
     std::fs::remove_file(&lock_path).unwrap();
     std::fs::remove_file(&cfg).unwrap();
     let _ = std::fs::remove_dir_all(crate::paths::routine_dir(&slug));
+}
+
+#[test]
+fn crontab_sync_lock_is_mutually_exclusive() {
+    // Same static `Mutex` instance every call: while held here, a second attempt to acquire it
+    // must fail instead of silently locking a *different* mutex.
+    let _guard = crontab_sync_lock().lock_recover();
+    assert!(
+        crontab_sync_lock().try_lock().is_err(),
+        "crontab_sync_lock() must return the same process-wide mutex on every call"
+    );
+}
+
+#[test]
+fn sync_routines_to_crontab_serializes_concurrent_calls() {
+    // Regression test for #365: two `sync_routines_to_crontab` calls whose crontab I/O overlaps
+    // must not interleave. Proven by timing rather than by racing on store content: the shim
+    // sleeps a fixed delay on every `crontab -` write, so two *unserialized* read-modify-write
+    // round trips would overlap and finish in roughly one delay; serialized by the lock, they run
+    // back to back and take roughly two.
+    let agent_name = "test-sync-agent-concurrent-lock";
+    std::fs::create_dir_all(crate::paths::agents_dir()).unwrap();
+    let cfg = crate::paths::agent_toml_path(agent_name);
+    std::fs::write(&cfg, "command = \"claude\"\nargs = []\n").unwrap();
+
+    const DELAY_MS: u64 = 150;
+    let shim = CronShim::new_with_write_delay(
+        "# BEGIN MOADIM-ROUTINES\n# END MOADIM-ROUTINES\n",
+        DELAY_MS,
+    );
+
+    let store_a = new_store();
+    store_a.lock().unwrap().insert(
+        "lock-a".into(),
+        make_routine("lock-a", "Lock A Sync Routine", agent_name),
+    );
+    let store_b = new_store();
+    store_b.lock().unwrap().insert(
+        "lock-b".into(),
+        make_routine("lock-b", "Lock B Sync Routine", agent_name),
+    );
+
+    let start = std::time::Instant::now();
+    std::thread::scope(|scope| {
+        scope.spawn(|| sync_routines_to_crontab(&store_a).unwrap());
+        scope.spawn(|| sync_routines_to_crontab(&store_b).unwrap());
+    });
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed.as_millis() >= u128::from(DELAY_MS) * 2,
+        "two concurrent syncs completed in {elapsed:?}, faster than {}ms — the crontab lock did \
+         not serialize their read-modify-write round trips",
+        DELAY_MS * 2,
+    );
+
+    drop(shim);
+    std::fs::remove_file(&cfg).unwrap();
 }


### PR DESCRIPTION
## Summary

`sync_routines_to_crontab` does an unsynchronized `crontab -l` → edit → `crontab -` round trip. Two calls whose round trips overlap (concurrent routine mutations arriving from REST/MCP handlers on the multi-threaded runtime) can interleave; `crontab -` replaces the whole crontab, so the later write wins outright with no merge. A just-created/updated routine's crontab line can be silently dropped with no error surfaced.

The original issue also named a second, independent `sync_to_crontab` (cron-job) path racing against this one — that path no longer exists (cron jobs were removed per #794), so this PR scopes the fix to the one remaining sync path: concurrent calls to `sync_routines_to_crontab` itself.

## Fix

- Add a process-wide `Mutex<()>` (`crontab_sync_lock`) that serializes the full `read_crontab()` → build → `write_crontab()` sequence.
- The lock is acquired as the very first thing in `sync_routines_to_crontab`, before the (separate) `RoutineStore` lock, so lock order is always crontab-lock → store-lock and this can never deadlock against a caller that only takes the store lock.
- No change to the existing idempotent "skip write when unchanged" fast path.

## Test plan

- [x] `cargo test` — 722 passed, including two new tests:
  - `crontab_sync_lock_is_mutually_exclusive` — the lock accessor returns the same static mutex on every call.
  - `sync_routines_to_crontab_serializes_concurrent_calls` — a timing-based regression test: the test's `crontab` shim sleeps a fixed delay on every write; two concurrent `sync_routines_to_crontab` calls must take ~2× that delay (proving they ran back-to-back, not overlapped).
  - Sanity-checked: temporarily removing the lock makes the new concurrency test fail (the shim's two writes collide), confirming the test actually exercises the fix.
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

Closes #365

---
This pull request was opened by the *Open issues → fix PRs (owned repos + my orgs)* routine of moadim.