### PR TITLE
feat(ui): add FLAGS KPI tile to overview dashboard

### DIFF
--- a/.changeset/ui-flags-kpi.md
+++ b/.changeset/ui-flags-kpi.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+feat(ui): add FLAGS KPI tile to overview dashboard
+
+Surface the total count of open flags across all routines as a FLAGS
+tile in the overview stat row. Red when non-zero, green when clear —
+gives operators an at-a-glance signal without navigating into individual
+routines. Adds `flag_count` to `SchedSource` and `flags` to `Kpis`.

--- a/ui/src/overview.rs
+++ b/ui/src/overview.rs
@@ -68,6 +68,8 @@ pub(crate) struct SchedSource {
     /// Whether the routine's agent is registered. `Some(false)` when the
     /// routine's agent is missing.
     pub agent_registered: Option<bool>,
+    /// Number of open flags raised against this entity.
+    pub flag_count: usize,
 }
 
 /// Aggregate counts shown as the KPI tile row.
@@ -83,6 +85,8 @@ pub(crate) struct Kpis {
     pub due_soon: usize,
     /// Enabled-but-misconfigured entities (see [`attention_items`]).
     pub attention: usize,
+    /// Total open flags across all entities.
+    pub flags: usize,
 }
 
 /// Why an enabled entity needs attention. Listed in triage priority order: a
@@ -165,12 +169,14 @@ pub(crate) fn compute_kpis(sources: &[SchedSource], now: DateTime<Local>) -> Kpi
         .iter()
         .filter(|s| s.enabled && fires_within(&s.schedule, now, window))
         .count();
+    let flags = sources.iter().map(|s| s.flag_count).sum();
     Kpis {
         total,
         enabled,
         disabled: total - enabled,
         due_soon,
         attention: attention_items(sources, now).len(),
+        flags,
     }
 }
 
@@ -265,6 +271,7 @@ fn from_routine(routine: &Routine) -> SchedSource {
         enabled: routine.enabled,
         machines_empty: targets_no_machine(&routine.machines),
         agent_registered: Some(routine.agent_registered),
+        flag_count: routine.flag_count,
     }
 }
 
@@ -449,6 +456,12 @@ fn overview_stats(props: &OverviewStatsProps) -> Html {
             <div class="stat-card disabled">
                 <div class="stat-label">{"DISABLED"}</div>
                 <div class="stat-val c-amber">{k.disabled}</div>
+            </div>
+            <div class="stat-card flags">
+                <div class="stat-label">{"FLAGS"}</div>
+                <div class={classes!("stat-val", if k.flags > 0 { "c-red" } else { "c-accent" })}>
+                    {k.flags}
+                </div>
             </div>
             <div class="stat-card system">
                 <div class="stat-label">{"NEXT RUN"}</div>

--- a/ui/src/overview_tests.rs
+++ b/ui/src/overview_tests.rs
@@ -27,6 +27,7 @@ fn src(kind: Kind, label: &str, schedule: &str, enabled: bool) -> SchedSource {
         agent_registered: match kind {
             Kind::Routine => Some(true),
         },
+        flag_count: 0,
     }
 }
 
@@ -51,6 +52,28 @@ fn kpis_default_is_zeroed() {
     assert_eq!(kpis.enabled, 0);
     assert_eq!(kpis.disabled, 0);
     assert_eq!(kpis.due_soon, 0);
+    assert_eq!(kpis.flags, 0);
+}
+
+#[test]
+fn kpis_flags_sums_across_all_sources() {
+    let mut a = src(Kind::Routine, "a", "*/5 * * * *", true);
+    a.flag_count = 3;
+    let mut b = src(Kind::Routine, "b", "0 0 * * *", false);
+    b.flag_count = 1;
+    let c = src(Kind::Routine, "c", "*/5 * * * *", true);
+    let kpis = compute_kpis(&[a, b, c], at_ten());
+    assert_eq!(kpis.flags, 4);
+}
+
+#[test]
+fn kpis_flags_zero_when_no_flags() {
+    let sources = vec![
+        src(Kind::Routine, "a", "*/5 * * * *", true),
+        src(Kind::Routine, "b", "0 0 * * *", true),
+    ];
+    let kpis = compute_kpis(&sources, at_ten());
+    assert_eq!(kpis.flags, 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Adds a **FLAGS** stat tile to the overview dashboard, showing the total count of open flags across all routines
- Red when non-zero, accent-green when clear — at-a-glance signal without navigating to individual routine pages
- Carries `flag_count` from `Routine` into `SchedSource`, sums it in `compute_kpis` into the new `Kpis.flags` field
- Two new host tests: `kpis_flags_sums_across_all_sources` and `kpis_flags_zero_when_no_flags`

Follows up on #942 (dependency health warnings) to continue improving operator visibility in the UI.

## Test plan

- [ ] With routines that have open flags, confirm FLAGS tile shows the correct count in red
- [ ] With no open flags, confirm FLAGS tile shows 0 in green
- [ ] Existing tests pass + 2 new flag-count tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)