### PR TITLE
feat(ui): make FLAGS tile in stats bar a clickable filter

### DIFF
--- a/.changeset/ui-flags-filter.md
+++ b/.changeset/ui-flags-filter.md
@@ -1,0 +1,14 @@
+---
+"moadim": patch
+---
+
+feat(ui): make FLAGS tile in stats bar a clickable filter
+
+The FLAGS tile in the routines stats bar was informational-only. It is
+now a clickable filter button (like SNOOZED, DUE SOON, etc.) that narrows
+the table to routines with one or more open flags. Clicking it again
+clears the filter. The tile border and value turn red when any flags are
+present.
+
+Adds `RoutineStatusFacet::HasFlags` with codec roundtrip and one new host
+test.

--- a/ui/index.html
+++ b/ui/index.html
@@ -439,6 +439,9 @@
     .stat-card.due      { border-left-color: var(--red); }
     .stat-card.unreg    { border-left-color: var(--red); }
     .stat-card.attention { border-left-color: var(--red); }
+    .stat-card.flags    { border-left-color: var(--border-hi); }
+    .stat-card.has-flags { border-left-color: var(--red); }
+    .stat-card.has-flags .stat-val { color: var(--red); }
     .stat-card.system   { border-left-color: #7c8fc9; }
 
     .stat-label {

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -328,6 +328,7 @@ const NEXT_RUN_TICK_MS: u32 = 30_000;
 /// Enabled / disabled / dormant / due-soon status facet for routines.
 /// `Dormant` means enabled but with an empty machines list — it will never fire.
 /// `DueSoon` means enabled with a next fire within [`DUE_SOON_WINDOW_SECS`].
+/// `HasFlags` means the routine has one or more open flags.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum RoutineStatusFacet {
     #[default]
@@ -337,6 +338,7 @@ pub enum RoutineStatusFacet {
     Dormant,
     DueSoon,
     Snoozed,
+    HasFlags,
 }
 
 impl RoutineStatusFacet {
@@ -349,6 +351,7 @@ impl RoutineStatusFacet {
             RoutineStatusFacet::Dormant => "dormant",
             RoutineStatusFacet::DueSoon => "due",
             RoutineStatusFacet::Snoozed => "snoozed",
+            RoutineStatusFacet::HasFlags => "flagged",
         }
     }
 
@@ -360,6 +363,7 @@ impl RoutineStatusFacet {
             "dormant" => RoutineStatusFacet::Dormant,
             "due" => RoutineStatusFacet::DueSoon,
             "snoozed" => RoutineStatusFacet::Snoozed,
+            "flagged" => RoutineStatusFacet::HasFlags,
             _ => RoutineStatusFacet::All,
         }
     }
@@ -495,6 +499,7 @@ impl RoutineFilter {
                 return false
             }
             RoutineStatusFacet::Snoozed if !is_routine_snoozed(r, now) => return false,
+            RoutineStatusFacet::HasFlags if r.flag_count == 0 => return false,
             _ => {}
         }
         match &self.agent {
@@ -1932,10 +1937,7 @@ pub fn routine_stats_bar(props: &StatsBarProps) -> Html {
             { mk(RoutineStatusFacet::Disabled, "DISABLED", disabled, "disabled") }
             { mk(RoutineStatusFacet::DueSoon, "DUE SOON", due_soon, "due") }
             { mk(RoutineStatusFacet::Snoozed, "SNOOZED", snoozed, "snoozed") }
-            <div class={classes!("stat-card", "flags", if flags > 0 { Some("has-flags") } else { None })}>
-                <div class="stat-label">{"FLAGS"}</div>
-                <div class={classes!("stat-val", if flags > 0 { "c-red" } else { "c-accent" })}>{flags}</div>
-            </div>
+            { mk(RoutineStatusFacet::HasFlags, "FLAGS", flags, if flags > 0 { "flags has-flags" } else { "flags" }) }
             <div class="stat-card unreg">
                 <div class="stat-label">{"UNREGISTERED AGENT"}</div>
                 <div class="stat-val">{unreg}</div>

--- a/ui/src/routines_tests.rs
+++ b/ui/src/routines_tests.rs
@@ -85,6 +85,7 @@ fn status_facet_roundtrips_and_defaults_to_all() {
         RoutineStatusFacet::Dormant,
         RoutineStatusFacet::DueSoon,
         RoutineStatusFacet::Snoozed,
+        RoutineStatusFacet::HasFlags,
     ] {
         assert_eq!(RoutineStatusFacet::from_str(f.as_str()), f);
     }
@@ -302,6 +303,21 @@ fn status_snoozed_matches_only_snoozed_routines() {
     assert!(!f.matches(&active, now(), window()));
     // Disabled+snoozed: snoozed filter does not check enabled state.
     assert!(f.matches(&disabled_snoozed, now(), window()));
+}
+
+#[test]
+fn status_has_flags_matches_only_flagged_routines() {
+    let f = RoutineFilter {
+        status: RoutineStatusFacet::HasFlags,
+        ..Default::default()
+    };
+    let flagged = Routine {
+        flag_count: 2,
+        ..routine("a", "t", "claude", "0 * * * *", &["m1"], &[], true)
+    };
+    let clean = routine("b", "t", "claude", "0 * * * *", &["m1"], &[], true);
+    assert!(f.matches(&flagged, now(), window()));
+    assert!(!f.matches(&clean, now(), window()));
 }
 
 // ── Agent facet matching ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- The FLAGS tile in the routines stats bar was read-only and informational; clicking it did nothing
- Now it's a full filter button like SNOOZED, DUE SOON, etc. — clicking filters the table to routines with `flag_count > 0`; clicking again clears the filter
- Tile border and value turn red when any flags are present (via `.has-flags` CSS)
- New `RoutineStatusFacet::HasFlags` with codec roundtrip and a host test

## Test plan

- [ ] Open Routines page with flagged routines → FLAGS tile shows red count
- [ ] Click FLAGS tile → table narrows to only routines with open flags
- [ ] Click again → filter clears back to ALL
- [ ] `cargo test -p ui routines::routines_tests::status_has_flags` → passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)