### PR TITLE
docs: prune TODO.md entries already shipped

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,10 +6,8 @@ This is a list of todos for consumption, in a pr remove the todo you have implem
 
 - Add a CI step (or weekly scheduled job) that checks whether a newer `crate-ci/typos` release exists than the pinned tag and opens/updates a tracking issue, so the pin gets bumped on a cadence instead of drifting silently
 - Add a day-detail popover to the routines calendar: clicking a day lists each fire time (HH:MM) with its routine, and a "run now" shortcut per routine
-- Auto-stamp the release version/date into CHANGELOG.md from the `chore(release)` step so the `## [Unreleased]` section rolls over on tag
 - Have a commands folder for all the cli commands, we want to work with colocation of files
 - Add a TTL preset row (1h / 1d / 7d / 30d) under the WORKBENCH TTL input in the routine form, mirroring the cron schedule presets
 - Show a humanized retention countdown ("expires in 2d" / "expired") per finished run in the routine LOGS view, derived from the run's finish time and the routine's effective TTL
-- Give `moadim restart` a `--quiet`/`-q` flag that prints only the rotation line (`restarted: pid <old> -> <new>`) and suppresses the UI/stop/logs hint block, for script consumption
 - Auto-refresh the routine LOGS view (or show a removed badge) after a CLEANUP NOW sweep so stale run output isn't shown for reaped workbenches
 - Run the README's fenced `sh`/`json` blocks through a docs lint in CI (e.g. a `markdownlint`/`mdsh` check or a `--json | jq -e` smoke test) so the documented JSON shapes can't drift from the actual CLI output silently


### PR DESCRIPTION
## Why

TODO.md's own convention is "in a PR remove the todo you have implemented", but two entries were left behind after landing:

- `Give moadim restart a --quiet/-q flag ...` — implemented in #516 (`wants_quiet` in src/cli.rs, `restart(json, quiet)` in src/restart.rs, tested by `quiet_flag_only_applies_to_stop` et al.).
- `Auto-stamp the release version/date into CHANGELOG.md ...` — implemented in #845 (`scripts/release/version-and-sync.mjs`'s `updateChangelog`, which rolls `## [Unreleased]` into a dated section on every release cut).

Leaving completed items in TODO.md risks someone picking one back up as if it were still open.

## What

Removes just those two lines. No other TODO.md entries touched — the rest (typos-version CI, day-detail popover, commands/ colocation, TTL presets, retention countdown, LOGS auto-refresh, README fenced-block lint) were checked against current `main` and are still genuinely unimplemented.

Docs-only change (TODO.md), no `src/`/`ui/` touched, so no changeset needed.