### PR TITLE
ci: run test and clippy jobs on macOS too

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -67,7 +67,14 @@ jobs:
 
   clippy:
     name: clippy
-    runs-on: ubuntu-latest
+    # macOS lints the `#[cfg(target_os = "macos")]` launchd service installer (src/service/macos.rs),
+    # which a Linux-only runner strips from compilation, so a lint regression there could land on
+    # main fully green. fail-fast: false so a failure on one OS still reports the other (#341).
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -82,9 +89,9 @@ jobs:
       - name: Cache cargo registry and target/
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          # Scoped so the `clippy` job's --all-targets target/ artifacts
-          # don't clobber the `test` job's cache entry.
-          shared-key: clippy
+          # Scoped so the `clippy` job's --all-targets target/ artifacts don't clobber the `test`
+          # job's cache entry, and so the two OSes in this job's matrix don't clobber each other's.
+          shared-key: clippy-${{ matrix.os }}
 
       - name: Run clippy
         # Match the local pre-push hook exactly: this is a non-virtual

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,14 @@ concurrency:
 jobs:
   test:
     name: cargo test
-    runs-on: ubuntu-latest
+    # macOS runs the `#[cfg(target_os = "macos")]` launchd service installer (src/service/macos.rs)
+    # and its tests, which a Linux-only runner silently strips from compilation and never
+    # exercises. fail-fast: false so a failure on one OS still reports the other (#341).
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -58,10 +65,10 @@ jobs:
       - name: Cache cargo registry and target/
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          # Scoped so the `test` and `clippy` jobs' target/ artifacts (built
-          # with different flags: plain build vs --all-targets clippy) don't
-          # clobber each other's cache entry.
-          shared-key: test
+          # Scoped so the `test` and `clippy` jobs' target/ artifacts (built with different flags:
+          # plain build vs --all-targets clippy) don't clobber each other's cache entry, and so the
+          # two OSes in this job's matrix don't clobber each other's either.
+          shared-key: test-${{ matrix.os }}
 
       - name: Run tests
         run: cargo test


### PR DESCRIPTION
## Summary

CI (`lint.yml`, `test.yml`) runs exclusively on `ubuntu-latest`, but `src/service/macos.rs` (the launchd LaunchAgent installer) and its `#[cfg(target_os = "macos")]` tests in `mod_tests.rs` are entirely stripped from compilation on a Linux runner. A compile error, type mismatch, or clippy violation in that code could currently land on `main` fully green — nothing in CI would catch it.

## Change

Both the `test` job (`test.yml`) and the `clippy` job (`lint.yml`) now run on an `[ubuntu-latest, macos-latest]` matrix with `fail-fast: false`, so a failure on one OS still reports the other. The existing `MOADIM_LAUNCHCTL_BIN`/`MOADIM_HOME_OVERRIDE` test seams already keep the macOS-gated tests from touching the runner's real launchd session, so the new job stays hermetic. The `rust-cache` `shared-key` for each job is suffixed with `${{ matrix.os }}` so the two OSes don't clobber each other's cache entry.

`fmt` and `coverage` stay Linux-only: formatting is OS-independent, and the 100% line-coverage gate is a single aggregate measurement that doesn't need duplicating per OS.

## Testing

- `actionlint .github/workflows/test.yml .github/workflows/lint.yml` — clean.
- YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`).

Closes #341