### PR TITLE
fix(the-1-percent): work in a temp clone, never mutate ~/.config/moadim

### DIFF
--- a/.changeset/1pct-temp-clone.md
+++ b/.changeset/1pct-temp-clone.md
@@ -1,0 +1,7 @@
+---
+"moadim": patch
+---
+
+### Fixed
+
+- **"The 1 Percent" routine no longer mutates the live `~/.config/moadim` checkout.** Its PR step now clones the routines repo to a disposable temp directory and does all branch/commit/push work there, instead of running `checkout -b` / `commit` / `push` directly against the daemon's own routines checkout. This avoids leaving that checkout parked on a stale branch after merge and avoids racing the daemon's own reads of the routines folder.

--- a/src/routines/defaults/the_1_percent.rs
+++ b/src/routines/defaults/the_1_percent.rs
@@ -63,17 +63,23 @@ Good improvement examples:
 
 ## Step 4: Open the PR
 
+**Never edit, checkout, or commit inside `~/.config/moadim` directly** — it is the live \
+checkout the daemon reads routines from. Do all work in a disposable temp clone instead:
+
 ```bash
-git -C ~/.config/moadim checkout -b 1pct/$(date +%Y%m%d-%H%M)
-# Edit/add/delete files under ~/.config/moadim/routines/ as needed.
-# Only touch routine.toml / prompts/prompt.pure.md files. Do NOT modify moadim daemon config.
-git -C ~/.config/moadim add -A
-git -C ~/.config/moadim commit -m \"routines: <concise description>\"
-git -C ~/.config/moadim push -u origin HEAD
 origin=$(git -C ~/.config/moadim remote get-url origin)
+tmp=$(mktemp -d)
+git clone \"$origin\" \"$tmp\"
+git -C \"$tmp\" checkout -b 1pct/$(date +%Y%m%d-%H%M)
+# Edit/add/delete files under $tmp/routines/ as needed.
+# Only touch routine.toml / prompts/prompt.pure.md files. Do NOT modify moadim daemon config.
+git -C \"$tmp\" add -A
+git -C \"$tmp\" commit -m \"routines: <concise description>\"
+git -C \"$tmp\" push -u origin HEAD
 gh pr create --repo \"$origin\" \
   --title \"1%: <short description>\" \
   --body \"$(printf '## What changed\\n<one paragraph>\\n\\n## Why this improves the portfolio\\n<one paragraph>\\n\\n## Expected impact\\n<one line>')\"
+rm -rf \"$tmp\"
 ```
 
 ## Report


### PR DESCRIPTION
## What changed
"The 1 Percent" routine's PR step ran `checkout -b` / `commit` / `push` directly against the live `~/.config/moadim` checkout — the same checkout the daemon reads routines from at runtime. It now clones the routines repo's origin into a `mktemp -d` temp directory and does all branching, editing, committing, and pushing there, then removes the temp dir.

## Why
Operating directly on `~/.config/moadim` left it parked on stale `1pct/*` branches after each run's PR merged upstream (confirmed in practice — local checkout was found sitting 13 commits behind `main` on a dead branch), and risked racing the daemon's own filesystem reads of the routines folder mid-run.

## Test plan
- [x] `cargo check` passes
- [x] Full test suite (728 tests) + 100% coverage gate pass
- [x] Changeset added for the `src/` change