### PR TITLE
fix: rotate daemon.log when it exceeds 10 MiB

### DIFF
--- a/.changeset/fix-issue-316-daemon-log-rotation.md
+++ b/.changeset/fix-issue-316-daemon-log-rotation.md
@@ -1,0 +1,11 @@
+---
+"moadim": patch
+---
+
+fix: rotate daemon.log when it exceeds 10 MiB
+
+`spawn_detached_with()` opened `daemon.log` in pure append mode with no
+size cap, so a long-lived install could grow the file unbounded until it
+filled the disk. Before opening the log, its size is now checked and
+rotated to `daemon.log.1` past 10 MiB (best-effort — a failed rotation
+falls through to the existing append-open rather than blocking the spawn).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -656,7 +656,7 @@ use cli_system::{
     spawn_detached, wait_until,
 };
 #[cfg(test)]
-pub(crate) use cli_system::{parse_body, parse_status_code};
+pub(crate) use cli_system::{parse_body, parse_status_code, DAEMON_LOG_MAX_BYTES};
 
 #[cfg(test)]
 #[path = "cli_tests.rs"]

--- a/src/cli_spawn_tests.rs
+++ b/src/cli_spawn_tests.rs
@@ -440,6 +440,36 @@ fn spawn_detached_errors_when_log_file_path_is_directory() {
 }
 
 #[test]
+fn spawn_detached_rotates_oversized_daemon_log() {
+    // An existing daemon.log past the size cap is rotated to daemon.log.1 before the
+    // detached child is spawned, instead of being appended to forever (#316).
+    let base = temp_home("spawn-log-rotate");
+    let config_dir = base.join(".config/moadim");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let log_path = config_dir.join("daemon.log");
+    std::fs::write(&log_path, vec![b'x'; (DAEMON_LOG_MAX_BYTES + 1) as usize]).unwrap();
+    let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", base.to_str().unwrap());
+    let pid = spawn_detached().expect("spawn detached child");
+    let rotated = config_dir.join("daemon.log.1");
+    assert!(
+        rotated.exists(),
+        "oversized daemon.log should be rotated to daemon.log.1"
+    );
+    assert!(
+        std::fs::metadata(&log_path).unwrap().len() < DAEMON_LOG_MAX_BYTES,
+        "fresh daemon.log should not still hold the oversized contents"
+    );
+    // The detached child is a real process; kill it so the test doesn't leak one.
+    #[cfg(unix)]
+    unsafe {
+        libc::kill(pid as libc::pid_t, libc::SIGKILL);
+    }
+    #[cfg(not(unix))]
+    let _ = pid;
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[test]
 fn run_background_errors_when_stop_running_times_out() {
     // A server that never stops causes stop_running_and_wait() to time out and
     // return Err, which run_background() propagates (the `?` error branch at L208).

--- a/src/cli_system.rs
+++ b/src/cli_system.rs
@@ -7,6 +7,25 @@ use std::time::Duration;
 /// How long to wait when probing or signalling a running server over HTTP.
 const PROBE_TIMEOUT: Duration = Duration::from_millis(750);
 
+/// Size at which `daemon.log` is rotated to `daemon.log.1` on the next detached spawn. The daemon
+/// is long-lived and appends to this file on every start/restart with no other trim point, so
+/// without a cap it grows unbounded until it fills the disk (#316).
+pub(crate) const DAEMON_LOG_MAX_BYTES: u64 = 10 * 1024 * 1024;
+
+/// Rotate `log_path` to a sibling `.1` file (overwriting any previous one) if it has grown past
+/// [`DAEMON_LOG_MAX_BYTES`]. Best-effort: a failed rotation (permissions, race) falls through to
+/// the caller's own `append(true)` open rather than blocking the spawn.
+fn rotate_daemon_log_if_oversized(log_path: &std::path::Path) {
+    let Ok(metadata) = std::fs::metadata(log_path) else {
+        return;
+    };
+    if metadata.len() <= DAEMON_LOG_MAX_BYTES {
+        return;
+    }
+    let rotated_path = log_path.with_extension("log.1");
+    let _ = std::fs::rename(log_path, rotated_path);
+}
+
 /// Write the current process PID into the pid file so `stop`/`status` and signals can find it.
 pub fn write_pid_file() -> anyhow::Result<()> {
     let path = crate::paths::pid_file();
@@ -326,6 +345,7 @@ fn spawn_detached_with(configure: impl FnOnce(&mut std::process::Command)) -> an
     crate::utils::fs_perms::create_private_dir_all(
         log_path.parent().expect("daemon log path has a parent dir"),
     )?;
+    rotate_daemon_log_if_oversized(&log_path);
     let out = std::fs::OpenOptions::new()
         .create(true)
         .append(true)


### PR DESCRIPTION
## Problem

`spawn_detached_with()` opens `~/.config/moadim/daemon.log` in pure append mode with no size cap or rotation. Every detached start/restart appends to the same file forever, and the web UI's 30s health-check poll (plus `moadim status --wait`) adds steady request-logger noise on top — so on a long-lived install the file grows unbounded until it fills the disk.

## Fix

Before opening the log file, check its size; if it's past 10 MiB, rotate it to `daemon.log.1` (best-effort — a failed rotation falls through to the existing append-open rather than blocking the spawn).

## Test plan
- [x] `cargo test` (933 passed)
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt --check` clean
- [x] New test `spawn_detached_rotates_oversized_daemon_log` covers the rotation path

Closes #316