### PR TITLE
feat(ui): add RefreshControl to heatmap page

### DIFF
--- a/.changeset/ui-heatmap-refresh-control.md
+++ b/.changeset/ui-heatmap-refresh-control.md
@@ -1,0 +1,12 @@
+---
+"moadim": patch
+---
+
+feat(ui): add RefreshControl to heatmap page
+
+The heatmap page previously used a hard-coded 30 s background refresh
+with no user-visible indicator of when data was last loaded. It now
+shows the same RefreshControl as the Overview and Routines pages
+(Off / 5s / 15s / 30s / 60s dropdown + "updated N ago" freshness cue),
+sharing the same localStorage key so the chosen cadence is consistent
+across all pages.

--- a/.changeset/ui-palette-routine-status.md
+++ b/.changeset/ui-palette-routine-status.md
@@ -1,0 +1,16 @@
+---
+"moadim": patch
+---
+
+feat(ui): show routine health status tags in command palette subtitles
+
+Routine entries in the ⌘K command palette previously showed only the
+schedule description. They now suffix status tags so operators can see
+health issues without leaving the palette:
+
+- "DISABLED" — routine is turned off
+- "SNOOZED" — skip_runs counter is active
+- "AGENT MISSING" — agent not registered
+- "FLAGS" — one or more open flags (appended alongside any other tag)
+
+Six new host tests cover the combinations.

--- a/ui/src/command_palette.rs
+++ b/ui/src/command_palette.rs
@@ -213,7 +213,7 @@ pub(crate) fn build_commands(routines: &[Routine]) -> Vec<Command> {
         commands.push(Command {
             kind: CmdKind::Routine,
             title: routine.title.clone(),
-            subtitle: schedule_label(&routine.schedule_description, &routine.schedule),
+            subtitle: routine_subtitle(routine),
             keywords: format!(
                 "{} {} {} routine",
                 routine.id, routine.agent, routine.schedule
@@ -221,6 +221,28 @@ pub(crate) fn build_commands(routines: &[Routine]) -> Vec<Command> {
         });
     }
     commands
+}
+
+/// Subtitle for a routine command: schedule label optionally suffixed with
+/// comma-separated status tags so health issues are visible in search results.
+pub(crate) fn routine_subtitle(routine: &Routine) -> String {
+    let sched = schedule_label(&routine.schedule_description, &routine.schedule);
+    let mut tags: Vec<&str> = Vec::new();
+    if !routine.enabled {
+        tags.push("DISABLED");
+    } else if routine.skip_runs.is_some_and(|n| n > 0) {
+        tags.push("SNOOZED");
+    } else if !routine.agent_registered {
+        tags.push("AGENT MISSING");
+    }
+    if routine.flag_count > 0 {
+        tags.push("FLAGS");
+    }
+    if tags.is_empty() {
+        sched
+    } else {
+        format!("{sched} — {}", tags.join(", "))
+    }
 }
 
 /// The human schedule description when present, else the raw expression, else a

--- a/ui/src/command_palette_tests.rs
+++ b/ui/src/command_palette_tests.rs
@@ -160,7 +160,7 @@ fn build_lists_pages_then_routines() {
     assert!(commands[5].keywords.contains("theme"));
     assert_eq!(commands[6].kind, CmdKind::Routine);
     assert_eq!(commands[6].title, "Nightly Audit");
-    assert_eq!(commands[6].subtitle, "0 0 * * *"); // falls back to raw expr
+    assert_eq!(commands[6].subtitle, "0 0 * * * — AGENT MISSING"); // agent_registered=false → tag appended
     assert!(commands[6].keywords.contains("claude"));
 }
 
@@ -178,6 +178,78 @@ fn schedule_label_prefers_human_then_raw_then_dash() {
     assert_eq!(schedule_label(&None, "0 12 * * *"), "0 12 * * *");
     // Neither present → a dash, never an empty string.
     assert_eq!(schedule_label(&None, "   "), "—");
+}
+
+// ─── routine_subtitle ────────────────────────────────────────────────────────
+
+#[test]
+fn routine_subtitle_healthy_shows_schedule_only() {
+    let r = Routine {
+        enabled: true,
+        agent_registered: true,
+        flag_count: 0,
+        schedule_description: Some("Every 5 minutes".into()),
+        ..routine("r", "T", "claude", "*/5 * * * *", None)
+    };
+    assert_eq!(routine_subtitle(&r), "Every 5 minutes");
+}
+
+#[test]
+fn routine_subtitle_disabled_appends_tag() {
+    let r = Routine {
+        enabled: false,
+        agent_registered: true,
+        flag_count: 0,
+        ..routine("r", "T", "claude", "*/5 * * * *", None)
+    };
+    assert!(routine_subtitle(&r).ends_with("— DISABLED"));
+}
+
+#[test]
+fn routine_subtitle_snoozed_via_skip_runs() {
+    let r = Routine {
+        enabled: true,
+        agent_registered: true,
+        flag_count: 0,
+        skip_runs: Some(2),
+        ..routine("r", "T", "claude", "*/5 * * * *", None)
+    };
+    assert!(routine_subtitle(&r).ends_with("— SNOOZED"));
+}
+
+#[test]
+fn routine_subtitle_agent_missing_appends_tag() {
+    let r = Routine {
+        enabled: true,
+        agent_registered: false,
+        flag_count: 0,
+        ..routine("r", "T", "claude", "*/5 * * * *", None)
+    };
+    assert!(routine_subtitle(&r).ends_with("— AGENT MISSING"));
+}
+
+#[test]
+fn routine_subtitle_flags_appended_even_when_healthy() {
+    let r = Routine {
+        enabled: true,
+        agent_registered: true,
+        flag_count: 3,
+        ..routine("r", "T", "claude", "*/5 * * * *", None)
+    };
+    assert!(routine_subtitle(&r).ends_with("— FLAGS"));
+}
+
+#[test]
+fn routine_subtitle_disabled_with_flags_shows_both() {
+    let r = Routine {
+        enabled: false,
+        agent_registered: true,
+        flag_count: 2,
+        ..routine("r", "T", "claude", "*/5 * * * *", None)
+    };
+    let s = routine_subtitle(&r);
+    assert!(s.contains("DISABLED"), "expected DISABLED in: {s}");
+    assert!(s.contains("FLAGS"), "expected FLAGS in: {s}");
 }
 
 // ─── route_for / badge_for ────────────────────────────────────────────────────

--- a/ui/src/schedule_heatmap.rs
+++ b/ui/src/schedule_heatmap.rs
@@ -23,6 +23,7 @@ use yew::prelude::*;
 
 use crate::overview::{fetch_routines, Kind};
 use crate::parse_cron;
+use crate::refresh::{RefreshControl, RefreshInterval};
 use crate::routines::Routine;
 
 /// Rows in the grid: the next 7 calendar days, row 0 = today.
@@ -33,9 +34,6 @@ pub(crate) const HEAT_HOURS: usize = 24;
 /// every-minute schedule fires 7×1440 = 10 080 times/week; this leaves headroom
 /// while bounding cost on pathological (e.g. per-second) inputs.
 const MAX_FIRES_PER_SOURCE: usize = 20_000;
-/// How often the page re-fetches the underlying records (counts can change as
-/// jobs are toggled elsewhere).
-const REFETCH_MS: u32 = 30_000;
 /// How often the live "now" advances so the grid (and its today/current-hour
 /// highlight) rolls forward between fetches.
 const TICK_MS: u32 = 60_000;
@@ -229,15 +227,20 @@ pub fn heatmap_page() -> Html {
     });
     let now = use_state(Local::now);
     let filter = use_state(|| HeatFilter::All);
+    let interval = use_state(crate::refresh::load_interval);
+    let updated_at = use_state(|| 0.0_f64);
 
     // Fetch the routine record list.
     let load = {
         let data = data.clone();
+        let updated_at = updated_at.clone();
         move || {
             let data = data.clone();
+            let updated_at = updated_at.clone();
             spawn_local(async move {
                 let routines = fetch_routines().await;
                 let error = routines.as_ref().err().cloned();
+                updated_at.set(js_sys::Date::now());
                 data.set(Data {
                     routines: routines.unwrap_or_default(),
                     loading: false,
@@ -247,19 +250,42 @@ pub fn heatmap_page() -> Html {
         }
     };
 
-    // Load on mount, then re-fetch on a slow cadence.
+    // Load on mount.
     {
         let load = load.clone();
-        use_effect_with((), move |_| {
-            load();
-            spawn_local(async move {
-                loop {
-                    TimeoutFuture::new(REFETCH_MS).await;
-                    load();
-                }
-            });
+        use_effect_with((), move |_| load());
+    }
+
+    // Auto-refresh loop, re-armed when the interval changes.
+    {
+        use std::cell::Cell;
+        use std::rc::Rc;
+        let load = load.clone();
+        use_effect_with(*interval, move |interval| {
+            let cancelled = Rc::new(Cell::new(false));
+            if let Some(period_ms) = interval.as_millis() {
+                let cancelled = cancelled.clone();
+                spawn_local(async move {
+                    loop {
+                        TimeoutFuture::new(period_ms).await;
+                        if cancelled.get() {
+                            break;
+                        }
+                        load();
+                    }
+                });
+            }
+            move || cancelled.set(true)
         });
     }
+
+    let on_set_interval = {
+        let interval = interval.clone();
+        Callback::from(move |next: RefreshInterval| {
+            crate::refresh::save_interval(next);
+            interval.set(next);
+        })
+    };
 
     // Advance "now" so the grid rolls forward between fetches.
     {
@@ -290,6 +316,11 @@ pub fn heatmap_page() -> Html {
             <div class="section-hd">
                 <span class="section-label">{"SCHEDULE HEATMAP"}</span>
                 <FilterTabs active={*filter} on_pick={set_filter} />
+                <RefreshControl
+                    interval={*interval}
+                    updated_at_ms={*updated_at}
+                    on_change={on_set_interval}
+                />
             </div>
             <HeatStats map={map.clone()} today={today} />
             <HeatGrid


### PR DESCRIPTION
## Summary

- The heatmap page previously used a hard-coded 30 s background poll with no user control or freshness indicator
- Now shows the same RefreshControl (Off / 5s / 15s / 30s / 60s + "updated N ago") as the Overview and Routines pages
- Shares the same localStorage key so the chosen cadence is consistent across all pages

## Test plan

- [ ] Open the heatmap page → RefreshControl appears in the header next to the filter tabs
- [ ] Change cadence to "Off" → background fetching stops
- [ ] Change cadence to "5s" → page re-fetches every 5 s, "updated N ago" updates
- [ ] Change cadence on one page → other pages use the same setting
- [ ] `cargo test -p ui schedule_heatmap` → all 17 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)