### PR TITLE
docs: document machines and tags fields in the Routine reference table

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,11 @@ git-trackable:
 | `agent`        | string | yes      | Agent registry key (e.g. `claude`), resolved from `~/.config/moadim/agents/<agent>.toml`.    |
 | `goal`         | string | no       | A very short (≤5 lines) statement of the routine's goal — the "why" behind the prompt. Rendered into `prompt.md` as a `## Goal` preamble. |
 | `repositories` | list   | no       | Git repos listed in the prompt as context. Moadim does **not** clone them — the agent does.   |
+| `machines`     | list   | no       | Machine identities this routine runs on (matched against `machine.local.toml`). Defaults to empty — **an empty list runs nowhere**, so a new routine is dormant until explicitly assigned. |
 | `enabled`      | bool   | no       | Defaults to `true`. Set `false` to pause without deleting.                                    |
 | `ttl_secs`     | int    | no       | How long a finished run's workbench is retained before auto-cleanup. Caps the cron-derived retention lower — it can only shorten, never extend it. `None` uses the cron-derived value. |
 | `max_runtime_secs` | int | no       | Max wall-clock seconds a single run may execute before the cleanup watchdog force-kills its (hung) tmux session; the workbench is then reaped under the normal TTL rules. Caps the cron-derived runtime (`min(MAX_RUNTIME_SECS, cron interval)`) lower — it can only shorten, never extend it. `None` uses the cron-derived value. |
+| `tags`         | list   | no       | Free-form labels for grouping/filtering routines (e.g. `"nightly"`). Defaults to empty; each entry is trimmed and must be non-blank. |
 
 **Workbenches and cleanup:** each run executes in a workbench under
 `~/.moadim/workbenches/`. Finished, expired workbenches are reaped on an


### PR DESCRIPTION
## Why

The README's Routine field table (`## Routines`) documents 8 fields —
`schedule`, `title`, `agent`, `goal`, `repositories`, `enabled`, `ttl_secs`,
`max_runtime_secs` — but `Routine`/`CreateRoutineRequest`/
`UpdateRoutineRequest` (`src/routines/model.rs`) have shipped two more
create/update-able fields, `machines` and `tags`, that were never added to
the table.

`machines` is the important one: its own doc comment warns that an
**empty list runs nowhere** — a routine stays dormant until a machine is
explicitly assigned. A user who only reads the README table has no way to
learn this field exists, and could create a routine that silently never
fires with no indication why. `tags` is a smaller but still real,
already-shipped, user-facing gap (grouping/filtering routines).

## What

Adds two rows to the Routine field table:
- `machines` — with the "empty list runs nowhere" caveat called out explicitly.
- `tags` — free-form labels, trimmed/non-blank per-entry.

Docs-only change (no `src/`/`ui/` touched, no changeset needed). Verified
`cargo fmt --check` / `cargo clippy --workspace --all-targets -- -D warnings`
still pass on this branch (unaffected), and `typos README.md` is clean.

Not a duplicate of any of the 60 currently-open PRs from this same
automated-improvement routine — none of them touch the Routine field
reference table (closest are #910, which removes an overclaiming
CLI/REST/MCP parity statement, and #896, which prunes stale TODO.md entries;
neither addresses this table).

🤖 Generated as part of an automated repo-improvement routine.