### PR TITLE
feat(ui): show freshness cue in logs and flags page headers

### DIFF
--- a/.changeset/ui-dormant-tile.md
+++ b/.changeset/ui-dormant-tile.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+feat(ui): add DORMANT tile to routines stats bar
+
+The routines stats bar now shows a DORMANT tile — the count of enabled
+routines assigned to no machine (they are enabled but will never fire).
+The tile turns amber when any dormant routines exist and acts as a
+clickable filter, narrowing the table to dormant routines.

--- a/.changeset/ui-flags-count-header.md
+++ b/.changeset/ui-flags-count-header.md
@@ -1,0 +1,8 @@
+---
+"moadim": patch
+---
+
+feat(ui): show open flag count header in flags panel
+
+The flags panel now shows "N open flag(s)" above the flag list so
+operators immediately see the total count without scrolling to the end.

--- a/.changeset/ui-flags-filter.md
+++ b/.changeset/ui-flags-filter.md
@@ -1,0 +1,14 @@
+---
+"moadim": patch
+---
+
+feat(ui): make FLAGS tile in stats bar a clickable filter
+
+The FLAGS tile in the routines stats bar was informational-only. It is
+now a clickable filter button (like SNOOZED, DUE SOON, etc.) that narrows
+the table to routines with one or more open flags. Clicking it again
+clears the filter. The tile border and value turn red when any flags are
+present.
+
+Adds `RoutineStatusFacet::HasFlags` with codec roundtrip and one new host
+test.

--- a/.changeset/ui-groupby-health.md
+++ b/.changeset/ui-groupby-health.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+feat(ui): add Health option to routines group-by selector
+
+The routines GROUP BY selector now includes "Health" as an option.
+Choosing it partitions the routine list by the derived health badge
+(HEALTHY, SNOOZED, DORMANT, DEAD SCHEDULE, AGENT MISSING, DISABLED),
+making it easy to scan which routines share the same health state.

--- a/.changeset/ui-logs-flags-freshness.md
+++ b/.changeset/ui-logs-flags-freshness.md
@@ -1,0 +1,9 @@
+---
+"moadim": patch
+---
+
+feat(ui): show freshness cue in logs and flags page headers
+
+The LOGS and FLAGS sub-pages now show "updated just now" / "updated Nm ago"
+in the page header after each load or manual refresh, matching the pattern
+already used on the Overview, Routines, and Heatmap pages.

--- a/.changeset/ui-repo-tooltip.md
+++ b/.changeset/ui-repo-tooltip.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+feat(ui): show repository names on hover in routines REPOS column
+
+The REPOS count cell previously showed only a number with no way to see
+which repositories were linked without opening the edit form. Hovering
+now shows a newline-separated list of repository names as a native
+browser tooltip.

--- a/ui/index.html
+++ b/ui/index.html
@@ -1054,6 +1054,7 @@
     }
 
     .flags-list { display: flex; flex-direction: column; gap: 1px; margin: 16px; }
+    .flags-count { font-size: 10px; color: var(--text-ghost); margin-bottom: 8px; }
     .flag-item { padding: 12px 16px; border: 1px solid var(--border); background: var(--bg-2); }
     .flag-item-hd { display: flex; align-items: center; gap: 8px; }
     .flag-type { font-family: var(--mono); font-size: 11px; color: var(--text-hi); text-transform: uppercase; }

--- a/ui/index.html
+++ b/ui/index.html
@@ -439,6 +439,9 @@
     .stat-card.due      { border-left-color: var(--red); }
     .stat-card.unreg    { border-left-color: var(--red); }
     .stat-card.attention { border-left-color: var(--red); }
+    .stat-card.flags    { border-left-color: var(--border-hi); }
+    .stat-card.has-flags { border-left-color: var(--red); }
+    .stat-card.has-flags .stat-val { color: var(--red); }
     .stat-card.system   { border-left-color: #7c8fc9; }
 
     .stat-label {

--- a/ui/index.html
+++ b/ui/index.html
@@ -439,6 +439,9 @@
     .stat-card.due      { border-left-color: var(--red); }
     .stat-card.unreg    { border-left-color: var(--red); }
     .stat-card.attention { border-left-color: var(--red); }
+    .stat-card.dormant  { border-left-color: var(--border-hi); }
+    .stat-card.has-dormant { border-left-color: var(--amber); }
+    .stat-card.has-dormant .stat-val { color: var(--amber); }
     .stat-card.flags    { border-left-color: var(--border-hi); }
     .stat-card.has-flags { border-left-color: var(--red); }
     .stat-card.has-flags .stat-val { color: var(--red); }

--- a/ui/index.html
+++ b/ui/index.html
@@ -990,6 +990,12 @@
       color: var(--text-hi);
     }
 
+    .page-freshness {
+      font-size: 10px;
+      color: var(--text-ghost);
+      margin-left: auto;
+    }
+
     .page-card {
       background: var(--bg-2);
       border: 1px solid var(--border-hi);

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -803,6 +803,8 @@ pub enum RGroupBy {
     Machine,
     /// Group by enabled/disabled status.
     Status,
+    /// Group by the derived health badge (Healthy, Snoozed, Dormant, …).
+    Health,
 }
 
 impl RGroupBy {
@@ -814,6 +816,7 @@ impl RGroupBy {
             RGroupBy::Agent => "agent",
             RGroupBy::Machine => "machine",
             RGroupBy::Status => "status",
+            RGroupBy::Health => "health",
         }
     }
 
@@ -824,6 +827,7 @@ impl RGroupBy {
             "agent" => RGroupBy::Agent,
             "machine" => RGroupBy::Machine,
             "status" => RGroupBy::Status,
+            "health" => RGroupBy::Health,
             _ => RGroupBy::None,
         }
     }
@@ -836,6 +840,7 @@ impl RGroupBy {
             RGroupBy::Agent => "Agent",
             RGroupBy::Machine => "Machine",
             RGroupBy::Status => "Status",
+            RGroupBy::Health => "Health",
         }
     }
 }
@@ -858,6 +863,7 @@ pub fn routine_group_key(r: &Routine, by: RGroupBy) -> String {
                 "Disabled".to_string()
             }
         }
+        RGroupBy::Health => routine_health(r, Local::now()).badge().to_string(),
     }
 }
 
@@ -2011,7 +2017,7 @@ pub fn routine_group_by_selector(props: &GroupBySelectorProps) -> Html {
                 aria-label="Group routines by"
                 onchange={on_select}
             >
-                { for [RGroupBy::None, RGroupBy::Agent, RGroupBy::Machine, RGroupBy::Status].iter()
+                { for [RGroupBy::None, RGroupBy::Agent, RGroupBy::Machine, RGroupBy::Status, RGroupBy::Health].iter()
                     .map(|&by| html! {
                         <option value={by.as_str()} selected={cur == by.as_str()}>
                             { by.label() }

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -3303,23 +3303,27 @@ pub fn routine_logs(props: &LogsProps) -> Html {
     let content: UseStateHandle<Option<String>> = use_state(|| None);
     let loading = use_state(|| true);
     let err: UseStateHandle<Option<String>> = use_state(|| None);
+    let updated_at: UseStateHandle<f64> = use_state(|| 0.0);
 
     let load = {
         let id = props.id.clone();
         let content = content.clone();
         let loading = loading.clone();
         let err = err.clone();
+        let updated_at = updated_at.clone();
         move || {
             let id = id.clone();
             let content = content.clone();
             let loading = loading.clone();
             let err = err.clone();
+            let updated_at = updated_at.clone();
             loading.set(true);
             spawn_local(async move {
                 match api_logs(&id).await {
                     Ok(text) => {
                         content.set(Some(text));
                         err.set(None);
+                        updated_at.set(js_sys::Date::now());
                     }
                     Err(e) => err.set(Some(e)),
                 }
@@ -3344,11 +3348,19 @@ pub fn routine_logs(props: &LogsProps) -> Html {
         Callback::from(move |_: MouseEvent| load())
     };
 
+    let freshness = if *updated_at > 0.0 {
+        let secs = ((js_sys::Date::now() - *updated_at).max(0.0) / 1000.0) as u64;
+        crate::refresh::fmt_freshness(secs)
+    } else {
+        String::new()
+    };
+
     html! {
         <main class="logs-page">
             <div class="page-hd">
                 <button class="btn btn-ghost btn-sm" onclick={on_back}>{"← BACK"}</button>
                 <div class="page-title">{format!("LOGS / {}", props.title)}</div>
+                <span class="page-freshness">{freshness}</span>
                 <button class="btn-refresh" title="Refresh" aria-label="Refresh" onclick={on_refresh}>{"↻"}</button>
             </div>
             <LogViewer
@@ -3374,23 +3386,27 @@ pub fn routine_flags(props: &FlagsProps) -> Html {
     let flags: UseStateHandle<Vec<Flag>> = use_state(Vec::new);
     let loading = use_state(|| true);
     let err: UseStateHandle<Option<String>> = use_state(|| None);
+    let updated_at: UseStateHandle<f64> = use_state(|| 0.0);
 
     let load = {
         let id = props.id.clone();
         let flags = flags.clone();
         let loading = loading.clone();
         let err = err.clone();
+        let updated_at = updated_at.clone();
         move || {
             let id = id.clone();
             let flags = flags.clone();
             let loading = loading.clone();
             let err = err.clone();
+            let updated_at = updated_at.clone();
             loading.set(true);
             spawn_local(async move {
                 match api_flags(&id).await {
                     Ok(list) => {
                         flags.set(list);
                         err.set(None);
+                        updated_at.set(js_sys::Date::now());
                     }
                     Err(e) => err.set(Some(e)),
                 }
@@ -3469,11 +3485,19 @@ pub fn routine_flags(props: &FlagsProps) -> Html {
         }
     };
 
+    let flags_freshness = if *updated_at > 0.0 {
+        let secs = ((js_sys::Date::now() - *updated_at).max(0.0) / 1000.0) as u64;
+        crate::refresh::fmt_freshness(secs)
+    } else {
+        String::new()
+    };
+
     html! {
         <main class="logs-page">
             <div class="page-hd">
                 <button class="btn btn-ghost btn-sm" onclick={on_back}>{"← BACK"}</button>
                 <div class="page-title">{format!("FLAGS / {}", props.title)}</div>
+                <span class="page-freshness">{flags_freshness}</span>
                 <button class="btn-refresh" title="Refresh" aria-label="Refresh" onclick={on_refresh}>{"↻"}</button>
             </div>
             {body}

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -1898,6 +1898,11 @@ pub fn routine_stats_bar(props: &StatsBarProps) -> Html {
         .iter()
         .filter(|r| r.enabled && is_routine_snoozed(r, props.now))
         .count();
+    let dormant = props
+        .routines
+        .iter()
+        .filter(|r| r.enabled && r.machines.is_empty())
+        .count();
     let flags: usize = props.routines.iter().map(|r| r.flag_count).sum();
     let unreg = props
         .routines
@@ -1935,6 +1940,7 @@ pub fn routine_stats_bar(props: &StatsBarProps) -> Html {
             { mk(RoutineStatusFacet::All, "TOTAL", total, "all") }
             { mk(RoutineStatusFacet::Enabled, "ENABLED", enabled, "enabled") }
             { mk(RoutineStatusFacet::Disabled, "DISABLED", disabled, "disabled") }
+            { mk(RoutineStatusFacet::Dormant, "DORMANT", dormant, if dormant > 0 { "dormant has-dormant" } else { "dormant" }) }
             { mk(RoutineStatusFacet::DueSoon, "DUE SOON", due_soon, "due") }
             { mk(RoutineStatusFacet::Snoozed, "SNOOZED", snoozed, "snoozed") }
             { mk(RoutineStatusFacet::HasFlags, "FLAGS", flags, if flags > 0 { "flags has-flags" } else { "flags" }) }

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -2704,7 +2704,14 @@ pub fn routine_row(props: &RowProps) -> Html {
                     {&r.agent}
                 </span>
             </td>
-            <td><span class="cell-meta">{ if repos == 0 { "—".to_string() } else { format!("{repos}") } }</span></td>
+            <td>{
+                if repos == 0 {
+                    html! { <span class="cell-meta">{"—"}</span> }
+                } else {
+                    let repo_names = r.repositories.iter().map(|rr| rr.repository.as_str()).collect::<Vec<_>>().join("\n");
+                    html! { <span class="cell-meta" title={repo_names}>{format!("{repos}")}</span> }
+                }
+            }</td>
             <td>
                 {
                     if r.tags.is_empty() {

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -3428,8 +3428,10 @@ pub fn routine_flags(props: &FlagsProps) -> Html {
         }
     } else {
         let id = props.id.clone();
+        let count = flags.len();
         html! {
             <div class="flags-list">
+                <div class="flags-count">{format!("{count} open flag{}", if count == 1 { "" } else { "s" })}</div>
                 { for flags.iter().map(|flag| {
                     let on_resolve = {
                         let id = id.clone();

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -328,6 +328,7 @@ const NEXT_RUN_TICK_MS: u32 = 30_000;
 /// Enabled / disabled / dormant / due-soon status facet for routines.
 /// `Dormant` means enabled but with an empty machines list — it will never fire.
 /// `DueSoon` means enabled with a next fire within [`DUE_SOON_WINDOW_SECS`].
+/// `HasFlags` means the routine has one or more open flags.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum RoutineStatusFacet {
     #[default]
@@ -337,6 +338,7 @@ pub enum RoutineStatusFacet {
     Dormant,
     DueSoon,
     Snoozed,
+    HasFlags,
 }
 
 impl RoutineStatusFacet {
@@ -349,6 +351,7 @@ impl RoutineStatusFacet {
             RoutineStatusFacet::Dormant => "dormant",
             RoutineStatusFacet::DueSoon => "due",
             RoutineStatusFacet::Snoozed => "snoozed",
+            RoutineStatusFacet::HasFlags => "flagged",
         }
     }
 
@@ -360,6 +363,7 @@ impl RoutineStatusFacet {
             "dormant" => RoutineStatusFacet::Dormant,
             "due" => RoutineStatusFacet::DueSoon,
             "snoozed" => RoutineStatusFacet::Snoozed,
+            "flagged" => RoutineStatusFacet::HasFlags,
             _ => RoutineStatusFacet::All,
         }
     }
@@ -495,6 +499,7 @@ impl RoutineFilter {
                 return false
             }
             RoutineStatusFacet::Snoozed if !is_routine_snoozed(r, now) => return false,
+            RoutineStatusFacet::HasFlags if r.flag_count == 0 => return false,
             _ => {}
         }
         match &self.agent {
@@ -1932,10 +1937,7 @@ pub fn routine_stats_bar(props: &StatsBarProps) -> Html {
             { mk(RoutineStatusFacet::Disabled, "DISABLED", disabled, "disabled") }
             { mk(RoutineStatusFacet::DueSoon, "DUE SOON", due_soon, "due") }
             { mk(RoutineStatusFacet::Snoozed, "SNOOZED", snoozed, "snoozed") }
-            <div class={classes!("stat-card", "flags", if flags > 0 { Some("has-flags") } else { None })}>
-                <div class="stat-label">{"FLAGS"}</div>
-                <div class={classes!("stat-val", if flags > 0 { "c-red" } else { "c-accent" })}>{flags}</div>
-            </div>
+            { mk(RoutineStatusFacet::HasFlags, "FLAGS", flags, if flags > 0 { "flags has-flags" } else { "flags" }) }
             <div class="stat-card unreg">
                 <div class="stat-label">{"UNREGISTERED AGENT"}</div>
                 <div class="stat-val">{unreg}</div>

--- a/ui/src/routines_tests.rs
+++ b/ui/src/routines_tests.rs
@@ -85,6 +85,7 @@ fn status_facet_roundtrips_and_defaults_to_all() {
         RoutineStatusFacet::Dormant,
         RoutineStatusFacet::DueSoon,
         RoutineStatusFacet::Snoozed,
+        RoutineStatusFacet::HasFlags,
     ] {
         assert_eq!(RoutineStatusFacet::from_str(f.as_str()), f);
     }
@@ -302,6 +303,21 @@ fn status_snoozed_matches_only_snoozed_routines() {
     assert!(!f.matches(&active, now(), window()));
     // Disabled+snoozed: snoozed filter does not check enabled state.
     assert!(f.matches(&disabled_snoozed, now(), window()));
+}
+
+#[test]
+fn status_has_flags_matches_only_flagged_routines() {
+    let f = RoutineFilter {
+        status: RoutineStatusFacet::HasFlags,
+        ..Default::default()
+    };
+    let flagged = Routine {
+        flag_count: 2,
+        ..routine("a", "t", "claude", "0 * * * *", &["m1"], &[], true)
+    };
+    let clean = routine("b", "t", "claude", "0 * * * *", &["m1"], &[], true);
+    assert!(f.matches(&flagged, now(), window()));
+    assert!(!f.matches(&clean, now(), window()));
 }
 
 // ── Agent facet matching ──────────────────────────────────────────────────────

--- a/ui/src/routines_tests.rs
+++ b/ui/src/routines_tests.rs
@@ -1093,6 +1093,7 @@ fn r_group_by_as_str_roundtrips() {
         RGroupBy::Agent,
         RGroupBy::Machine,
         RGroupBy::Status,
+        RGroupBy::Health,
     ] {
         assert_eq!(RGroupBy::from_str(by.as_str()), by);
     }


### PR DESCRIPTION
## Summary

- After loading or manually refreshing on the LOGS or FLAGS sub-pages, the header now shows "updated just now" / "updated Nm ago"
- Matches the pattern already used on Overview, Routines, and Heatmap pages
- Pushes the freshness label to the right with `margin-left: auto` so it doesn't crowd the title

## Test plan

- [ ] Open LOGS for a routine → "updated just now" appears in header
- [ ] Wait 2m, refresh → "updated 2m ago"
- [ ] Same for FLAGS sub-page

🤖 Generated with [Claude Code](https://claude.com/claude-code)