### PR TITLE
fix(deny): drop stale wit-bindgen skip entry

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -30,10 +30,12 @@ wildcards = "allow"
 workspace-default-features = "allow"
 external-default-features = "allow"
 deny = []
-# rand 0.10 and the wasm component tooling pull a newer getrandom/wit-bindgen
-# than the rest of the tree; both major versions are maintained upstream, so
-# this is noise rather than a real duplication problem worth failing CI over.
-skip = ["getrandom", "wit-bindgen"]
+# rand 0.10 pulls a newer getrandom than the rest of the tree; both major
+# versions are maintained upstream, so this is noise rather than a real
+# duplication problem worth failing CI over. (wit-bindgen was listed here too,
+# but it isn't actually in the dependency tree — `cargo deny check` has been
+# printing an `unmatched-skip` warning on every run because of it.)
+skip = ["getrandom"]
 
 [sources]
 unknown-registry = "warn"


### PR DESCRIPTION
## Why

`deny.toml`'s `[bans] skip` list includes `wit-bindgen`, added in #906 alongside `getrandom` under the assumption that "wasm component tooling" pulls a newer copy of it into the tree. It doesn't — `wit-bindgen` doesn't appear in `Cargo.lock` at all (`grep -c wit-bindgen Cargo.lock` → `0`).

Because of that, every `cargo deny check bans` run (i.e. every PR, every push to `main`, and the weekly scheduled run) has been printing:

```
warning[unmatched-skip]: skipped crate 'wit-bindgen' was not encountered
   ┌─ deny.toml:36:23
   │
36 │ skip = ["getrandom", "wit-bindgen"]
   │                       ━━━━━━━━━━━ unmatched skip configuration
```

It's non-fatal today (`bans` warnings don't fail the job), but it's permanent noise in CI logs and mildly misleading — it makes it look like `wit-bindgen` duplication is a known, deliberately-suppressed issue when it never was one.

## What

- Drop `wit-bindgen` from `[bans] skip`, keeping the still-valid `getrandom` entry (rand 0.10 genuinely does pull a newer `getrandom` than the rest of the tree — confirmed by `cargo deny check` no longer flagging it as unmatched).
- Tighten the adjacent comment to match reality.

## Verification

- `cargo deny check bans licenses sources` — no more `unmatched-skip` warning; only the 4 pre-existing, legitimate `multiple-versions` (`warn`, non-fatal) duplicates remain, unchanged.
- `cargo deny check advisories` — ok.
- `cargo fmt --check` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.

No `src/` or `ui/` changes, so no changeset needed.

---

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.

cc @tupe12334 if this needs a look before merging.