### PR TITLE
fix(ui): stop log-viewer search highlight panicking on Unicode case folding

### DIFF
--- a/.changeset/log-viewer-highlight-panic.md
+++ b/.changeset/log-viewer-highlight-panic.md
@@ -1,0 +1,7 @@
+---
+"moadim": patch
+---
+
+### Fixed
+
+- **The routine LOGS view search/highlight could panic the UI on ordinary Unicode log content.** `highlight()` found matches by lowercasing the whole line and then reapplying *those* byte offsets to the original (un-lowercased) string. Case folding isn't always byte-length-preserving (`ẞ`, U+1E9E, 3 bytes, lowercases to `ß`, U+00DF, 2 bytes) or even char-count-preserving (Turkish `İ` expands to two chars), so a matching search query after such a character could compute an offset that lands mid-character and panics on the slice (crashing the Yew render for that log line). The matching logic now projects each original char to exactly one lowercase char and tracks byte spans via `char_indices()`, so every slice boundary is guaranteed valid regardless of the log content's script.

--- a/ui/src/log_viewer.rs
+++ b/ui/src/log_viewer.rs
@@ -156,43 +156,71 @@ fn render_line(ln: usize, text: &str, query: &str) -> Html {
     }
 }
 
-/// Split `text` into `Html` with each case-insensitive occurrence of `query`
-/// wrapped in `<mark class="log-hl">`.  Returns plain text when `query` is blank.
+/// Split `text` into `(is_match, segment)` pairs, `true` for each case-insensitive occurrence of
+/// `query`, in original order; `false` segments fill the gaps. Blank `query` (after trimming)
+/// yields the whole text as a single non-matching segment.
 ///
-/// Note: byte-offset arithmetic is correct for ASCII log content (the primary use
-/// case).  Non-ASCII queries that change byte length when lowercased are guarded
-/// by the `end > text.len()` safety check.
-fn highlight(text: &str, query: &str) -> Html {
-    let needle = query.trim().to_lowercase();
+/// Every slice boundary comes from `text.char_indices()`, so it is always a valid char boundary in
+/// `text`. This matters because a naive approach — find the match in `text.to_lowercase()` and
+/// reapply *its* byte offsets to `text` — panics on input like `text = "ẞzz"`, `query = "zz"`:
+/// `ẞ` (U+1E9E, 3 bytes) lowercases to `ß` (U+00DF, 2 bytes), so the byte offset found in the
+/// lowercased string no longer lands on a char boundary in the original. Some chars also *expand*
+/// under `to_lowercase()` (Turkish `İ` → `i̇`, two chars), which a byte-length guard alone can't
+/// catch either. Instead, each char of `text` is projected to exactly one lowercase char (dropping
+/// any expansion beyond the first), keeping a 1:1 index correspondence between `chars` and `lower`
+/// so every match position maps back to an exact, valid byte span in `text`.
+#[must_use]
+fn highlight_segments<'a>(text: &'a str, query: &str) -> Vec<(bool, &'a str)> {
+    let needle: Vec<char> = query.trim().to_lowercase().chars().collect();
     if needle.is_empty() {
-        return html! { {text} };
+        return vec![(false, text)];
     }
-    let lower = text.to_lowercase();
-    let mut parts: Vec<Html> = Vec::new();
-    let mut start = 0usize;
-    while start <= text.len() {
-        match lower[start..].find(&needle) {
-            None => break,
-            Some(pos) => {
-                let abs = start + pos;
-                let end = abs + needle.len();
-                if end > text.len() {
-                    break;
-                }
-                if abs > start {
-                    let before = &text[start..abs];
-                    parts.push(html! { {before} });
-                }
-                let matched = &text[abs..end];
-                parts.push(html! { <mark class="log-hl">{matched}</mark> });
-                start = end;
+    let chars: Vec<(usize, char)> = text.char_indices().collect();
+    let lower: Vec<char> = chars
+        .iter()
+        .map(|&(_, c)| c.to_lowercase().next().unwrap_or(c))
+        .collect();
+
+    let mut segments = Vec::new();
+    let mut cursor = 0usize; // char index into `chars`/`lower`
+    let mut last_byte = 0usize; // byte offset in `text` already emitted
+    while cursor + needle.len() <= lower.len() {
+        if lower[cursor..cursor + needle.len()] == needle[..] {
+            let match_start = chars[cursor].0;
+            let match_end = chars
+                .get(cursor + needle.len())
+                .map_or(text.len(), |&(byte, _)| byte);
+            if match_start > last_byte {
+                segments.push((false, &text[last_byte..match_start]));
             }
+            segments.push((true, &text[match_start..match_end]));
+            last_byte = match_end;
+            cursor += needle.len();
+        } else {
+            cursor += 1;
         }
     }
-    if start < text.len() {
-        parts.push(html! { {&text[start..]} });
+    if last_byte < text.len() {
+        segments.push((false, &text[last_byte..]));
     }
-    html! { <>{for parts.into_iter()}</> }
+    segments
+}
+
+/// Render `text` as `Html`, wrapping each case-insensitive occurrence of `query` in
+/// `<mark class="log-hl">`. Returns plain text when `query` is blank. See
+/// [`highlight_segments`] for the (host-testable) matching logic.
+fn highlight(text: &str, query: &str) -> Html {
+    html! {
+        <>
+            { for highlight_segments(text, query).into_iter().map(|(is_match, seg)| {
+                if is_match {
+                    html! { <mark class="log-hl">{seg}</mark> }
+                } else {
+                    html! { {seg} }
+                }
+            }) }
+        </>
+    }
 }
 
 #[cfg(test)]

--- a/ui/src/log_viewer_tests.rs
+++ b/ui/src/log_viewer_tests.rs
@@ -102,3 +102,68 @@ fn empty_content_blank_query() {
     assert_eq!(hits, 0);
     assert_eq!(total, 0);
 }
+
+// ── highlight_segments ───────────────────────────────────────────────────────
+
+#[test]
+fn blank_query_yields_a_single_unmatched_segment() {
+    assert_eq!(
+        highlight_segments("hello world", ""),
+        vec![(false, "hello world")]
+    );
+    assert_eq!(
+        highlight_segments("hello world", "   "),
+        vec![(false, "hello world")]
+    );
+}
+
+#[test]
+fn single_case_insensitive_match_in_the_middle() {
+    assert_eq!(
+        highlight_segments("see ERROR here", "error"),
+        vec![(false, "see "), (true, "ERROR"), (false, " here")]
+    );
+}
+
+#[test]
+fn multiple_matches_are_all_highlighted() {
+    assert_eq!(
+        highlight_segments("foo bar foo", "foo"),
+        vec![(true, "foo"), (false, " bar "), (true, "foo")]
+    );
+}
+
+#[test]
+fn no_match_yields_a_single_unmatched_segment() {
+    assert_eq!(
+        highlight_segments("hello world", "zzz"),
+        vec![(false, "hello world")]
+    );
+}
+
+#[test]
+fn match_spanning_the_whole_text_yields_one_segment() {
+    assert_eq!(highlight_segments("foo", "foo"), vec![(true, "foo")]);
+}
+
+#[test]
+fn regression_case_folding_that_shrinks_byte_length_does_not_panic_or_misalign() {
+    // `ẞ` (U+1E9E, capital sharp S, 3 bytes) lowercases to `ß` (U+00DF, 2 bytes): searching for
+    // the match in `text.to_lowercase()` and reapplying its byte offsets to the original `text`
+    // lands mid-character and panics. `chars.get()`-derived boundaries must never do that.
+    assert_eq!(
+        highlight_segments("ẞzz", "zz"),
+        vec![(false, "ẞ"), (true, "zz")]
+    );
+}
+
+#[test]
+fn regression_case_folding_that_grows_byte_length_does_not_panic_or_misalign() {
+    // The reverse direction: `ß` (2 bytes) uppercases to `SS` in full case folding, but even for
+    // lowercasing some single chars expand under `to_lowercase()` (Turkish `İ` → 2 chars); the
+    // per-char projection this relies on must still keep `chars`/`lower` index-aligned.
+    assert_eq!(
+        highlight_segments("İzz", "zz"),
+        vec![(false, "İ"), (true, "zz")]
+    );
+}


### PR DESCRIPTION
## Why

The routine LOGS view's search box highlights matches by lowercasing the
whole line (`text.to_lowercase()`) and then reapplying *that* string's byte
offsets to the original, un-lowercased `text` when slicing out the matched
substring.

Case folding is not guaranteed to be byte-length-preserving: `ẞ` (U+1E9E,
capital sharp S, 3 bytes) lowercases to `ß` (U+00DF, 2 bytes). It's not even
char-count-preserving: Turkish `İ` (U+0130) lowercases to two chars (`i` +
combining dot above). Either way, a byte offset found in the lowercased
string can land mid-character in the original `text`, and slicing there
panics — crashing the Yew render for that log line the moment an operator's
search query happens to match text that follows such a character in
arbitrary AI-agent log output (foreign text, unicode escapes, etc.). The
existing `end > text.len()` comment claimed this was "guarded", but that
check only catches the match running past the end of the string — not this
interior offset drift.

Reproduced directly: `text = "ẞzz"`, `query = "zz"` panics with `byte index 2
is not a char boundary` under the old algorithm.

## What

- Replaced the byte-offset-reuse algorithm with a new pure helper,
  `highlight_segments()`, that projects each original char to exactly one
  lowercase char and derives every slice boundary from `text.char_indices()`
  — so a slice can never land off a char boundary, regardless of the
  content's script.
- `highlight()` is now a thin `Html`-rendering wrapper over
  `highlight_segments()`, mirroring the existing `filter_lines`/`match_count`
  pure-helper pattern already used in this file for host-side testability.
- Added regression tests for both case-folding directions (`ẞ`→`ß` shrinking,
  `İ` expanding) plus the existing match/no-match/blank-query cases against
  the new segment-based API.

## Verification (local)

```
cargo fmt --check                                             # clean
cargo clippy --all-targets --all-features -- -D warnings      # clean (root + `cargo clippy -p ui`)
cargo test -p ui log_viewer                                   # 22/22 pass, including the two panic regressions
cargo test -p ui                                               # 202/202 pass
cargo test --bin moadim                                        # 752/752 pass (root crate, untouched by this change)
```