### PR TITLE
chore: add linecheck.yml exclusion config

### DIFF
--- a/linecheck.yml
+++ b/linecheck.yml
@@ -1,0 +1,5 @@
+exclude:
+  - "target/**"
+  - "node_modules/**"
+  - "Cargo.lock"
+  - "pnpm-lock.yaml"


### PR DESCRIPTION
## Summary
- Adds `linecheck.yml` to exclude generated/vendored paths (`target/**`, `node_modules/**`, `Cargo.lock`, `pnpm-lock.yaml`) from line checks

## Test plan
- [ ] CI passes