### PR TITLE
feat(ui): add SOURCES KPI tile to schedule heatmap

### DIFF
--- a/.changeset/ui-dormant-tile.md
+++ b/.changeset/ui-dormant-tile.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+feat(ui): add DORMANT tile to routines stats bar
+
+The routines stats bar now shows a DORMANT tile — the count of enabled
+routines assigned to no machine (they are enabled but will never fire).
+The tile turns amber when any dormant routines exist and acts as a
+clickable filter, narrowing the table to dormant routines.

--- a/.changeset/ui-flags-count-header.md
+++ b/.changeset/ui-flags-count-header.md
@@ -1,0 +1,8 @@
+---
+"moadim": patch
+---
+
+feat(ui): show open flag count header in flags panel
+
+The flags panel now shows "N open flag(s)" above the flag list so
+operators immediately see the total count without scrolling to the end.

--- a/.changeset/ui-flags-filter.md
+++ b/.changeset/ui-flags-filter.md
@@ -1,0 +1,14 @@
+---
+"moadim": patch
+---
+
+feat(ui): make FLAGS tile in stats bar a clickable filter
+
+The FLAGS tile in the routines stats bar was informational-only. It is
+now a clickable filter button (like SNOOZED, DUE SOON, etc.) that narrows
+the table to routines with one or more open flags. Clicking it again
+clears the filter. The tile border and value turn red when any flags are
+present.
+
+Adds `RoutineStatusFacet::HasFlags` with codec roundtrip and one new host
+test.

--- a/.changeset/ui-groupby-health.md
+++ b/.changeset/ui-groupby-health.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+feat(ui): add Health option to routines group-by selector
+
+The routines GROUP BY selector now includes "Health" as an option.
+Choosing it partitions the routine list by the derived health badge
+(HEALTHY, SNOOZED, DORMANT, DEAD SCHEDULE, AGENT MISSING, DISABLED),
+making it easy to scan which routines share the same health state.

--- a/.changeset/ui-heatmap-sources-kpi.md
+++ b/.changeset/ui-heatmap-sources-kpi.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+feat(ui): add SOURCES KPI tile to the schedule heatmap
+
+The heatmap stats bar now shows a SOURCES tile — the number of enabled
+routines that contributed at least one fire to the 7-day grid. This lets
+operators quickly distinguish a high-density grid (many routines, many
+fires) from a high-frequency grid (few routines, very frequent fires).

--- a/.changeset/ui-logs-flags-freshness.md
+++ b/.changeset/ui-logs-flags-freshness.md
@@ -1,0 +1,9 @@
+---
+"moadim": patch
+---
+
+feat(ui): show freshness cue in logs and flags page headers
+
+The LOGS and FLAGS sub-pages now show "updated just now" / "updated Nm ago"
+in the page header after each load or manual refresh, matching the pattern
+already used on the Overview, Routines, and Heatmap pages.

--- a/.changeset/ui-palette-tags-keywords.md
+++ b/.changeset/ui-palette-tags-keywords.md
@@ -1,0 +1,9 @@
+---
+"moadim": patch
+---
+
+feat(ui): include routine tags in command palette search keywords
+
+Routine tags are now indexed as search keywords in the command palette
+(⌘K), so typing a tag name (e.g. "security", "weekly") surfaces all
+matching routines without needing to know their exact titles.

--- a/.changeset/ui-repo-tooltip.md
+++ b/.changeset/ui-repo-tooltip.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+feat(ui): show repository names on hover in routines REPOS column
+
+The REPOS count cell previously showed only a number with no way to see
+which repositories were linked without opening the edit form. Hovering
+now shows a newline-separated list of repository names as a native
+browser tooltip.

--- a/.changeset/ui-routine-goal-subtitle.md
+++ b/.changeset/ui-routine-goal-subtitle.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+feat(ui): show routine goal as subtitle in routines table TITLE column
+
+Routines with a goal set now show the first line of the goal text as a
+muted subtitle beneath the routine name in the TITLE column. Hovering
+reveals the full goal text. This surfaces the "why" behind the routine
+directly in the table without requiring the operator to open the edit form.

--- a/.changeset/ui-upcoming-schedule-fallback.md
+++ b/.changeset/ui-upcoming-schedule-fallback.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+feat(ui): show raw cron in upcoming runs when no human description exists
+
+The SCHEDULE column in the upcoming runs table previously showed "—" for
+routines whose daemon had not yet computed a human-readable description.
+It now falls back to the raw cron expression (e.g. `*/15 * * * *`) so
+operators always see something actionable.

--- a/ui/index.html
+++ b/ui/index.html
@@ -1054,6 +1054,7 @@
     }
 
     .flags-list { display: flex; flex-direction: column; gap: 1px; margin: 16px; }
+    .flags-count { font-size: 10px; color: var(--text-ghost); margin-bottom: 8px; }
     .flag-item { padding: 12px 16px; border: 1px solid var(--border); background: var(--bg-2); }
     .flag-item-hd { display: flex; align-items: center; gap: 8px; }
     .flag-type { font-family: var(--mono); font-size: 11px; color: var(--text-hi); text-transform: uppercase; }

--- a/ui/index.html
+++ b/ui/index.html
@@ -439,6 +439,9 @@
     .stat-card.due      { border-left-color: var(--red); }
     .stat-card.unreg    { border-left-color: var(--red); }
     .stat-card.attention { border-left-color: var(--red); }
+    .stat-card.flags    { border-left-color: var(--border-hi); }
+    .stat-card.has-flags { border-left-color: var(--red); }
+    .stat-card.has-flags .stat-val { color: var(--red); }
     .stat-card.system   { border-left-color: #7c8fc9; }
 
     .stat-label {

--- a/ui/index.html
+++ b/ui/index.html
@@ -996,6 +996,16 @@
       margin-left: auto;
     }
 
+    .cell-goal {
+      font-size: 10px;
+      color: var(--text-ghost);
+      margin-top: 2px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 220px;
+    }
+
     .page-card {
       background: var(--bg-2);
       border: 1px solid var(--border-hi);

--- a/ui/index.html
+++ b/ui/index.html
@@ -439,6 +439,9 @@
     .stat-card.due      { border-left-color: var(--red); }
     .stat-card.unreg    { border-left-color: var(--red); }
     .stat-card.attention { border-left-color: var(--red); }
+    .stat-card.dormant  { border-left-color: var(--border-hi); }
+    .stat-card.has-dormant { border-left-color: var(--amber); }
+    .stat-card.has-dormant .stat-val { color: var(--amber); }
     .stat-card.flags    { border-left-color: var(--border-hi); }
     .stat-card.has-flags { border-left-color: var(--red); }
     .stat-card.has-flags .stat-val { color: var(--red); }

--- a/ui/index.html
+++ b/ui/index.html
@@ -990,6 +990,12 @@
       color: var(--text-hi);
     }
 
+    .page-freshness {
+      font-size: 10px;
+      color: var(--text-ghost);
+      margin-left: auto;
+    }
+
     .page-card {
       background: var(--bg-2);
       border: 1px solid var(--border-hi);

--- a/ui/src/command_palette.rs
+++ b/ui/src/command_palette.rs
@@ -215,8 +215,9 @@ pub(crate) fn build_commands(routines: &[Routine]) -> Vec<Command> {
             title: routine.title.clone(),
             subtitle: routine_subtitle(routine),
             keywords: format!(
-                "{} {} {} routine",
-                routine.id, routine.agent, routine.schedule
+                "{} {} {} {} routine",
+                routine.id, routine.agent, routine.schedule,
+                routine.tags.join(" ")
             ),
         });
     }

--- a/ui/src/command_palette.rs
+++ b/ui/src/command_palette.rs
@@ -216,7 +216,9 @@ pub(crate) fn build_commands(routines: &[Routine]) -> Vec<Command> {
             subtitle: routine_subtitle(routine),
             keywords: format!(
                 "{} {} {} {} routine",
-                routine.id, routine.agent, routine.schedule,
+                routine.id,
+                routine.agent,
+                routine.schedule,
                 routine.tags.join(" ")
             ),
         });

--- a/ui/src/command_palette_tests.rs
+++ b/ui/src/command_palette_tests.rs
@@ -147,6 +147,17 @@ fn non_matching_commands_are_dropped() {
 // ─── build_commands ──────────────────────────────────────────────────────────
 
 #[test]
+fn routine_tags_appear_in_keywords() {
+    let mut r = routine("r1", "Report", "claude", "0 0 * * *", None);
+    r.tags = vec!["security".into(), "weekly".into()];
+    r.agent_registered = true;
+    let commands = build_commands(&[r]);
+    let kw = &commands.last().unwrap().keywords;
+    assert!(kw.contains("security"), "tag 'security' not in keywords: {kw}");
+    assert!(kw.contains("weekly"), "tag 'weekly' not in keywords: {kw}");
+}
+
+#[test]
 fn build_lists_pages_then_routines() {
     let routines = vec![routine("r1", "Nightly Audit", "claude", "0 0 * * *", None)];
     let commands = build_commands(&routines);

--- a/ui/src/command_palette_tests.rs
+++ b/ui/src/command_palette_tests.rs
@@ -153,7 +153,10 @@ fn routine_tags_appear_in_keywords() {
     r.agent_registered = true;
     let commands = build_commands(&[r]);
     let kw = &commands.last().unwrap().keywords;
-    assert!(kw.contains("security"), "tag 'security' not in keywords: {kw}");
+    assert!(
+        kw.contains("security"),
+        "tag 'security' not in keywords: {kw}"
+    );
     assert!(kw.contains("weekly"), "tag 'weekly' not in keywords: {kw}");
 }
 

--- a/ui/src/overview.rs
+++ b/ui/src/overview.rs
@@ -163,6 +163,8 @@ pub(crate) struct UpcomingRun {
     pub label: String,
     /// Human schedule description, when present.
     pub human: Option<String>,
+    /// Raw cron expression, used as fallback when `human` is absent.
+    pub schedule: String,
     /// The next fire instant.
     pub at: DateTime<Local>,
     /// Whether `at` lands within the due-soon window.
@@ -256,6 +258,7 @@ pub(crate) fn upcoming_runs(sources: &[SchedSource], now: DateTime<Local>) -> Ve
                 id: s.id.clone(),
                 label: s.label.clone(),
                 human: s.human.clone(),
+                schedule: s.schedule.clone(),
                 at,
                 soon: at - now <= window,
                 flag_count: s.flag_count,
@@ -699,7 +702,7 @@ fn upcoming_table(props: &UpcomingTableProps) -> Html {
                                 </td>
                                 <td>
                                     <div class="cell-schedule-human">
-                                        {run.human.clone().unwrap_or_else(|| "—".into())}
+                                        {run.human.clone().unwrap_or_else(|| run.schedule.clone())}
                                     </div>
                                 </td>
                                 <td class="cell-next">

--- a/ui/src/overview_tests.rs
+++ b/ui/src/overview_tests.rs
@@ -392,6 +392,13 @@ fn upcoming_run_routine_id_differs_from_label() {
 }
 
 #[test]
+fn upcoming_run_carries_schedule_string() {
+    let source = src(Kind::Routine, "r", "*/15 * * * *", true);
+    let runs = upcoming_runs(&[source], at_ten());
+    assert_eq!(runs[0].schedule, "*/15 * * * *");
+}
+
+#[test]
 fn upcoming_run_carries_flag_count_from_source() {
     let mut source = src(Kind::Routine, "flagged", "*/5 * * * *", true);
     source.flag_count = 4;

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -803,6 +803,8 @@ pub enum RGroupBy {
     Machine,
     /// Group by enabled/disabled status.
     Status,
+    /// Group by the derived health badge (Healthy, Snoozed, Dormant, …).
+    Health,
 }
 
 impl RGroupBy {
@@ -814,6 +816,7 @@ impl RGroupBy {
             RGroupBy::Agent => "agent",
             RGroupBy::Machine => "machine",
             RGroupBy::Status => "status",
+            RGroupBy::Health => "health",
         }
     }
 
@@ -824,6 +827,7 @@ impl RGroupBy {
             "agent" => RGroupBy::Agent,
             "machine" => RGroupBy::Machine,
             "status" => RGroupBy::Status,
+            "health" => RGroupBy::Health,
             _ => RGroupBy::None,
         }
     }
@@ -836,6 +840,7 @@ impl RGroupBy {
             RGroupBy::Agent => "Agent",
             RGroupBy::Machine => "Machine",
             RGroupBy::Status => "Status",
+            RGroupBy::Health => "Health",
         }
     }
 }
@@ -858,6 +863,7 @@ pub fn routine_group_key(r: &Routine, by: RGroupBy) -> String {
                 "Disabled".to_string()
             }
         }
+        RGroupBy::Health => routine_health(r, Local::now()).badge().to_string(),
     }
 }
 
@@ -2011,7 +2017,7 @@ pub fn routine_group_by_selector(props: &GroupBySelectorProps) -> Html {
                 aria-label="Group routines by"
                 onchange={on_select}
             >
-                { for [RGroupBy::None, RGroupBy::Agent, RGroupBy::Machine, RGroupBy::Status].iter()
+                { for [RGroupBy::None, RGroupBy::Agent, RGroupBy::Machine, RGroupBy::Status, RGroupBy::Health].iter()
                     .map(|&by| html! {
                         <option value={by.as_str()} selected={cur == by.as_str()}>
                             { by.label() }

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -3303,23 +3303,27 @@ pub fn routine_logs(props: &LogsProps) -> Html {
     let content: UseStateHandle<Option<String>> = use_state(|| None);
     let loading = use_state(|| true);
     let err: UseStateHandle<Option<String>> = use_state(|| None);
+    let updated_at: UseStateHandle<f64> = use_state(|| 0.0);
 
     let load = {
         let id = props.id.clone();
         let content = content.clone();
         let loading = loading.clone();
         let err = err.clone();
+        let updated_at = updated_at.clone();
         move || {
             let id = id.clone();
             let content = content.clone();
             let loading = loading.clone();
             let err = err.clone();
+            let updated_at = updated_at.clone();
             loading.set(true);
             spawn_local(async move {
                 match api_logs(&id).await {
                     Ok(text) => {
                         content.set(Some(text));
                         err.set(None);
+                        updated_at.set(js_sys::Date::now());
                     }
                     Err(e) => err.set(Some(e)),
                 }
@@ -3344,11 +3348,19 @@ pub fn routine_logs(props: &LogsProps) -> Html {
         Callback::from(move |_: MouseEvent| load())
     };
 
+    let freshness = if *updated_at > 0.0 {
+        let secs = ((js_sys::Date::now() - *updated_at).max(0.0) / 1000.0) as u64;
+        crate::refresh::fmt_freshness(secs)
+    } else {
+        String::new()
+    };
+
     html! {
         <main class="logs-page">
             <div class="page-hd">
                 <button class="btn btn-ghost btn-sm" onclick={on_back}>{"← BACK"}</button>
                 <div class="page-title">{format!("LOGS / {}", props.title)}</div>
+                <span class="page-freshness">{freshness}</span>
                 <button class="btn-refresh" title="Refresh" aria-label="Refresh" onclick={on_refresh}>{"↻"}</button>
             </div>
             <LogViewer
@@ -3374,23 +3386,27 @@ pub fn routine_flags(props: &FlagsProps) -> Html {
     let flags: UseStateHandle<Vec<Flag>> = use_state(Vec::new);
     let loading = use_state(|| true);
     let err: UseStateHandle<Option<String>> = use_state(|| None);
+    let updated_at: UseStateHandle<f64> = use_state(|| 0.0);
 
     let load = {
         let id = props.id.clone();
         let flags = flags.clone();
         let loading = loading.clone();
         let err = err.clone();
+        let updated_at = updated_at.clone();
         move || {
             let id = id.clone();
             let flags = flags.clone();
             let loading = loading.clone();
             let err = err.clone();
+            let updated_at = updated_at.clone();
             loading.set(true);
             spawn_local(async move {
                 match api_flags(&id).await {
                     Ok(list) => {
                         flags.set(list);
                         err.set(None);
+                        updated_at.set(js_sys::Date::now());
                     }
                     Err(e) => err.set(Some(e)),
                 }
@@ -3469,11 +3485,19 @@ pub fn routine_flags(props: &FlagsProps) -> Html {
         }
     };
 
+    let flags_freshness = if *updated_at > 0.0 {
+        let secs = ((js_sys::Date::now() - *updated_at).max(0.0) / 1000.0) as u64;
+        crate::refresh::fmt_freshness(secs)
+    } else {
+        String::new()
+    };
+
     html! {
         <main class="logs-page">
             <div class="page-hd">
                 <button class="btn btn-ghost btn-sm" onclick={on_back}>{"← BACK"}</button>
                 <div class="page-title">{format!("FLAGS / {}", props.title)}</div>
+                <span class="page-freshness">{flags_freshness}</span>
                 <button class="btn-refresh" title="Refresh" aria-label="Refresh" onclick={on_refresh}>{"↻"}</button>
             </div>
             {body}

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -1898,6 +1898,11 @@ pub fn routine_stats_bar(props: &StatsBarProps) -> Html {
         .iter()
         .filter(|r| r.enabled && is_routine_snoozed(r, props.now))
         .count();
+    let dormant = props
+        .routines
+        .iter()
+        .filter(|r| r.enabled && r.machines.is_empty())
+        .count();
     let flags: usize = props.routines.iter().map(|r| r.flag_count).sum();
     let unreg = props
         .routines
@@ -1935,6 +1940,7 @@ pub fn routine_stats_bar(props: &StatsBarProps) -> Html {
             { mk(RoutineStatusFacet::All, "TOTAL", total, "all") }
             { mk(RoutineStatusFacet::Enabled, "ENABLED", enabled, "enabled") }
             { mk(RoutineStatusFacet::Disabled, "DISABLED", disabled, "disabled") }
+            { mk(RoutineStatusFacet::Dormant, "DORMANT", dormant, if dormant > 0 { "dormant has-dormant" } else { "dormant" }) }
             { mk(RoutineStatusFacet::DueSoon, "DUE SOON", due_soon, "due") }
             { mk(RoutineStatusFacet::Snoozed, "SNOOZED", snoozed, "snoozed") }
             { mk(RoutineStatusFacet::HasFlags, "FLAGS", flags, if flags > 0 { "flags has-flags" } else { "flags" }) }

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -2704,7 +2704,14 @@ pub fn routine_row(props: &RowProps) -> Html {
                     {&r.agent}
                 </span>
             </td>
-            <td><span class="cell-meta">{ if repos == 0 { "—".to_string() } else { format!("{repos}") } }</span></td>
+            <td>{
+                if repos == 0 {
+                    html! { <span class="cell-meta">{"—"}</span> }
+                } else {
+                    let repo_names = r.repositories.iter().map(|rr| rr.repository.as_str()).collect::<Vec<_>>().join("\n");
+                    html! { <span class="cell-meta" title={repo_names}>{format!("{repos}")}</span> }
+                }
+            }</td>
             <td>
                 {
                     if r.tags.is_empty() {

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -2683,6 +2683,9 @@ pub fn routine_row(props: &RowProps) -> Html {
             </td>
             <td>
                 <div class="cell-schedule" title={r.id.clone()}>{&r.title}</div>
+                if let Some(goal) = r.goal.as_ref().filter(|g| !g.is_empty()) {
+                    <div class="cell-goal" title={goal.clone()}>{goal.lines().next().unwrap_or("")}</div>
+                }
             </td>
             <td>
                 <div class="cell-schedule">{&r.schedule}</div>

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -3428,8 +3428,10 @@ pub fn routine_flags(props: &FlagsProps) -> Html {
         }
     } else {
         let id = props.id.clone();
+        let count = flags.len();
         html! {
             <div class="flags-list">
+                <div class="flags-count">{format!("{count} open flag{}", if count == 1 { "" } else { "s" })}</div>
                 { for flags.iter().map(|flag| {
                     let on_resolve = {
                         let id = id.clone();

--- a/ui/src/routines.rs
+++ b/ui/src/routines.rs
@@ -328,6 +328,7 @@ const NEXT_RUN_TICK_MS: u32 = 30_000;
 /// Enabled / disabled / dormant / due-soon status facet for routines.
 /// `Dormant` means enabled but with an empty machines list — it will never fire.
 /// `DueSoon` means enabled with a next fire within [`DUE_SOON_WINDOW_SECS`].
+/// `HasFlags` means the routine has one or more open flags.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum RoutineStatusFacet {
     #[default]
@@ -337,6 +338,7 @@ pub enum RoutineStatusFacet {
     Dormant,
     DueSoon,
     Snoozed,
+    HasFlags,
 }
 
 impl RoutineStatusFacet {
@@ -349,6 +351,7 @@ impl RoutineStatusFacet {
             RoutineStatusFacet::Dormant => "dormant",
             RoutineStatusFacet::DueSoon => "due",
             RoutineStatusFacet::Snoozed => "snoozed",
+            RoutineStatusFacet::HasFlags => "flagged",
         }
     }
 
@@ -360,6 +363,7 @@ impl RoutineStatusFacet {
             "dormant" => RoutineStatusFacet::Dormant,
             "due" => RoutineStatusFacet::DueSoon,
             "snoozed" => RoutineStatusFacet::Snoozed,
+            "flagged" => RoutineStatusFacet::HasFlags,
             _ => RoutineStatusFacet::All,
         }
     }
@@ -495,6 +499,7 @@ impl RoutineFilter {
                 return false
             }
             RoutineStatusFacet::Snoozed if !is_routine_snoozed(r, now) => return false,
+            RoutineStatusFacet::HasFlags if r.flag_count == 0 => return false,
             _ => {}
         }
         match &self.agent {
@@ -1932,10 +1937,7 @@ pub fn routine_stats_bar(props: &StatsBarProps) -> Html {
             { mk(RoutineStatusFacet::Disabled, "DISABLED", disabled, "disabled") }
             { mk(RoutineStatusFacet::DueSoon, "DUE SOON", due_soon, "due") }
             { mk(RoutineStatusFacet::Snoozed, "SNOOZED", snoozed, "snoozed") }
-            <div class={classes!("stat-card", "flags", if flags > 0 { Some("has-flags") } else { None })}>
-                <div class="stat-label">{"FLAGS"}</div>
-                <div class={classes!("stat-val", if flags > 0 { "c-red" } else { "c-accent" })}>{flags}</div>
-            </div>
+            { mk(RoutineStatusFacet::HasFlags, "FLAGS", flags, if flags > 0 { "flags has-flags" } else { "flags" }) }
             <div class="stat-card unreg">
                 <div class="stat-label">{"UNREGISTERED AGENT"}</div>
                 <div class="stat-val">{unreg}</div>

--- a/ui/src/routines_tests.rs
+++ b/ui/src/routines_tests.rs
@@ -85,6 +85,7 @@ fn status_facet_roundtrips_and_defaults_to_all() {
         RoutineStatusFacet::Dormant,
         RoutineStatusFacet::DueSoon,
         RoutineStatusFacet::Snoozed,
+        RoutineStatusFacet::HasFlags,
     ] {
         assert_eq!(RoutineStatusFacet::from_str(f.as_str()), f);
     }
@@ -302,6 +303,21 @@ fn status_snoozed_matches_only_snoozed_routines() {
     assert!(!f.matches(&active, now(), window()));
     // Disabled+snoozed: snoozed filter does not check enabled state.
     assert!(f.matches(&disabled_snoozed, now(), window()));
+}
+
+#[test]
+fn status_has_flags_matches_only_flagged_routines() {
+    let f = RoutineFilter {
+        status: RoutineStatusFacet::HasFlags,
+        ..Default::default()
+    };
+    let flagged = Routine {
+        flag_count: 2,
+        ..routine("a", "t", "claude", "0 * * * *", &["m1"], &[], true)
+    };
+    let clean = routine("b", "t", "claude", "0 * * * *", &["m1"], &[], true);
+    assert!(f.matches(&flagged, now(), window()));
+    assert!(!f.matches(&clean, now(), window()));
 }
 
 // ── Agent facet matching ──────────────────────────────────────────────────────

--- a/ui/src/routines_tests.rs
+++ b/ui/src/routines_tests.rs
@@ -1093,6 +1093,7 @@ fn r_group_by_as_str_roundtrips() {
         RGroupBy::Agent,
         RGroupBy::Machine,
         RGroupBy::Status,
+        RGroupBy::Health,
     ] {
         assert_eq!(RGroupBy::from_str(by.as_str()), by);
     }

--- a/ui/src/schedule_heatmap.rs
+++ b/ui/src/schedule_heatmap.rs
@@ -92,6 +92,8 @@ pub(crate) struct Heatmap {
     pub max_cell: u32,
     /// `(day, hour)` of the busiest cell, or `None` when nothing fires.
     pub peak: Option<(usize, usize)>,
+    /// Number of enabled, filter-matching sources that contributed at least one fire.
+    pub sources: u32,
 }
 
 /// Aggregate the next-7-day fire density of every enabled source matching
@@ -105,6 +107,7 @@ pub(crate) fn compute_heatmap(
     let today = now.date_naive();
     let end_date = today + Duration::days(HEAT_DAYS as i64);
     let mut grid = vec![vec![0u32; HEAT_HOURS]; HEAT_DAYS];
+    let mut sources_counted = 0u32;
 
     for source in sources
         .iter()
@@ -113,6 +116,7 @@ pub(crate) fn compute_heatmap(
         let Some(cron) = parse_cron(&source.schedule) else {
             continue;
         };
+        let mut contributed = false;
         // `iter_after(now)` yields fires strictly after `now` in chronological
         // order, so each `date` is on or after `today`; stop at the first fire
         // that lands on or past the window's end. The take() caps cost on
@@ -124,6 +128,10 @@ pub(crate) fn compute_heatmap(
             }
             let day = (date - today).num_days() as usize;
             grid[day][dt.hour() as usize] += 1;
+            contributed = true;
+        }
+        if contributed {
+            sources_counted += 1;
         }
     }
 
@@ -145,6 +153,7 @@ pub(crate) fn compute_heatmap(
         total,
         max_cell,
         peak,
+        sources: sources_counted,
     }
 }
 
@@ -391,6 +400,10 @@ fn heat_stats(props: &HeatStatsProps) -> Html {
             <div class="stat-card enabled">
                 <div class="stat-label">{"PEAK / HOUR"}</div>
                 <div class="stat-val c-accent">{map.max_cell}</div>
+            </div>
+            <div class="stat-card disabled">
+                <div class="stat-label">{"SOURCES"}</div>
+                <div class="stat-val">{map.sources}</div>
             </div>
             <div class="stat-card system">
                 <div class="stat-label">{"OPEN SLOTS"}</div>

--- a/ui/src/schedule_heatmap_tests.rs
+++ b/ui/src/schedule_heatmap_tests.rs
@@ -131,6 +131,15 @@ fn empty_sources_produce_a_zeroed_grid() {
     assert_eq!(map.total, 0);
     assert_eq!(map.max_cell, 0);
     assert!(map.peak.is_none());
+    assert_eq!(map.sources, 0);
+}
+
+#[test]
+fn heatmap_counts_sources_that_fire_within_window() {
+    let active = source(Kind::Routine, "0 12 * * *", true);
+    let disabled = source(Kind::Routine, "0 12 * * *", false);
+    let map = compute_heatmap(&[active, disabled], now(), HeatFilter::All);
+    assert_eq!(map.sources, 1, "disabled sources should not be counted");
 }
 
 // ─── intensity_level ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- The heatmap stats bar now shows a SOURCES tile — the count of enabled routines that contributed at least one fire to the 7-day grid
- Lets operators distinguish a high-density grid (many routines firing occasionally) from a high-frequency grid (few routines firing very often)
- Adds `sources: u32` to the `Heatmap` struct and a new host test

## Test plan

- [ ] Open Heatmap → SOURCES tile shows count of contributing routines
- [ ] Disable all routines → SOURCES shows 0
- [ ] `cargo test -p ui heatmap_counts_sources_that_fire_within_window` → passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)