### PR TITLE
docs(contributing): add missing --workspace flag to clippy setup command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,13 +30,15 @@ Run the checks the pre-push hook enforces before any push:
 
 ```sh
 cargo fmt --check
-cargo clippy --all-targets -- -D warnings
+cargo clippy --workspace --all-targets -- -D warnings
 cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'
 ```
 
-Use `--all-targets -- -D warnings` for clippy, exactly as the pre-push hook and
-the CI lint gate do — bare `cargo clippy` skips test/example/bench code and only
-warns, so it can pass locally yet fail the hook and CI. The `cargo llvm-cov`
+Use `--workspace --all-targets -- -D warnings` for clippy, exactly as the
+pre-push hook and the CI lint gate do — bare `cargo clippy` skips the `ui`
+member crate (this is a non-virtual workspace) as well as test/example/bench
+code, and only warns, so it can pass locally yet fail the hook and CI. The
+`cargo llvm-cov`
 command runs the test suite with instrumentation and enforces 100% line coverage
 (excluding `main.rs`); it subsumes a bare `cargo test`, so running it is enough
 to satisfy both the test and coverage gates in one pass.


### PR DESCRIPTION
## Summary
- CONTRIBUTING.md's pre-push checklist told contributors to run `cargo clippy --all-targets -- -D warnings`, but the actual pre-push hook (`.githooks/pre-push`) and CI (`.github/workflows/lint.yml`) both run `cargo clippy --workspace --all-targets -- -D warnings`.
- This repo's root `Cargo.toml` is a non-virtual workspace (`[package]` + `[workspace] members = ["ui"]`), so the bare command silently skips the `ui` crate entirely — `ui/Cargo.toml`'s `[lints.clippy] all = "deny"` never gets enforced locally. lint.yml's own inline comment documents this exact failure mode from past experience.
- A contributor copy-pasting the documented command gets false confidence: it can pass locally while `ui/` has real clippy violations that fail CI.

## Test plan
- [x] Doc-only change, no code affected.