### PR TITLE
fix(ui): show "snoozed" in NEXT RUN cell instead of suppressed fire time

### DIFF
--- a/.changeset/ui-next-run-snoozed.md
+++ b/.changeset/ui-next-run-snoozed.md
@@ -1,0 +1,13 @@
+---
+"moadim": patch
+---
+
+fix(ui): show "snoozed" in NEXT RUN cell instead of suppressed fire time
+
+When a routine is snoozed its scheduled fires are suppressed, but the
+NEXT RUN column still showed the upcoming time as if the run would happen.
+Now shows "snoozed" (muted, consistent with "paused" for disabled
+routines) so the table accurately reflects what will execute.
+
+Extracts `is_routine_snoozed` as a shared helper used by both
+`routine_health` and `next_routine_run_cell`, with four dedicated tests.

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -617,6 +617,14 @@ impl RoutineHealth {
 ///
 /// Faults are checked in priority order — `Dormant` outranks `DeadSchedule`
 /// which outranks `AgentMissing` — matching the Overview triage ordering.
+/// `true` when the routine's scheduled fires are currently suppressed by a
+/// snooze deadline or a non-zero skip-runs counter.
+pub(crate) fn is_routine_snoozed(r: &Routine, now: DateTime<Local>) -> bool {
+    r.snoozed_until
+        .is_some_and(|until| (until as i64) > now.timestamp())
+        || r.skip_runs.is_some_and(|runs| runs > 0)
+}
+
 #[must_use]
 pub fn routine_health(r: &Routine, now: DateTime<Local>) -> RoutineHealth {
     if !r.enabled {
@@ -631,11 +639,7 @@ pub fn routine_health(r: &Routine, now: DateTime<Local>) -> RoutineHealth {
     if !r.agent_registered {
         return RoutineHealth::AgentMissing;
     }
-    let snoozed = r
-        .snoozed_until
-        .is_some_and(|until| (until as i64) > now.timestamp())
-        || r.skip_runs.is_some_and(|runs| runs > 0);
-    if snoozed {
+    if is_routine_snoozed(r, now) {
         return RoutineHealth::Snoozed;
     }
     RoutineHealth::Healthy
@@ -2444,6 +2448,9 @@ pub fn routine_table(props: &TableProps) -> Html {
 pub(crate) fn next_routine_run_cell(routine: &Routine, now: chrono::DateTime<Local>) -> Html {
     if !routine.enabled {
         return html! { <span class="cell-next muted">{"paused"}</span> };
+    }
+    if is_routine_snoozed(routine, now) {
+        return html! { <span class="cell-next muted">{"snoozed"}</span> };
     }
     match next_fire_after(&routine.schedule, now) {
         Some(then) => {

--- a/ui/src/routines_tests.rs
+++ b/ui/src/routines_tests.rs
@@ -859,6 +859,42 @@ fn health_fully_configured_is_healthy() {
 }
 
 #[test]
+fn is_routine_snoozed_true_when_deadline_in_future() {
+    let r = Routine {
+        snoozed_until: Some((now() + Duration::hours(1)).timestamp() as u64),
+        ..routine("a", "A", "claude", "0 * * * *", &["machine1"], &[], true)
+    };
+    assert!(is_routine_snoozed(&r, now()));
+}
+
+#[test]
+fn is_routine_snoozed_false_when_deadline_past() {
+    let r = Routine {
+        snoozed_until: Some((now() - Duration::hours(1)).timestamp() as u64),
+        ..routine("a", "A", "claude", "0 * * * *", &["machine1"], &[], true)
+    };
+    assert!(!is_routine_snoozed(&r, now()));
+}
+
+#[test]
+fn is_routine_snoozed_true_when_skip_runs_nonzero() {
+    let r = Routine {
+        skip_runs: Some(3),
+        ..routine("a", "A", "claude", "0 * * * *", &["machine1"], &[], true)
+    };
+    assert!(is_routine_snoozed(&r, now()));
+}
+
+#[test]
+fn is_routine_snoozed_false_when_skip_runs_zero() {
+    let r = Routine {
+        skip_runs: Some(0),
+        ..routine("a", "A", "claude", "0 * * * *", &["machine1"], &[], true)
+    };
+    assert!(!is_routine_snoozed(&r, now()));
+}
+
+#[test]
 fn health_snoozed_until_future_is_snoozed() {
     let r = Routine {
         agent_registered: true,


### PR DESCRIPTION
## Summary

- The NEXT RUN column in the routines table showed the upcoming scheduled fire time even when a routine was snoozed — those fires are suppressed and will never execute
- Now shows "snoozed" (muted text, consistent with "paused" for disabled routines) so the table accurately reflects what will actually run
- Extracts `is_routine_snoozed` as a shared helper used by both `routine_health` and `next_routine_run_cell`, replacing duplicated inline logic
- Adds four dedicated unit tests: future deadline → snoozed, past deadline → not snoozed, non-zero skip_runs → snoozed, zero skip_runs → not snoozed

Completes the snoozed-visibility set: #944 added the SNOOZED KPI tile, #945 fixed the overview table, this PR fixes the routines table.

## Test plan

- [ ] Snooze a routine — confirm NEXT RUN shows "snoozed" (not a timestamp)
- [ ] Wait for snooze to expire — confirm NEXT RUN returns to normal
- [ ] All CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)