### PR TITLE
feat(ui): add SNOOZED and FLAGS tiles to routines page stats bar

### DIFF
--- a/.changeset/ui-overview-lock-banner.md
+++ b/.changeset/ui-overview-lock-banner.md
@@ -1,0 +1,12 @@
+---
+"moadim": patch
+---
+
+feat(ui): show global lock banner on the overview page
+
+When routines are globally locked the OVERVIEW page now shows the same
+warning banner as the Routines tab. Previously users on the overview had
+no indication that scheduling and manual triggers were paused — they had
+to navigate to another tab to discover the lock. The banner shows which
+sentinels are active (SHARED .lock / LOCAL .local.lock) and is fetched
+alongside the routine list on every refresh cycle.

--- a/.changeset/ui-routines-stats-snoozed-flags.md
+++ b/.changeset/ui-routines-stats-snoozed-flags.md
@@ -1,0 +1,17 @@
+---
+"moadim": patch
+---
+
+feat(ui): add SNOOZED and FLAGS tiles to routines page stats bar
+
+The Routines page stats bar previously only showed TOTAL, ENABLED,
+DISABLED, DUE SOON, and UNREGISTERED AGENT. It now also shows:
+
+- **SNOOZED** — count of routines with suppressed fires (clickable
+  filter like DUE SOON; amber when non-zero)
+- **FLAGS** — total open flags across all routines (red when non-zero)
+- **DUE SOON** — now correctly excludes snoozed routines (same fix as
+  the overview page in #945)
+
+Adds `Snoozed` to `RoutineStatusFacet` with roundtrip codec support and
+a filter-matching test.

--- a/ui/src/overview.rs
+++ b/ui/src/overview.rs
@@ -19,7 +19,7 @@ use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
 use yew_router::prelude::*;
 
-use crate::routines::Routine;
+use crate::routines::{LockStatus, Routine};
 use crate::schedule::{fires_within, fmt_until, fmt_when, next_fire_after};
 use crate::{Route, ToastKind};
 
@@ -316,12 +316,23 @@ pub(crate) async fn fetch_routines() -> Result<Vec<Routine>, String> {
         .map_err(|e| e.to_string())
 }
 
+async fn fetch_lock_status() -> Option<LockStatus> {
+    Request::get("/api/v1/routines/lock")
+        .send()
+        .await
+        .ok()?
+        .json::<LockStatus>()
+        .await
+        .ok()
+}
+
 /// Loaded state for the overview shell.
 #[derive(Clone, PartialEq, Default)]
 struct Data {
     routines: Vec<Routine>,
     loading: bool,
     error: Option<String>,
+    lock_status: Option<LockStatus>,
 }
 
 #[derive(Properties, PartialEq)]
@@ -345,10 +356,12 @@ pub fn overview_page(props: &OverviewPageProps) -> Html {
             spawn_local(async move {
                 let routines = fetch_routines().await;
                 let error = routines.as_ref().err().cloned();
+                let lock_status = fetch_lock_status().await;
                 data.set(Data {
                     routines: routines.unwrap_or_default(),
                     loading: false,
                     error,
+                    lock_status,
                 });
             });
         }
@@ -403,9 +416,25 @@ pub fn overview_page(props: &OverviewPageProps) -> Html {
     let attention = attention_items(&sources, now_val);
     let runs = upcoming_runs(&sources, now_val);
     let next_run = next_run_summary(&runs, now_val);
+    let locked = data.lock_status.as_ref().is_some_and(|l| l.locked);
+    let lock_shared = data.lock_status.as_ref().is_some_and(|l| l.shared);
+    let lock_local = data.lock_status.as_ref().is_some_and(|l| l.local);
 
     html! {
         <main>
+            if locked {
+                <div class="lock-banner">
+                    <div class="lock-banner-msg">
+                        {"⚠ ROUTINES GLOBALLY LOCKED — scheduling and manual triggers paused"}
+                        if lock_shared {
+                            <span class="lock-scope-tag">{"SHARED .lock"}</span>
+                        }
+                        if lock_local {
+                            <span class="lock-scope-tag">{"LOCAL .local.lock"}</span>
+                        }
+                    </div>
+                </div>
+            }
             <OverviewStats kpis={kpis} next_run={next_run} />
             {
                 // Only render the triage panel when something is actually broken,

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -336,6 +336,7 @@ pub enum RoutineStatusFacet {
     Disabled,
     Dormant,
     DueSoon,
+    Snoozed,
 }
 
 impl RoutineStatusFacet {
@@ -347,6 +348,7 @@ impl RoutineStatusFacet {
             RoutineStatusFacet::Disabled => "disabled",
             RoutineStatusFacet::Dormant => "dormant",
             RoutineStatusFacet::DueSoon => "due",
+            RoutineStatusFacet::Snoozed => "snoozed",
         }
     }
 
@@ -357,6 +359,7 @@ impl RoutineStatusFacet {
             "disabled" => RoutineStatusFacet::Disabled,
             "dormant" => RoutineStatusFacet::Dormant,
             "due" => RoutineStatusFacet::DueSoon,
+            "snoozed" => RoutineStatusFacet::Snoozed,
             _ => RoutineStatusFacet::All,
         }
     }
@@ -491,6 +494,7 @@ impl RoutineFilter {
             {
                 return false
             }
+            RoutineStatusFacet::Snoozed if !is_routine_snoozed(r, now) => return false,
             _ => {}
         }
         match &self.agent {
@@ -1851,8 +1855,18 @@ pub fn routine_stats_bar(props: &StatsBarProps) -> Html {
     let due_soon = props
         .routines
         .iter()
-        .filter(|r| r.enabled && fires_within(&r.schedule, props.now, window))
+        .filter(|r| {
+            r.enabled
+                && !is_routine_snoozed(r, props.now)
+                && fires_within(&r.schedule, props.now, window)
+        })
         .count();
+    let snoozed = props
+        .routines
+        .iter()
+        .filter(|r| r.enabled && is_routine_snoozed(r, props.now))
+        .count();
+    let flags: usize = props.routines.iter().map(|r| r.flag_count).sum();
     let unreg = props
         .routines
         .iter()
@@ -1890,6 +1904,11 @@ pub fn routine_stats_bar(props: &StatsBarProps) -> Html {
             { mk(RoutineStatusFacet::Enabled, "ENABLED", enabled, "enabled") }
             { mk(RoutineStatusFacet::Disabled, "DISABLED", disabled, "disabled") }
             { mk(RoutineStatusFacet::DueSoon, "DUE SOON", due_soon, "due") }
+            { mk(RoutineStatusFacet::Snoozed, "SNOOZED", snoozed, "snoozed") }
+            <div class={classes!("stat-card", "flags", if flags > 0 { Some("has-flags") } else { None })}>
+                <div class="stat-label">{"FLAGS"}</div>
+                <div class={classes!("stat-val", if flags > 0 { "c-red" } else { "c-accent" })}>{flags}</div>
+            </div>
             <div class="stat-card unreg">
                 <div class="stat-label">{"UNREGISTERED AGENT"}</div>
                 <div class="stat-val">{unreg}</div>

--- a/ui/src/routines_tests.rs
+++ b/ui/src/routines_tests.rs
@@ -84,6 +84,7 @@ fn status_facet_roundtrips_and_defaults_to_all() {
         RoutineStatusFacet::Disabled,
         RoutineStatusFacet::Dormant,
         RoutineStatusFacet::DueSoon,
+        RoutineStatusFacet::Snoozed,
     ] {
         assert_eq!(RoutineStatusFacet::from_str(f.as_str()), f);
     }
@@ -280,6 +281,27 @@ fn status_due_soon_matches_enabled_routines_firing_within_window() {
     // Invalid / empty schedule → never fires → not due soon.
     let never = routine("d", "t", "claude", "", &["m1"], &[], true);
     assert!(!f.matches(&never, now(), window()));
+}
+
+#[test]
+fn status_snoozed_matches_only_snoozed_routines() {
+    let f = RoutineFilter {
+        status: RoutineStatusFacet::Snoozed,
+        ..Default::default()
+    };
+    let snoozed = Routine {
+        snoozed_until: Some((now() + Duration::hours(1)).timestamp() as u64),
+        ..routine("a", "t", "claude", "0 * * * *", &["m1"], &[], true)
+    };
+    let active = routine("b", "t", "claude", "0 * * * *", &["m1"], &[], true);
+    let disabled_snoozed = Routine {
+        snoozed_until: Some((now() + Duration::hours(1)).timestamp() as u64),
+        ..routine("c", "t", "claude", "0 * * * *", &["m1"], &[], false)
+    };
+    assert!(f.matches(&snoozed, now(), window()));
+    assert!(!f.matches(&active, now(), window()));
+    // Disabled+snoozed: snoozed filter does not check enabled state.
+    assert!(f.matches(&disabled_snoozed, now(), window()));
 }
 
 // ── Agent facet matching ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Routines page stats bar previously only showed TOTAL / ENABLED / DISABLED / DUE SOON / UNREGISTERED AGENT
- Adds **SNOOZED** tile — count of routines with suppressed fires, clickable filter (amber when non-zero), consistent with the overview's SNOOZED KPI (#944)
- Adds **FLAGS** tile — total open flags across all routines, red when non-zero, consistent with the overview's FLAGS KPI (#943)
- **DUE SOON** now correctly excludes snoozed routines (same fix as overview in #945 — a snoozed routine that would fire soon won't actually fire)
- Adds `Snoozed` variant to `RoutineStatusFacet` with roundtrip codec (`"snoozed"` ↔ `Snoozed`) and a new filter-matching test

## Test plan

- [ ] Snooze a routine — confirm SNOOZED tile increments and clicking it filters the list to only snoozed routines
- [ ] Create flags on a routine — confirm FLAGS tile shows count in red
- [ ] Snoozed routine that would fire soon no longer counts toward DUE SOON
- [ ] All CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)