### PR TITLE
chore(lint): enable clippy::todo and clippy::unimplemented

### DIFF
--- a/.changeset/enable-todo-unimplemented.md
+++ b/.changeset/enable-todo-unimplemented.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::todo` and `clippy::unimplemented`
+
+Denies leftover `todo!()`/`unimplemented!()` stubs so they never ship to
+production — a stray one would panic the daemon on that code path, same
+rationale as the existing `dbg_macro` deny. Zero violations found; no code
+changes needed.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,10 @@ doc_markdown = "deny"
 uninlined_format_args = "deny"
 # Reject leftover `dbg!` debugging macros so they never ship to production.
 dbg_macro = "deny"
+# Reject leftover `todo!()`/`unimplemented!()` stubs so they never ship to
+# production — a stray one would panic the daemon on that code path.
+todo = "deny"
+unimplemented = "deny"
 # Reject `async fn`s that never `.await` anything — they don't need to be
 # async, and being async needlessly propagates async-ness to callers.
 unused_async = "deny"


### PR DESCRIPTION
## Summary

Adds `todo = "deny"` and `unimplemented = "deny"` to the root `[lints.clippy]` table in `Cargo.toml`, same rationale as the existing `dbg_macro = "deny"`: a stray `todo!()`/`unimplemented!()` left in shipped code would panic a long-running daemon on that code path, so deny them outright.

## Verification

- Grepped `src/` and `ui/src/` — zero existing occurrences of `todo!()` or `unimplemented!()`, so this is a config-only change, no code to fix.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo build` / `cargo test --workspace` — pass.

`ui/Cargo.toml` intentionally only denies `all`, not the granular restriction lints, so left untouched there — matches the pattern of prior single-lint-enablement PRs.