### PR TITLE
fix(server): add Cache-Control: no-store to prevent stale routine responses

### DIFF
--- a/.changeset/cache-control-no-store.md
+++ b/.changeset/cache-control-no-store.md
@@ -1,0 +1,7 @@
+---
+"moadim": patch
+---
+
+### Fixed
+
+- **Routine list no longer shows stale data after a page reload.** The server now sends `Cache-Control: no-store` on all API responses that don't already carry a cache directive, preventing browsers from heuristically caching `GET /routines` responses and serving stale JSON on reload.

--- a/src/middlewares/security_headers.rs
+++ b/src/middlewares/security_headers.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::Request,
-    http::{header::HeaderName, HeaderValue},
+    http::{header, header::HeaderName, HeaderValue},
     middleware::Next,
     response::Response,
 };
@@ -59,6 +59,12 @@ const SECURITY_HEADERS: &[(&str, &str)] = &[
 ];
 
 /// Inject the [`SECURITY_HEADERS`] onto every response.
+///
+/// `Cache-Control: no-store` is also added as a fallback for responses that don't already carry a
+/// `Cache-Control` header. Responses that set their own directive (e.g. the SPA's `index.html`
+/// uses `no-cache` to enable ETag-based 304 revalidation, issue #401) are left untouched.
+/// Without this fallback, browsers apply heuristic caching to API `GET` responses and may serve
+/// stale JSON on page reload (issue #921).
 pub async fn security_headers(req: Request, next: Next) -> Response {
     let mut res = next.run(req).await;
     let headers = res.headers_mut();
@@ -69,6 +75,9 @@ pub async fn security_headers(req: Request, next: Next) -> Response {
             HeaderValue::from_static(value),
         );
     }
+    headers
+        .entry(header::CACHE_CONTROL)
+        .or_insert(HeaderValue::from_static("no-store"));
     res
 }
 

--- a/src/middlewares/security_headers_tests.rs
+++ b/src/middlewares/security_headers_tests.rs
@@ -2,7 +2,7 @@
 
 use axum::{
     body::Body,
-    http::{Request, StatusCode},
+    http::{header, HeaderValue, Request, StatusCode},
     middleware,
     routing::get,
     Router,
@@ -47,6 +47,11 @@ async fn frame_ancestors_blocks_framing() {
     // / `base-uri` / `form-action` denials so an injected `<script>`, `<base>`, or off-origin
     // `<form>` cannot act on behalf of the unauthenticated destructive API.
     assert_eq!(
+        resp.headers().get("cache-control").unwrap(),
+        "no-store",
+        "no-store fallback absent on a plain response (issue #921)"
+    );
+    assert_eq!(
         resp.headers().get("content-security-policy").unwrap(),
         "default-src 'self'; \
          script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; \
@@ -59,4 +64,28 @@ async fn frame_ancestors_blocks_framing() {
          object-src 'none'; \
          frame-ancestors 'none'"
     );
+}
+
+#[tokio::test]
+async fn cache_control_fallback_does_not_override_handler_directive() {
+    // A handler that already sets Cache-Control: no-cache (like the SPA index.html, issue #401)
+    // must not have its value replaced by the no-store fallback.
+    let app = Router::new()
+        .route(
+            "/",
+            get(|| async {
+                let mut resp = axum::response::Response::new(Body::empty());
+                resp.headers_mut()
+                    .insert(header::CACHE_CONTROL, HeaderValue::from_static("no-cache"));
+                resp
+            }),
+        )
+        .layer(middleware::from_fn(security_headers));
+
+    let resp = app
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.headers().get("cache-control").unwrap(), "no-cache");
 }


### PR DESCRIPTION
Closes #921

## Problem

`GET /routines` (and other API endpoints) returned no `Cache-Control` header. Without an explicit directive, browsers apply **heuristic caching** to GET responses — so on page reload they serve the last cached JSON instead of fetching from the daemon. Changes made to routines (e.g. adding a machine to the `machines` list) were invisible until the daemon was restarted, which resets the TCP connection and forces a fresh fetch.

## Fix

In `security_headers` middleware, fall back to `Cache-Control: no-store` for any response that doesn't already carry a `Cache-Control` header. This propagates to all API responses in one place with no per-handler changes.

Responses that set their own directive are left untouched — specifically, the SPA's `index.html` handler uses `no-cache` (with ETag/304 revalidation from #401) and continues to do so.

## Tests

- `security_headers_present_on_response` — updated to assert `cache-control: no-store` is present on a plain response
- `cache_control_fallback_does_not_override_handler_directive` — new: verifies a handler that already sets `Cache-Control: no-cache` is not overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)