### PR TITLE
fix(ui): exclude snoozed routines from DUE SOON count and UPCOMING RUNS table

### DIFF
--- a/.changeset/ui-snoozed-filter.md
+++ b/.changeset/ui-snoozed-filter.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+fix(ui): exclude snoozed routines from DUE SOON count and UPCOMING RUNS table
+
+Snoozed routines appeared in the overview's DUE SOON KPI and UPCOMING
+RUNS table as if they would fire, even though their scheduled fires are
+suppressed. Fixes both to only include enabled, non-snoozed sources so
+the dashboard reflects what will actually run.

--- a/ui/src/overview.rs
+++ b/ui/src/overview.rs
@@ -171,7 +171,7 @@ pub(crate) fn compute_kpis(sources: &[SchedSource], now: DateTime<Local>) -> Kpi
     let window = Duration::seconds(DUE_SOON_WINDOW_SECS);
     let due_soon = sources
         .iter()
-        .filter(|s| s.enabled && fires_within(&s.schedule, now, window))
+        .filter(|s| s.enabled && !s.snoozed && fires_within(&s.schedule, now, window))
         .count();
     let flags = sources.iter().map(|s| s.flag_count).sum();
     let snoozed = sources.iter().filter(|s| s.enabled && s.snoozed).count();
@@ -231,13 +231,14 @@ pub(crate) fn attention_items(sources: &[SchedSource], now: DateTime<Local>) -> 
 }
 
 /// The merged, soonest-first list of the next [`UPCOMING_LIMIT`] fires across
-/// every enabled source. Disabled entities and ones with no valid future fire
-/// are dropped; ties on fire time break by label for a stable order.
+/// every enabled, non-snoozed source. Disabled, snoozed, and ones with no
+/// valid future fire are dropped; ties on fire time break by label for a
+/// stable order.
 pub(crate) fn upcoming_runs(sources: &[SchedSource], now: DateTime<Local>) -> Vec<UpcomingRun> {
     let window = Duration::seconds(DUE_SOON_WINDOW_SECS);
     let mut runs: Vec<UpcomingRun> = sources
         .iter()
-        .filter(|s| s.enabled)
+        .filter(|s| s.enabled && !s.snoozed)
         .filter_map(|s| {
             next_fire_after(&s.schedule, now).map(|at| UpcomingRun {
                 kind: s.kind,

--- a/ui/src/overview_tests.rs
+++ b/ui/src/overview_tests.rs
@@ -47,6 +47,15 @@ fn kpis_count_total_enabled_disabled_due_soon() {
 }
 
 #[test]
+fn kpis_due_soon_excludes_snoozed() {
+    let mut a = src(Kind::Routine, "a", "*/5 * * * *", true);
+    a.snoozed = true; // would fire in 5m but snoozed → not due
+    let b = src(Kind::Routine, "b", "*/5 * * * *", true); // enabled + not snoozed → due
+    let kpis = compute_kpis(&[a, b], at_ten());
+    assert_eq!(kpis.due_soon, 1);
+}
+
+#[test]
 fn kpis_default_is_zeroed() {
     let kpis = Kpis::default();
     assert_eq!(kpis.total, 0);
@@ -114,6 +123,16 @@ fn upcoming_sorted_soonest_first_excludes_disabled_and_invalid() {
     assert_eq!(runs[1].label, "midnight");
     assert!(runs[0].soon);
     assert!(!runs[1].soon);
+}
+
+#[test]
+fn upcoming_excludes_snoozed_sources() {
+    let mut a = src(Kind::Routine, "snoozed", "*/5 * * * *", true);
+    a.snoozed = true; // enabled but snoozed → fires suppressed → not upcoming
+    let b = src(Kind::Routine, "active", "*/5 * * * *", true);
+    let runs = upcoming_runs(&[a, b], at_ten());
+    assert_eq!(runs.len(), 1);
+    assert_eq!(runs[0].label, "active");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Snoozed routines appeared in the DUE SOON KPI count and UPCOMING RUNS table as if they would fire, even though their fires are suppressed
- Fixes `compute_kpis` and `upcoming_runs` to require `!s.snoozed` alongside `s.enabled`
- Two new host tests: `kpis_due_soon_excludes_snoozed` and `upcoming_excludes_snoozed_sources`

Follows up on #944 (SNOOZED KPI tile) — the SNOOZED tile now correctly shows the count of suppressed routines while DUE SOON and UPCOMING RUNS show only what will actually execute.

## Test plan

- [ ] Snooze a due-soon routine — confirm DUE SOON count drops and it disappears from UPCOMING RUNS
- [ ] Un-snooze — confirm it reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)