### PR TITLE
chore(lint): enable clippy::needless_pass_by_ref_mut

### DIFF
--- a/.changeset/enable-needless-pass-by-ref-mut.md
+++ b/.changeset/enable-needless-pass-by-ref-mut.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Enable `clippy::needless_pass_by_ref_mut` in `[lints.clippy]`. The codebase was already clean against it (no violations), so this is a lint-only change that locks in the invariant that every `&mut` parameter is actually mutated through.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,3 +118,9 @@ use_self = "deny"
 # other path already printed via `.display()` in this codebase. `Path::display`
 # is the correct, consistent way to show a filesystem path to a human.
 unnecessary_debug_formatting = "deny"
+# Reject a `&mut` parameter that's never actually mutated through. A stale
+# `&mut` overstates what the function does to its caller (and to the borrow
+# checker, needlessly ruling out concurrent shared borrows) — the signature
+# should say `&T` once the mutation it was written for is gone. The codebase
+# is already clean, so `deny` keeps every future `&mut` parameter honest.
+needless_pass_by_ref_mut = "deny"


### PR DESCRIPTION
## Summary
- Enables `clippy::needless_pass_by_ref_mut` in `[lints.clippy]` (a nursery lint, not covered by `clippy::all`), following the same incremental-lint-adoption pattern as the other `chore(lint): enable clippy::*` entries already in this repo.
- The codebase has zero existing violations, so this is purely a guardrail: it locks in that every `&mut` parameter is actually mutated through, so a future stale `&mut` (overstating what a function does to the caller, and needlessly ruling out concurrent shared borrows once its mutation is refactored away) gets caught at compile time instead of drifting in silently.
- No production code changes — only `Cargo.toml` plus a changeset.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (0 violations from the new lint)
- [x] `cargo test` (770 passed, 0 failed)

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.