### PR TITLE
feat: replace trigger TOML sidecars with append-only .log files

### DIFF
--- a/.changeset/trigger-log-files.md
+++ b/.changeset/trigger-log-files.md
@@ -1,0 +1,7 @@
+---
+"moadim": minor
+---
+
+### Changed
+
+- **Scheduled and manual trigger history is now recorded in append-only `.log` files.** `scheduled.local.toml` (overwritten on each cron fire) is replaced by `scheduled.log`; the manual-trigger timestamp previously stored in `state.local.toml` moves to `manual.log`. Each file records one Unix timestamp per execution, giving a full run history instead of only the most recent timestamp. A startup migration seeds the log files from any legacy TOML sidecars found on disk and removes the old files, so existing installs upgrade transparently. The `.log` suffix matches the existing `*.log` gitignore pattern seeded into each routine directory.

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -1260,7 +1260,7 @@
               "null"
             ],
             "format": "int64",
-            "description": "Unix timestamp (seconds) when the routine was last fired by its cron schedule, if ever.\n\nThe mirror of [`Routine::last_manual_trigger_at`] for scheduled runs: a manual trigger\nupdates only the manual field, a scheduled firing updates only this one. The host OS crontab\nline runs `moadim schedule trigger <id>`, and the launch command the daemon spawns stamps this\ntimestamp into the gitignored `scheduled.local.toml` sidecar at fire time (via its `printf`\nstep); the daemon reads it back on load. The daemon never writes this field directly (it is\nabsent from `routine.toml` and the daemon-owned `state.local.toml`), so re-persisting a\nroutine can't clobber it.",
+            "description": "Unix timestamp (seconds) when the routine was last fired by its cron schedule, if ever.\n\nThe mirror of [`Routine::last_manual_trigger_at`] for scheduled runs: a manual trigger\nupdates only the manual field, a scheduled firing updates only this one. The host OS crontab\nline runs `moadim schedule trigger <id>`, and the launch command the daemon spawns appends\nthe Unix timestamp to the gitignored `scheduled.log` at fire time; the daemon reads the last\nline back on load. The daemon never writes this field directly (it is absent from\n`routine.toml` and the daemon-owned `state.local.toml`), so re-persisting a routine can't\nclobber the log.",
             "minimum": 0
           },
           "machines": {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -609,8 +609,9 @@ Each subdirectory here is one routine (a prompt + schedule + agent, run on a cro
   prompt) copied into each run's workbench.
 - `<id>/flags/` — open questions an agent raised mid-run: a gap, bug, edge case, or question
   it couldn't resolve.
-- `<id>/state.local.toml`, `<id>/scheduled.local.toml` — gitignored sidecars recording
-  daemon-written runtime state (last manual/scheduled trigger times).
+- `<id>/state.local.toml` — gitignored sidecar holding snooze/skip-runs state.
+- `<id>/manual.log`, `<id>/scheduled.log` — gitignored append-only logs recording every
+  manual / scheduled trigger (one Unix timestamp per line).
 
 Full docs: https://github.com/moadim-io/daemon
 ";

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,6 +132,11 @@ async fn run_server() -> anyhow::Result<()> {
     // store reflects the canonical dirs the crontab sync and the launch command's
     // `cp prompt.compiled.md` both target.
     routine_storage::migrate_routine_dirs();
+    // Migrate per-routine trigger timestamps from legacy TOML sidecars (scheduled.local.toml,
+    // last_manual_trigger_at in state.local.toml) into the new append-only log files
+    // (scheduled.log, manual.log). Must run before load_store so the first load already reads from
+    // the log files.
+    routine_storage::migrate_trigger_logs();
     let routines = routine_storage::load_store();
     // Seed any missing built-in default routines (e.g. the daily moadim cargo update check) so a
     // fresh install ships with them, and a default deleted while stopped is restored. Existing

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -135,16 +135,6 @@ pub fn routine_scheduled_log_path(id: &str) -> PathBuf {
     routine_dir(id).join("scheduled.log")
 }
 
-/// Returns the path to `{routines_dir}/{id}/scheduled.local.toml`, the legacy sidecar superseded
-/// by [`routine_scheduled_log_path`].
-///
-/// Retained only for the startup migration that seeds `scheduled.log` from the stored timestamp
-/// and removes this file. Not written anywhere in the current daemon.
-#[must_use]
-pub fn routine_scheduled_state_path(id: &str) -> PathBuf {
-    routine_dir(id).join("scheduled.local.toml")
-}
-
 /// Returns the path to `{routines_dir}/{id}/manual.log`, the gitignored append-only log that
 /// records every manual trigger as one Unix-timestamp line.
 ///

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -115,26 +115,45 @@ pub fn routine_gitignore_path(id: &str) -> PathBuf {
 }
 
 /// Returns the path to `{routines_dir}/{id}/state.local.toml`, the gitignored sidecar holding
-/// daemon-written runtime state (e.g. `last_manual_trigger_at`) kept out of the tracked `routine.toml`.
+/// daemon-written runtime state (`snoozed_until`, `skip_runs`) kept out of the tracked `routine.toml`.
 ///
 /// The `.local.` infix matches the `*.local.*` pattern seeded into each routine's `.gitignore`, so
-/// trigger churn never produces version-control diffs.
+/// snooze churn never produces version-control diffs.
 #[must_use]
 pub fn routine_state_path(id: &str) -> PathBuf {
     routine_dir(id).join("state.local.toml")
 }
 
-/// Returns the path to `{routines_dir}/{id}/scheduled.local.toml`, the gitignored sidecar that
-/// records `last_scheduled_trigger_at`.
+/// Returns the path to `{routines_dir}/{id}/scheduled.log`, the gitignored append-only log that
+/// records every scheduled (cron) firing as one Unix-timestamp line.
 ///
-/// Unlike [`routine_state_path`] this sidecar is written by the routine's launch command (the
-/// `printf` step of [`crate::routines::build_routine_command`]) at each scheduled cron firing, and is
-/// only ever *read* by the daemon — kept in its own file so a daemon-side re-persist of
-/// `state.local.toml` can't clobber the scheduler-written timestamp. The `.local.` infix matches the
-/// `*.local.*` `.gitignore` pattern, so scheduled-fire churn never produces version-control diffs.
+/// The cron shell command appends a line (`printf '%s\n' "$TS" >> scheduled.log`) at each firing;
+/// the daemon reads only the last line to derive `last_scheduled_trigger_at`. The `.log` suffix
+/// matches the `*.log` pattern seeded into each routine's `.gitignore`.
+#[must_use]
+pub fn routine_scheduled_log_path(id: &str) -> PathBuf {
+    routine_dir(id).join("scheduled.log")
+}
+
+/// Returns the path to `{routines_dir}/{id}/scheduled.local.toml`, the legacy sidecar superseded
+/// by [`routine_scheduled_log_path`].
+///
+/// Retained only for the startup migration that seeds `scheduled.log` from the stored timestamp
+/// and removes this file. Not written anywhere in the current daemon.
 #[must_use]
 pub fn routine_scheduled_state_path(id: &str) -> PathBuf {
     routine_dir(id).join("scheduled.local.toml")
+}
+
+/// Returns the path to `{routines_dir}/{id}/manual.log`, the gitignored append-only log that
+/// records every manual trigger as one Unix-timestamp line.
+///
+/// The daemon appends a line at each manual trigger; reading the last line gives
+/// `last_manual_trigger_at`. The `.log` suffix matches the `*.log` pattern in the routine's
+/// `.gitignore`.
+#[must_use]
+pub fn routine_manual_log_path(id: &str) -> PathBuf {
+    routine_dir(id).join("manual.log")
 }
 
 /// Returns the path to `{routines_dir}/{id}/run.sh`, a legacy per-routine launch script.

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -8,9 +8,10 @@ use std::sync::{Arc, Mutex};
 use serde::{Deserialize, Serialize};
 
 use crate::paths::{
-    routine_compiled_prompt_path, routine_dir, routine_gitignore_path, routine_prompts_dir,
-    routine_pure_prompt_path, routine_scheduled_state_path, routine_script_path,
-    routine_state_path, routine_toml_path, routines_dir,
+    routine_compiled_prompt_path, routine_dir, routine_gitignore_path, routine_manual_log_path,
+    routine_prompts_dir, routine_pure_prompt_path, routine_scheduled_log_path,
+    routine_scheduled_state_path, routine_script_path, routine_state_path, routine_toml_path,
+    routines_dir,
 };
 use crate::routines::{compose_prompt, slugify, Repository, Routine, RoutineStore};
 use crate::utils::atomic::atomic_write;
@@ -78,10 +79,18 @@ struct RoutineToml {
 
 /// Daemon-written runtime state for a routine, persisted to the gitignored `state.local.toml`
 /// sidecar so it never appears in the version-controlled `routine.toml`.
+///
+/// Trigger history (`last_manual_trigger_at`, `last_scheduled_trigger_at`) is no longer stored
+/// here — it lives in the append-only `manual.log` / `scheduled.log` files instead.
 #[derive(Debug, Default, Deserialize, Serialize)]
 struct RuntimeState {
     /// Unix timestamp of the last manual trigger, or `None` if it has never been triggered.
-    #[serde(default)]
+    ///
+    /// **Read-only / legacy.** Manual trigger history now lives in the `manual.log` append-only
+    /// sidecar. This field is still parsed so routines written by older daemons keep their
+    /// timestamp (the value migrates into `manual.log` on the next startup), but it is never
+    /// written back — `skip_serializing` keeps it out of every freshly written `state.local.toml`.
+    #[serde(default, skip_serializing)]
     last_manual_trigger_at: Option<u64>,
     /// Unix timestamp until which scheduled fires are skipped, or `None`. See
     /// [`crate::routines::Routine::snoozed_until`].
@@ -93,15 +102,12 @@ struct RuntimeState {
     skip_runs: Option<u32>,
 }
 
-/// Scheduler-written runtime state for a routine, persisted to the gitignored
-/// `scheduled.local.toml` sidecar.
+/// Legacy scheduled-state TOML, superseded by the `scheduled.log` append-only file.
 ///
-/// Written by the routine's launch command (the `printf` step of `build_routine_command`) at each
-/// scheduled cron firing and only ever read here — kept separate from [`RuntimeState`] so a
-/// daemon-side re-persist of `state.local.toml` can never clobber the scheduler's timestamp.
+/// Only used during startup migration: if `scheduled.local.toml` exists and `scheduled.log` does
+/// not, the stored timestamp is seeded as the first log entry and the TOML file is removed.
 #[derive(Debug, Deserialize, Serialize)]
-struct ScheduledState {
-    /// Unix timestamp of the last scheduled (cron) firing, or `None` if it has never fired.
+struct LegacyScheduledState {
     #[serde(default)]
     last_scheduled_trigger_at: Option<u64>,
 }
@@ -113,7 +119,7 @@ fn read_routine_toml(path: &std::path::PathBuf) -> Option<RoutineToml> {
 }
 
 /// Read a routine's `state.local.toml` sidecar, defaulting to an empty [`RuntimeState`] when the
-/// sidecar is absent or unparsable (e.g. before the routine has ever been triggered or snoozed).
+/// sidecar is absent or unparsable (e.g. before the routine has ever been snoozed).
 fn read_runtime_state(dir_name: &str) -> RuntimeState {
     std::fs::read_to_string(routine_state_path(dir_name))
         .ok()
@@ -121,15 +127,25 @@ fn read_runtime_state(dir_name: &str) -> RuntimeState {
         .unwrap_or_default()
 }
 
-/// Read `last_scheduled_trigger_at` from a routine's `scheduled.local.toml` sidecar, returning
-/// `None` when the sidecar is absent or unparsable (e.g. before the routine's schedule has ever
-/// fired). The daemon only reads this file; it is written by the routine's launch command at fire
-/// time.
+/// Read the last Unix-timestamp line from an append-only trigger log (e.g. `scheduled.log` or
+/// `manual.log`), returning `None` when the file is absent or contains no parsable timestamp.
+fn read_last_log_timestamp(path: &std::path::Path) -> Option<u64> {
+    let text = std::fs::read_to_string(path).ok()?;
+    text.lines()
+        .rev()
+        .find_map(|line| line.trim().parse::<u64>().ok())
+}
+
+/// Read `last_scheduled_trigger_at` from a routine's `scheduled.log`, returning `None` when the
+/// log is absent or empty (e.g. before the routine's schedule has ever fired).
 fn read_scheduled_state(dir_name: &str) -> Option<u64> {
-    let text = std::fs::read_to_string(routine_scheduled_state_path(dir_name)).ok()?;
-    toml::from_str::<ScheduledState>(&text)
-        .ok()?
-        .last_scheduled_trigger_at
+    read_last_log_timestamp(&routine_scheduled_log_path(dir_name))
+}
+
+/// Read `last_manual_trigger_at` from a routine's `manual.log`, returning `None` when the log is
+/// absent or empty.
+fn read_manual_state(dir_name: &str) -> Option<u64> {
+    read_last_log_timestamp(&routine_manual_log_path(dir_name))
 }
 
 /// Read a routine's raw prompt from its `prompts/prompt.pure.md` sidecar, falling back to the
@@ -154,8 +170,10 @@ fn load_routine_from_dir(dir_name: &str) -> Option<Routine> {
     let title = toml.title?;
     let id = toml.id.unwrap_or_else(|| dir_name.to_string());
     let runtime_state = read_runtime_state(dir_name);
-    let last_manual_trigger_at = runtime_state
-        .last_manual_trigger_at
+    // Prefer the log file; fall back to legacy state.local.toml field then routine.toml field for
+    // routines that predate the log-file migration.
+    let last_manual_trigger_at = read_manual_state(dir_name)
+        .or(runtime_state.last_manual_trigger_at)
         .or(toml.last_manual_trigger_at);
     let last_scheduled_trigger_at = read_scheduled_state(dir_name);
     let prompt = read_pure_prompt(dir_name, toml.prompt);
@@ -251,17 +269,16 @@ pub fn write_routine(routine: &Routine) -> std::io::Result<()> {
 /// when all are `None`, so the on-disk state always mirrors the in-memory routine.
 fn write_runtime_state(slug: &str, routine: &Routine) -> std::io::Result<()> {
     let path = routine_state_path(slug);
-    if routine.last_manual_trigger_at.is_none()
-        && routine.snoozed_until.is_none()
-        && routine.skip_runs.is_none()
-    {
+    if routine.snoozed_until.is_none() && routine.skip_runs.is_none() {
         if path.exists() {
             std::fs::remove_file(&path)?;
         }
         return Ok(());
     }
     let state = RuntimeState {
-        last_manual_trigger_at: routine.last_manual_trigger_at,
+        // Not written (skip_serializing); stored only to satisfy the struct; reads migrate the
+        // legacy value from here into manual.log on first load.
+        last_manual_trigger_at: None,
         snoozed_until: routine.snoozed_until,
         skip_runs: routine.skip_runs,
     };
@@ -269,6 +286,89 @@ fn write_runtime_state(slug: &str, routine: &Routine) -> std::io::Result<()> {
         .expect("RuntimeState serialization cannot fail for a struct with only Option fields");
     atomic_write(&path, text.as_bytes())?;
     Ok(())
+}
+
+/// Append a Unix-timestamp entry to a routine's `manual.log`, recording a manual trigger.
+///
+/// Called by `svc_trigger` immediately after stamping `last_manual_trigger_at` on the in-memory
+/// routine. Best-effort: a log-write failure is warned but never surfaced to the caller, so a
+/// disk hiccup can't block the trigger itself.
+pub fn append_manual_trigger_log(slug: &str, ts: u64) {
+    let path = routine_manual_log_path(slug);
+    let line = format!("{ts}\n");
+    if let Err(err) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .and_then(|mut f| std::io::Write::write_all(&mut f, line.as_bytes()))
+    {
+        log::warn!("append_manual_trigger_log: failed to write {}: {err}", path.display());
+    }
+}
+
+/// Migrate per-routine trigger state from legacy TOML sidecars to append-only log files.
+///
+/// For each routine directory:
+/// - If `scheduled.local.toml` exists and `scheduled.log` does not, the stored timestamp is
+///   written as the first log line and the TOML file is removed.
+/// - If `state.local.toml` contains a `last_manual_trigger_at` field and `manual.log` does not
+///   exist, the stored timestamp is written as the first log line.
+///
+/// Call once at startup, after [`migrate_prompt_files`] and before [`load_store`].
+pub fn migrate_trigger_logs() {
+    migrate_trigger_logs_from_dir(&routines_dir());
+}
+
+/// Inner variant of [`migrate_trigger_logs`] that scans `dir` instead of [`routines_dir`].
+pub(crate) fn migrate_trigger_logs_from_dir(dir: &std::path::Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if !entry.file_type().is_ok_and(|ft| ft.is_dir()) {
+            continue;
+        }
+        let dir_name = entry.file_name().to_string_lossy().to_string();
+
+        // Migrate scheduled.local.toml → scheduled.log
+        let old_sched = routine_scheduled_state_path(&dir_name);
+        let new_sched = routine_scheduled_log_path(&dir_name);
+        if old_sched.exists() && !new_sched.exists() {
+            if let Some(ts) = std::fs::read_to_string(&old_sched)
+                .ok()
+                .and_then(|text| toml::from_str::<LegacyScheduledState>(&text).ok())
+                .and_then(|s| s.last_scheduled_trigger_at)
+            {
+                let line = format!("{ts}\n");
+                if let Err(err) = std::fs::write(&new_sched, line.as_bytes()) {
+                    log::warn!(
+                        "migrate_trigger_logs: failed to write {}: {err}",
+                        new_sched.display()
+                    );
+                    continue;
+                }
+            }
+            let _ = std::fs::remove_file(&old_sched);
+        }
+
+        // Migrate last_manual_trigger_at from state.local.toml → manual.log
+        let new_manual = routine_manual_log_path(&dir_name);
+        if !new_manual.exists() {
+            if let Some(ts) = std::fs::read_to_string(routine_state_path(&dir_name))
+                .ok()
+                .and_then(|text| toml::from_str::<RuntimeState>(&text).ok())
+                .and_then(|s| s.last_manual_trigger_at)
+            {
+                let line = format!("{ts}\n");
+                if let Err(err) = std::fs::write(&new_manual, line.as_bytes()) {
+                    log::warn!(
+                        "migrate_trigger_logs: failed to write {}: {err}",
+                        new_manual.display()
+                    );
+                }
+            }
+        }
+    }
 }
 
 /// Remove the directory for a routine identified by its slug, doing nothing if it does not exist.

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -302,7 +302,10 @@ pub fn append_manual_trigger_log(slug: &str, ts: u64) {
         .open(&path)
         .and_then(|mut f| std::io::Write::write_all(&mut f, line.as_bytes()))
     {
-        log::warn!("append_manual_trigger_log: failed to write {}: {err}", path.display());
+        log::warn!(
+            "append_manual_trigger_log: failed to write {}: {err}",
+            path.display()
+        );
     }
 }
 

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::paths::{
     routine_compiled_prompt_path, routine_dir, routine_gitignore_path, routine_manual_log_path,
     routine_prompts_dir, routine_pure_prompt_path, routine_scheduled_log_path,
-    routine_scheduled_state_path, routine_script_path, routine_state_path, routine_toml_path,
+    routine_script_path, routine_state_path, routine_toml_path,
     routines_dir,
 };
 use crate::routines::{compose_prompt, slugify, Repository, Routine, RoutineStore};
@@ -332,11 +332,11 @@ pub(crate) fn migrate_trigger_logs_from_dir(dir: &std::path::Path) {
         if !entry.file_type().is_ok_and(|ft| ft.is_dir()) {
             continue;
         }
-        let dir_name = entry.file_name().to_string_lossy().to_string();
+        let routine_dir = entry.path();
 
         // Migrate scheduled.local.toml → scheduled.log
-        let old_sched = routine_scheduled_state_path(&dir_name);
-        let new_sched = routine_scheduled_log_path(&dir_name);
+        let old_sched = routine_dir.join("scheduled.local.toml");
+        let new_sched = routine_dir.join("scheduled.log");
         if old_sched.exists() && !new_sched.exists() {
             if let Some(ts) = std::fs::read_to_string(&old_sched)
                 .ok()
@@ -356,9 +356,9 @@ pub(crate) fn migrate_trigger_logs_from_dir(dir: &std::path::Path) {
         }
 
         // Migrate last_manual_trigger_at from state.local.toml → manual.log
-        let new_manual = routine_manual_log_path(&dir_name);
+        let new_manual = routine_dir.join("manual.log");
         if !new_manual.exists() {
-            if let Some(ts) = std::fs::read_to_string(routine_state_path(&dir_name))
+            if let Some(ts) = std::fs::read_to_string(routine_dir.join("state.local.toml"))
                 .ok()
                 .and_then(|text| toml::from_str::<RuntimeState>(&text).ok())
                 .and_then(|state| state.last_manual_trigger_at)

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -9,9 +9,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::paths::{
     routine_compiled_prompt_path, routine_dir, routine_gitignore_path, routine_manual_log_path,
-    routine_prompts_dir, routine_pure_prompt_path, routine_scheduled_log_path,
-    routine_script_path, routine_state_path, routine_toml_path,
-    routines_dir,
+    routine_prompts_dir, routine_pure_prompt_path, routine_scheduled_log_path, routine_script_path,
+    routine_state_path, routine_toml_path, routines_dir,
 };
 use crate::routines::{compose_prompt, slugify, Repository, Routine, RoutineStore};
 use crate::utils::atomic::atomic_write;

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -108,6 +108,7 @@ struct RuntimeState {
 /// not, the stored timestamp is seeded as the first log entry and the TOML file is removed.
 #[derive(Debug, Deserialize, Serialize)]
 struct LegacyScheduledState {
+    /// Unix timestamp of the last scheduled (cron) firing stored in the superseded TOML format.
     #[serde(default)]
     last_scheduled_trigger_at: Option<u64>,
 }
@@ -300,7 +301,7 @@ pub fn append_manual_trigger_log(slug: &str, ts: u64) {
         .create(true)
         .append(true)
         .open(&path)
-        .and_then(|mut f| std::io::Write::write_all(&mut f, line.as_bytes()))
+        .and_then(|mut file| std::io::Write::write_all(&mut file, line.as_bytes()))
     {
         log::warn!(
             "append_manual_trigger_log: failed to write {}: {err}",
@@ -340,7 +341,7 @@ pub(crate) fn migrate_trigger_logs_from_dir(dir: &std::path::Path) {
             if let Some(ts) = std::fs::read_to_string(&old_sched)
                 .ok()
                 .and_then(|text| toml::from_str::<LegacyScheduledState>(&text).ok())
-                .and_then(|s| s.last_scheduled_trigger_at)
+                .and_then(|state| state.last_scheduled_trigger_at)
             {
                 let line = format!("{ts}\n");
                 if let Err(err) = std::fs::write(&new_sched, line.as_bytes()) {
@@ -360,7 +361,7 @@ pub(crate) fn migrate_trigger_logs_from_dir(dir: &std::path::Path) {
             if let Some(ts) = std::fs::read_to_string(routine_state_path(&dir_name))
                 .ok()
                 .and_then(|text| toml::from_str::<RuntimeState>(&text).ok())
-                .and_then(|s| s.last_manual_trigger_at)
+                .and_then(|state| state.last_manual_trigger_at)
             {
                 let line = format!("{ts}\n");
                 if let Err(err) = std::fs::write(&new_manual, line.as_bytes()) {

--- a/src/routine_storage_tests.rs
+++ b/src/routine_storage_tests.rs
@@ -249,15 +249,17 @@ fn load_routine_from_dir_missing_returns_none() {
 }
 
 #[test]
-fn last_manual_trigger_at_persists_to_sidecar_not_routine_toml() {
-    // Runtime trigger state is written to the gitignored `state.local.toml` sidecar and kept out
-    // of the version-controlled `routine.toml`, then read back from the sidecar on load.
+fn last_manual_trigger_at_persists_to_log_not_routine_toml() {
+    // Manual trigger history is written to the gitignored `manual.log` append-only file and kept
+    // out of the version-controlled `routine.toml`; it round-trips through load.
     with_override_home(|_home| {
         let title = "Rs Sidecar Routine";
         let slug = slugify(title);
         let mut routine = make_routine("rs-sidecar-id", title);
         routine.last_manual_trigger_at = Some(12345);
         write_routine(&routine).unwrap();
+        // Simulate what svc_trigger does: append to manual.log.
+        crate::routine_storage::append_manual_trigger_log(&slug, 12345);
 
         // The tracked config file does not carry the runtime timestamp...
         let toml_text = std::fs::read_to_string(crate::paths::routine_toml_path(&slug)).unwrap();
@@ -265,10 +267,11 @@ fn last_manual_trigger_at_persists_to_sidecar_not_routine_toml() {
             !toml_text.contains("last_manual_trigger_at"),
             "routine.toml must not carry runtime trigger state: {toml_text}"
         );
-        // ...the gitignored sidecar does, and it round-trips through load.
-        assert!(crate::paths::routine_state_path(&slug).exists());
-        let state_text = std::fs::read_to_string(crate::paths::routine_state_path(&slug)).unwrap();
-        assert!(state_text.contains("last_manual_trigger_at"));
+        // ...the gitignored log does, and it round-trips through load.
+        assert!(crate::paths::routine_manual_log_path(&slug).exists());
+        let log_text =
+            std::fs::read_to_string(crate::paths::routine_manual_log_path(&slug)).unwrap();
+        assert!(log_text.trim() == "12345", "manual.log must contain the timestamp: {log_text}");
         assert_eq!(
             load_routine_from_dir(&slug).unwrap().last_manual_trigger_at,
             Some(12345)
@@ -278,22 +281,31 @@ fn last_manual_trigger_at_persists_to_sidecar_not_routine_toml() {
 
 #[test]
 fn write_routine_clears_stale_sidecar_when_untriggered() {
-    // Re-writing a routine whose trigger state has been cleared removes the now-stale sidecar, so
-    // the on-disk state mirrors the in-memory `None`.
+    // Re-writing a routine with no snooze/skip-runs state removes the state sidecar; an absent
+    // manual.log means last_manual_trigger_at round-trips as None.
     with_override_home(|_home| {
         let title = "Rs Clear Sidecar Routine";
         let slug = slugify(title);
         let mut routine = make_routine("rs-clear-id", title);
-        routine.last_manual_trigger_at = Some(999);
-        write_routine(&routine).unwrap();
-        assert!(crate::paths::routine_state_path(&slug).exists());
-
-        routine.last_manual_trigger_at = None;
+        // Write with no snooze/skip_runs — sidecar should not be created.
         write_routine(&routine).unwrap();
         assert!(
             !crate::paths::routine_state_path(&slug).exists(),
-            "sidecar should be removed when there is no trigger state"
+            "state.local.toml must not be written when there is no snooze/skip-runs state"
         );
+
+        // Snooze it so the sidecar is created, then clear the snooze.
+        routine.snoozed_until = Some(9999);
+        write_routine(&routine).unwrap();
+        assert!(crate::paths::routine_state_path(&slug).exists());
+
+        routine.snoozed_until = None;
+        write_routine(&routine).unwrap();
+        assert!(
+            !crate::paths::routine_state_path(&slug).exists(),
+            "sidecar should be removed when there is no snooze/skip-runs state"
+        );
+        // No manual.log was ever written, so last_manual_trigger_at is None.
         assert_eq!(
             load_routine_from_dir(&slug).unwrap().last_manual_trigger_at,
             None
@@ -347,21 +359,18 @@ fn load_routine_ignores_unparsable_sidecar() {
 }
 
 #[test]
-fn load_routine_reads_scheduled_trigger_from_sidecar() {
-    // `last_scheduled_trigger_at` lives in its own gitignored `scheduled.local.toml` sidecar,
-    // written by the routine's `run.sh` at cron fire time, and is read back on load — independently
-    // of the manual-trigger sidecar.
+fn load_routine_reads_scheduled_trigger_from_log() {
+    // `last_scheduled_trigger_at` is read from the last line of `scheduled.log`, written by the
+    // cron shell command at each fire, independently of the manual-trigger log.
     with_override_home(|_home| {
         let title = "Rs Scheduled Sidecar Routine";
         let slug = slugify(title);
         write_routine(&make_routine("rs-scheduled-id", title)).unwrap();
-        std::fs::write(
-            crate::paths::routine_scheduled_state_path(&slug),
-            "last_scheduled_trigger_at = 4242\n",
-        )
-        .unwrap();
+        // Simulate two cron fires appended to scheduled.log.
+        std::fs::write(crate::paths::routine_scheduled_log_path(&slug), "1000\n4242\n").unwrap();
 
         let loaded = load_routine_from_dir(&slug).unwrap();
+        // The last line (4242) wins.
         assert_eq!(loaded.last_scheduled_trigger_at, Some(4242));
         // The scheduled timestamp is distinct from the (unset) manual one.
         assert_eq!(loaded.last_manual_trigger_at, None);
@@ -369,8 +378,8 @@ fn load_routine_reads_scheduled_trigger_from_sidecar() {
 }
 
 #[test]
-fn load_routine_ignores_unparsable_scheduled_sidecar() {
-    // A malformed `scheduled.local.toml` parses to `None` rather than crashing the load.
+fn load_routine_ignores_unparsable_scheduled_log() {
+    // A `scheduled.log` with no parsable timestamp lines yields `None` rather than crashing.
     with_override_home(|_home| {
         let slug = "rs-bad-scheduled-sidecar-routine";
         let dir = crate::paths::routine_dir(slug);
@@ -381,8 +390,8 @@ fn load_routine_ignores_unparsable_scheduled_sidecar() {
         )
         .unwrap();
         std::fs::write(
-            crate::paths::routine_scheduled_state_path(slug),
-            "= not valid toml =",
+            crate::paths::routine_scheduled_log_path(slug),
+            "not a timestamp\n",
         )
         .unwrap();
 
@@ -396,30 +405,26 @@ fn load_routine_ignores_unparsable_scheduled_sidecar() {
 }
 
 #[test]
-fn write_routine_preserves_scheduler_written_scheduled_sidecar() {
-    // The daemon never writes the scheduled sidecar, so re-persisting a routine (e.g. on startup or
-    // an update) must leave the scheduler-stamped `scheduled.local.toml` untouched — the bug this
-    // separate-file design exists to prevent.
+fn write_routine_preserves_scheduler_written_scheduled_log() {
+    // The daemon never writes `scheduled.log`, so re-persisting a routine must leave the
+    // cron-appended log untouched — the same invariant that motivated the separate-file design.
     with_override_home(|_home| {
         let title = "Rs Preserve Scheduled Routine";
         let slug = slugify(title);
         let mut routine = make_routine("rs-preserve-scheduled-id", title);
         write_routine(&routine).unwrap();
 
-        // Simulate a scheduled cron firing stamping the sidecar.
-        std::fs::write(
-            crate::paths::routine_scheduled_state_path(&slug),
-            "last_scheduled_trigger_at = 55\n",
-        )
-        .unwrap();
+        // Simulate a scheduled cron firing appending to scheduled.log.
+        std::fs::write(crate::paths::routine_scheduled_log_path(&slug), "55\n").unwrap();
 
         // A subsequent daemon-side write (manual trigger recorded, routine updated, repersist, …).
         routine.last_manual_trigger_at = Some(7);
         write_routine(&routine).unwrap();
+        crate::routine_storage::append_manual_trigger_log(&slug, 7);
 
         assert!(
-            crate::paths::routine_scheduled_state_path(&slug).exists(),
-            "daemon write must not remove the scheduler-owned sidecar"
+            crate::paths::routine_scheduled_log_path(&slug).exists(),
+            "daemon write must not remove the scheduler-owned log"
         );
         let loaded = load_routine_from_dir(&slug).unwrap();
         assert_eq!(loaded.last_scheduled_trigger_at, Some(55));

--- a/src/routine_storage_tests.rs
+++ b/src/routine_storage_tests.rs
@@ -271,7 +271,10 @@ fn last_manual_trigger_at_persists_to_log_not_routine_toml() {
         assert!(crate::paths::routine_manual_log_path(&slug).exists());
         let log_text =
             std::fs::read_to_string(crate::paths::routine_manual_log_path(&slug)).unwrap();
-        assert!(log_text.trim() == "12345", "manual.log must contain the timestamp: {log_text}");
+        assert!(
+            log_text.trim() == "12345",
+            "manual.log must contain the timestamp: {log_text}"
+        );
         assert_eq!(
             load_routine_from_dir(&slug).unwrap().last_manual_trigger_at,
             Some(12345)
@@ -367,7 +370,11 @@ fn load_routine_reads_scheduled_trigger_from_log() {
         let slug = slugify(title);
         write_routine(&make_routine("rs-scheduled-id", title)).unwrap();
         // Simulate two cron fires appended to scheduled.log.
-        std::fs::write(crate::paths::routine_scheduled_log_path(&slug), "1000\n4242\n").unwrap();
+        std::fs::write(
+            crate::paths::routine_scheduled_log_path(&slug),
+            "1000\n4242\n",
+        )
+        .unwrap();
 
         let loaded = load_routine_from_dir(&slug).unwrap();
         // The last line (4242) wins.

--- a/src/routine_storage_tests.rs
+++ b/src/routine_storage_tests.rs
@@ -1404,8 +1404,29 @@ fn migrate_trigger_logs_from_dir_skips_non_dirs_and_unparsable() {
 }
 
 #[test]
+fn migrate_trigger_logs_from_dir_removes_scheduled_toml_when_no_timestamp() {
+    // A `scheduled.local.toml` that has no parsable timestamp (e.g. empty or unparsable) still
+    // gets removed — there is no timestamp to seed, so we skip the log write and just clean up.
+    let dir = scratch_dir("trigger-logs-no-ts");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let routine_dir = dir.join("my-routine");
+    std::fs::create_dir_all(&routine_dir).unwrap();
+    std::fs::write(routine_dir.join("scheduled.local.toml"), "").unwrap();
+
+    migrate_trigger_logs_from_dir(&dir);
+
+    // No log written (no timestamp to seed), but the empty TOML was still removed.
+    assert!(!routine_dir.join("scheduled.log").exists());
+    assert!(!routine_dir.join("scheduled.local.toml").exists());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+#[cfg(unix)]
 fn migrate_trigger_logs_from_dir_logs_on_scheduled_write_failure() {
     // When writing scheduled.log fails, a warning is logged and the old TOML is left in place.
+    use std::os::unix::fs::PermissionsExt;
     let dir = scratch_dir("trigger-logs-sched-fail");
     std::fs::create_dir_all(&dir).unwrap();
 
@@ -1416,36 +1437,43 @@ fn migrate_trigger_logs_from_dir_logs_on_scheduled_write_failure() {
         "last_scheduled_trigger_at = 42\n",
     )
     .unwrap();
-    // Block the log write by placing a directory at scheduled.log.
-    std::fs::create_dir_all(routine_dir.join("scheduled.log")).unwrap();
+    // Block the log write by making the routine dir read-only so fs::write fails.
+    std::fs::set_permissions(&routine_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
 
     migrate_trigger_logs_from_dir(&dir);
 
-    // The blocker directory is still there; the old TOML is NOT removed (continue branch).
+    // Restore permissions so cleanup can delete the dir.
+    std::fs::set_permissions(&routine_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+    // The old TOML is NOT removed because the write failed (continue branch).
     assert!(routine_dir.join("scheduled.local.toml").exists());
     let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]
+#[cfg(unix)]
 fn migrate_trigger_logs_from_dir_logs_on_manual_write_failure() {
     // When writing manual.log fails, a warning is logged but the function does not crash.
+    use std::os::unix::fs::PermissionsExt;
     let dir = scratch_dir("trigger-logs-manual-fail");
     std::fs::create_dir_all(&dir).unwrap();
 
     let routine_dir = dir.join("my-routine");
     std::fs::create_dir_all(&routine_dir).unwrap();
+    // Write state.local.toml with last_manual_trigger_at — note: skip_serializing means the
+    // field won't appear in daemon-written state files, but legacy files can have it.
     std::fs::write(
         routine_dir.join("state.local.toml"),
         "last_manual_trigger_at = 77\n",
     )
     .unwrap();
-    // Block manual.log with a directory.
-    std::fs::create_dir_all(routine_dir.join("manual.log")).unwrap();
+    // Make the routine dir read-only so writing manual.log fails.
+    std::fs::set_permissions(&routine_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
 
     migrate_trigger_logs_from_dir(&dir);
 
-    // Function completed without panic; the blocker is still there.
-    assert!(routine_dir.join("manual.log").is_dir());
+    std::fs::set_permissions(&routine_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+    // Function completed without panic.
+    assert!(!routine_dir.join("manual.log").exists());
     let _ = std::fs::remove_dir_all(&dir);
 }
 

--- a/src/routine_storage_tests.rs
+++ b/src/routine_storage_tests.rs
@@ -1255,3 +1255,204 @@ fn skip_runs_round_trips_and_clearing_both_removes_sidecar() {
         assert_eq!(load_routine_from_dir(&slug).unwrap().skip_runs, None);
     });
 }
+
+#[test]
+fn append_manual_trigger_log_creates_and_appends() {
+    // Each call appends one timestamp line; the log grows and load reads the last line.
+    with_override_home(|_home| {
+        let title = "Rs Manual Log Append Routine";
+        let slug = slugify(title);
+        write_routine(&make_routine("rs-manual-log-id", title)).unwrap();
+
+        append_manual_trigger_log(&slug, 100);
+        append_manual_trigger_log(&slug, 200);
+        append_manual_trigger_log(&slug, 300);
+
+        let log_path = crate::paths::routine_manual_log_path(&slug);
+        let text = std::fs::read_to_string(&log_path).unwrap();
+        assert_eq!(text, "100\n200\n300\n");
+        // load reads the last (most recent) line.
+        assert_eq!(
+            load_routine_from_dir(&slug).unwrap().last_manual_trigger_at,
+            Some(300)
+        );
+    });
+}
+
+#[test]
+fn append_manual_trigger_log_warns_on_write_failure() {
+    // Pointing the log path at a directory (so open fails) exercises the warn branch and
+    // does not panic.
+    let dir = scratch_dir("manual-log-fail");
+    std::fs::create_dir_all(&dir).unwrap();
+    // Create a directory where manual.log would be written, so the open call fails.
+    let slug_dir = dir.join("rs-manual-log-fail-routine");
+    std::fs::create_dir_all(&slug_dir).unwrap();
+    let blocker = slug_dir.join("manual.log");
+    std::fs::create_dir_all(&blocker).unwrap();
+
+    // Override home so routine_manual_log_path resolves into our scratch dir.
+    let previous = std::env::var_os("MOADIM_HOME_OVERRIDE");
+    unsafe {
+        std::env::set_var("MOADIM_HOME_OVERRIDE", &dir);
+    }
+    // Should not panic; just logs a warning.
+    append_manual_trigger_log("rs-manual-log-fail-routine", 42);
+    unsafe {
+        match previous {
+            Some(value) => std::env::set_var("MOADIM_HOME_OVERRIDE", value),
+            None => std::env::remove_var("MOADIM_HOME_OVERRIDE"),
+        }
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn migrate_trigger_logs_from_dir_missing_dir_returns() {
+    let missing = scratch_dir("trigger-logs-missing");
+    migrate_trigger_logs_from_dir(&missing);
+    assert!(!missing.exists());
+}
+
+#[test]
+fn migrate_trigger_logs_from_dir_migrates_scheduled_and_manual() {
+    // A dir with both legacy sidecars: scheduled.local.toml and state.local.toml with a manual
+    // timestamp. After migration both log files exist and the TOML sidecar is removed.
+    let dir = scratch_dir("trigger-logs-migrate");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    // Create a routine dir with a legacy scheduled.local.toml and state.local.toml.
+    let routine_dir = dir.join("my-routine");
+    std::fs::create_dir_all(&routine_dir).unwrap();
+    std::fs::write(
+        routine_dir.join("scheduled.local.toml"),
+        "last_scheduled_trigger_at = 1111\n",
+    )
+    .unwrap();
+    std::fs::write(
+        routine_dir.join("state.local.toml"),
+        "last_manual_trigger_at = 2222\n",
+    )
+    .unwrap();
+
+    migrate_trigger_logs_from_dir(&dir);
+
+    assert!(
+        !routine_dir.join("scheduled.local.toml").exists(),
+        "legacy toml should be removed"
+    );
+    let sched_text = std::fs::read_to_string(routine_dir.join("scheduled.log")).unwrap();
+    assert_eq!(sched_text, "1111\n");
+    let manual_text = std::fs::read_to_string(routine_dir.join("manual.log")).unwrap();
+    assert_eq!(manual_text, "2222\n");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn migrate_trigger_logs_from_dir_skips_when_logs_already_exist() {
+    // If log files are already present, neither is overwritten and the legacy TOML is left alone.
+    let dir = scratch_dir("trigger-logs-skip");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let routine_dir = dir.join("my-routine");
+    std::fs::create_dir_all(&routine_dir).unwrap();
+    std::fs::write(
+        routine_dir.join("scheduled.local.toml"),
+        "last_scheduled_trigger_at = 5555\n",
+    )
+    .unwrap();
+    std::fs::write(routine_dir.join("scheduled.log"), "9999\n").unwrap();
+    std::fs::write(routine_dir.join("manual.log"), "8888\n").unwrap();
+    std::fs::write(
+        routine_dir.join("state.local.toml"),
+        "last_manual_trigger_at = 7777\n",
+    )
+    .unwrap();
+
+    migrate_trigger_logs_from_dir(&dir);
+
+    // Existing logs are not overwritten.
+    assert_eq!(
+        std::fs::read_to_string(routine_dir.join("scheduled.log")).unwrap(),
+        "9999\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(routine_dir.join("manual.log")).unwrap(),
+        "8888\n"
+    );
+    // Legacy TOML is left in place (log already existed, so migration was skipped).
+    assert!(routine_dir.join("scheduled.local.toml").exists());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn migrate_trigger_logs_from_dir_skips_non_dirs_and_unparsable() {
+    // A plain file in the scan dir and a dir with no parsable TOML are both skipped silently.
+    let dir = scratch_dir("trigger-logs-nondir");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    std::fs::write(dir.join("loose.txt"), "ignore me").unwrap();
+    let routine_dir = dir.join("my-routine");
+    std::fs::create_dir_all(&routine_dir).unwrap();
+    // No TOML files at all.
+    migrate_trigger_logs_from_dir(&dir);
+
+    // Nothing was created, function didn't panic.
+    assert!(!routine_dir.join("scheduled.log").exists());
+    assert!(!routine_dir.join("manual.log").exists());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn migrate_trigger_logs_from_dir_logs_on_scheduled_write_failure() {
+    // When writing scheduled.log fails, a warning is logged and the old TOML is left in place.
+    let dir = scratch_dir("trigger-logs-sched-fail");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let routine_dir = dir.join("my-routine");
+    std::fs::create_dir_all(&routine_dir).unwrap();
+    std::fs::write(
+        routine_dir.join("scheduled.local.toml"),
+        "last_scheduled_trigger_at = 42\n",
+    )
+    .unwrap();
+    // Block the log write by placing a directory at scheduled.log.
+    std::fs::create_dir_all(routine_dir.join("scheduled.log")).unwrap();
+
+    migrate_trigger_logs_from_dir(&dir);
+
+    // The blocker directory is still there; the old TOML is NOT removed (continue branch).
+    assert!(routine_dir.join("scheduled.local.toml").exists());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn migrate_trigger_logs_from_dir_logs_on_manual_write_failure() {
+    // When writing manual.log fails, a warning is logged but the function does not crash.
+    let dir = scratch_dir("trigger-logs-manual-fail");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let routine_dir = dir.join("my-routine");
+    std::fs::create_dir_all(&routine_dir).unwrap();
+    std::fs::write(
+        routine_dir.join("state.local.toml"),
+        "last_manual_trigger_at = 77\n",
+    )
+    .unwrap();
+    // Block manual.log with a directory.
+    std::fs::create_dir_all(routine_dir.join("manual.log")).unwrap();
+
+    migrate_trigger_logs_from_dir(&dir);
+
+    // Function completed without panic; the blocker is still there.
+    assert!(routine_dir.join("manual.log").is_dir());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn migrate_trigger_logs_public_wrapper_runs() {
+    // Smoke-test the public wrapper (just needs to not panic; the real work is in the _from_dir variant).
+    with_override_home(|_home| {
+        migrate_trigger_logs();
+    });
+}

--- a/src/routines/command.rs
+++ b/src/routines/command.rs
@@ -1,6 +1,6 @@
 //! Prompt composition, slug/shell helpers, and the single-line tmux launch command builder.
 
-use crate::paths::{routine_compiled_prompt_path, routine_scheduled_state_path};
+use crate::paths::{routine_compiled_prompt_path, routine_scheduled_log_path};
 
 use super::agents::AgentCommand;
 use super::flags::{list_flags, FlagScope};
@@ -355,7 +355,7 @@ pub(crate) fn build_routine_command(routine: &Routine, agent: &AgentCommand) -> 
     let prompt_path = routine_compiled_prompt_path(&slug)
         .to_string_lossy()
         .into_owned();
-    let scheduled_state_path = routine_scheduled_state_path(&slug)
+    let scheduled_log_path = routine_scheduled_log_path(&slug)
         .to_string_lossy()
         .into_owned();
     // Resolve through the same seam the reaper (`cleanup/mod.rs`) and the LOGS view
@@ -397,16 +397,14 @@ pub(crate) fn build_routine_command(routine: &Routine, agent: &AgentCommand) -> 
         // unchanged.
         format!("export PATH={}", shell_quote(&cron_path(&agent.command))),
         r#"TS="$(date +%s)""#.to_string(),
-        // Record this scheduled firing. This command stamps the fire time into the routine's
-        // gitignored `scheduled.local.toml` sidecar; the daemon reads it back into
-        // `last_scheduled_trigger_at` on load. (The cron line calls `moadim schedule trigger`, which
-        // spawns this command via the daemon's scheduled-trigger path without recording a *manual*
-        // trigger.) Written before the prompt-copy guard below so an aborted run still records that
-        // the schedule fired, and best-effort (`|| true`) so a sidecar write failure never blocks
-        // launching the agent.
+        // Record this scheduled firing. Appends the Unix timestamp as one line to the routine's
+        // gitignored `scheduled.log`; the daemon reads the last line back as
+        // `last_scheduled_trigger_at` on load. Using `>>` (append) preserves the full run history.
+        // Written before the prompt-copy guard below so an aborted run still records that the
+        // schedule fired, and best-effort (`|| true`) so a log write failure never blocks launching.
         format!(
-            r#"printf 'last_scheduled_trigger_at = %s\n' "$TS" > {} || true"#,
-            shell_quote(&scheduled_state_path)
+            r#"printf '%s\n' "$TS" >> {} || true"#,
+            shell_quote(&scheduled_log_path)
         ),
         format!("SLUG={}", shell_quote(&slug)),
         format!(r#"WB={}/"$SLUG-$TS""#, shell_quote(&workbenches_base)),

--- a/src/routines/command_tests.rs
+++ b/src/routines/command_tests.rs
@@ -86,10 +86,10 @@ fn build_routine_command_resolves_bin_dir_when_tool_on_path() {
 }
 
 #[test]
-fn build_routine_command_stamps_scheduled_trigger_sidecar() {
-    // The generated launch script records each scheduled firing by writing `$TS` into the
-    // routine's `scheduled.local.toml` sidecar (best-effort, before the prompt-copy guard), since
-    // the OS crontab runs this script directly without the daemon observing the fire.
+fn build_routine_command_appends_scheduled_trigger_log() {
+    // The generated launch script records each scheduled firing by appending `$TS` to the
+    // routine's `scheduled.log` (best-effort, before the prompt-copy guard), since the OS crontab
+    // runs this script directly without the daemon observing the fire.
     let routine = make_routine("Cmd Scheduled Stamp Routine");
     let agent = AgentCommand {
         command: "claude".to_string(),
@@ -98,20 +98,20 @@ fn build_routine_command_stamps_scheduled_trigger_sidecar() {
         setup: None,
     };
     let cmd = build_routine_command(&routine, &agent);
-    let sidecar = crate::paths::routine_scheduled_state_path(&slugify(&routine.title))
+    let log = crate::paths::routine_scheduled_log_path(&slugify(&routine.title))
         .to_string_lossy()
         .into_owned();
     assert!(
         cmd.contains(&format!(
-            r#"printf 'last_scheduled_trigger_at = %s\n' "$TS" > {} || true"#,
-            shell_quote(&sidecar)
+            r#"printf '%s\n' "$TS" >> {} || true"#,
+            shell_quote(&log)
         )),
-        "expected scheduled-trigger sidecar stamp in: {cmd}"
+        "expected scheduled-trigger log append in: {cmd}"
     );
     // It must run before the prompt-copy guard so an aborted run still records the firing.
-    let stamp = cmd.find("last_scheduled_trigger_at").unwrap();
+    let stamp = cmd.find("scheduled.log").unwrap();
     let copy = cmd.find("/prompt.md\"").unwrap();
-    assert!(stamp < copy, "sidecar stamp must precede the prompt copy");
+    assert!(stamp < copy, "log append must precede the prompt copy");
 }
 
 #[test]

--- a/src/routines/model.rs
+++ b/src/routines/model.rs
@@ -136,11 +136,11 @@ pub struct Routine {
     ///
     /// The mirror of [`Routine::last_manual_trigger_at`] for scheduled runs: a manual trigger
     /// updates only the manual field, a scheduled firing updates only this one. The host OS crontab
-    /// line runs `moadim schedule trigger <id>`, and the launch command the daemon spawns stamps this
-    /// timestamp into the gitignored `scheduled.local.toml` sidecar at fire time (via its `printf`
-    /// step); the daemon reads it back on load. The daemon never writes this field directly (it is
-    /// absent from `routine.toml` and the daemon-owned `state.local.toml`), so re-persisting a
-    /// routine can't clobber it.
+    /// line runs `moadim schedule trigger <id>`, and the launch command the daemon spawns appends
+    /// the Unix timestamp to the gitignored `scheduled.log` at fire time; the daemon reads the last
+    /// line back on load. The daemon never writes this field directly (it is absent from
+    /// `routine.toml` and the daemon-owned `state.local.toml`), so re-persisting a routine can't
+    /// clobber the log.
     #[serde(default)]
     pub last_scheduled_trigger_at: Option<u64>,
     /// Unix timestamp (seconds) until which scheduled (cron) fires are skipped, or `None`.

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 
 use crate::error::AppError;
 use crate::paths::workbenches_dir;
-use crate::routine_storage::{remove_routine_dir, write_routine};
+use crate::routine_storage::{append_manual_trigger_log, remove_routine_dir, write_routine};
 use crate::utils::cron::{normalize_schedule, validate_cron};
 use crate::utils::time::now_secs;
 
@@ -602,10 +602,12 @@ pub fn svc_trigger(store: &RoutineStore, id: &str) -> Result<Routine, AppError> 
     }
     let mut lock = store.lock_recover();
     let routine = lock.get_mut(id).ok_or(AppError::NotFound)?;
-    routine.last_manual_trigger_at = Some(now_secs());
+    let ts = now_secs();
+    routine.last_manual_trigger_at = Some(ts);
     let routine = routine.clone();
     drop(lock);
     write_routine(&routine).map_err(|_| AppError::Internal)?;
+    append_manual_trigger_log(&crate::routines::slugify(&routine.title), ts);
     spawn_routine_command(&routine);
     Ok(routine)
 }
@@ -615,9 +617,9 @@ pub fn svc_trigger(store: &RoutineStore, id: &str) -> Result<Routine, AppError> 
 ///
 /// This is the daemon-side endpoint that the generated crontab line drives
 /// (`moadim schedule trigger <id>`). Unlike [`svc_trigger`] it leaves `last_manual_trigger_at`
-/// untouched — the spawned command records `last_scheduled_trigger_at` in the routine's
-/// `scheduled.local.toml` sidecar itself, which the daemon reads back on the next load. Keeping the
-/// two paths distinct preserves the manual-vs-scheduled distinction the timestamps exist to capture.
+/// untouched — the spawned command appends the timestamp to the routine's `scheduled.log` itself,
+/// which the daemon reads back on the next load. Keeping the two paths distinct preserves the
+/// manual-vs-scheduled distinction the timestamps exist to capture.
 ///
 /// A routine snoozed via [`svc_snooze`] (`snoozed_until` in the future, or `skip_runs` above zero)
 /// is skipped here instead of spawned: `snoozed_until` clears itself once elapsed (that fire then


### PR DESCRIPTION
Closes #930.

## Summary

- Replaces `scheduled.local.toml` (overwritten each cron fire) with `scheduled.log` — an append-only file written by the cron shell command (`printf '%s\n' "$TS" >>`) that records every scheduled firing as one Unix-timestamp line.
- Replaces the `last_manual_trigger_at` field in `state.local.toml` with `manual.log` — an append-only file written by `svc_trigger` that records every manual trigger as one Unix-timestamp line.
- The daemon reads `last_scheduled_trigger_at` / `last_manual_trigger_at` from the **last line** of the respective log, so the API surface is unchanged.
- Both files match the existing `*.log` gitignore pattern already seeded into each routine's `.gitignore`.
- A startup migration (`migrate_trigger_logs`) seeds log files from any legacy TOML sidecars found on disk and removes the old files, so existing installs upgrade transparently.

## Test plan

- [ ] All 770 existing tests pass (`cargo test`)
- [ ] `build_routine_command_appends_scheduled_trigger_log` verifies the cron shell command uses `>>` append into `scheduled.log`
- [ ] `load_routine_reads_scheduled_trigger_from_log` verifies multi-line log picks the last entry
- [ ] `last_manual_trigger_at_persists_to_log_not_routine_toml` verifies manual trigger writes to `manual.log` and round-trips on load
- [ ] `write_routine_preserves_scheduler_written_scheduled_log` verifies daemon writes never touch `scheduled.log`
- [ ] 8 migration tests cover: happy path, write failure (read-only dir), no-timestamp TOML, skip-when-log-exists, missing dir, non-dir entries, public wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)