### PR TITLE
feat(ui): mute snoozed routines in the month calendar view

### DIFF
--- a/.changeset/ui-calendar-snoozed.md
+++ b/.changeset/ui-calendar-snoozed.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+feat(ui): mute snoozed routines in the month calendar view
+
+Calendar chips for currently-snoozed routines now render at 45% opacity
+with an amber left border, matching the treatment added to the day
+timeline, so operators can see at a glance which future fire times belong
+to suppressed routines.

--- a/.changeset/ui-day-timeline-snoozed-flags.md
+++ b/.changeset/ui-day-timeline-snoozed-flags.md
@@ -1,0 +1,13 @@
+---
+"moadim": patch
+---
+
+feat(ui): show snoozed and flag indicators on day-timeline chips
+
+Day-view timeline chips now carry two additional signals:
+
+- **Snoozed routines** render at 45% opacity with an amber left-border
+  instead of the standard accent border, so operators can distinguish
+  suppressed fire times from active ones at a glance.
+- **Flagged routines** show a red `⚑N` badge on the chip so pending
+  flags are visible without leaving the timeline view.

--- a/.changeset/ui-flag-age.md
+++ b/.changeset/ui-flag-age.md
@@ -1,0 +1,9 @@
+---
+"moadim": patch
+---
+
+feat(ui): show flag age in the flags panel
+
+Each flag row now shows a relative timestamp ("3h ago", "2d ago") next
+to the scope badge, so operators can see at a glance how long a flag
+has been open without cross-referencing the file metadata.

--- a/.changeset/ui-snooze-detail.md
+++ b/.changeset/ui-snooze-detail.md
@@ -1,0 +1,14 @@
+---
+"moadim": patch
+---
+
+feat(ui): show snooze-until detail in the NEXT RUN cell
+
+Snoozed routines previously showed only "snoozed" in the NEXT RUN
+column. The cell now includes a secondary line with context:
+
+- "Nm left" / "Nh left" / "Nd left" — when a `snoozed_until` deadline
+  is set, showing how long until the routine resumes automatically.
+- "N run(s) skipped" — when a `skip_runs` counter is active.
+
+Seven new host tests cover all the formatting branches.

--- a/.changeset/ui-upcoming-flag-badge.md
+++ b/.changeset/ui-upcoming-flag-badge.md
@@ -1,0 +1,11 @@
+---
+"moadim": patch
+---
+
+feat(ui): show open-flag badge on upcoming-runs rows
+
+The UPCOMING RUNS table now shows a small "⚑ N" badge next to the name
+of any routine that has open flags, so operators can see at a glance
+which about-to-fire routines still need flag review without navigating
+to the NEEDS ATTENTION panel. Two new tests verify the flag count is
+correctly propagated from SchedSource to UpcomingRun.

--- a/ui/index.html
+++ b/ui/index.html
@@ -1432,6 +1432,13 @@
     }
     .day-chip.clickable { cursor: pointer; }
     .day-chip.clickable:hover { filter: brightness(1.12); }
+    .day-chip.snoozed { opacity: 0.45; border-left-color: var(--amber); }
+    .day-chip-flag {
+      font-size: 9px;
+      color: var(--red);
+      margin-left: auto;
+      flex-shrink: 0;
+    }
 
     @media (max-width: 640px) {
       .day-hour { grid-template-columns: 52px 1fr; }

--- a/ui/index.html
+++ b/ui/index.html
@@ -1295,6 +1295,7 @@
       text-overflow: ellipsis;
     }
     .cal-more { font-size: 9px; color: var(--text-ghost); padding: 0 5px; }
+    .cal-chip.snoozed { opacity: 0.45; border-left-color: var(--amber); }
     .cal-chip.clickable,
     .cal-event.clickable { cursor: pointer; }
     .cal-chip.clickable:hover,

--- a/ui/index.html
+++ b/ui/index.html
@@ -1052,6 +1052,7 @@
     .flag-item-hd { display: flex; align-items: center; gap: 8px; }
     .flag-type { font-family: var(--mono); font-size: 11px; color: var(--text-hi); text-transform: uppercase; }
     .flag-scope { font-size: 10px; color: var(--text-ghost); border: 1px solid var(--border); border-radius: 3px; padding: 0 4px; }
+    .flag-age { font-size: 10px; color: var(--text-dim); }
     .flag-item-hd .btn { margin-left: auto; }
     .flag-desc { margin-top: 6px; font-size: 12px; color: var(--text-mid); white-space: pre-wrap; }
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -530,6 +530,15 @@
       transition: color 0.1s, border-color 0.1s;
     }
     .ov-name-link:hover { color: var(--accent); border-bottom-color: var(--accent-dim); }
+    .ov-flag-badge {
+      display: inline-block;
+      margin-left: 6px;
+      font-size: 9px;
+      letter-spacing: 0.06em;
+      color: var(--red);
+      opacity: 0.85;
+      vertical-align: middle;
+    }
 
     /* ── Section header ── */
     .section-hd {

--- a/ui/src/day_timeline.rs
+++ b/ui/src/day_timeline.rs
@@ -33,6 +33,19 @@ pub struct TimelineItem {
     pub id: Option<String>,
     pub label: String,
     pub schedule: String,
+    /// True when this routine is currently snoozed; the chip is rendered muted.
+    pub snoozed: bool,
+    /// Open flag count; shown as a badge when non-zero.
+    pub flag_count: usize,
+}
+
+/// One resolved fire event inside a single hour bucket.
+struct BucketEntry {
+    time: NaiveTime,
+    label: String,
+    id: Option<String>,
+    snoozed: bool,
+    flag_count: usize,
 }
 
 /// All fire times for `schedule` that fall on `day`, in chronological order.
@@ -130,17 +143,22 @@ pub fn day_timeline(props: &DayTimelineProps) -> Html {
     };
 
     // Bucket every item's fire times into the hour rows.
-    // Each entry is (fire time, display label, optional entity id for click handling).
-    let mut buckets: Vec<Vec<(NaiveTime, String, Option<String>)>> = vec![Vec::new(); 24];
+    let mut buckets: Vec<Vec<BucketEntry>> = (0..24).map(|_| Vec::new()).collect();
     let mut total = 0usize;
     for it in props.items.iter() {
         for t in fire_times(&it.schedule, day) {
-            buckets[t.hour() as usize].push((t, it.label.clone(), it.id.clone()));
+            buckets[t.hour() as usize].push(BucketEntry {
+                time: t,
+                label: it.label.clone(),
+                id: it.id.clone(),
+                snoozed: it.snoozed,
+                flag_count: it.flag_count,
+            });
             total += 1;
         }
     }
     for b in buckets.iter_mut() {
-        b.sort_by_key(|(t, _, _)| *t);
+        b.sort_by_key(|e| e.time);
     }
 
     let date_label = format!(
@@ -195,23 +213,30 @@ pub fn day_timeline(props: &DayTimelineProps) -> Html {
                         <div class={cls} ref={row_ref}>
                             {label}
                             <div class="day-hour-slot">
-                                { for slot.iter().map(|(t, lbl, id)| {
+                                { for slot.iter().map(|e| {
+                                    let t = e.time;
                                     let frac = (t.minute() as f32 + t.second() as f32 / 60.0) / 60.0;
                                     let style = if detailed {
                                         Some(format!("top:{:.3}%", frac * 100.0))
                                     } else {
                                         None
                                     };
-                                    let on_chip = props.on_click.as_ref().zip(id.as_ref()).map(|(cb, item_id)| {
+                                    let on_chip = props.on_click.as_ref().zip(e.id.as_ref()).map(|(cb, item_id)| {
                                         let cb = cb.clone();
                                         let item_id = item_id.clone();
                                         Callback::from(move |_: MouseEvent| cb.emit(item_id.clone()))
                                     });
-                                    let chip_cls = if on_chip.is_some() { "day-chip clickable" } else { "day-chip" };
+                                    let mut chip_cls = String::from("day-chip");
+                                    if on_chip.is_some() { chip_cls.push_str(" clickable"); }
+                                    if e.snoozed { chip_cls.push_str(" snoozed"); }
+                                    let flag_count = e.flag_count;
                                     html! {
-                                        <div class={chip_cls} style={style} title={lbl.clone()} onclick={on_chip}>
+                                        <div class={chip_cls} style={style} title={e.label.clone()} onclick={on_chip}>
                                             <span class="day-chip-time">{format!("{:02}:{:02}", t.hour(), t.minute())}</span>
-                                            <span class="day-chip-label">{lbl.clone()}</span>
+                                            <span class="day-chip-label">{e.label.clone()}</span>
+                                            if flag_count > 0 {
+                                                <span class="day-chip-flag">{format!("⚑{flag_count}")}</span>
+                                            }
                                         </div>
                                     }
                                 }) }

--- a/ui/src/overview.rs
+++ b/ui/src/overview.rs
@@ -167,6 +167,8 @@ pub(crate) struct UpcomingRun {
     pub at: DateTime<Local>,
     /// Whether `at` lands within the due-soon window.
     pub soon: bool,
+    /// Total open flags on this routine (0 when none).
+    pub flag_count: usize,
 }
 
 /// Count the KPI tiles from `sources` as of `now`.
@@ -256,6 +258,7 @@ pub(crate) fn upcoming_runs(sources: &[SchedSource], now: DateTime<Local>) -> Ve
                 human: s.human.clone(),
                 at,
                 soon: at - now <= window,
+                flag_count: s.flag_count,
             })
         })
         .collect();
@@ -688,6 +691,11 @@ fn upcoming_table(props: &UpcomingTableProps) -> Html {
                                     <Link<Route> classes={classes!("ov-name-link")} to={to}>
                                         {run.label.clone()}
                                     </Link<Route>>
+                                    if run.flag_count > 0 {
+                                        <span class="ov-flag-badge" title={format!("{} open flag{}", run.flag_count, if run.flag_count == 1 { "" } else { "s" })}>
+                                            {format!("⚑ {}", run.flag_count)}
+                                        </span>
+                                    }
                                 </td>
                                 <td>
                                     <div class="cell-schedule-human">

--- a/ui/src/overview_tests.rs
+++ b/ui/src/overview_tests.rs
@@ -392,6 +392,21 @@ fn upcoming_run_routine_id_differs_from_label() {
 }
 
 #[test]
+fn upcoming_run_carries_flag_count_from_source() {
+    let mut source = src(Kind::Routine, "flagged", "*/5 * * * *", true);
+    source.flag_count = 4;
+    let runs = upcoming_runs(&[source], at_ten());
+    assert_eq!(runs[0].flag_count, 4);
+}
+
+#[test]
+fn upcoming_run_flag_count_zero_when_none() {
+    let source = src(Kind::Routine, "clean", "*/5 * * * *", true);
+    let runs = upcoming_runs(&[source], at_ten());
+    assert_eq!(runs[0].flag_count, 0);
+}
+
+#[test]
 fn sources_of_maps_routines() {
     let routine: Routine = serde_json::from_value(serde_json::json!({
         "id": "r1", "schedule": "0 0 * * *", "title": "T", "agent": "a",

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -629,6 +629,31 @@ pub(crate) fn is_routine_snoozed(r: &Routine, now: DateTime<Local>) -> bool {
         || r.skip_runs.is_some_and(|runs| runs > 0)
 }
 
+/// Short human-readable detail for a snoozed routine's NEXT RUN cell:
+/// "until HH:MM" for a timestamp snooze, or "N run(s) skipped" for a
+/// counter snooze. Returns an empty string when neither applies.
+pub(crate) fn snooze_detail(r: &Routine, now: DateTime<Local>) -> String {
+    if let Some(until) = r.snoozed_until {
+        let until_secs = until as i64;
+        if until_secs > now.timestamp() {
+            let remaining = (until_secs - now.timestamp()) as u64;
+            return if remaining < 3_600 {
+                format!("{}m left", remaining / 60)
+            } else if remaining < 86_400 {
+                format!("{}h left", remaining / 3_600)
+            } else {
+                format!("{}d left", remaining / 86_400)
+            };
+        }
+    }
+    if let Some(runs) = r.skip_runs {
+        if runs > 0 {
+            return format!("{runs} run{} skipped", if runs == 1 { "" } else { "s" });
+        }
+    }
+    String::new()
+}
+
 #[must_use]
 pub fn routine_health(r: &Routine, now: DateTime<Local>) -> RoutineHealth {
     if !r.enabled {
@@ -2471,7 +2496,15 @@ pub(crate) fn next_routine_run_cell(routine: &Routine, now: chrono::DateTime<Loc
         return html! { <span class="cell-next muted">{"paused"}</span> };
     }
     if is_routine_snoozed(routine, now) {
-        return html! { <span class="cell-next muted">{"snoozed"}</span> };
+        let detail = snooze_detail(routine, now);
+        return html! {
+            <div class="cell-next">
+                <span class="cell-next muted">{"snoozed"}</span>
+                if !detail.is_empty() {
+                    <div class="cell-next-until muted">{detail}</div>
+                }
+            </div>
+        };
     }
     match next_fire_after(&routine.schedule, now) {
         Some(then) => {

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -3396,11 +3396,13 @@ pub fn routine_flags(props: &FlagsProps) -> Html {
                         FlagScope::General => "general",
                         FlagScope::Local => "local",
                     };
+                    let age = crate::reltime(flag.created_at);
                     html! {
                         <div class="flag-item" key={flag.filename.clone()}>
                             <div class="flag-item-hd">
                                 <span class="flag-type">{&flag.flag_type}</span>
                                 <span class="flag-scope">{scope_label}</span>
+                                <span class="flag-age" title={flag.filename.clone()}>{age}</span>
                                 <button class="btn btn-ghost btn-sm" onclick={on_resolve}>{"RESOLVE"}</button>
                             </div>
                             <div class="flag-desc">{&flag.description}</div>

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -1751,6 +1751,8 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
                                             id: Some(r.id.clone()),
                                             label: r.title.clone(),
                                             schedule: r.schedule.clone(),
+                                            snoozed: is_routine_snoozed(r, now_val),
+                                            flag_count: r.flag_count,
                                         }).collect::<Vec<_>>();
                                         html! { <DayTimeline items={items} loading={loading} on_click={Some(on_edit)} /> }
                                     },

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -2215,15 +2215,17 @@ pub fn routine_calendar(props: &CalendarProps) -> Html {
     let grid_start = first - Duration::days(first.weekday().num_days_from_sunday() as i64);
 
     // Accumulate per-cell chips in routine order: only enabled routines with a parseable schedule.
-    // Each entry is (id, title, count) so chips can dispatch the edit modal on click.
-    let mut cells: Vec<Vec<(String, String, u32)>> = vec![Vec::new(); GRID_CELLS];
+    // Each entry is (id, title, count, snoozed) so chips can dispatch the edit modal on click.
+    let cal_now = Local::now();
+    let mut cells: Vec<Vec<(String, String, u32, bool)>> = vec![Vec::new(); GRID_CELLS];
     let mut scheduled = 0usize;
     for r in props.routines.iter().filter(|r| r.enabled) {
         if let Some(counts) = occurrences_per_day(&r.schedule, grid_start) {
             scheduled += 1;
+            let snoozed = is_routine_snoozed(r, cal_now);
             for (i, &c) in counts.iter().enumerate() {
                 if c > 0 {
-                    cells[i].push((r.id.clone(), r.title.clone(), c));
+                    cells[i].push((r.id.clone(), r.title.clone(), c, snoozed));
                 }
             }
         }
@@ -2259,7 +2261,7 @@ pub fn routine_calendar(props: &CalendarProps) -> Html {
                             <div class={cls}>
                                 <div class="cal-daynum">{date.day()}</div>
                                 <div class="cal-hits">
-                                    { for hits.iter().take(4).map(|(id, title, count)| {
+                                    { for hits.iter().take(4).map(|(id, title, count, snoozed)| {
                                         let label = if *count > 1 {
                                             format!("{title} ×{count}")
                                         } else {
@@ -2270,7 +2272,9 @@ pub fn routine_calendar(props: &CalendarProps) -> Html {
                                             let id = id.clone();
                                             Callback::from(move |_: MouseEvent| cb.emit(id.clone()))
                                         });
-                                        let chip_cls = if on_chip.is_some() { "cal-chip clickable" } else { "cal-chip" };
+                                        let mut chip_cls = String::from("cal-chip");
+                                        if on_chip.is_some() { chip_cls.push_str(" clickable"); }
+                                        if *snoozed { chip_cls.push_str(" snoozed"); }
                                         html! { <div class={chip_cls} title={label.clone()} onclick={on_chip}>{label}</div> }
                                     }) }
                                     if hits.len() > 4 {

--- a/ui/src/routines_tests.rs
+++ b/ui/src/routines_tests.rs
@@ -880,6 +880,68 @@ fn health_fully_configured_is_healthy() {
     assert_eq!(routine_health(&r, now()), RoutineHealth::Healthy);
 }
 
+// ─── snooze_detail ────────────────────────────────────────────────────────────
+
+#[test]
+fn snooze_detail_empty_when_not_snoozed() {
+    let r = routine("a", "A", "claude", "0 * * * *", &["m"], &[], true);
+    assert_eq!(snooze_detail(&r, now()), "");
+}
+
+#[test]
+fn snooze_detail_shows_minutes_left_for_short_snooze() {
+    let r = Routine {
+        snoozed_until: Some((now() + Duration::minutes(45)).timestamp() as u64),
+        ..routine("a", "A", "claude", "0 * * * *", &["m"], &[], true)
+    };
+    assert_eq!(snooze_detail(&r, now()), "45m left");
+}
+
+#[test]
+fn snooze_detail_shows_hours_left() {
+    let r = Routine {
+        snoozed_until: Some((now() + Duration::hours(3)).timestamp() as u64),
+        ..routine("a", "A", "claude", "0 * * * *", &["m"], &[], true)
+    };
+    assert_eq!(snooze_detail(&r, now()), "3h left");
+}
+
+#[test]
+fn snooze_detail_shows_days_left() {
+    let r = Routine {
+        snoozed_until: Some((now() + Duration::days(2)).timestamp() as u64),
+        ..routine("a", "A", "claude", "0 * * * *", &["m"], &[], true)
+    };
+    assert_eq!(snooze_detail(&r, now()), "2d left");
+}
+
+#[test]
+fn snooze_detail_shows_skip_runs() {
+    let r = Routine {
+        skip_runs: Some(5),
+        ..routine("a", "A", "claude", "0 * * * *", &["m"], &[], true)
+    };
+    assert_eq!(snooze_detail(&r, now()), "5 runs skipped");
+}
+
+#[test]
+fn snooze_detail_skip_runs_singular() {
+    let r = Routine {
+        skip_runs: Some(1),
+        ..routine("a", "A", "claude", "0 * * * *", &["m"], &[], true)
+    };
+    assert_eq!(snooze_detail(&r, now()), "1 run skipped");
+}
+
+#[test]
+fn snooze_detail_empty_when_deadline_past() {
+    let r = Routine {
+        snoozed_until: Some((now() - Duration::hours(1)).timestamp() as u64),
+        ..routine("a", "A", "claude", "0 * * * *", &["m"], &[], true)
+    };
+    assert_eq!(snooze_detail(&r, now()), "");
+}
+
 #[test]
 fn is_routine_snoozed_true_when_deadline_in_future() {
     let r = Routine {


### PR DESCRIPTION
## Summary

- Calendar chips for currently-snoozed routines now render at 45% opacity with an amber left border
- Matches the same treatment applied to the day timeline in #955
- Operators can now see at a glance which future fire times belong to suppressed routines without navigating to the routines table

## Test plan

- [ ] Calendar view: a snoozed routine's chip appears muted (amber border, low opacity)
- [ ] Non-snoozed routine chips unchanged
- [ ] `cargo check -p ui` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)