### PR TITLE
fix(routines): don't duplicate run history when workbench removal fails and retries

### DIFF
--- a/.changeset/dedupe-persisted-run-history-on-retry.md
+++ b/.changeset/dedupe-persisted-run-history-on-retry.md
@@ -1,0 +1,13 @@
+---
+"moadim": patch
+---
+
+fix: don't duplicate a workbench's `runs.log` entry when its removal is retried
+
+The reap sweep persists a finished workbench's outcome to the routine's durable
+`runs.log` *before* removing its directory, so `svc_list_runs` still knows
+about the run once the workbench is gone. If that `remove_dir_all` then fails
+(a permission hiccup, a file still open, a crash), the workbench survives and
+gets expired again on the next sweep — which re-persisted the same run,
+appending a duplicate `runs.log` entry every sweep the removal kept failing.
+The `persist` step now skips workbenches that already have a matching record.

--- a/src/routines/cleanup/cleanup_tests.rs
+++ b/src/routines/cleanup/cleanup_tests.rs
@@ -679,4 +679,62 @@ fn cleanup_expired_workbenches_persists_run_history_before_removal() {
     let _ = std::fs::remove_dir_all(&home);
 }
 
+#[test]
+fn cleanup_expired_workbenches_does_not_duplicate_history_on_retry() {
+    // Simulates a workbench whose `remove_dir_all` failed on a prior sweep: it still exists (as if
+    // recreated identically) and gets expired again on the next sweep. Without the
+    // `has_persisted_run` guard in the `persist` closure, this would append a second `runs.log`
+    // record for the same run every sweep the removal keeps failing.
+    let home = std::env::temp_dir().join(format!("moadim-cleanup-retry-{}", uuid::Uuid::new_v4()));
+    let previous = std::env::var_os("MOADIM_HOME_OVERRIDE");
+    // SAFETY: tests in this crate run single-threaded (RUST_TEST_THREADS=1); restored below.
+    unsafe {
+        std::env::set_var("MOADIM_HOME_OVERRIDE", &home);
+    }
+
+    let title = "Cleanup Retry ZZQ";
+    let slug = super::super::command::slugify(title);
+    let store = super::super::model::new_store();
+    store
+        .lock()
+        .unwrap()
+        .insert("retry-id".into(), make_routine("retry-id", title));
+
+    let workbenches = crate::paths::workbenches_dir();
+    let workbench = workbenches.join(format!("{slug}-1"));
+    std::fs::create_dir_all(&workbench).unwrap();
+    std::fs::write(workbench.join("exit_code"), "0").unwrap();
+
+    let first = cleanup_expired_workbenches(&store);
+    assert_eq!(first.removed, 1);
+    assert!(!workbench.exists());
+    assert_eq!(
+        super::super::run_history::read_persisted_runs("retry-id").len(),
+        1
+    );
+
+    // Recreate the identical workbench, standing in for a removal that failed and left it in
+    // place for the next sweep.
+    std::fs::create_dir_all(&workbench).unwrap();
+    std::fs::write(workbench.join("exit_code"), "0").unwrap();
+
+    let second = cleanup_expired_workbenches(&store);
+    assert_eq!(second.removed, 1);
+    let history = super::super::run_history::read_persisted_runs("retry-id");
+    assert_eq!(
+        history.len(),
+        1,
+        "the retry must not append a duplicate history entry for the same workbench"
+    );
+
+    // SAFETY: single-threaded harness; restore the saved override.
+    unsafe {
+        match previous {
+            Some(value) => std::env::set_var("MOADIM_HOME_OVERRIDE", value),
+            None => std::env::remove_var("MOADIM_HOME_OVERRIDE"),
+        }
+    }
+    let _ = std::fs::remove_dir_all(&home);
+}
+
 // `dir_size`/`freed_bytes` coverage lives in `cleanup_freed_bytes_tests.rs`.

--- a/src/routines/cleanup/mod.rs
+++ b/src/routines/cleanup/mod.rs
@@ -25,7 +25,7 @@ use crate::utils::claude_json::prune_project;
 use crate::utils::time::now_secs;
 
 use super::model::{RoutineStore, RunStatus};
-use super::run_history::{append_persisted_run, read_exit_code, PersistedRun};
+use super::run_history::{append_persisted_run, has_persisted_run, read_exit_code, PersistedRun};
 
 mod runtime;
 mod session;
@@ -313,6 +313,12 @@ pub fn cleanup_expired_workbenches(store: &RoutineStore) -> ReapStats {
             let Some(routine_id) = routine_ids.get(slug) else {
                 return;
             };
+            if has_persisted_run(routine_id, name) {
+                // Already recorded on a prior sweep whose `remove_dir_all` then failed, leaving
+                // this workbench to be re-expired and re-persisted on the next sweep. Skip it so
+                // one real run doesn't accumulate duplicate `runs.log` entries.
+                return;
+            }
             let exit_code = read_exit_code(workbench_path);
             let status = match exit_code {
                 Some(0) => RunStatus::Success,

--- a/src/routines/run_history.rs
+++ b/src/routines/run_history.rs
@@ -95,6 +95,19 @@ pub(crate) fn read_persisted_runs(id: &str) -> Vec<PersistedRun> {
         .collect()
 }
 
+/// Whether routine `id` already has a persisted record for `workbench`.
+///
+/// A reap sweep persists a workbench's outcome *before* removing its directory (see
+/// `cleanup::reap_dir`); if that removal then fails (permission hiccup, a still-open file, a crash),
+/// the workbench survives and is expired again on the next sweep. Callers use this to skip
+/// re-persisting a workbench that already made it into `runs.log`, so a stuck removal doesn't grow
+/// an unbounded run of duplicate history entries for the same run.
+pub(crate) fn has_persisted_run(id: &str, workbench: &str) -> bool {
+    read_persisted_runs(id)
+        .iter()
+        .any(|run| run.workbench == workbench)
+}
+
 #[cfg(test)]
 #[path = "run_history_tests.rs"]
 mod run_history_tests;

--- a/src/routines/run_history_tests.rs
+++ b/src/routines/run_history_tests.rs
@@ -131,6 +131,22 @@ fn append_persisted_run_is_best_effort_when_path_unwritable() {
     assert_eq!(read_persisted_runs("blocked-id"), vec![]);
 }
 
+#[test]
+fn has_persisted_run_false_when_file_absent() {
+    let _home = TempHome::set();
+    assert!(!has_persisted_run("no-such-id", "my-routine-1000"));
+}
+
+#[test]
+fn has_persisted_run_true_only_for_matching_workbench() {
+    let _home = TempHome::set();
+    append_persisted_run("some-id", &sample_run("my-routine-1000", 1000));
+
+    assert!(has_persisted_run("some-id", "my-routine-1000"));
+    assert!(!has_persisted_run("some-id", "my-routine-2000"));
+    assert!(!has_persisted_run("other-id", "my-routine-1000"));
+}
+
 #[cfg(unix)]
 #[test]
 fn append_persisted_run_creates_owner_only_log_and_dir() {


### PR DESCRIPTION
## Why

`cleanup::reap_dir` persists a finished workbench's outcome to the routine's
durable `runs.log` *before* removing its directory, so `svc_list_runs` /
`svc_list_all_runs` still know about the run after the workbench itself is
gone (its `exit_code` file goes away with the directory).

If the subsequent `remove_dir_all` then fails — a permission hiccup, a file
still held open, a crash mid-sweep — the workbench directory survives and
still looks "finished + expired" on the next hourly sweep. `reap_dir` would
run the same persist step again, and since `append_persisted_run` only ever
appends and nothing deduplicates, the same run got a second `runs.log`
record. This would repeat every sweep the removal kept failing, so one real
run could accumulate an unbounded number of duplicate history entries
surfaced through the run-history API/UI.

## What changed

- Added `run_history::has_persisted_run(id, workbench)`, checking whether a
  routine's `runs.log` already has a record for a given workbench name.
- The `persist` closure in `cleanup_expired_workbenches` now skips persisting
  (and, implicitly, gets a fresh chance to retry removal) when the workbench
  was already recorded on a prior sweep.

## Testing

- `run_history_tests.rs`: new unit tests for `has_persisted_run`
  (absent file, matching/non-matching workbench, different routine id).
- `cleanup_tests.rs`: new integration test
  `cleanup_expired_workbenches_does_not_duplicate_history_on_retry` that runs
  `cleanup_expired_workbenches` twice against the same workbench name
  (simulating a removal that failed and left the workbench in place) and
  asserts `runs.log` still has exactly one entry.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` all pass locally (891 tests).
- A changeset (`patch`) is included since this touches `src/`.

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.