### PR TITLE
feat(ui): show routine health status in command palette subtitles

### DIFF
--- a/.changeset/ui-palette-routine-status.md
+++ b/.changeset/ui-palette-routine-status.md
@@ -1,0 +1,16 @@
+---
+"moadim": patch
+---
+
+feat(ui): show routine health status tags in command palette subtitles
+
+Routine entries in the ⌘K command palette previously showed only the
+schedule description. They now suffix status tags so operators can see
+health issues without leaving the palette:
+
+- "DISABLED" — routine is turned off
+- "SNOOZED" — skip_runs counter is active
+- "AGENT MISSING" — agent not registered
+- "FLAGS" — one or more open flags (appended alongside any other tag)
+
+Six new host tests cover the combinations.

--- a/ui/src/command_palette.rs
+++ b/ui/src/command_palette.rs
@@ -213,7 +213,7 @@ pub(crate) fn build_commands(routines: &[Routine]) -> Vec<Command> {
         commands.push(Command {
             kind: CmdKind::Routine,
             title: routine.title.clone(),
-            subtitle: schedule_label(&routine.schedule_description, &routine.schedule),
+            subtitle: routine_subtitle(routine),
             keywords: format!(
                 "{} {} {} routine",
                 routine.id, routine.agent, routine.schedule
@@ -221,6 +221,28 @@ pub(crate) fn build_commands(routines: &[Routine]) -> Vec<Command> {
         });
     }
     commands
+}
+
+/// Subtitle for a routine command: schedule label optionally suffixed with
+/// comma-separated status tags so health issues are visible in search results.
+pub(crate) fn routine_subtitle(routine: &Routine) -> String {
+    let sched = schedule_label(&routine.schedule_description, &routine.schedule);
+    let mut tags: Vec<&str> = Vec::new();
+    if !routine.enabled {
+        tags.push("DISABLED");
+    } else if routine.skip_runs.is_some_and(|n| n > 0) {
+        tags.push("SNOOZED");
+    } else if !routine.agent_registered {
+        tags.push("AGENT MISSING");
+    }
+    if routine.flag_count > 0 {
+        tags.push("FLAGS");
+    }
+    if tags.is_empty() {
+        sched
+    } else {
+        format!("{sched} — {}", tags.join(", "))
+    }
 }
 
 /// The human schedule description when present, else the raw expression, else a

--- a/ui/src/command_palette_tests.rs
+++ b/ui/src/command_palette_tests.rs
@@ -160,7 +160,7 @@ fn build_lists_pages_then_routines() {
     assert!(commands[5].keywords.contains("theme"));
     assert_eq!(commands[6].kind, CmdKind::Routine);
     assert_eq!(commands[6].title, "Nightly Audit");
-    assert_eq!(commands[6].subtitle, "0 0 * * *"); // falls back to raw expr
+    assert_eq!(commands[6].subtitle, "0 0 * * * — AGENT MISSING"); // agent_registered=false → tag appended
     assert!(commands[6].keywords.contains("claude"));
 }
 
@@ -178,6 +178,78 @@ fn schedule_label_prefers_human_then_raw_then_dash() {
     assert_eq!(schedule_label(&None, "0 12 * * *"), "0 12 * * *");
     // Neither present → a dash, never an empty string.
     assert_eq!(schedule_label(&None, "   "), "—");
+}
+
+// ─── routine_subtitle ────────────────────────────────────────────────────────
+
+#[test]
+fn routine_subtitle_healthy_shows_schedule_only() {
+    let r = Routine {
+        enabled: true,
+        agent_registered: true,
+        flag_count: 0,
+        schedule_description: Some("Every 5 minutes".into()),
+        ..routine("r", "T", "claude", "*/5 * * * *", None)
+    };
+    assert_eq!(routine_subtitle(&r), "Every 5 minutes");
+}
+
+#[test]
+fn routine_subtitle_disabled_appends_tag() {
+    let r = Routine {
+        enabled: false,
+        agent_registered: true,
+        flag_count: 0,
+        ..routine("r", "T", "claude", "*/5 * * * *", None)
+    };
+    assert!(routine_subtitle(&r).ends_with("— DISABLED"));
+}
+
+#[test]
+fn routine_subtitle_snoozed_via_skip_runs() {
+    let r = Routine {
+        enabled: true,
+        agent_registered: true,
+        flag_count: 0,
+        skip_runs: Some(2),
+        ..routine("r", "T", "claude", "*/5 * * * *", None)
+    };
+    assert!(routine_subtitle(&r).ends_with("— SNOOZED"));
+}
+
+#[test]
+fn routine_subtitle_agent_missing_appends_tag() {
+    let r = Routine {
+        enabled: true,
+        agent_registered: false,
+        flag_count: 0,
+        ..routine("r", "T", "claude", "*/5 * * * *", None)
+    };
+    assert!(routine_subtitle(&r).ends_with("— AGENT MISSING"));
+}
+
+#[test]
+fn routine_subtitle_flags_appended_even_when_healthy() {
+    let r = Routine {
+        enabled: true,
+        agent_registered: true,
+        flag_count: 3,
+        ..routine("r", "T", "claude", "*/5 * * * *", None)
+    };
+    assert!(routine_subtitle(&r).ends_with("— FLAGS"));
+}
+
+#[test]
+fn routine_subtitle_disabled_with_flags_shows_both() {
+    let r = Routine {
+        enabled: false,
+        agent_registered: true,
+        flag_count: 2,
+        ..routine("r", "T", "claude", "*/5 * * * *", None)
+    };
+    let s = routine_subtitle(&r);
+    assert!(s.contains("DISABLED"), "expected DISABLED in: {s}");
+    assert!(s.contains("FLAGS"), "expected FLAGS in: {s}");
 }
 
 // ─── route_for / badge_for ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Routine entries in the ⌘K command palette now show health status tags in their subtitle line
- Tags: **DISABLED**, **SNOOZED** (skip_runs > 0), **AGENT MISSING**, **FLAGS** (open flags count)
- FLAGS is appended alongside any other tag so operators can see both the primary issue and flag count at a glance
- Six new host tests cover all tag combinations

## Test plan

- [ ] Open command palette (⌘K), search for a disabled routine → subtitle ends with "— DISABLED"
- [ ] Search for a routine with skip_runs active → subtitle ends with "— SNOOZED"
- [ ] Search for a routine with no registered agent → subtitle ends with "— AGENT MISSING"
- [ ] Search for a routine with open flags → subtitle ends with "— FLAGS"
- [ ] Healthy routine → subtitle shows schedule only, no extra tags
- [ ] `cargo test -p ui command_palette` → all 26 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)