### PR TITLE
feat(ui): show open flag count in NEEDS ATTENTION detail column

### DIFF
--- a/.changeset/ui-attention-flag-count.md
+++ b/.changeset/ui-attention-flag-count.md
@@ -1,0 +1,11 @@
+---
+"moadim": patch
+---
+
+feat(ui): show open flag count in NEEDS ATTENTION detail column
+
+The NEEDS ATTENTION panel now shows "N open flag(s) — needs review"
+instead of a generic detail string for HasOpenFlags rows, so operators
+can see the severity at a glance without navigating into the routine.
+AttentionItem now carries flag_count; a new test verifies it is
+correctly propagated from SchedSource.

--- a/ui/src/overview.rs
+++ b/ui/src/overview.rs
@@ -151,6 +151,8 @@ pub(crate) struct AttentionItem {
     pub label: String,
     /// The single most fundamental fault to fix.
     pub reason: AttentionReason,
+    /// Open flag count; non-zero only when `reason == HasOpenFlags`.
+    pub flag_count: usize,
 }
 
 /// One entry in the merged upcoming-runs timeline.
@@ -226,6 +228,7 @@ pub(crate) fn attention_items(sources: &[SchedSource], now: DateTime<Local>) -> 
             attention_reason(s, now).map(|reason| AttentionItem {
                 kind: s.kind,
                 label: s.label.clone(),
+                flag_count: s.flag_count,
                 reason,
             })
         })
@@ -564,7 +567,13 @@ fn attention_table(props: &AttentionTableProps) -> Html {
                                     </Link<Route>>
                                 </td>
                                 <td><span class="attn-badge">{item.reason.badge()}</span></td>
-                                <td class="attn-detail">{item.reason.detail()}</td>
+                                <td class="attn-detail">{
+                                    if item.reason == AttentionReason::HasOpenFlags && item.flag_count > 0 {
+                                        format!("{} open flag{} — needs review", item.flag_count, if item.flag_count == 1 { "" } else { "s" })
+                                    } else {
+                                        item.reason.detail().to_string()
+                                    }
+                                }</td>
                             </tr>
                         }
                     }) }

--- a/ui/src/overview_tests.rs
+++ b/ui/src/overview_tests.rs
@@ -299,6 +299,16 @@ fn attention_items_sorted_by_rank_then_label() {
 }
 
 #[test]
+fn attention_items_carries_flag_count_for_open_flags_reason() {
+    let mut s = src(Kind::Routine, "flagged", "*/5 * * * *", true);
+    s.flag_count = 7;
+    let items = attention_items(&[s], at_ten());
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].reason, AttentionReason::HasOpenFlags);
+    assert_eq!(items[0].flag_count, 7);
+}
+
+#[test]
 fn attention_items_empty_for_healthy_fleet() {
     let items = attention_items(
         &[


### PR DESCRIPTION
## Summary

- The NEEDS ATTENTION panel (added in #949) showed "OPEN FLAGS — agent raised flags during a run — needs review" for flagged routines, but the flag count was hidden
- Operators had to navigate into the routine to learn how many flags are open
- Now shows **"N open flag(s) — needs review"** inline in the DETAIL column (e.g. "3 open flags — needs review")
- `AttentionItem` now carries `flag_count` (populated from `SchedSource`); a new test `attention_items_carries_flag_count_for_open_flags_reason` verifies propagation

## Test plan

- [ ] Create 3 flags on a healthy routine — confirm NEEDS ATTENTION shows "3 open flags — needs review"
- [ ] Create 1 flag — confirm "1 open flag — needs review" (singular)
- [ ] All CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)