### PR TITLE
feat(ui): add SNOOZED KPI tile to overview dashboard

### DIFF
--- a/.changeset/ui-snoozed-kpi.md
+++ b/.changeset/ui-snoozed-kpi.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+feat(ui): add SNOOZED KPI tile to overview dashboard
+
+Surface the count of enabled routines whose scheduled fires are
+currently suppressed (snoozed or skip-runs active) as a SNOOZED tile
+in the overview stat row. Amber when non-zero, green when clear —
+makes it immediately visible when routines are intentionally silenced.

--- a/ui/src/overview.rs
+++ b/ui/src/overview.rs
@@ -269,9 +269,7 @@ fn targets_no_machine(machines: &[String]) -> bool {
 /// Map a routine onto the shared schedule abstraction.
 fn is_snoozed(routine: &Routine) -> bool {
     let now_secs = (js_sys::Date::now() / 1000.0) as u64;
-    routine
-        .snoozed_until
-        .is_some_and(|until| until > now_secs)
+    routine.snoozed_until.is_some_and(|until| until > now_secs)
         || routine.skip_runs.is_some_and(|n| n > 0)
 }
 

--- a/ui/src/overview.rs
+++ b/ui/src/overview.rs
@@ -70,6 +70,8 @@ pub(crate) struct SchedSource {
     pub agent_registered: Option<bool>,
     /// Number of open flags raised against this entity.
     pub flag_count: usize,
+    /// Whether scheduled fires are currently suppressed (snoozed or skip-runs active).
+    pub snoozed: bool,
 }
 
 /// Aggregate counts shown as the KPI tile row.
@@ -87,6 +89,8 @@ pub(crate) struct Kpis {
     pub attention: usize,
     /// Total open flags across all entities.
     pub flags: usize,
+    /// Enabled entities whose scheduled fires are currently suppressed.
+    pub snoozed: usize,
 }
 
 /// Why an enabled entity needs attention. Listed in triage priority order: a
@@ -170,6 +174,7 @@ pub(crate) fn compute_kpis(sources: &[SchedSource], now: DateTime<Local>) -> Kpi
         .filter(|s| s.enabled && fires_within(&s.schedule, now, window))
         .count();
     let flags = sources.iter().map(|s| s.flag_count).sum();
+    let snoozed = sources.iter().filter(|s| s.enabled && s.snoozed).count();
     Kpis {
         total,
         enabled,
@@ -177,6 +182,7 @@ pub(crate) fn compute_kpis(sources: &[SchedSource], now: DateTime<Local>) -> Kpi
         due_soon,
         attention: attention_items(sources, now).len(),
         flags,
+        snoozed,
     }
 }
 
@@ -261,6 +267,14 @@ fn targets_no_machine(machines: &[String]) -> bool {
 }
 
 /// Map a routine onto the shared schedule abstraction.
+fn is_snoozed(routine: &Routine) -> bool {
+    let now_secs = (js_sys::Date::now() / 1000.0) as u64;
+    routine
+        .snoozed_until
+        .is_some_and(|until| until > now_secs)
+        || routine.skip_runs.is_some_and(|n| n > 0)
+}
+
 fn from_routine(routine: &Routine) -> SchedSource {
     SchedSource {
         kind: Kind::Routine,
@@ -272,6 +286,7 @@ fn from_routine(routine: &Routine) -> SchedSource {
         machines_empty: targets_no_machine(&routine.machines),
         agent_registered: Some(routine.agent_registered),
         flag_count: routine.flag_count,
+        snoozed: is_snoozed(routine),
     }
 }
 
@@ -461,6 +476,12 @@ fn overview_stats(props: &OverviewStatsProps) -> Html {
                 <div class="stat-label">{"FLAGS"}</div>
                 <div class={classes!("stat-val", if k.flags > 0 { "c-red" } else { "c-accent" })}>
                     {k.flags}
+                </div>
+            </div>
+            <div class="stat-card snoozed">
+                <div class="stat-label">{"SNOOZED"}</div>
+                <div class={classes!("stat-val", if k.snoozed > 0 { "c-amber" } else { "c-accent" })}>
+                    {k.snoozed}
                 </div>
             </div>
             <div class="stat-card system">

--- a/ui/src/overview_tests.rs
+++ b/ui/src/overview_tests.rs
@@ -28,6 +28,7 @@ fn src(kind: Kind, label: &str, schedule: &str, enabled: bool) -> SchedSource {
             Kind::Routine => Some(true),
         },
         flag_count: 0,
+        snoozed: false,
     }
 }
 
@@ -53,6 +54,7 @@ fn kpis_default_is_zeroed() {
     assert_eq!(kpis.disabled, 0);
     assert_eq!(kpis.due_soon, 0);
     assert_eq!(kpis.flags, 0);
+    assert_eq!(kpis.snoozed, 0);
 }
 
 #[test]
@@ -74,6 +76,27 @@ fn kpis_flags_zero_when_no_flags() {
     ];
     let kpis = compute_kpis(&sources, at_ten());
     assert_eq!(kpis.flags, 0);
+}
+
+#[test]
+fn kpis_snoozed_counts_only_enabled_snoozed_sources() {
+    let mut a = src(Kind::Routine, "a", "*/5 * * * *", true);
+    a.snoozed = true;
+    let mut b = src(Kind::Routine, "b", "0 0 * * *", false); // disabled — not counted
+    b.snoozed = true;
+    let c = src(Kind::Routine, "c", "*/5 * * * *", true);
+    let kpis = compute_kpis(&[a, b, c], at_ten());
+    assert_eq!(kpis.snoozed, 1);
+}
+
+#[test]
+fn kpis_snoozed_zero_when_none_snoozed() {
+    let sources = vec![
+        src(Kind::Routine, "a", "*/5 * * * *", true),
+        src(Kind::Routine, "b", "0 0 * * *", true),
+    ];
+    let kpis = compute_kpis(&sources, at_ten());
+    assert_eq!(kpis.snoozed, 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Adds a **SNOOZED** stat tile to the overview, showing the count of enabled routines with suppressed scheduled fires
- Amber when non-zero, green when clear — makes it immediately visible when routines are intentionally silenced without navigating to the routines tab
- Carries snooze state from `Routine` (`snoozed_until` / `skip_runs`) into `SchedSource.snoozed`, sums it in `Kpis.snoozed`
- Two new host tests: `kpis_snoozed_counts_only_enabled_snoozed_sources` and `kpis_snoozed_zero_when_none_snoozed`
- `kpis_default_is_zeroed` updated to cover the new field

Follows up on #942 (dep health) and #943 (flags KPI) to continue improving operator visibility.

## Test plan

- [ ] Snooze a routine — confirm SNOOZED tile increments in amber
- [ ] Un-snooze — confirm tile returns to 0 in green
- [ ] All CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)