### PR TITLE
chore(lint): enable clippy::manual_string_new

### DIFF
--- a/.changeset/enable-manual-string-new.md
+++ b/.changeset/enable-manual-string-new.md
@@ -1,0 +1,9 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::manual_string_new`
+
+Requires `String::new()` over `"".into()`/`"".to_string()` for constructing
+an empty `String`. Fixed the two violations this newly-`deny`d lint caught
+(both in test fixtures).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,3 +138,7 @@ unnecessary_debug_formatting = "deny"
 # should say `&T` once the mutation it was written for is gone. The codebase
 # is already clean, so `deny` keeps every future `&mut` parameter honest.
 needless_pass_by_ref_mut = "deny"
+# Prefer `String::new()` over `"".into()`/`"".to_string()`/`"".to_owned()` for
+# constructing an empty `String` — it says "empty string" directly instead of
+# making the reader infer it from an empty literal plus a conversion call.
+manual_string_new = "deny"

--- a/src/routines/service_coverage_tests.rs
+++ b/src/routines/service_coverage_tests.rs
@@ -129,7 +129,7 @@ fn svc_create_rejects_empty_prompt() {
             schedule: "@daily".into(),
             title: "Svc Create Empty Prompt ZZZ".into(),
             agent: "claude".into(),
-            prompt: "".into(),
+            prompt: String::new(),
             goal: None,
             repositories: vec![],
             machines: vec![],

--- a/src/routines/service_tests.rs
+++ b/src/routines/service_tests.rs
@@ -1663,7 +1663,7 @@ fn svc_create_rejects_empty_prompt() {
             schedule: "@daily".into(),
             title: "Svc Create Empty Prompt ZZZ".into(),
             agent: "claude".into(),
-            prompt: "".into(),
+            prompt: String::new(),
             repositories: vec![],
             machines: vec![],
             tags: vec![],


### PR DESCRIPTION
## What

Adds `manual_string_new = "deny"` to `[lints.clippy]` in `Cargo.toml`, continuing the repo's established one-lint-at-a-time hardening pattern (`doc_markdown`, `map_unwrap_or`, `use_self`, `match_same_arms`, etc.).

`clippy::manual_string_new` catches `"".into()` / `"".to_string()` / `"".to_owned()` used to build an empty `String`, where `String::new()` says the intent directly.

## Why

Ran `cargo clippy --workspace --all-targets --all-features -- -W clippy::pedantic` to survey pedantic lints not yet enabled in this codebase. `manual_string_new` had exactly two violations, both trivial and test-only — a clean, small, safe lint to lock in.

## Changes

- `Cargo.toml`: enable `clippy::manual_string_new` as `deny`, with the same rationale-comment style as its neighbors.
- `src/routines/service_tests.rs:1666` and `src/routines/service_coverage_tests.rs:132`: `prompt: "".into()` → `prompt: String::new()` (no behavior change).
- `.changeset/enable-manual-string-new.md` added, matching the style of e.g. `enable-doc-markdown.md`.

## Verified locally

- `cargo fmt --check` — passes
- `cargo clippy --workspace --all-targets -- -D warnings` — passes
- `cargo test` — 932 passed
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% line coverage maintained