### PR TITLE
fix: attach pipe-pane atomically with tmux new-session

### DIFF
--- a/.changeset/fix-issue-289-atomic-pipe-pane.md
+++ b/.changeset/fix-issue-289-atomic-pipe-pane.md
@@ -1,0 +1,11 @@
+---
+"moadim": patch
+---
+
+fix: attach pipe-pane atomically with tmux new-session
+
+`pipe-pane` was attached as a separate statement after `new-session -d`, so
+any output the agent emitted before the attach (banner, initial plan,
+startup crash) was silently dropped from `agent.log`. Both are now chained
+in a single `tmux` invocation via `\;`, so the pipe is attached before the
+pane can produce output.

--- a/src/routines/command.rs
+++ b/src/routines/command.rs
@@ -226,9 +226,10 @@ fn bin_dir_in(path: &str, bin: &str) -> Option<String> {
 
 /// Whether `tmux` resolves to a file on the given `:`-separated `path` list.
 ///
-/// `tmux` is a hard runtime dependency: routine launches run `tmux new-session …; tmux pipe-pane …`
-/// and a missing `tmux` would be silently ignored (the statements are `;`-joined), making the run a
-/// no-op. This helper surfaces its presence so startup can warn and `GET /health` can report it.
+/// `tmux` is a hard runtime dependency: routine launches run `tmux new-session … \; pipe-pane …`
+/// and a missing `tmux` would be silently ignored (the statement is one of several `;`-joined
+/// steps), making the run a no-op. This helper surfaces its presence so startup can warn and
+/// `GET /health` can report it.
 /// Injectable for tests via the `path` argument; see [`tmux_available`] for the live-`PATH` variant.
 pub(crate) fn tmux_available_in(path: &str) -> bool {
     bin_dir_in(path, "tmux").is_some()
@@ -553,15 +554,23 @@ pub(crate) fn build_routine_command(routine: &Routine, agent: &AgentCommand) -> 
     // `$WB/exit_code`): `$WB` is a plain (non-exported) shell variable in the launcher script and
     // is not inherited by the new shell tmux spawns, but the pane's cwd is already `$WB` (`-c`).
     let invocation_with_exit_code = format!(r#"{invocation}; printf '%s' "$?" > exit_code"#);
+    // `pipe-pane` is chained onto the *same* tmux invocation as `new-session` via `\;` (tmux's own
+    // multi-command separator, escaped so the outer shell passes it through literally) rather than
+    // being a separate `;`-joined statement. `new-session -d` starts the agent immediately, so a
+    // pipe attached by a later, separate `tmux pipe-pane` call misses everything the agent writes
+    // in the gap between session creation and that second command running — the agent's opening
+    // banner, initial plan, and any immediate startup crash, silently dropped from `agent.log`
+    // (#289). Chaining within one invocation attaches the pipe to the pane tmux itself just
+    // created, before the calling shell moves on, so there is no such window.
+    //
     // Fail loudly if the session can't start — most likely a residual `$SESS` collision. Without
     // this guard a `duplicate session` error from tmux is swallowed by the `;`-join and the trigger
     // returns success while launching nothing (the silent no-op #411 hardens against). Mirror the
     // prompt-copy guard: record the reason in agent.log and on stderr, then exit non-zero.
     inner_stmts.push(format!(
-        r#"tmux new-session -d -s "$SESS" -c "$WB" {} || {{ echo "moadim: failed to start tmux session $SESS (already exists?); aborting launch" | tee -a "$WB/agent.log" >&2; exit 1; }}"#,
+        r#"tmux new-session -d -s "$SESS" -c "$WB" {} \; pipe-pane -o -t "$SESS" "cat >> \"$WB\"/agent.log" || {{ echo "moadim: failed to start tmux session $SESS (already exists?); aborting launch" | tee -a "$WB/agent.log" >&2; exit 1; }}"#,
         shell_quote(&invocation_with_exit_code)
     ));
-    inner_stmts.push(r#"tmux pipe-pane -o -t "$SESS" "cat >> \"$WB\"/agent.log""#.to_string());
     stmts.push(format!(
         r#"{{ {} ; }} >> "$WB/launch.log" 2>&1"#,
         inner_stmts.join("; ")

--- a/src/routines/command_tests.rs
+++ b/src/routines/command_tests.rs
@@ -655,6 +655,44 @@ fn build_routine_command_records_exit_code_after_invocation() {
 }
 
 #[test]
+fn build_routine_command_attaches_pipe_pane_in_the_same_tmux_invocation() {
+    // `pipe-pane` must be chained onto the *same* tmux invocation as `new-session` via `\;`
+    // (tmux's own multi-command separator) rather than run as a separate, later `;`-joined shell
+    // statement — otherwise output the agent writes between session creation and that second
+    // statement running is silently dropped from `agent.log` (#289).
+    // Deliberately avoids "pipe" or "pane" in the title: it becomes part of the slugified
+    // workbench/log paths embedded earlier in the script, which would otherwise collide with the
+    // `pipe-pane` substring this test searches for.
+    let routine = make_routine("Cmd Log Capture Routine");
+    let agent = AgentCommand {
+        command: "claude".to_string(),
+        args: vec![],
+        instructions_file: "CLAUDE.md".to_string(),
+        setup: None,
+    };
+    let cmd = build_routine_command(&routine, &agent);
+    let new_session_pos = cmd.find("tmux new-session").unwrap();
+    // No `tmux pipe-pane` invocation as its own separate command: the only "pipe-pane" text is the
+    // subcommand name chained after `new-session` via `\;` within the same `tmux` invocation.
+    assert!(
+        !cmd.contains("tmux pipe-pane"),
+        "pipe-pane must not be a standalone tmux invocation, but chained onto new-session: {cmd}"
+    );
+    let pipe_pane_pos = cmd.find("pipe-pane").unwrap();
+    let next_tmux_or_end = cmd[new_session_pos + 1..]
+        .find("tmux ")
+        .map_or(cmd.len(), |offset| new_session_pos + 1 + offset);
+    assert!(
+        new_session_pos < pipe_pane_pos && pipe_pane_pos < next_tmux_or_end,
+        "expected pipe-pane chained via \\; inside the same tmux new-session invocation in: {cmd}"
+    );
+    assert!(
+        cmd.contains(r#"\; pipe-pane -o -t "$SESS""#),
+        "expected pipe-pane chained with tmux's own \\; separator, targeting $SESS, in: {cmd}"
+    );
+}
+
+#[test]
 fn inline_prompt_overflow_none_for_prompt_file_agent_regardless_of_size() {
     // `{prompt_file}` (codex/hermes) passes the prompt as a path, never as an inlined argument, so
     // it is never subject to the inline-argument cap no matter how large the composed prompt is.

--- a/src/routines/mod_tests.rs
+++ b/src/routines/mod_tests.rs
@@ -195,7 +195,9 @@ fn build_routine_command_contains_expected_pieces() {
     assert!(cmd.contains(r#""$(cat prompt.md)""#));
     assert!(!cmd.contains("send-keys"));
     assert!(!cmd.contains("capture-pane"));
-    assert!(cmd.contains("tmux pipe-pane"));
+    // pipe-pane is chained onto the same tmux invocation as new-session (#289), not a
+    // standalone `tmux pipe-pane` statement.
+    assert!(cmd.contains(r#"\; pipe-pane -o -t "$SESS""#));
     assert!(cmd.contains("SLUG='my-routine'"));
     // single line — no newlines
     assert!(!cmd.contains('\n'));
@@ -343,8 +345,9 @@ fn build_routine_command_inserts_setup_before_launch() {
 #[test]
 fn build_routine_command_redirects_launch_wrapper_to_launch_log() {
     // Setup/tmux failures must not be silently mailed by cron on a headless host (#375): everything
-    // from the prompt copy through `tmux pipe-pane` runs inside a `{ … } >> "$WB/launch.log" 2>&1`
-    // group, so a failure anywhere in that wrapper leaves a readable trace in the workbench.
+    // from the prompt copy through the chained `pipe-pane` (#289) runs inside a
+    // `{ … } >> "$WB/launch.log" 2>&1` group, so a failure anywhere in that wrapper leaves a
+    // readable trace in the workbench.
     let routine = make_routine("rid");
     let agent = AgentCommand {
         command: "claude".to_string(),
@@ -359,11 +362,13 @@ fn build_routine_command_redirects_launch_wrapper_to_launch_log() {
     );
 
     // The redirect group opens after `mkdir -p "$WB"` (so $WB exists before anything tries to
-    // write into it) and closes after the final `tmux pipe-pane` statement.
+    // write into it) and closes after the final (chained) `pipe-pane` statement.
     let mkdir_at = cmd.find(r#"mkdir -p "$WB""#).expect("mkdir present");
     let group_open_at = cmd[mkdir_at..].find('{').map(|off| mkdir_at + off).unwrap();
     let setup_at = cmd.find("seed-trust").expect("setup present");
-    let pipe_pane_at = cmd.find("tmux pipe-pane").expect("pipe-pane present");
+    let pipe_pane_at = cmd
+        .find(r#"\; pipe-pane -o -t "$SESS""#)
+        .expect("pipe-pane present");
     let redirect_at = cmd.find(r#"} >> "$WB/launch.log""#).unwrap();
     assert!(
         mkdir_at < group_open_at,


### PR DESCRIPTION
## Problem

In `build_routine_command` (`src/routines/command.rs`), the agent is launched and its log capture is attached in two separate, `;`-joined statements:

```rust
stmts.push(format!(r#"tmux new-session -d -s "$SESS" -c "$WB" {}"#, shell_quote(&invocation)));
stmts.push(r#"tmux pipe-pane -o -t "$SESS" "cat >> \"$WB\"/agent.log""#.to_string());
```

`tmux pipe-pane` only forwards output produced *after* it is attached. Because `new-session -d` starts the agent process immediately and `pipe-pane` runs as the next statement, any output the agent emits in the window between session creation and the pipe-pane attach is silently dropped from `agent.log` — exactly the part an operator most wants for an audit trail: the agent's opening banner, initial plan, early handshakes, and any immediate startup crash.

## Fix

Chain `pipe-pane` onto the same `tmux` invocation as `new-session` via tmux's own `\;` multi-command separator (escaped so the outer shell passes it through literally), per the issue's suggested direction:

```sh
tmux new-session -d -s "$SESS" -c "$WB" <invocation> \; pipe-pane -o -t "$SESS" "cat >> \"$WB\"/agent.log"
```

This attaches the pipe to the pane tmux itself just created, within the same tmux invocation, so there's no `;`-joined gap for output to slip through.

## Verification

Manually reproduced against a real tmux 3.6a session — output written in the very first statement of the launched command is captured into the piped log:

```
$ tmux new-session -d -s test -c "$WB" 'echo hello-from-start; ...' \; pipe-pane -o -t test "cat >> agent.log"
$ cat agent.log
hello-from-start
```

## Test plan
- [x] `cargo test` (933 passed)
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt --check` clean
- [x] New test `build_routine_command_attaches_pipe_pane_in_the_same_tmux_invocation` asserts the chained (not standalone) form
- [x] Updated two existing tests (`mod_tests.rs`) that asserted the old standalone `tmux pipe-pane` statement
- [x] Manual verification against a real tmux session (see above)

Closes #289