### PR TITLE
fix: add global concurrency limit to the HTTP server

### DIFF
--- a/.changeset/fix-issue-410-concurrency-limit.md
+++ b/.changeset/fix-issue-410-concurrency-limit.md
@@ -1,0 +1,12 @@
+---
+"moadim": patch
+---
+
+fix: add global concurrency limit to the HTTP server
+
+The Axum router had no cap on in-flight requests, so a burst of concurrent
+requests or a few hung `crontab`/`tmux` calls could exhaust the runtime's
+worker/blocking pool and leave even `GET /health` unreachable. A
+`tower::limit::GlobalConcurrencyLimitLayer` (a single shared semaphore, cap
+64) now sits as the outermost layer, queuing excess requests instead of
+piling more work onto the runtime.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2351,6 +2351,7 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ toml = "1.1"
 rmcp = { version = "2.0.0", features = ["server", "macros", "transport-io", "transport-streamable-http-server"] }
 schemars = "1"
 tokio = { version = "1", features = ["full"] }
+tower = { version = "0.5", features = ["limit", "util"] }
 tower-http = { version = "0.7", features = ["catch-panic", "compression-gzip"] }
 utoipa = { version = "5", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "9", features = ["axum"] }
@@ -53,9 +54,6 @@ libc = "0.2"
 [[bin]]
 name = "moadim"
 path = "src/main.rs"
-
-[dev-dependencies]
-tower = { version = "0.5", features = ["util"] }
 
 [build-dependencies]
 serde_json = "1"

--- a/src/routes/http.rs
+++ b/src/routes/http.rs
@@ -20,9 +20,19 @@ use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
 use std::sync::{Arc, LazyLock};
 use std::time::Duration;
+use tower::limit::GlobalConcurrencyLimitLayer;
 use tower_http::catch_panic::CatchPanicLayer;
 use tower_http::compression::CompressionLayer;
 use utoipa_swagger_ui::SwaggerUi;
+
+/// Maximum number of requests the server services at once, across every route.
+///
+/// Handlers perform blocking `crontab`/`tmux`/filesystem I/O directly on Tokio worker threads (no
+/// `spawn_blocking`, #360), and the server has no per-request concurrency cap otherwise — a burst
+/// of concurrent requests (or a few hung crontab calls) could exhaust the runtime's worker/blocking
+/// pool and leave even `GET /health` unreachable. This bounds that blast radius: requests beyond
+/// the cap simply queue for a free slot instead of piling onto more threads (#410).
+const MAX_CONCURRENT_REQUESTS: usize = 64;
 
 /// Shared signal that asks the running server to shut down gracefully.
 ///
@@ -449,6 +459,10 @@ pub(crate) fn build_app_with_shutdown(
         // resetting the connection with no response and no logged error (issue #337). Catch it
         // here and answer with a plain 500 instead.
         .layer(CatchPanicLayer::new())
+        // Global cap on in-flight requests, shared across every clone of the router (see
+        // MAX_CONCURRENT_REQUESTS). Placed outermost (alongside CatchPanicLayer) so it bounds
+        // *all* traffic, not just the REST API under /api/v1.
+        .layer(GlobalConcurrencyLimitLayer::new(MAX_CONCURRENT_REQUESTS))
         .with_state(app_state)
 }
 


### PR DESCRIPTION
## Problem

The Axum router (`src/routes/http.rs`) has no cap on in-flight requests. Handlers perform blocking `crontab`/`tmux`/filesystem I/O directly on Tokio worker threads (no `spawn_blocking`, see #360), and there's no per-request timeout on non-API routes — so a burst of concurrent requests, or a few hung crontab calls, can exhaust the runtime's worker/blocking pool and leave even `GET /health` unreachable, with no backpressure signal to callers.

## Fix

Add `tower::limit::GlobalConcurrencyLimitLayer` (a single shared semaphore across every clone of the router, not a per-clone limit) as the outermost layer, alongside `CatchPanicLayer`, so it bounds all traffic rather than just the REST API under `/api/v1`. Requests beyond the cap (64) queue for a free slot instead of piling more work onto the runtime.

`tower` was previously a dev-only dependency (used for `ServiceExt::oneshot` in tests); promoted it to a regular dependency and added the `limit` feature.

## Test plan
- [x] `cargo build` / `cargo test` (932 passed)
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt --check` clean
- [x] `cargo deny check` — advisories/bans/licenses/sources all ok

Scoped to the concurrency-limit ask specifically; load-shedding (fast `503` instead of queuing) would be a good follow-up but is a separate, larger change.

Closes #410