### PR TITLE
fix(ui): make Overview's is_snoozed/from_routine testable by passing now

### DIFF
--- a/.changeset/overview-is-snoozed-uses-passed-now.md
+++ b/.changeset/overview-is-snoozed-uses-passed-now.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+fix(ui): derive the Overview page's per-source `snoozed` flag from the same `now` already threaded through its KPI/attention/upcoming-run math instead of sampling `js_sys::Date::now()` inline, so `is_snoozed`/`from_routine`/`sources_of` stay deterministic and host-testable (this was silently broken: `cargo test --workspace` panicked with "cannot call wasm-bindgen imported functions on non-wasm targets" in 4 `overview_tests`, invisible in CI because `test.yml` only runs bare `cargo test`, which skips the `ui` workspace member).

--- a/ui/src/overview.rs
+++ b/ui/src/overview.rs
@@ -290,14 +290,18 @@ fn targets_no_machine(machines: &[String]) -> bool {
     machines.iter().all(|m| m.trim().is_empty())
 }
 
-/// Map a routine onto the shared schedule abstraction.
-fn is_snoozed(routine: &Routine) -> bool {
-    let now_secs = (js_sys::Date::now() / 1000.0) as u64;
-    routine.snoozed_until.is_some_and(|until| until > now_secs)
+/// Map a routine onto the shared schedule abstraction. Takes `now` explicitly
+/// (rather than sampling the wall clock here) so this stays a pure, host-
+/// testable function and stays in lockstep with the same `now` the rest of
+/// the page's KPI/attention/upcoming-run math uses.
+fn is_snoozed(routine: &Routine, now: DateTime<Local>) -> bool {
+    routine
+        .snoozed_until
+        .is_some_and(|until| (until as i64) > now.timestamp())
         || routine.skip_runs.is_some_and(|n| n > 0)
 }
 
-fn from_routine(routine: &Routine) -> SchedSource {
+fn from_routine(routine: &Routine, now: DateTime<Local>) -> SchedSource {
     SchedSource {
         kind: Kind::Routine,
         id: routine.id.clone(),
@@ -308,13 +312,13 @@ fn from_routine(routine: &Routine) -> SchedSource {
         machines_empty: targets_no_machine(&routine.machines),
         agent_registered: Some(routine.agent_registered),
         flag_count: routine.flag_count,
-        snoozed: is_snoozed(routine),
+        snoozed: is_snoozed(routine, now),
     }
 }
 
 /// Map the routine record list into one `SchedSource` vector.
-fn sources_of(routines: &[Routine]) -> Vec<SchedSource> {
-    routines.iter().map(from_routine).collect()
+fn sources_of(routines: &[Routine], now: DateTime<Local>) -> Vec<SchedSource> {
+    routines.iter().map(|r| from_routine(r, now)).collect()
 }
 
 async fn api_trigger_routine(id: &str) -> Result<(), String> {
@@ -462,7 +466,7 @@ pub fn overview_page(props: &OverviewPageProps) -> Html {
     };
 
     let now_val = *now;
-    let sources = sources_of(&data.routines);
+    let sources = sources_of(&data.routines, now_val);
     let kpis = compute_kpis(&sources, now_val);
     let attention = attention_items(&sources, now_val);
     let runs = upcoming_runs(&sources, now_val);

--- a/ui/src/overview_tests.rs
+++ b/ui/src/overview_tests.rs
@@ -193,7 +193,7 @@ fn from_routine_uses_title_as_label() {
         "enabled": false
     }))
     .expect("valid routine json");
-    let source = from_routine(&routine);
+    let source = from_routine(&routine, at_ten());
     assert_eq!(source.kind, Kind::Routine);
     assert_eq!(source.id, "r1");
     assert_eq!(source.label, "Nightly sweep");
@@ -370,9 +370,25 @@ fn from_routine_carries_agent_registration_and_machines() {
         "machines": ["box-1"], "enabled": true, "agent_registered": false
     }))
     .expect("valid routine json");
-    let s = from_routine(&routine);
+    let s = from_routine(&routine, at_ten());
     assert_eq!(s.agent_registered, Some(false));
     assert!(!s.machines_empty);
+}
+
+/// `snoozed` is derived from the caller-supplied `now`, not the real wall
+/// clock — this is what makes `from_routine` host-testable/deterministic at
+/// all (it previously sampled `js_sys::Date::now()` internally, which panics
+/// outside a wasm target).
+#[test]
+fn from_routine_snoozed_until_respects_passed_in_now() {
+    let routine: Routine = serde_json::from_value(serde_json::json!({
+        "id": "r1", "schedule": "0 0 * * *", "title": "T", "agent": "a", "prompt": "p",
+        "enabled": true, "snoozed_until": at_ten().timestamp() as u64 + 60
+    }))
+    .expect("valid routine json");
+    assert!(from_routine(&routine, at_ten()).snoozed);
+    let later = at_ten() + Duration::hours(1);
+    assert!(!from_routine(&routine, later).snoozed);
 }
 
 #[test]
@@ -394,7 +410,7 @@ fn upcoming_run_routine_id_differs_from_label() {
         "enabled": true
     }))
     .expect("valid routine json");
-    let source = from_routine(&routine);
+    let source = from_routine(&routine, at_ten());
     assert_eq!(source.id, "abc-uuid-123");
     assert_eq!(source.label, "My Routine");
     let runs = upcoming_runs(&[source], at_ten());
@@ -431,7 +447,7 @@ fn sources_of_maps_routines() {
         "prompt": "p", "enabled": true
     }))
     .expect("valid routine json");
-    let sources = sources_of(&[routine]);
+    let sources = sources_of(&[routine], at_ten());
     assert_eq!(sources.len(), 1);
     assert_eq!(sources[0].kind, Kind::Routine);
     assert_eq!(sources[0].label, "T");


### PR DESCRIPTION
## Why

`overview::is_snoozed` sampled `js_sys::Date::now()` directly instead of taking `now` as a parameter, unlike every sibling helper on the same page (`compute_kpis`, `attention_items`, `upcoming_runs`, `next_run_summary` all already thread an explicit `now: DateTime<Local>` for determinism — see the file's own doc comment: "All deterministic given a fixed `now`").

This has two real consequences:

1. **Broken tests, invisible in CI.** `js_sys::Date::now()` is a wasm-bindgen import; calling it outside a wasm target panics with `cannot call wasm-bindgen imported functions on non-wasm targets`. Any test that reaches `from_routine`/`sources_of` (4 tests in `ui/src/overview_tests.rs`) panicked when run with `cargo test --workspace`. This regressed silently because `.github/workflows/test.yml`'s `cargo test` step has no `--workspace` flag — in this non-virtual workspace (root package `moadim` + member `ui`), bare `cargo test` only builds/tests the root package, so the `ui` crate's own test suite never actually runs in CI. (CONTRIBUTING.md already calls out that clippy needs `--workspace` for this exact reason; `cargo test` was missed.)
2. **Inconsistent "now".** The rest of the Overview page renders off a `now` state that ticks on a timer (`use_state(Local::now)`, advanced every `TICK_MS`), but `is_snoozed` queried the live wall clock independently — so the snoozed flag could momentarily disagree with the KPI/attention/upcoming-run math computed in the same render pass.

## What

- `is_snoozed`, `from_routine`, and `sources_of` now take `now: DateTime<Local>` and reuse the `now_val` already computed at the Overview page's single call site, instead of querying `js_sys::Date::now()` inline.
- Updated the 4 existing tests that call `from_routine`/`sources_of` to pass a fixed `now` (the file's existing `at_ten()` fixture).
- Added `from_routine_snoozed_until_respects_passed_in_now`, asserting `snoozed` flips based on the `now` argument rather than the wall clock.

## Testing

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test` (matches CI's `test.yml`, root package only) — 771 passed
- `cargo test --workspace` — 238 `ui` tests passed, 0 failed (previously 4 failed)
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main.rs'` — 100% line coverage held (this PR only touches `ui/`, which isn't part of that gate)
- `linecheck --max-lines 700` — clean
- Added a changeset (`.changeset/overview-is-snoozed-uses-passed-now.md`)

Scope note: this run left `prebuilt.html` untouched even though building locally regenerates it (trunk was available) — recent merged UI PRs on `main` haven't been keeping it in sync either, and there's already a dedicated open PR/issue for enforcing that (`#557`/`#809`), so bundling a regen here would conflate two unrelated concerns.