### PR TITLE
fix(routines): dedupe tags on create/update, mirroring machines

### DIFF
--- a/.changeset/routines-dedupe-tags.md
+++ b/.changeset/routines-dedupe-tags.md
@@ -1,0 +1,13 @@
+---
+"moadim": patch
+---
+
+fix(routines): dedupe `tags` on create/update, mirroring `machines`
+
+`validate_tags` trimmed and rejected blank entries but never collapsed
+duplicates, unlike its `validate_machines` sibling. A duplicate (or
+whitespace-padded repeat) tag such as `["nightly", "nightly"]` or
+`["nightly", " nightly "]` persisted verbatim, rendering as a doubled chip
+in the routine row and an inflated tag list for a label that names one
+concept once. `validate_tags` now dedupes on the trimmed value, keeping the
+first occurrence, matching `validate_machines`'s existing behavior.

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -258,13 +258,17 @@ fn validate_repositories(repos: &[Repository]) -> Result<Vec<Repository>, AppErr
 }
 
 /// Reject blank (empty/whitespace-only) `tags` entries and return a normalized copy with each tag
-/// trimmed.
+/// trimmed and duplicates collapsed (first occurrence kept).
 ///
 /// Tags are free-form labels for grouping routines; an empty list is valid. This only guards the
 /// contents of non-empty entries, mirroring [`validate_repositories`]: a blank label carries no
 /// meaning and would render as an empty chip, so it is refused at edit time rather than stored.
+/// The dedup step mirrors [`validate_machines`]: left unchecked, `["nightly", "nightly"]` (or a
+/// padded repeat like `" nightly "`) persists and renders as a doubled chip in the routine row and
+/// an inflated (if harmless) entry in the tag facet's per-tag matching, for a label that names one
+/// concept once.
 fn validate_tags(tags: &[String]) -> Result<Vec<String>, AppError> {
-    let mut normalized = Vec::with_capacity(tags.len());
+    let mut normalized: Vec<String> = Vec::with_capacity(tags.len());
     for (index, tag) in tags.iter().enumerate() {
         let trimmed = tag.trim();
         if trimmed.is_empty() {
@@ -272,7 +276,9 @@ fn validate_tags(tags: &[String]) -> Result<Vec<String>, AppError> {
                 "tags[{index}] must not be empty or whitespace-only"
             )));
         }
-        normalized.push(trimmed.to_string());
+        if !normalized.iter().any(|existing| existing == trimmed) {
+            normalized.push(trimmed.to_string());
+        }
     }
     Ok(normalized)
 }

--- a/src/routines/service_model_tests.rs
+++ b/src/routines/service_model_tests.rs
@@ -110,6 +110,30 @@ fn svc_create_trims_and_stores_tags() {
 }
 
 #[test]
+fn svc_create_dedupes_tags() {
+    // Covers the dedup step of `validate_tags`: a duplicate (post-trim) tag entry is
+    // collapsed to one, mirroring `validate_machines`'s dedup behavior.
+    crate::routines::ensure_default_agents();
+    let title = "Svc Create Tags Dedup ZZZ";
+    let store = new_store();
+    let created = svc_create(
+        &store,
+        CreateRoutineRequest {
+            tags: vec!["  nightly  ".into(), "nightly".into(), "triage".into()],
+            ..create_req_with_title(title)
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        created.routine.tags,
+        vec!["nightly".to_string(), "triage".to_string()]
+    );
+
+    svc_delete(&store, &created.routine.id).unwrap();
+    let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
+}
+
+#[test]
 fn svc_create_rejects_blank_machine() {
     // Covers the machines-validation error branch in `svc_create` (#600): an
     // empty or whitespace-only machines entry must 400 before anything is persisted,


### PR DESCRIPTION
## Why

`validate_tags` (in `src/routines/service.rs`) trims and rejects blank
entries, but never collapsed duplicates — unlike its sibling
`validate_machines`, which dedupes on the trimmed value. This is an
inconsistency between two nearly-identical normalization functions in
the same file, not a hypothetical: a duplicate or whitespace-padded
repeat like `["nightly", "nightly"]` or `["nightly", " nightly "]`
persists verbatim today.

The visible symptom is a doubled chip in the routine row
(`r.tags.join(", ")` in `ui/src/routines/row.rs` renders `"nightly,
nightly"`) for a label that's supposed to name one concept once. It's
a small thing, but it's silent data mess that compounds every time a
tag is retyped via the comma-separated form field
(`ui/src/routines/form.rs`) without the user noticing the duplicate.

## What

`validate_tags` now dedupes on the trimmed value, keeping the first
occurrence — the same rule `validate_machines` already applies (added
for #600). No behavior change for the common case (no duplicates);
existing single-tag/no-tag routines are unaffected.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'`
- [x] Added `svc_create_dedupes_tags` covering the new dedup branch, mirroring the existing `svc_create_trims_and_dedupes_machines` test
- [x] Added a changeset (`.changeset/routines-dedupe-tags.md`)