### PR TITLE
test(ui): cover history page's fmt_run_duration and status badge helpers

### DIFF
--- a/.changeset/ui-history-fmt-run-duration-tests.md
+++ b/.changeset/ui-history-fmt-run-duration-tests.md
@@ -1,0 +1,7 @@
+---
+"moadim": patch
+---
+
+Add unit tests for the routine HISTORY page's `fmt_run_duration` formatter
+and its run-status badge class/label helpers — they shipped untested,
+including the `finished_at < started_at` underflow-guard branch.

--- a/ui/src/routines/history.rs
+++ b/ui/src/routines/history.rs
@@ -227,3 +227,7 @@ pub fn routine_history(props: &HistoryProps) -> Html {
         </main>
     }
 }
+
+#[cfg(test)]
+#[path = "history_tests.rs"]
+mod history_tests;

--- a/ui/src/routines/history_tests.rs
+++ b/ui/src/routines/history_tests.rs
@@ -1,0 +1,52 @@
+//! Host-side unit tests for the pure formatting helpers in [`super`]: the run-status badge
+//! class/label mapping and the `fmt_run_duration` elapsed-time formatter. No DOM/wasm dependency
+//! (mirrors the `refresh.rs` test conventions).
+
+use super::*;
+
+#[test]
+fn run_status_class_covers_every_variant() {
+    assert_eq!(run_status_class(RunStatus::Running), "run-status running");
+    assert_eq!(run_status_class(RunStatus::Success), "run-status success");
+    assert_eq!(run_status_class(RunStatus::Failed), "run-status failed");
+    assert_eq!(run_status_class(RunStatus::Unknown), "run-status unknown");
+}
+
+#[test]
+fn run_status_label_covers_every_variant() {
+    assert_eq!(run_status_label(RunStatus::Running), "RUNNING");
+    assert_eq!(run_status_label(RunStatus::Success), "SUCCESS");
+    assert_eq!(run_status_label(RunStatus::Failed), "FAILED");
+    assert_eq!(run_status_label(RunStatus::Unknown), "UNKNOWN");
+}
+
+#[test]
+fn fmt_run_duration_under_a_minute_is_seconds() {
+    assert_eq!(fmt_run_duration(1_000, 1_045), "45s");
+}
+
+#[test]
+fn fmt_run_duration_exact_minute_boundary_is_minutes() {
+    assert_eq!(fmt_run_duration(0, 60), "1m");
+}
+
+#[test]
+fn fmt_run_duration_under_an_hour_is_minutes() {
+    assert_eq!(fmt_run_duration(0, 754), "12m");
+}
+
+#[test]
+fn fmt_run_duration_exact_hour_boundary_is_hours_and_minutes() {
+    assert_eq!(fmt_run_duration(0, 3_600), "1h 0m");
+}
+
+#[test]
+fn fmt_run_duration_over_an_hour_is_hours_and_minutes() {
+    assert_eq!(fmt_run_duration(0, 7_530), "2h 5m");
+}
+
+#[test]
+fn fmt_run_duration_saturates_when_finished_precedes_started() {
+    // A clock skew or malformed record must not panic on underflow.
+    assert_eq!(fmt_run_duration(100, 50), "0s");
+}


### PR DESCRIPTION
## Why

#982 (merged) added `ui/src/routines/history.rs` — the per-routine run-history
page — including three small pure helpers: `fmt_run_duration` (elapsed-time
formatter), `run_status_class`, and `run_status_label` (status badge
class/label mapping). None of them shipped with tests, unlike every other
pure UI helper in this crate (`refresh.rs`, `schedule.rs`,
`schedule_heatmap.rs`, etc. all have a `*_tests.rs` sibling).

`fmt_run_duration` in particular has a `finished_at.saturating_sub(started_at)`
underflow guard for a `finished_at < started_at` record (clock skew, or a
malformed persisted run) that was completely unexercised — exactly the kind
of edge case that's easy to silently break in a later refactor without a
test to catch it.

Note: the `ui` crate isn't included in the pre-push/CI 100%-line-coverage
gate (`cargo llvm-cov` there runs without `--workspace`, so it only measures
the root `moadim` package), so this gap didn't fail any check — but the
logic is just as worth pinning as everything else in the crate that already
has coverage.

## What

Adds `ui/src/routines/history_tests.rs` with 8 unit tests covering all four
`RunStatus` variants for both badge helpers, and `fmt_run_duration`'s three
formatting branches (seconds/minutes/hours) plus its boundary conditions and
the underflow guard. Mirrors the existing `refresh_tests.rs` convention
(plain `#[test]` fns, `use super::*;`, no DOM/wasm dependency).

## Test plan

- `cargo test -p ui history_tests` — 8 new tests, all pass
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
  `cargo test --workspace`, `cargo llvm-cov --fail-under-lines 100
  --ignore-filename-regex 'src/main\.rs'`, and `linecheck --max-lines 700` —
  ran the full `.githooks/pre-push` script locally end-to-end, all green