### PR TITLE
fix(service): enable systemd lingering so the daemon survives logout/reboot

### DIFF
--- a/.changeset/enable-systemd-linger.md
+++ b/.changeset/enable-systemd-linger.md
@@ -1,0 +1,13 @@
+---
+"moadim": patch
+---
+
+fix(service): enable systemd lingering so the daemon survives logout/reboot (#294)
+
+On Linux, `moadim install` starts the daemon under the systemd *user* manager, but without
+lingering enabled that manager — and `moadim.service` with it — only runs while the user has an
+active login session, so the daemon stopped at logout and never started at boot. `install()` now
+runs `loginctl enable-linger` and records a marker file so `uninstall()` disables it symmetrically,
+without ever touching lingering the operator enabled themselves for an unrelated reason. Never
+fails the install: if `loginctl` is unavailable or errors, a warning with the manual command is
+printed instead of aborting.

--- a/src/service/linux.rs
+++ b/src/service/linux.rs
@@ -141,7 +141,7 @@ fn enable_linger(unit: &Path) {
 /// Disable lingering previously enabled by `install()` (#294), but only when the marker shows
 /// moadim was the one that turned it on — never touch lingering the operator enabled themselves
 /// for an unrelated reason.
-fn disable_linger_if_owned(unit: &Path) {
+pub(super) fn disable_linger_if_owned(unit: &Path) {
     let Some(marker) = linger_marker_path(unit) else {
         return;
     };

--- a/src/service/linux.rs
+++ b/src/service/linux.rs
@@ -25,6 +25,33 @@ pub(super) fn systemctl_bin() -> String {
     fallback
 }
 
+/// The `loginctl` executable, overridable via `MOADIM_LOGINCTL_BIN` so tests can substitute a
+/// no-op shim instead of toggling the developer's live systemd-logind lingering state. Mirrors
+/// `systemctl_bin()`.
+pub(super) fn loginctl_bin() -> String {
+    if let Ok(bin) = std::env::var("MOADIM_LOGINCTL_BIN") {
+        return bin;
+    }
+    // Same test-build guard as `systemctl_bin()`: never fall back to the real `loginctl` so a test
+    // that forgets to wire up `MOADIM_LOGINCTL_BIN` cannot toggle the developer's live lingering
+    // state. The guard path does not exist, so the eventual spawn fails harmlessly.
+    #[cfg(test)]
+    let fallback = "/nonexistent/moadim-test-loginctl-guard".to_string();
+    #[cfg(not(test))]
+    let fallback = "loginctl".to_string();
+    fallback
+}
+
+/// Marker file (sibling to the systemd unit) recording that `install()` enabled lingering, so
+/// `uninstall()` disables it symmetrically and never clobbers lingering the operator enabled
+/// themselves for an unrelated reason.
+const LINGER_MARKER_NAME: &str = ".moadim-linger-enabled";
+
+/// Path to the lingering-ownership marker, sibling to the systemd unit file.
+pub(super) fn linger_marker_path(unit: &Path) -> Option<PathBuf> {
+    unit.parent().map(|dir| dir.join(LINGER_MARKER_NAME))
+}
+
 /// Absolute path to the systemd *user* unit file for the moadim service.
 pub(super) fn unit_path() -> anyhow::Result<PathBuf> {
     unit_path_from_config_dir(dirs::config_dir())
@@ -89,6 +116,42 @@ fn report_installed(unit: &Path) {
     println!("  status  systemctl --user status {SYSTEMD_UNIT_NAME}");
 }
 
+/// Enable lingering for the current user so the systemd user manager — and `moadim.service` with
+/// it — starts at boot and survives logout, instead of only running during an active login
+/// session (#294). Never fails `install()`: if `loginctl` is unavailable or the call errors (e.g.
+/// no systemd-logind, insufficient privilege), print a warning with the manual command instead of
+/// aborting the install.
+fn enable_linger(unit: &Path) {
+    match run(&loginctl_bin(), &["enable-linger"]) {
+        Ok(()) => {
+            if let Some(marker) = linger_marker_path(unit) {
+                // Best-effort: if the marker can't be written, uninstall just won't disable
+                // linger later, which is the safe direction to fail in.
+                let _ = std::fs::write(&marker, "");
+            }
+            println!("  linger  enabled (survives logout and starts at boot)");
+        }
+        Err(_) => {
+            println!("  linger  NOT enabled — service stops at logout, won't start at boot");
+            println!("          run `loginctl enable-linger` as this user for persistence");
+        }
+    }
+}
+
+/// Disable lingering previously enabled by `install()` (#294), but only when the marker shows
+/// moadim was the one that turned it on — never touch lingering the operator enabled themselves
+/// for an unrelated reason.
+fn disable_linger_if_owned(unit: &Path) {
+    let Some(marker) = linger_marker_path(unit) else {
+        return;
+    };
+    if !marker.exists() {
+        return;
+    }
+    let _ = run(&loginctl_bin(), &["disable-linger"]);
+    let _ = std::fs::remove_file(&marker);
+}
+
 /// Write the systemd user unit for the running binary and enable + start it.
 pub fn install() -> anyhow::Result<()> {
     let exe = moadim_exe()?;
@@ -96,6 +159,7 @@ pub fn install() -> anyhow::Result<()> {
     write_unit(&unit, &exe)?;
     enable_unit()?;
     report_installed(&unit);
+    enable_linger(&unit);
     Ok(())
 }
 
@@ -108,6 +172,7 @@ pub fn uninstall() -> anyhow::Result<()> {
             &systemctl,
             &["--user", "disable", "--now", SYSTEMD_UNIT_NAME],
         );
+        disable_linger_if_owned(&unit);
         std::fs::remove_file(&unit)?;
         let _ = run(&systemctl, &["--user", "daemon-reload"]);
         println!("moadim systemd user service removed ({})", unit.display());

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -28,8 +28,8 @@ pub use linux::{install, uninstall};
 // `service_tests` submodule can reach them via `super::*` regardless of which OS compiles.
 #[cfg(all(test, target_os = "linux"))]
 use linux::{
-    linger_marker_path, loginctl_bin, render_unit, systemctl_bin, unit_path,
-    unit_path_from_config_dir, write_unit,
+    disable_linger_if_owned, linger_marker_path, loginctl_bin, render_unit, systemctl_bin,
+    unit_path, unit_path_from_config_dir, write_unit,
 };
 #[cfg(all(test, target_os = "macos"))]
 use macos::{

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -27,7 +27,10 @@ pub use linux::{install, uninstall};
 // Bring the platform render/path helpers into this module's namespace so the shared
 // `service_tests` submodule can reach them via `super::*` regardless of which OS compiles.
 #[cfg(all(test, target_os = "linux"))]
-use linux::{render_unit, systemctl_bin, unit_path, unit_path_from_config_dir, write_unit};
+use linux::{
+    linger_marker_path, loginctl_bin, render_unit, systemctl_bin, unit_path,
+    unit_path_from_config_dir, write_unit,
+};
 #[cfg(all(test, target_os = "macos"))]
 use macos::{
     launchctl_bin, plist_path, plist_path_from_home, render_plist, write_plist, xml_escape,

--- a/src/service/mod_tests.rs
+++ b/src/service/mod_tests.rs
@@ -323,6 +323,199 @@ fn install_then_uninstall_round_trips_against_a_sandbox() {
     let _ = std::fs::remove_dir_all(&base);
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn loginctl_bin_never_resolves_to_real_loginctl_in_test_builds() {
+    // Structural guard mirroring `systemctl_bin_never_resolves_to_real_systemctl_in_test_builds`:
+    // with no `MOADIM_LOGINCTL_BIN` shim configured, `loginctl_bin()` must never fall back to the
+    // real `loginctl`, so a test that forgets to isolate it cannot toggle the developer's live
+    // lingering state.
+    let previous = std::env::var_os("MOADIM_LOGINCTL_BIN");
+    // SAFETY: tests run single-threaded (RUST_TEST_THREADS=1); restored below.
+    unsafe {
+        std::env::remove_var("MOADIM_LOGINCTL_BIN");
+    }
+    let bin = loginctl_bin();
+    // SAFETY: single-threaded harness; restore the saved value if any.
+    unsafe {
+        match previous {
+            Some(value) => std::env::set_var("MOADIM_LOGINCTL_BIN", value),
+            None => std::env::remove_var("MOADIM_LOGINCTL_BIN"),
+        }
+    }
+    assert_ne!(
+        bin, "loginctl",
+        "test build must not fall back to the real loginctl"
+    );
+    assert!(
+        !std::path::Path::new(&bin).exists(),
+        "the test-build loginctl guard path must not exist so the spawn fails: {bin}"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn install_enables_linger_and_marks_ownership_when_loginctl_succeeds() {
+    use std::os::unix::fs::PermissionsExt as _;
+    // Covers the success arm of `enable_linger()` inside `install()` (#294): both `systemctl` and
+    // `loginctl` shims exit 0, so install() writes the linger-ownership marker.
+    let base = std::env::temp_dir().join(format!("moadim-linger-ok-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&base).unwrap();
+    let systemctl = base.join("systemctl");
+    std::fs::write(&systemctl, "#!/bin/sh\nexit 0\n").unwrap();
+    std::fs::set_permissions(&systemctl, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let loginctl = base.join("loginctl");
+    std::fs::write(&loginctl, "#!/bin/sh\nexit 0\n").unwrap();
+    std::fs::set_permissions(&loginctl, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+    let prev_systemctl = std::env::var_os("MOADIM_SYSTEMCTL_BIN");
+    let prev_loginctl = std::env::var_os("MOADIM_LOGINCTL_BIN");
+    // SAFETY: tests run single-threaded (RUST_TEST_THREADS=1); all three restored below.
+    unsafe {
+        std::env::set_var("XDG_CONFIG_HOME", &base);
+        std::env::set_var("MOADIM_SYSTEMCTL_BIN", &systemctl);
+        std::env::set_var("MOADIM_LOGINCTL_BIN", &loginctl);
+    }
+
+    let unit = base.join("systemd/user/moadim.service");
+    install().unwrap();
+    let marker = linger_marker_path(&unit).unwrap();
+
+    // SAFETY: single-threaded harness; restore the saved values.
+    unsafe {
+        match prev_xdg {
+            Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
+            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        }
+        match prev_systemctl {
+            Some(value) => std::env::set_var("MOADIM_SYSTEMCTL_BIN", value),
+            None => std::env::remove_var("MOADIM_SYSTEMCTL_BIN"),
+        }
+        match prev_loginctl {
+            Some(value) => std::env::set_var("MOADIM_LOGINCTL_BIN", value),
+            None => std::env::remove_var("MOADIM_LOGINCTL_BIN"),
+        }
+    }
+    assert!(
+        marker.exists(),
+        "install must record linger ownership when loginctl succeeds"
+    );
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn install_warns_without_failing_when_loginctl_fails() {
+    use std::os::unix::fs::PermissionsExt as _;
+    // Covers the error arm of `enable_linger()` inside `install()` (#294): `systemctl` succeeds but
+    // `loginctl` exits 1 (e.g. no systemd-logind). install() must still return Ok and must not
+    // write the ownership marker.
+    let base = std::env::temp_dir().join(format!("moadim-linger-fail-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&base).unwrap();
+    let systemctl = base.join("systemctl");
+    std::fs::write(&systemctl, "#!/bin/sh\nexit 0\n").unwrap();
+    std::fs::set_permissions(&systemctl, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let loginctl = base.join("loginctl");
+    std::fs::write(&loginctl, "#!/bin/sh\nexit 1\n").unwrap();
+    std::fs::set_permissions(&loginctl, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+    let prev_systemctl = std::env::var_os("MOADIM_SYSTEMCTL_BIN");
+    let prev_loginctl = std::env::var_os("MOADIM_LOGINCTL_BIN");
+    // SAFETY: tests run single-threaded (RUST_TEST_THREADS=1); all three restored below.
+    unsafe {
+        std::env::set_var("XDG_CONFIG_HOME", &base);
+        std::env::set_var("MOADIM_SYSTEMCTL_BIN", &systemctl);
+        std::env::set_var("MOADIM_LOGINCTL_BIN", &loginctl);
+    }
+
+    let unit = base.join("systemd/user/moadim.service");
+    let result = install();
+    let marker = linger_marker_path(&unit).unwrap();
+
+    // SAFETY: single-threaded harness; restore the saved values.
+    unsafe {
+        match prev_xdg {
+            Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
+            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        }
+        match prev_systemctl {
+            Some(value) => std::env::set_var("MOADIM_SYSTEMCTL_BIN", value),
+            None => std::env::remove_var("MOADIM_SYSTEMCTL_BIN"),
+        }
+        match prev_loginctl {
+            Some(value) => std::env::set_var("MOADIM_LOGINCTL_BIN", value),
+            None => std::env::remove_var("MOADIM_LOGINCTL_BIN"),
+        }
+    }
+    assert!(
+        result.is_ok(),
+        "install must not fail when only linger enablement fails"
+    );
+    assert!(
+        !marker.exists(),
+        "install must not record linger ownership when loginctl fails"
+    );
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn uninstall_disables_linger_only_when_moadim_owns_it() {
+    // Covers `disable_linger_if_owned()` inside `uninstall()` (#294): with the ownership marker
+    // present, uninstall must invoke `loginctl disable-linger` and remove the marker; without it
+    // (lingering enabled by the operator, not moadim), uninstall must leave lingering untouched.
+    let base = std::env::temp_dir().join(format!("moadim-linger-uninst-{}", uuid::Uuid::new_v4()));
+    let unit_dir = base.join("systemd/user");
+    std::fs::create_dir_all(&unit_dir).unwrap();
+    let unit = unit_dir.join("moadim.service");
+    std::fs::write(&unit, "unit content").unwrap();
+    let marker = linger_marker_path(&unit).unwrap();
+    std::fs::write(&marker, "").unwrap();
+
+    let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+    let prev_systemctl = std::env::var_os("MOADIM_SYSTEMCTL_BIN");
+    let prev_loginctl = std::env::var_os("MOADIM_LOGINCTL_BIN");
+    // SAFETY: tests run single-threaded (RUST_TEST_THREADS=1); all three restored below.
+    unsafe {
+        std::env::set_var("XDG_CONFIG_HOME", &base);
+        std::env::set_var("MOADIM_SYSTEMCTL_BIN", "/bin/true");
+        std::env::set_var("MOADIM_LOGINCTL_BIN", "/bin/true");
+    }
+
+    uninstall().unwrap();
+    assert!(
+        !marker.exists(),
+        "uninstall must remove the ownership marker once linger is disabled"
+    );
+
+    // Re-create the unit without a marker: lingering the operator set themselves must survive.
+    std::fs::write(&unit, "unit content").unwrap();
+    uninstall().unwrap();
+    assert!(
+        !marker.exists(),
+        "no marker means uninstall has nothing to clean up"
+    );
+
+    // SAFETY: single-threaded harness; restore the saved values.
+    unsafe {
+        match prev_xdg {
+            Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
+            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        }
+        match prev_systemctl {
+            Some(value) => std::env::set_var("MOADIM_SYSTEMCTL_BIN", value),
+            None => std::env::remove_var("MOADIM_SYSTEMCTL_BIN"),
+        }
+        match prev_loginctl {
+            Some(value) => std::env::set_var("MOADIM_LOGINCTL_BIN", value),
+            None => std::env::remove_var("MOADIM_LOGINCTL_BIN"),
+        }
+    }
+    let _ = std::fs::remove_dir_all(&base);
+}
+
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 #[test]
 fn run_succeeds_for_a_zero_exit_command() {

--- a/src/service/mod_tests.rs
+++ b/src/service/mod_tests.rs
@@ -516,6 +516,16 @@ fn uninstall_disables_linger_only_when_moadim_owns_it() {
     let _ = std::fs::remove_dir_all(&base);
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn disable_linger_if_owned_returns_when_unit_has_no_parent() {
+    // Covers the `None` arm of `linger_marker_path()` reached from inside
+    // `disable_linger_if_owned()`: a unit path with no parent directory (e.g. the filesystem
+    // root) has nowhere to look for the ownership marker, so the function must return without
+    // touching `loginctl` or panicking, instead of unwrapping `None`.
+    disable_linger_if_owned(std::path::Path::new("/"));
+}
+
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 #[test]
 fn run_succeeds_for_a_zero_exit_command() {


### PR DESCRIPTION
## Summary

`service::linux::install()` writes a systemd *user* unit and enables it with `systemctl --user enable --now`, but never enables lingering (`loginctl enable-linger`). Without lingering, a systemd user manager only runs while the user has an active login session:

- **Never starts at boot on a headless box** — with no interactive login after reboot, the user manager isn't started, so `moadim.service` never activates.
- **Dies on logout** — the last session closing tears down the user manager and stops `moadim.service`, even though `Restart=always`/`on-failure` is set (the restart policy doesn't survive manager shutdown).

## Change

- `install()` now calls `loginctl enable-linger` after enabling the unit. This is best-effort: if `loginctl` is unavailable or the call fails (no systemd-logind, insufficient privilege), it prints a warning with the manual command instead of failing the install.
- On success, a `.moadim-linger-enabled` marker file (sibling to the unit) records that *moadim* turned lingering on.
- `uninstall()` disables lingering only when that marker is present, so it never clobbers lingering the operator enabled themselves for an unrelated reason.
- The post-install summary now prints the linger status.

## Testing

- `cargo test --bin moadim service::` — 157 passed, 0 failed (run as a non-root user in a Linux container; the Linux-only `service::linux` module can't compile/run on this contributor's macOS machine, and the permission-based pre-existing tests need non-root to actually enforce mode bits).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- Cross-compiled `cargo check`/`cargo clippy --target x86_64-unknown-linux-musl` from macOS as an additional sanity check.

Closes #294