### PR TITLE
chore(release): version packages

### DIFF
--- a/.changeset/linecheck-2500.md
+++ b/.changeset/linecheck-2500.md
@@ -1,7 +1,0 @@
----
-"moadim": patch
----
-
-### Changed
-
-- **Pre-push linecheck gate lowered from 3000 → 2500 lines per `.rs` file.** `service_tests.rs` was split again to comply — tags, machines, and model tests now live in `service_model_tests.rs`.

--- a/.changeset/linecheck-gate-2500.md
+++ b/.changeset/linecheck-gate-2500.md
@@ -1,7 +1,0 @@
----
-"moadim": patch
----
-
-### Changed
-
-- **Pre-push hook linecheck gate lowered from 3000 → 2500 lines per `.rs` file.** `service_tests.rs` (2677 lines) was split into `service_tests.rs` and `service_model_tests.rs` to satisfy the new ceiling.

--- a/.changeset/linecheck-gate.md
+++ b/.changeset/linecheck-gate.md
@@ -1,7 +1,0 @@
----
-"moadim": patch
----
-
-### Changed
-
-- **Pre-push hook now rejects `.rs` files exceeding 3000 lines.** Step 6 of `.githooks/pre-push` runs `linecheck --max-lines 3000` over all `src/**/*.rs` files. `cargo install linecheck` is required. `service_tests.rs` (3068 lines) was split into `service_tests.rs` and `service_flag_tests.rs` to satisfy the new gate.

--- a/.changeset/trigger-log-files.md
+++ b/.changeset/trigger-log-files.md
@@ -1,7 +1,0 @@
----
-"moadim": minor
----
-
-### Changed
-
-- **Scheduled and manual trigger history is now recorded in append-only `.log` files.** `scheduled.local.toml` (overwritten on each cron fire) is replaced by `scheduled.log`; the manual-trigger timestamp previously stored in `state.local.toml` moves to `manual.log`. Each file records one Unix timestamp per execution, giving a full run history instead of only the most recent timestamp. A startup migration seeds the log files from any legacy TOML sidecars found on disk and removes the old files, so existing installs upgrade transparently. The `.log` suffix matches the existing `*.log` gitignore pattern seeded into each routine directory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-07-03
+
+### Changed
+
+- **Pre-push linecheck gate lowered from 3000 → 2500 lines per `.rs` file.** `service_tests.rs` was split again to comply — tags, machines, and model tests now live in `service_model_tests.rs`.
+
+### Changed
+
+- **Pre-push hook linecheck gate lowered from 3000 → 2500 lines per `.rs` file.** `service_tests.rs` (2677 lines) was split into `service_tests.rs` and `service_model_tests.rs` to satisfy the new ceiling.
+
+### Changed
+
+- **Pre-push hook now rejects `.rs` files exceeding 3000 lines.** Step 6 of `.githooks/pre-push` runs `linecheck --max-lines 3000` over all `src/**/*.rs` files. `cargo install linecheck` is required. `service_tests.rs` (3068 lines) was split into `service_tests.rs` and `service_flag_tests.rs` to satisfy the new gate.
+
+### Changed
+
+- **Scheduled and manual trigger history is now recorded in append-only `.log` files.** `scheduled.local.toml` (overwritten on each cron fire) is replaced by `scheduled.log`; the manual-trigger timestamp previously stored in `state.local.toml` moves to `manual.log`. Each file records one Unix timestamp per execution, giving a full run history instead of only the most recent timestamp. A startup migration seeds the log files from any legacy TOML sidecars found on disk and removes the old files, so existing installs upgrade transparently. The `.log` suffix matches the existing `*.log` gitignore pattern seeded into each routine directory.
+
 ## [0.21.0] - 2026-07-03
 
 ### Added
@@ -1733,7 +1751,8 @@ Enable `clippy::match_same_arms` and merge the two duplicate-body arms it flagge
 - Ship the prebuilt UI in the published crate.
 - Rename the binary to `moadim` and add install docs.
 
-[Unreleased]: https://github.com/moadim-io/daemon/compare/v0.21.0...HEAD
+[Unreleased]: https://github.com/moadim-io/daemon/compare/v0.22.0...HEAD
+[0.22.0]: https://github.com/moadim-io/daemon/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/moadim-io/daemon/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/moadim-io/daemon/compare/v0.19.1...v0.20.0
 [0.19.1]: https://github.com/moadim-io/daemon/compare/v0.19.0...v0.19.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ opt-level = "z"
 
 [package]
 name = "moadim"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 # Floor set by the transitive proc-macro build dependency `darling 0.23`
 # (pulled in via `rmcp-macros` <- `rmcp`), which itself declares

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.21.0"
+    "version": "0.22.0"
   },
   "servers": [
     {

--- a/docs/moadim.1
+++ b/docs/moadim.1
@@ -1,7 +1,7 @@
 .\" Man page for moadim.
 .\" Mirrors the built-in `moadim --help` output (src/cli.rs::print_help).
 .\" View with:  man ./docs/moadim.1   or install into share/man/man1/.
-.TH MOADIM 1 "2026-07-02" "moadim 0.21.0" "Moadim Manual"
+.TH MOADIM 1 "2026-07-02" "moadim 0.22.0" "Moadim Manual"
 .SH NAME
 moadim \- routine scheduler with an MCP/REST API and a web control panel
 .SH SYNOPSIS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moadim",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "scripts": {


### PR DESCRIPTION
Automated version bump from cut-release workflow run [28658824924](https://github.com/moadim-io/daemon/actions/runs/28658824924). All lint and test checks passed.