### PR TITLE
fix: skip non-routine dirs in prompt-subfolder migration

### DIFF
--- a/.changeset/fix-migrate-prompts-orphan-dirs.md
+++ b/.changeset/fix-migrate-prompts-orphan-dirs.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+fix: skip dirs with no routine.toml in the prompt-subfolder migration, so an orphaned routines/ dir no longer gets an empty prompts/prompt.pure.md resurrected on every startup

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -441,6 +441,12 @@ pub(crate) fn migrate_prompts_to_subfolder_from_dir(dir: &std::path::Path) {
         if !entry.file_type().is_ok_and(|ft| ft.is_dir()) {
             continue;
         }
+        // Skip dirs with no `routine.toml` at all: not a routine (e.g. an orphaned/leftover dir),
+        // so there is nothing to migrate. Without this guard the migration resurrects an empty
+        // `prompts/prompt.pure.md` sidecar in such dirs on every startup.
+        if !entry.path().join("routine.toml").exists() {
+            continue;
+        }
         let prompts_dir = entry.path().join("prompts");
         if let Err(err) = std::fs::create_dir_all(&prompts_dir) {
             log::warn!(

--- a/src/routine_storage_migration_tests.rs
+++ b/src/routine_storage_migration_tests.rs
@@ -210,13 +210,18 @@ fn migrate_prompts_to_subfolder_from_dir_skips_already_migrated() {
 
 #[test]
 fn migrate_prompts_to_subfolder_from_dir_defaults_missing_legacy_prompt_to_empty() {
-    // A routine dir with no prompts/ subfolder and no legacy `prompt` field in routine.toml (nor
-    // any routine.toml at all) still gets an (empty) prompt.pure.md written.
+    // A routine dir with a routine.toml but no `prompt` field (and no prompts/ subfolder yet)
+    // still gets an (empty) prompt.pure.md written.
     let dir = scratch_dir("prompts-subfolder-no-legacy");
     std::fs::create_dir_all(&dir).unwrap();
 
     let routine = dir.join("no-legacy-prompt");
     std::fs::create_dir_all(&routine).unwrap();
+    std::fs::write(
+        routine.join("routine.toml"),
+        "title = \"No Legacy\"\nschedule = \"@daily\"\nagent = \"claude\"\n",
+    )
+    .unwrap();
 
     migrate_prompts_to_subfolder_from_dir(&dir);
 
@@ -224,6 +229,23 @@ fn migrate_prompts_to_subfolder_from_dir_defaults_missing_legacy_prompt_to_empty
         std::fs::read_to_string(routine.join("prompts").join("prompt.pure.md")).unwrap(),
         ""
     );
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[test]
+fn migrate_prompts_to_subfolder_from_dir_skips_dir_without_routine_toml() {
+    // An orphaned dir with no routine.toml at all (e.g. a leftover from a failed write) is not a
+    // routine, so it is left untouched rather than getting an empty prompts/ sidecar resurrected.
+    let dir = scratch_dir("prompts-subfolder-no-toml");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let orphan = dir.join("orphan-dir");
+    std::fs::create_dir_all(&orphan).unwrap();
+
+    migrate_prompts_to_subfolder_from_dir(&dir);
+
+    assert!(!orphan.join("prompts").exists());
 
     std::fs::remove_dir_all(&dir).unwrap();
 }
@@ -238,6 +260,11 @@ fn migrate_prompts_to_subfolder_from_dir_logs_on_create_dir_failure() {
 
     let routine = dir.join("blocked-routine");
     std::fs::create_dir_all(&routine).unwrap();
+    std::fs::write(
+        routine.join("routine.toml"),
+        "title = \"Blocked\"\nschedule = \"@daily\"\nagent = \"claude\"\n",
+    )
+    .unwrap();
     std::fs::write(routine.join("prompts"), "i block the prompts dir").unwrap();
 
     migrate_prompts_to_subfolder_from_dir(&dir);
@@ -262,6 +289,11 @@ fn migrate_prompts_to_subfolder_from_dir_logs_on_rename_failure() {
 
     let routine = dir.join("rename-fail-routine");
     std::fs::create_dir_all(routine.join("prompts")).unwrap();
+    std::fs::write(
+        routine.join("routine.toml"),
+        "title = \"Rename Fail\"\nschedule = \"@daily\"\nagent = \"claude\"\n",
+    )
+    .unwrap();
     std::fs::write(routine.join("prompt.md"), "old composed body").unwrap();
     std::fs::write(routine.join("prompts").join("prompt.pure.md"), "pure").unwrap();
     std::fs::set_permissions(&routine, std::fs::Permissions::from_mode(0o555)).unwrap();


### PR DESCRIPTION
## Summary
- `migrate_prompts_to_subfolder_from_dir` scanned every directory under `routines_dir()` with no check for `routine.toml`, so an orphaned leftover dir (no routine ever written there) got an empty `prompts/prompt.pure.md` resurrected on every daemon startup — even after the sidecar was manually deleted.
- Add the same `routine.toml`-exists guard `migrate_routine_dirs_from_dir` already uses, so non-routine dirs are left untouched.

## Test plan
- [x] `cargo test migrate_prompts_to_subfolder` — updated/added coverage for the new skip branch, all 9 tests pass
- [x] `cargo test` — 771 passed
- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets`
- [x] `cargo llvm-cov --fail-under-lines 100` (100% line coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)