### PR TITLE
fix(ical): give the schedule-truncation marker VEVENT a DURATION

### DIFF
--- a/.changeset/ical-truncation-marker-duration.md
+++ b/.changeset/ical-truncation-marker-duration.md
@@ -1,0 +1,13 @@
+---
+"moadim": patch
+---
+
+fix(ical): give the schedule-truncation marker VEVENT a DURATION
+
+The trailing "schedule truncated" marker event appended to the `.ics` feed
+when a high-frequency routine hits the 100-event cap carried no `DURATION`
+(unlike every regular fire event), so RFC 5545 treats it as a zero-length
+instant. Most calendar UIs render a zero-length event as a barely-visible
+sliver, defeating the marker's one job of telling subscribers the feed was
+capped. It now carries the same `DURATION`/`TRANSP`/`X-MICROSOFT-CDO-BUSYSTATUS`
+properties as a regular fire event.

--- a/src/routines/ical.rs
+++ b/src/routines/ical.rs
@@ -211,6 +211,14 @@ fn build_ical_core(
                 lines.push(format!("UID:{}-truncated@moadim", routine.id));
                 lines.push(format!("DTSTAMP:{dtstamp}"));
                 lines.push(format!("DTSTART:{stamp}"));
+                // Mirror the regular fire VEVENT's DURATION/TRANSP/BUSYSTATUS (see the comments
+                // on EVENT_DURATION and on the regular-fire VEVENT above): without a DURATION
+                // this marker is a zero-length instant, which most calendar UIs render as an
+                // invisible sliver — defeating its one job of telling subscribers the feed was
+                // truncated.
+                lines.push(format!("DURATION:{EVENT_DURATION}"));
+                lines.push("TRANSP:TRANSPARENT".to_string());
+                lines.push("X-MICROSOFT-CDO-BUSYSTATUS:FREE".to_string());
                 lines.push(format!("SUMMARY:⚠ {summary} (schedule truncated)"));
                 lines.push(format!("DESCRIPTION:{note}"));
                 lines.push("END:VEVENT".to_string());

--- a/src/routines/ical_tests.rs
+++ b/src/routines/ical_tests.rs
@@ -75,20 +75,23 @@ fn enabled_daily_routine_yields_events_within_horizon() {
 #[test]
 fn every_event_carries_a_duration() {
     // RFC 5545 requires each VEVENT to specify either DTEND or DURATION, otherwise
-    // calendar clients render it as a zero-length instant. Every fire must emit one.
-    let ics = build_ical(&[routine_with("r1", "@daily", true)], fixed_now());
+    // calendar clients render it as a zero-length instant. Every fire must emit one —
+    // including the trailing truncation-marker VEVENT, so use a capped ("* * * * *")
+    // schedule that emits both.
+    let ics = build_ical(&[routine_with("r1", "* * * * *", true)], fixed_now());
     assert_eq!(
         count(&ics, "BEGIN:VEVENT"),
         count(&ics, "DURATION:PT15M"),
-        "each VEVENT should carry exactly one DURATION line"
+        "each VEVENT, including the truncation marker, should carry exactly one DURATION line"
     );
 }
 
 #[test]
 fn events_are_transparent_to_free_busy() {
     // The feed is informational: a fire must not consume the subscriber's
-    // free/busy time (RFC 5545 §3.8.2.7 defaults TRANSP to OPAQUE = busy).
-    let ics = build_ical(&[routine_with("r1", "@daily", true)], fixed_now());
+    // free/busy time (RFC 5545 §3.8.2.7 defaults TRANSP to OPAQUE = busy). Use a
+    // capped schedule so the truncation-marker VEVENT is covered too.
+    let ics = build_ical(&[routine_with("r1", "* * * * *", true)], fixed_now());
     let events = count(&ics, "BEGIN:VEVENT");
     assert!(events > 0, "expected at least one event");
     // Exactly one TRANSP:TRANSPARENT (and Outlook free-busy hint) per VEVENT.


### PR DESCRIPTION
## Problem

`build_ical` in `src/routines/ical.rs` appends a trailing "schedule truncated" marker `VEVENT` when a high-frequency routine's fires hit the 100-event-per-routine cap, so subscribers know the feed stopped short of the full 30-day horizon. Every *regular* fire event carries a `DURATION:PT15M` line specifically because RFC 5545 requires a `VEVENT` to specify either `DTEND` or `DURATION` — without one, a client treats the event as a zero-length instant, which most calendar UIs (month/week grids) render as a barely-visible sliver or nothing at all.

The truncation-marker event skipped `DURATION` (and the `TRANSP:TRANSPARENT` / `X-MICROSOFT-CDO-BUSYSTATUS:FREE` free-busy hints every regular event gets) entirely — so the one event whose entire purpose is to be *seen* by the subscriber was the one event most likely to render invisibly.

## Fix

Mirror the regular fire `VEVENT`'s `DURATION`/`TRANSP`/`X-MICROSOFT-CDO-BUSYSTATUS` properties on the marker event.

Also strengthened the two existing coverage tests (`every_event_carries_a_duration`, `events_are_transparent_to_free_busy`) to use a capped (`* * * * *`) schedule instead of `@daily`, so they actually exercise the marker-event branch instead of only ever asserting on untruncated events — this is exactly the gap that let the bug ship unnoticed.

## Checks

Ran the repo's own pre-push gate locally before pushing (`.githooks/pre-push`): test-file convention, `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo llvm-cov --fail-under-lines 100`, `linecheck --max-lines 700`, and the changeset check — all passed.

---

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.