### PR TITLE
feat(ui): show snoozed and flag indicators on day-timeline chips

### DIFF
--- a/.changeset/ui-day-timeline-snoozed-flags.md
+++ b/.changeset/ui-day-timeline-snoozed-flags.md
@@ -1,0 +1,13 @@
+---
+"moadim": patch
+---
+
+feat(ui): show snoozed and flag indicators on day-timeline chips
+
+Day-view timeline chips now carry two additional signals:
+
+- **Snoozed routines** render at 45% opacity with an amber left-border
+  instead of the standard accent border, so operators can distinguish
+  suppressed fire times from active ones at a glance.
+- **Flagged routines** show a red `⚑N` badge on the chip so pending
+  flags are visible without leaving the timeline view.

--- a/.changeset/ui-upcoming-flag-badge.md
+++ b/.changeset/ui-upcoming-flag-badge.md
@@ -1,0 +1,11 @@
+---
+"moadim": patch
+---
+
+feat(ui): show open-flag badge on upcoming-runs rows
+
+The UPCOMING RUNS table now shows a small "⚑ N" badge next to the name
+of any routine that has open flags, so operators can see at a glance
+which about-to-fire routines still need flag review without navigating
+to the NEEDS ATTENTION panel. Two new tests verify the flag count is
+correctly propagated from SchedSource to UpcomingRun.

--- a/ui/index.html
+++ b/ui/index.html
@@ -1432,6 +1432,13 @@
     }
     .day-chip.clickable { cursor: pointer; }
     .day-chip.clickable:hover { filter: brightness(1.12); }
+    .day-chip.snoozed { opacity: 0.45; border-left-color: var(--amber); }
+    .day-chip-flag {
+      font-size: 9px;
+      color: var(--red);
+      margin-left: auto;
+      flex-shrink: 0;
+    }
 
     @media (max-width: 640px) {
       .day-hour { grid-template-columns: 52px 1fr; }

--- a/ui/index.html
+++ b/ui/index.html
@@ -530,6 +530,15 @@
       transition: color 0.1s, border-color 0.1s;
     }
     .ov-name-link:hover { color: var(--accent); border-bottom-color: var(--accent-dim); }
+    .ov-flag-badge {
+      display: inline-block;
+      margin-left: 6px;
+      font-size: 9px;
+      letter-spacing: 0.06em;
+      color: var(--red);
+      opacity: 0.85;
+      vertical-align: middle;
+    }
 
     /* ── Section header ── */
     .section-hd {

--- a/ui/src/day_timeline.rs
+++ b/ui/src/day_timeline.rs
@@ -33,6 +33,19 @@ pub struct TimelineItem {
     pub id: Option<String>,
     pub label: String,
     pub schedule: String,
+    /// True when this routine is currently snoozed; the chip is rendered muted.
+    pub snoozed: bool,
+    /// Open flag count; shown as a badge when non-zero.
+    pub flag_count: usize,
+}
+
+/// One resolved fire event inside a single hour bucket.
+struct BucketEntry {
+    time: NaiveTime,
+    label: String,
+    id: Option<String>,
+    snoozed: bool,
+    flag_count: usize,
 }
 
 /// All fire times for `schedule` that fall on `day`, in chronological order.
@@ -130,17 +143,22 @@ pub fn day_timeline(props: &DayTimelineProps) -> Html {
     };
 
     // Bucket every item's fire times into the hour rows.
-    // Each entry is (fire time, display label, optional entity id for click handling).
-    let mut buckets: Vec<Vec<(NaiveTime, String, Option<String>)>> = vec![Vec::new(); 24];
+    let mut buckets: Vec<Vec<BucketEntry>> = (0..24).map(|_| Vec::new()).collect();
     let mut total = 0usize;
     for it in props.items.iter() {
         for t in fire_times(&it.schedule, day) {
-            buckets[t.hour() as usize].push((t, it.label.clone(), it.id.clone()));
+            buckets[t.hour() as usize].push(BucketEntry {
+                time: t,
+                label: it.label.clone(),
+                id: it.id.clone(),
+                snoozed: it.snoozed,
+                flag_count: it.flag_count,
+            });
             total += 1;
         }
     }
     for b in buckets.iter_mut() {
-        b.sort_by_key(|(t, _, _)| *t);
+        b.sort_by_key(|e| e.time);
     }
 
     let date_label = format!(
@@ -195,23 +213,30 @@ pub fn day_timeline(props: &DayTimelineProps) -> Html {
                         <div class={cls} ref={row_ref}>
                             {label}
                             <div class="day-hour-slot">
-                                { for slot.iter().map(|(t, lbl, id)| {
+                                { for slot.iter().map(|e| {
+                                    let t = e.time;
                                     let frac = (t.minute() as f32 + t.second() as f32 / 60.0) / 60.0;
                                     let style = if detailed {
                                         Some(format!("top:{:.3}%", frac * 100.0))
                                     } else {
                                         None
                                     };
-                                    let on_chip = props.on_click.as_ref().zip(id.as_ref()).map(|(cb, item_id)| {
+                                    let on_chip = props.on_click.as_ref().zip(e.id.as_ref()).map(|(cb, item_id)| {
                                         let cb = cb.clone();
                                         let item_id = item_id.clone();
                                         Callback::from(move |_: MouseEvent| cb.emit(item_id.clone()))
                                     });
-                                    let chip_cls = if on_chip.is_some() { "day-chip clickable" } else { "day-chip" };
+                                    let mut chip_cls = String::from("day-chip");
+                                    if on_chip.is_some() { chip_cls.push_str(" clickable"); }
+                                    if e.snoozed { chip_cls.push_str(" snoozed"); }
+                                    let flag_count = e.flag_count;
                                     html! {
-                                        <div class={chip_cls} style={style} title={lbl.clone()} onclick={on_chip}>
+                                        <div class={chip_cls} style={style} title={e.label.clone()} onclick={on_chip}>
                                             <span class="day-chip-time">{format!("{:02}:{:02}", t.hour(), t.minute())}</span>
-                                            <span class="day-chip-label">{lbl.clone()}</span>
+                                            <span class="day-chip-label">{e.label.clone()}</span>
+                                            if flag_count > 0 {
+                                                <span class="day-chip-flag">{format!("⚑{flag_count}")}</span>
+                                            }
                                         </div>
                                     }
                                 }) }

--- a/ui/src/overview.rs
+++ b/ui/src/overview.rs
@@ -167,6 +167,8 @@ pub(crate) struct UpcomingRun {
     pub at: DateTime<Local>,
     /// Whether `at` lands within the due-soon window.
     pub soon: bool,
+    /// Total open flags on this routine (0 when none).
+    pub flag_count: usize,
 }
 
 /// Count the KPI tiles from `sources` as of `now`.
@@ -256,6 +258,7 @@ pub(crate) fn upcoming_runs(sources: &[SchedSource], now: DateTime<Local>) -> Ve
                 human: s.human.clone(),
                 at,
                 soon: at - now <= window,
+                flag_count: s.flag_count,
             })
         })
         .collect();
@@ -688,6 +691,11 @@ fn upcoming_table(props: &UpcomingTableProps) -> Html {
                                     <Link<Route> classes={classes!("ov-name-link")} to={to}>
                                         {run.label.clone()}
                                     </Link<Route>>
+                                    if run.flag_count > 0 {
+                                        <span class="ov-flag-badge" title={format!("{} open flag{}", run.flag_count, if run.flag_count == 1 { "" } else { "s" })}>
+                                            {format!("⚑ {}", run.flag_count)}
+                                        </span>
+                                    }
                                 </td>
                                 <td>
                                     <div class="cell-schedule-human">

--- a/ui/src/overview_tests.rs
+++ b/ui/src/overview_tests.rs
@@ -392,6 +392,21 @@ fn upcoming_run_routine_id_differs_from_label() {
 }
 
 #[test]
+fn upcoming_run_carries_flag_count_from_source() {
+    let mut source = src(Kind::Routine, "flagged", "*/5 * * * *", true);
+    source.flag_count = 4;
+    let runs = upcoming_runs(&[source], at_ten());
+    assert_eq!(runs[0].flag_count, 4);
+}
+
+#[test]
+fn upcoming_run_flag_count_zero_when_none() {
+    let source = src(Kind::Routine, "clean", "*/5 * * * *", true);
+    let runs = upcoming_runs(&[source], at_ten());
+    assert_eq!(runs[0].flag_count, 0);
+}
+
+#[test]
 fn sources_of_maps_routines() {
     let routine: Routine = serde_json::from_value(serde_json::json!({
         "id": "r1", "schedule": "0 0 * * *", "title": "T", "agent": "a",

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -1751,6 +1751,8 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
                                             id: Some(r.id.clone()),
                                             label: r.title.clone(),
                                             schedule: r.schedule.clone(),
+                                            snoozed: is_routine_snoozed(r, now_val),
+                                            flag_count: r.flag_count,
                                         }).collect::<Vec<_>>();
                                         html! { <DayTimeline items={items} loading={loading} on_click={Some(on_edit)} /> }
                                     },


### PR DESCRIPTION
## Summary

- Day-view timeline chips now reflect two additional signals per routine:
  - **Snoozed**: chip renders at 45% opacity with an amber left-border (vs. the standard accent border) so suppressed fire times are visually distinct from active ones
  - **Flagged**: a red `⚑N` badge appears on the chip so pending flags are visible without leaving the timeline
- `TimelineItem` gains `snoozed: bool` and `flag_count: usize`; the routine page populates them via `is_routine_snoozed`

## Test plan

- [ ] Day view: a snoozed routine's chips are muted (amber border, low opacity)
- [ ] Day view: a routine with open flags shows `⚑N` badge on each chip
- [ ] Day view: healthy routines unchanged
- [ ] `cargo check -p ui` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)