### PR TITLE
docs(todo): prune two TODO.md entries already shipped

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,14 +4,12 @@
 
 This is a list of todos for consumption, in a pr remove the todo you have implemented and add any new ones you think of.
 
-- Add a `test + coverage` CI job that mirrors the pre-push hook's final gate (`cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'`) so the 100% coverage contract is enforced in PRs, not just locally
 - Add a CI step (or weekly scheduled job) that checks whether a newer `crate-ci/typos` release exists than the pinned tag and opens/updates a tracking issue, so the pin gets bumped on a cadence instead of drifting silently
 - Add a day-detail popover to the routines calendar: clicking a day lists each fire time (HH:MM) with its routine, and a "run now" shortcut per routine
 - Auto-stamp the release version/date into CHANGELOG.md from the `chore(release)` step so the `## [Unreleased]` section rolls over on tag
 - Have a commands folder for all the cli commands, we want to work with colocation of files
 - Add a TTL preset row (1h / 1d / 7d / 30d) under the WORKBENCH TTL input in the routine form, mirroring the cron schedule presets
 - Show a humanized retention countdown ("expires in 2d" / "expired") per finished run in the routine LOGS view, derived from the run's finish time and the routine's effective TTL
-- Add a CLI integration test (spawn a real listener on an ephemeral port, point the probe at it) that exercises the `status`/`cleanup`/`stop` network paths end-to-end, lifting `cli.rs` off its ~27% coverage floor toward the repo's 100% line-coverage gate
 - Add a `moadim restart --interactive` (or `-i`) flavor that restarts the daemon in the foreground attached to the terminal instead of detached, mirroring `moadim -i`
 - Have `moadim restart` emit its PID-rotation summary as a `--json` object (`{"old":N|null,"new":M}`) too, mirroring the `status`/`cleanup` `--json` contract
 - Give `moadim restart` a `--quiet`/`-q` flag that prints only the rotation line (`restarted: pid <old> -> <new>`) and suppresses the UI/stop/logs hint block, for script consumption


### PR DESCRIPTION
## Summary
- Removes the "Add a `test + coverage` CI job..." TODO.md line — this shipped in #788 (HEAD of main), which added exactly that `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` job to `test.yml`.
- Removes the "Add a CLI integration test (spawn a real listener...) lifting `cli.rs` off its ~27% coverage floor..." TODO.md line — `src/cli_tests.rs` already binds a real `TcpListener` on an ephemeral port and exercises the `status`/`cleanup`/`stop` network paths end-to-end; `cargo llvm-cov` on current `main` shows `cli.rs` at 100.00% line coverage (420/420 lines).

Verified both by running `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` on a clean `main` checkout (exit 0, 100% total line coverage) and by checking `cli.rs`'s per-file row in that report.

This follows TODO.md's own stated convention ("in a pr remove the todo you have implemented"). Docs-only change (TODO.md), no `.changeset/` entry needed per the changelog gate (src/ or ui/ diffs only).

Does not overlap with the currently-open #896 ("docs(todo): prune two TODO.md entries already shipped"), which removes two different, unrelated TODO.md lines (the `status --json` uptime_secs line and the `restart --json` rotation-summary line) — confirmed by diffing against that PR's branch.

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (clean on main, unaffected by this docs-only diff)
- [x] `cargo test` passes (720 tests, clean on main)
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` passes on main (100% line coverage), confirming the pruned claims are accurate

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.

cc @tupe12334