### PR TITLE
fix(routines): migrate workbenches to the new slug on routine rename

### DIFF
--- a/.changeset/migrate-workbenches-on-rename.md
+++ b/.changeset/migrate-workbenches-on-rename.md
@@ -1,0 +1,7 @@
+---
+"moadim": patch
+---
+
+### Fixed
+
+- **Renaming a routine no longer strands its prior run history under the old slug.** Workbenches (`~/.moadim/workbenches/{slug}-{ts}`) are keyed by a routine's title slug, not its stable id. `PATCH`/`PUT /routines/{id}` now migrates every existing `{old_slug}-{ts}` workbench to `{new_slug}-{ts}` when the title changes, so `GET /routines/{id}/logs` keeps finding prior runs and the cleanup watchdog keeps resolving an in-flight run to the renamed routine's own `ttl_secs`/`max_runtime_secs` instead of falling back to orphan defaults (#267).

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -531,6 +531,7 @@ pub fn svc_update(
     let new_slug = slugify(&routine.title);
     write_routine(&routine).map_err(|_| AppError::Internal)?;
     if new_slug != old_slug {
+        migrate_workbenches(&old_slug, &new_slug);
         remove_routine_dir(&old_slug).map_err(|_| AppError::Internal)?;
     }
     if let Err(err) = crate::sync::routines::sync_routines_to_crontab(store) {
@@ -699,6 +700,36 @@ fn spawn_routine_command(routine: &Routine) {
 pub fn svc_cleanup(store: &RoutineStore) -> CleanupResponse {
     CleanupResponse {
         removed: cleanup_expired_workbenches(store),
+    }
+}
+
+/// Rename every existing workbench directory from `old_slug` to `new_slug`, preserving each run's
+/// trigger timestamp (`{old_slug}-{ts}` -> `{new_slug}-{ts}`).
+///
+/// Called from [`svc_update`] when a routine's title (and thus slug) changes. Workbenches are keyed
+/// by slug, not the routine's stable UUID, so without this migration a rename would strand every
+/// prior run under the old slug: [`svc_logs`] (which looks up by *current* slug) would find nothing,
+/// and an in-flight run would fall through to the cleanup watchdog's orphan defaults instead of the
+/// routine's own `ttl_secs`/`max_runtime_secs` (#267). A failed rename is logged and skipped rather
+/// than failing the update itself — this is best-effort history preservation, not a correctness
+/// requirement of the rename.
+fn migrate_workbenches(old_slug: &str, new_slug: &str) {
+    let Ok(entries) = std::fs::read_dir(workbenches_dir()) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let Some((dir_slug, ts)) = parse_workbench_name(&name) else {
+            continue;
+        };
+        if dir_slug != old_slug {
+            continue;
+        }
+        let from = workbenches_dir().join(&name);
+        let to = workbenches_dir().join(format!("{new_slug}-{ts}"));
+        if let Err(err) = std::fs::rename(&from, &to) {
+            log::warn!("failed to migrate workbench {name} to {new_slug}-{ts}: {err}");
+        }
     }
 }
 

--- a/src/routines/service_tests.rs
+++ b/src/routines/service_tests.rs
@@ -684,6 +684,73 @@ fn svc_update_rejects_renaming_into_existing_slug() {
 }
 
 #[test]
+fn svc_update_migrates_workbenches_on_rename() {
+    let _home = TempHome::set();
+    // Covers #267: renaming a routine must not strand its prior workbenches under the old
+    // slug, or `svc_logs` and the cleanup watchdog silently lose track of them.
+    let old_title = "Svc Update Rename Old ZZZ";
+    let new_title = "Svc Update Rename New ZZZ";
+    let old_slug = slugify(old_title);
+    let new_slug = slugify(new_title);
+    let store = store_with(vec![make_routine("rename-id", old_title, 1, 1)]);
+
+    let workbenches = crate::paths::workbenches_dir();
+    let old_dir = workbenches.join(format!("{old_slug}-1000"));
+    std::fs::create_dir_all(&old_dir).unwrap();
+    std::fs::write(old_dir.join("agent.log"), "prior run log").unwrap();
+
+    // An unparseable directory name alongside it: skipped by `parse_workbench_name`, left
+    // untouched by the migration.
+    let unparseable = workbenches.join("not-a-workbench-name");
+    std::fs::create_dir_all(&unparseable).unwrap();
+
+    // A second old-slug workbench (older than the one above, so it never wins "newest") whose
+    // destination is already occupied by a *non-empty* directory, so `std::fs::rename` fails for
+    // it: covers the best-effort warn-and-skip branch. The source is left in place rather than
+    // silently dropped.
+    let blocked_old = workbenches.join(format!("{old_slug}-500"));
+    std::fs::create_dir_all(&blocked_old).unwrap();
+    let blocked_new = workbenches.join(format!("{new_slug}-500"));
+    std::fs::create_dir_all(&blocked_new).unwrap();
+    std::fs::write(blocked_new.join("marker"), "occupied").unwrap();
+
+    with_empty_path(|| {
+        svc_update(
+            &store,
+            "rename-id",
+            UpdateRoutineRequest {
+                title: Some(new_title.into()),
+                ..empty_update_request()
+            },
+        )
+        .unwrap();
+    });
+
+    // The old-slug workbench is gone and its content now lives under the new slug, keyed by
+    // the same trigger timestamp.
+    assert!(!old_dir.exists());
+    let migrated = workbenches.join(format!("{new_slug}-1000"));
+    assert_eq!(
+        std::fs::read_to_string(migrated.join("agent.log")).unwrap(),
+        "prior run log"
+    );
+
+    // The unparseable directory is untouched.
+    assert!(unparseable.exists());
+
+    // The blocked rename left the source in place and the occupied destination unchanged.
+    assert!(blocked_old.exists());
+    assert_eq!(
+        std::fs::read_to_string(blocked_new.join("marker")).unwrap(),
+        "occupied"
+    );
+
+    // `svc_logs` (which looks up by the *current* slug) can still find the newest migrated run.
+    let logs = svc_logs(&store, "rename-id").unwrap();
+    assert_eq!(logs, "prior run log");
+}
+
+#[test]
 fn svc_update_sets_ttl_secs() {
     let _home = TempHome::set();
     // Covers the `req.ttl_secs` apply branch in `svc_update`.


### PR DESCRIPTION
## Problem

Workbenches (`~/.moadim/workbenches/{slug}-{ts}`) are keyed by a routine's **title slug**, not its stable UUID. `svc_update` already renames the routine's config dir when the title changes, but left existing workbenches behind under the old slug:

- `GET /routines/{id}/logs` looks up runs by the routine's *current* slug, so after a rename it silently returned an empty string — every prior run's `agent.log` was still on disk, just unreachable.
- The cleanup watchdog resolves `ttl_secs`/`max_runtime_secs` from a slug-keyed snapshot. An in-flight run started before the rename no longer matched any routine by its old slug, so it fell back to the orphan defaults (`MAX_TTL_SECS`/`MAX_RUNTIME_SECS`, 1h) instead of the routine's configured values.

Closes #267.

## Fix

`svc_update` now migrates every `{old_slug}-{ts}` workbench directory to `{new_slug}-{ts}` right alongside the existing config-dir rename, preserving each run's trigger timestamp. A failed individual rename (e.g. destination already occupied) is logged via `log::warn!` and skipped rather than failing the whole update — this is best-effort history preservation, not a correctness requirement of the rename itself.

## Tests

- `svc_update_migrates_workbenches_on_rename`: covers the happy path (workbench migrated, `svc_logs` still resolves it post-rename), an unparseable directory name being left untouched, and a blocked rename (occupied destination) leaving its source workbench in place.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 734 + 195 passed, 0 failed
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% line coverage, gate passes

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.
cc @tupe12334