### PR TITLE
fix(changeset): make clear-pets-relax.md valid for version-and-sync

### DIFF
--- a/.changeset/clear-pets-relax.md
+++ b/.changeset/clear-pets-relax.md
@@ -1,2 +1,7 @@
 ---
+"moadim": minor
 ---
+
+### Added
+
+- Group-by dimension selector for the Routines table (agent, machine, or status), mirroring the existing CronJobs page feature.


### PR DESCRIPTION
## Summary

- The `clear-pets-relax.md` changeset had empty frontmatter (`---\n---`), which was intentional to satisfy the CI gate but broke `version-and-sync.mjs` (the regex requires at least a bump type line between the delimiters).
- Added `"moadim": minor` and a description entry so the script can parse it correctly.
- This unblocks `cut-release.yml` which was failing at the "Bump version and sync Cargo/CHANGELOG" step.

## Test plan

- [ ] Merge this PR
- [ ] Re-trigger `cut-release.yml` → should proceed past the version bump step
- [ ] Open the resulting `ci/version-bump-*` PR and merge it to complete the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)