### PR TITLE
feat(ui): show open-flag badge on upcoming-runs rows

### DIFF
--- a/.changeset/ui-upcoming-flag-badge.md
+++ b/.changeset/ui-upcoming-flag-badge.md
@@ -1,0 +1,11 @@
+---
+"moadim": patch
+---
+
+feat(ui): show open-flag badge on upcoming-runs rows
+
+The UPCOMING RUNS table now shows a small "⚑ N" badge next to the name
+of any routine that has open flags, so operators can see at a glance
+which about-to-fire routines still need flag review without navigating
+to the NEEDS ATTENTION panel. Two new tests verify the flag count is
+correctly propagated from SchedSource to UpcomingRun.

--- a/ui/index.html
+++ b/ui/index.html
@@ -530,6 +530,15 @@
       transition: color 0.1s, border-color 0.1s;
     }
     .ov-name-link:hover { color: var(--accent); border-bottom-color: var(--accent-dim); }
+    .ov-flag-badge {
+      display: inline-block;
+      margin-left: 6px;
+      font-size: 9px;
+      letter-spacing: 0.06em;
+      color: var(--red);
+      opacity: 0.85;
+      vertical-align: middle;
+    }
 
     /* ── Section header ── */
     .section-hd {

--- a/ui/src/overview.rs
+++ b/ui/src/overview.rs
@@ -167,6 +167,8 @@ pub(crate) struct UpcomingRun {
     pub at: DateTime<Local>,
     /// Whether `at` lands within the due-soon window.
     pub soon: bool,
+    /// Total open flags on this routine (0 when none).
+    pub flag_count: usize,
 }
 
 /// Count the KPI tiles from `sources` as of `now`.
@@ -256,6 +258,7 @@ pub(crate) fn upcoming_runs(sources: &[SchedSource], now: DateTime<Local>) -> Ve
                 human: s.human.clone(),
                 at,
                 soon: at - now <= window,
+                flag_count: s.flag_count,
             })
         })
         .collect();
@@ -688,6 +691,11 @@ fn upcoming_table(props: &UpcomingTableProps) -> Html {
                                     <Link<Route> classes={classes!("ov-name-link")} to={to}>
                                         {run.label.clone()}
                                     </Link<Route>>
+                                    if run.flag_count > 0 {
+                                        <span class="ov-flag-badge" title={format!("{} open flag{}", run.flag_count, if run.flag_count == 1 { "" } else { "s" })}>
+                                            {format!("⚑ {}", run.flag_count)}
+                                        </span>
+                                    }
                                 </td>
                                 <td>
                                     <div class="cell-schedule-human">

--- a/ui/src/overview_tests.rs
+++ b/ui/src/overview_tests.rs
@@ -392,6 +392,21 @@ fn upcoming_run_routine_id_differs_from_label() {
 }
 
 #[test]
+fn upcoming_run_carries_flag_count_from_source() {
+    let mut source = src(Kind::Routine, "flagged", "*/5 * * * *", true);
+    source.flag_count = 4;
+    let runs = upcoming_runs(&[source], at_ten());
+    assert_eq!(runs[0].flag_count, 4);
+}
+
+#[test]
+fn upcoming_run_flag_count_zero_when_none() {
+    let source = src(Kind::Routine, "clean", "*/5 * * * *", true);
+    let runs = upcoming_runs(&[source], at_ten());
+    assert_eq!(runs[0].flag_count, 0);
+}
+
+#[test]
 fn sources_of_maps_routines() {
     let routine: Routine = serde_json::from_value(serde_json::json!({
         "id": "r1", "schedule": "0 0 * * *", "title": "T", "agent": "a",


### PR DESCRIPTION
## Summary

- The UPCOMING RUNS table now shows a `⚑ N` badge next to the name of any routine that has open flags
- Lets operators see at a glance which about-to-fire routines need flag review, without opening the NEEDS ATTENTION panel
- `UpcomingRun` struct gains `flag_count: usize`, populated from `SchedSource`
- Two new host tests verify flag count propagation

## Test plan

- [ ] Overview page: a routine with open flags shows `⚑ N` badge in its upcoming-runs row
- [ ] Routine with zero flags: no badge rendered
- [ ] `cargo test -p ui overview` → new tests pass alongside existing ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)