### PR TITLE
feat(cli): seed a README.md into the config directory and its subdirectories

### DIFF
--- a/.changeset/config-dir-readme.md
+++ b/.changeset/config-dir-readme.md
@@ -1,0 +1,14 @@
+---
+"moadim": minor
+---
+
+### Added
+
+- **`README.md` seeded into the config directory.** On every start, the daemon
+  now writes `{config_dir}/README.md` (default `~/.config/moadim/README.md`)
+  if it doesn't already exist, explaining the layout of `routines/`,
+  `agents/`, and the daemon-managed files (`.gitignore`, `machine.local.toml`,
+  `moadim.pid`, `daemon.log`) — so anyone who opens or git-tracks the config
+  folder directly has an orientation doc without needing to consult the
+  project README. Never overwrites an existing `README.md`, so user edits are
+  preserved.

--- a/.changeset/config-dir-readme.md
+++ b/.changeset/config-dir-readme.md
@@ -4,11 +4,15 @@
 
 ### Added
 
-- **`README.md` seeded into the config directory.** On every start, the daemon
-  now writes `{config_dir}/README.md` (default `~/.config/moadim/README.md`)
-  if it doesn't already exist, explaining the layout of `routines/`,
-  `agents/`, and the daemon-managed files (`.gitignore`, `machine.local.toml`,
-  `moadim.pid`, `daemon.log`) — so anyone who opens or git-tracks the config
-  folder directly has an orientation doc without needing to consult the
-  project README. Never overwrites an existing `README.md`, so user edits are
-  preserved.
+- **`README.md` seeded into the config directory and its generated
+  subdirectories.** On every start, the daemon now writes a `README.md` into
+  `{config_dir}` (default `~/.config/moadim/`), `{config_dir}/routines/`, and
+  `{config_dir}/agents/` if one doesn't already exist there, explaining each
+  folder's layout — the top-level file covers the daemon-managed files
+  (`.gitignore`, `machine.local.toml`, `moadim.pid`, `daemon.log`), the
+  `routines/` one covers the per-routine directory structure
+  (`routine.toml`, `prompts/`, `flags/`, the `.local.` sidecars), and the
+  `agents/` one covers the agent registry format. So anyone who opens or
+  git-tracks the config folder directly has an orientation doc without
+  needing to consult the project README. Never overwrites an existing
+  `README.md`, so user edits are preserved.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -572,12 +572,14 @@ pub fn write_pid_file() -> anyhow::Result<()> {
     let path = crate::paths::pid_file();
     std::fs::create_dir_all(path.parent().expect("pid file path has a parent dir"))?;
     ensure_config_gitignore();
-    ensure_config_readme();
+    ensure_readme(&crate::paths::config_readme_path(), CONFIG_README);
+    ensure_readme(&crate::paths::routines_readme_path(), ROUTINES_README);
+    ensure_readme(&crate::paths::agents_readme_path(), AGENTS_README);
     std::fs::write(&path, std::process::id().to_string())?;
     Ok(())
 }
 
-/// Orientation doc seeded into the config dir on every start; see [`ensure_config_readme`].
+/// Orientation doc seeded into the config dir on every start; see [`ensure_readme`].
 const CONFIG_README: &str = "\
 # moadim config
 
@@ -585,13 +587,8 @@ This is moadim's config directory (`$XDG_CONFIG_HOME/moadim`, default `~/.config
 It is git-trackable — commit it (or the parts you want to keep) to version-control your
 routines and agents across machines.
 
-- `routines/<id>/` — one directory per routine (a scheduled agent). Holds `routine.toml`
-  (the schedule, agent, and repositories), `prompts/prompt.pure.md` (the prompt you wrote)
-  and `prompts/prompt.compiled.md` (the composed prompt copied into each run's workbench),
-  `flags/` (open questions an agent raised mid-run), and `.local.` sidecars
-  (`state.local.toml`, `scheduled.local.toml`) recording daemon-written runtime state that's
-  gitignored on purpose.
-- `agents/<name>.toml` — the agent registry referenced by routines (e.g. `claude`).
+- `routines/` — one directory per routine (a scheduled agent); see its own `README.md`.
+- `agents/` — the agent registry referenced by routines; see its own `README.md`.
 - `machine.local.toml` — this machine's identity, used to match a routine's `machines`
   targeting list. Gitignored: it's per-machine, not shared.
 - `moadim.pid`, `daemon.log` — daemon-managed runtime files. Gitignored.
@@ -600,16 +597,50 @@ routines and agents across machines.
 Full docs: https://github.com/moadim-io/daemon
 ";
 
-/// Seed the config dir with a `README.md` explaining its layout, if one isn't already there.
+/// Orientation doc seeded into `routines/` on every start; see [`ensure_readme`].
+const ROUTINES_README: &str = "\
+# moadim routines
+
+Each subdirectory here is one routine (a prompt + schedule + agent, run on a cron schedule).
+
+- `<id>/routine.toml` — the schedule, agent, and repositories.
+- `<id>/prompts/prompt.pure.md` — the prompt you wrote.
+- `<id>/prompts/prompt.compiled.md` — the composed prompt (repositories preamble + pure
+  prompt) copied into each run's workbench.
+- `<id>/flags/` — open questions an agent raised mid-run: a gap, bug, edge case, or question
+  it couldn't resolve.
+- `<id>/state.local.toml`, `<id>/scheduled.local.toml` — gitignored sidecars recording
+  daemon-written runtime state (last manual/scheduled trigger times).
+
+Full docs: https://github.com/moadim-io/daemon
+";
+
+/// Orientation doc seeded into `agents/` on every start; see [`ensure_readme`].
+const AGENTS_README: &str = "\
+# moadim agents
+
+The agent registry referenced by routines. Each `<name>.toml` here (e.g. `claude.toml`)
+describes one coding agent: the command to launch it and any agent-specific settings.
+Routines reference an agent by name in their `routine.toml`.
+
+Full docs: https://github.com/moadim-io/daemon
+";
+
+/// Seed `path` with `content` if it doesn't already exist, creating its parent directory as
+/// needed.
 ///
-/// Runs on every start alongside [`ensure_config_gitignore`]. Only writes when the file is
+/// Runs on every start for the config dir and each of its generated subdirectories
+/// (`routines/`, `agents/`), alongside [`ensure_config_gitignore`]. Only writes when the file is
 /// missing, so a user's edits are never clobbered. Best-effort: failure is not fatal.
-fn ensure_config_readme() {
-    let readme = crate::paths::config_readme_path();
-    if readme.exists() {
+fn ensure_readme(path: &std::path::Path, content: &str) {
+    if path.exists() {
         return;
     }
-    let _ = std::fs::write(&readme, CONFIG_README);
+    let parent = path.parent().expect("readme path has a parent dir");
+    if std::fs::create_dir_all(parent).is_err() {
+        return;
+    }
+    let _ = std::fs::write(path, content);
 }
 
 /// Ensure the config dir `.gitignore` contains all required patterns on every start.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -572,8 +572,44 @@ pub fn write_pid_file() -> anyhow::Result<()> {
     let path = crate::paths::pid_file();
     std::fs::create_dir_all(path.parent().expect("pid file path has a parent dir"))?;
     ensure_config_gitignore();
+    ensure_config_readme();
     std::fs::write(&path, std::process::id().to_string())?;
     Ok(())
+}
+
+/// Orientation doc seeded into the config dir on every start; see [`ensure_config_readme`].
+const CONFIG_README: &str = "\
+# moadim config
+
+This is moadim's config directory (`$XDG_CONFIG_HOME/moadim`, default `~/.config/moadim`).
+It is git-trackable — commit it (or the parts you want to keep) to version-control your
+routines and agents across machines.
+
+- `routines/<id>/` — one directory per routine (a scheduled agent). Holds `routine.toml`
+  (the schedule, agent, and repositories), `prompts/prompt.pure.md` (the prompt you wrote)
+  and `prompts/prompt.compiled.md` (the composed prompt copied into each run's workbench),
+  `flags/` (open questions an agent raised mid-run), and `.local.` sidecars
+  (`state.local.toml`, `scheduled.local.toml`) recording daemon-written runtime state that's
+  gitignored on purpose.
+- `agents/<name>.toml` — the agent registry referenced by routines (e.g. `claude`).
+- `machine.local.toml` — this machine's identity, used to match a routine's `machines`
+  targeting list. Gitignored: it's per-machine, not shared.
+- `moadim.pid`, `daemon.log` — daemon-managed runtime files. Gitignored.
+- `.gitignore` — seeded and kept up to date by the daemon; append your own patterns freely.
+
+Full docs: https://github.com/moadim-io/daemon
+";
+
+/// Seed the config dir with a `README.md` explaining its layout, if one isn't already there.
+///
+/// Runs on every start alongside [`ensure_config_gitignore`]. Only writes when the file is
+/// missing, so a user's edits are never clobbered. Best-effort: failure is not fatal.
+fn ensure_config_readme() {
+    let readme = crate::paths::config_readme_path();
+    if readme.exists() {
+        return;
+    }
+    let _ = std::fs::write(&readme, CONFIG_README);
 }
 
 /// Ensure the config dir `.gitignore` contains all required patterns on every start.

--- a/src/cli_tests.rs
+++ b/src/cli_tests.rs
@@ -1027,6 +1027,22 @@ fn pid_file_write_read_clear_roundtrip() {
 }
 
 #[test]
+fn write_pid_file_seeds_readme_without_clobbering_edits() {
+    let home = temp_home("pidfile-readme");
+    let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", home.to_str().unwrap());
+    write_pid_file().unwrap();
+    let readme = crate::paths::config_readme_path();
+    assert!(readme.exists());
+    let content = std::fs::read_to_string(&readme).unwrap();
+    assert!(content.contains("moadim config"));
+    // A second start must not overwrite a user's edits to the README.
+    std::fs::write(&readme, "custom notes").unwrap();
+    write_pid_file().unwrap();
+    assert_eq!(std::fs::read_to_string(&readme).unwrap(), "custom notes");
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+#[test]
 fn run_background_starts_when_none_running() {
     let home = temp_home("runbg-fresh");
     let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", home.to_str().unwrap());

--- a/src/cli_tests.rs
+++ b/src/cli_tests.rs
@@ -1027,18 +1027,42 @@ fn pid_file_write_read_clear_roundtrip() {
 }
 
 #[test]
-fn write_pid_file_seeds_readme_without_clobbering_edits() {
+fn write_pid_file_seeds_readmes_without_clobbering_edits() {
     let home = temp_home("pidfile-readme");
     let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", home.to_str().unwrap());
     write_pid_file().unwrap();
-    let readme = crate::paths::config_readme_path();
-    assert!(readme.exists());
-    let content = std::fs::read_to_string(&readme).unwrap();
-    assert!(content.contains("moadim config"));
-    // A second start must not overwrite a user's edits to the README.
-    std::fs::write(&readme, "custom notes").unwrap();
+    let config_readme = crate::paths::config_readme_path();
+    let routines_readme = crate::paths::routines_readme_path();
+    let agents_readme = crate::paths::agents_readme_path();
+    assert!(config_readme.exists());
+    assert!(routines_readme.exists());
+    assert!(agents_readme.exists());
+    assert!(std::fs::read_to_string(&config_readme)
+        .unwrap()
+        .contains("moadim config"));
+    assert!(std::fs::read_to_string(&routines_readme)
+        .unwrap()
+        .contains("moadim routines"));
+    assert!(std::fs::read_to_string(&agents_readme)
+        .unwrap()
+        .contains("moadim agents"));
+    // A second start must not overwrite a user's edits to any of the READMEs.
+    std::fs::write(&config_readme, "custom notes").unwrap();
+    std::fs::write(&routines_readme, "custom notes").unwrap();
+    std::fs::write(&agents_readme, "custom notes").unwrap();
     write_pid_file().unwrap();
-    assert_eq!(std::fs::read_to_string(&readme).unwrap(), "custom notes");
+    assert_eq!(
+        std::fs::read_to_string(&config_readme).unwrap(),
+        "custom notes"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&routines_readme).unwrap(),
+        "custom notes"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&agents_readme).unwrap(),
+        "custom notes"
+    );
     let _ = std::fs::remove_dir_all(&home);
 }
 
@@ -1213,6 +1237,21 @@ fn write_pid_file_errors_when_config_dir_is_blocked() {
     std::fs::write(base.join(".config/moadim"), "block").unwrap();
     let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", base.to_str().unwrap());
     assert!(write_pid_file().is_err());
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[test]
+fn write_pid_file_skips_readme_when_its_subdir_is_blocked() {
+    // A regular file sitting where `routines/` should be blocks that README's create_dir_all,
+    // but write_pid_file is best-effort here and must still succeed overall.
+    let base = temp_home("readme-subdir-blocked");
+    let config_dir = base.join(".config/moadim");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(config_dir.join("routines"), "block").unwrap();
+    let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", base.to_str().unwrap());
+    write_pid_file().unwrap();
+    assert!(crate::paths::config_readme_path().exists());
+    assert!(!crate::paths::routines_readme_path().exists());
     let _ = std::fs::remove_dir_all(&base);
 }
 

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -183,6 +183,13 @@ pub fn config_gitignore_path() -> PathBuf {
     config_dir().join(".gitignore")
 }
 
+/// Returns the path to `{config_dir}/README.md`, a daemon-generated orientation doc explaining the
+/// config tree's layout for anyone who opens or git-tracks it directly.
+#[must_use]
+pub fn config_readme_path() -> PathBuf {
+    config_dir().join("README.md")
+}
+
 /// Returns the path to `~/.config/moadim/.lock`, a committed global lock that halts all routine
 /// scheduling and manual triggers when present. Checked into version control so the lock can be
 /// shared across machines via a git push/pull.

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -76,6 +76,13 @@ pub fn routine_dir(id: &str) -> PathBuf {
     routines_dir().join(id)
 }
 
+/// Returns the path to `{routines_dir}/README.md`, a daemon-generated orientation doc explaining
+/// the per-routine directory layout.
+#[must_use]
+pub fn routines_readme_path() -> PathBuf {
+    routines_dir().join("README.md")
+}
+
 /// Returns the path to `{routines_dir}/{id}/routine.toml`.
 #[must_use]
 pub fn routine_toml_path(id: &str) -> PathBuf {
@@ -160,6 +167,13 @@ pub fn agents_dir() -> PathBuf {
 #[must_use]
 pub fn agent_toml_path(name: &str) -> PathBuf {
     agents_dir().join(format!("{name}.toml"))
+}
+
+/// Returns the path to `{agents_dir}/README.md`, a daemon-generated orientation doc explaining the
+/// agent registry's file format.
+#[must_use]
+pub fn agents_readme_path() -> PathBuf {
+    agents_dir().join("README.md")
 }
 
 // ─── Daemon runtime files ────────────────────────────────────────────────────

--- a/src/paths/mod_tests.rs
+++ b/src/paths/mod_tests.rs
@@ -135,6 +135,13 @@ fn config_gitignore_path_in_config_dir() {
 }
 
 #[test]
+fn config_readme_path_in_config_dir() {
+    let path = config_readme_path();
+    assert_eq!(path.file_name().unwrap().to_str().unwrap(), "README.md");
+    assert_eq!(path.parent().unwrap(), config_dir());
+}
+
+#[test]
 fn pid_file_ends_with_moadim_pid() {
     let path = pid_file();
     assert!(

--- a/src/paths/mod_tests.rs
+++ b/src/paths/mod_tests.rs
@@ -36,6 +36,13 @@ fn routine_dir_is_child_of_routines_dir() {
 }
 
 #[test]
+fn routines_readme_path_in_routines_dir() {
+    let path = routines_readme_path();
+    assert_eq!(path.file_name().unwrap().to_str().unwrap(), "README.md");
+    assert_eq!(path.parent().unwrap(), routines_dir());
+}
+
+#[test]
 fn routine_toml_path_filename() {
     let path = routine_toml_path("abc");
     assert_eq!(path.file_name().unwrap().to_str().unwrap(), "routine.toml");
@@ -106,6 +113,13 @@ fn agents_dir_ends_with_agents() {
 fn agent_toml_path_appends_name_and_extension() {
     let path = agent_toml_path("claude");
     assert_eq!(path.file_name().unwrap().to_str().unwrap(), "claude.toml");
+}
+
+#[test]
+fn agents_readme_path_in_agents_dir() {
+    let path = agents_readme_path();
+    assert_eq!(path.file_name().unwrap().to_str().unwrap(), "README.md");
+    assert_eq!(path.parent().unwrap(), agents_dir());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- The config dir (`~/.config/moadim/`, or wherever `$XDG_CONFIG_HOME` points) is meant to be git-trackable, but had no explanation of its own layout for anyone who opens it or clones it after pushing it to a personal repo.
- On every start, alongside the existing `.gitignore` seeding, the daemon now writes a `README.md` into:
  - `{config_dir}/README.md` — daemon-managed files (`.gitignore`, `machine.local.toml`, `moadim.pid`, `daemon.log`) and a pointer to the `routines/`/`agents/` READMEs below.
  - `{config_dir}/routines/README.md` — the per-routine directory layout (`routine.toml`, `prompts/prompt.pure.md`/`prompt.compiled.md`, `flags/`, the `.local.` sidecars).
  - `{config_dir}/agents/README.md` — the agent registry (`<name>.toml`) format.
- Each is only written when missing — never overwrites, so user edits are preserved (same pattern as `ensure_config_gitignore`).

Closes #913.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% line coverage
- [x] `make spell` (typos)
- [x] New tests: `config_readme_path_in_config_dir`, `routines_readme_path_in_routines_dir`, `agents_readme_path_in_agents_dir`, `write_pid_file_seeds_readmes_without_clobbering_edits`, `write_pid_file_skips_readme_when_its_subdir_is_blocked`
- [x] Changeset added (`.changeset/config-dir-readme.md`)