### PR TITLE
fix(release): regenerate openapi.json after version bump in version-and-sync

### DIFF
--- a/.changeset/clear-pets-relax.md
+++ b/.changeset/clear-pets-relax.md
@@ -1,2 +1,7 @@
 ---
+"moadim": minor
 ---
+
+### Added
+
+- Group-by dimension selector for the Routines table (agent, machine, or status), mirroring the existing CronJobs page feature.

--- a/scripts/release/version-and-sync.mjs
+++ b/scripts/release/version-and-sync.mjs
@@ -148,7 +148,22 @@ function main() {
 
   execSync("cargo check -q", { cwd: ROOT, stdio: "inherit" });
 
-  console.log(`Synced Cargo.toml, Cargo.lock, CHANGELOG.md, and docs/moadim.1 to ${version}.`);
+  // The committed OpenAPI spec embeds the crate version. Run the self-healing
+  // test once (it regenerates apis/openapi.json and exits non-zero on drift),
+  // then again to confirm the regenerated file is stable.
+  try {
+    execSync(
+      "cargo test --quiet -- openapi::openapi_tests::committed_spec_is_current",
+      { cwd: ROOT, stdio: "inherit" },
+    );
+  } catch {
+    execSync(
+      "cargo test --quiet -- openapi::openapi_tests::committed_spec_is_current",
+      { cwd: ROOT, stdio: "inherit" },
+    );
+  }
+
+  console.log(`Synced Cargo.toml, Cargo.lock, CHANGELOG.md, docs/moadim.1, and apis/openapi.json to ${version}.`);
 }
 
 main();


### PR DESCRIPTION
## Summary

- `version-and-sync.mjs` runs `cargo check` after bumping `Cargo.toml`, but the committed `apis/openapi.json` embeds the crate version (via `CARGO_PKG_VERSION`). `cargo check` doesn't run tests, so the self-healing `committed_spec_is_current` test never fires during the bump, leaving the spec stale.
- The subsequent `cargo test` step in `cut-release.yml` then hits the stale spec, fails, and blocks the release.
- Fix: run `cargo test -- openapi::openapi_tests::committed_spec_is_current` once after `cargo check` (regenerates the file on drift, exits non-zero), then a second time to confirm the file is stable.

## Test plan

- [ ] Merge this PR
- [ ] Re-trigger `cut-release.yml` → the version bump step should now regenerate `apis/openapi.json` and the test step should pass
- [ ] Open and merge the resulting `ci/version-bump-*` PR to complete the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)