### PR TITLE
test(claude_json): cover prune_project_at's error-propagation branches

### DIFF
--- a/.changeset/claude-json-prune-error-paths.md
+++ b/.changeset/claude-json-prune-error-paths.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Add tests exercising `prune_project_at`/`prune_locked`'s three previously branch-uncovered `?` error paths in `src/utils/claude_json.rs` (lock-file creation denied, `~/.claude.json` unreadable, and `atomic_write`'s temp-file creation denied). No behavior change — test-only.

--- a/src/utils/claude_json_tests.rs
+++ b/src/utils/claude_json_tests.rs
@@ -146,6 +146,67 @@ fn lock_exclusive_and_unlock_round_trip_on_a_real_file() {
 
 #[cfg(unix)]
 #[test]
+fn prune_project_at_errors_when_lock_file_cannot_be_created() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    // No `.claude.json.lock` exists yet, and the containing directory is read-only, so
+    // `File::create(&lock_path)` in `prune_project_at` fails with a permission error —
+    // exercising that `?` without touching `prune_locked` at all.
+    let dir = temp_dir("lock-create-denied");
+    let claude_json = dir.join(".claude.json");
+    fs::write(&claude_json, r#"{"projects":{}}"#).unwrap();
+    fs::set_permissions(&dir, fs::Permissions::from_mode(0o555)).unwrap();
+
+    let result = prune_project_at(Some(claude_json), Path::new("/workbenches/gone"));
+
+    fs::set_permissions(&dir, fs::Permissions::from_mode(0o755)).unwrap();
+    assert!(result.is_err());
+    fs::remove_dir_all(&dir).unwrap();
+}
+
+#[test]
+fn prune_project_at_errors_when_claude_json_is_a_directory() {
+    // `claude_json.exists()` is true for a directory too, so this reaches `prune_locked`, where
+    // `fs::read_to_string` fails because the path isn't a regular file.
+    let dir = temp_dir("claude-json-is-dir");
+    let claude_json = dir.join(".claude.json");
+    fs::create_dir(&claude_json).unwrap();
+
+    let result = prune_project_at(Some(claude_json), Path::new("/workbenches/gone"));
+
+    assert!(result.is_err());
+    fs::remove_dir_all(&dir).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn prune_project_at_errors_when_atomic_write_cannot_create_its_temp_file() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    // The lock file already exists, so `File::create` on it only needs to truncate an existing
+    // directory entry (no directory-write permission required). The matching `projects` entry
+    // still gets removed in memory, but the read-only directory then rejects the sibling temp
+    // file `atomic_write` creates before its rename, exercising that `?` specifically.
+    let dir = temp_dir("atomic-write-denied");
+    let claude_json = dir.join(".claude.json");
+    let workbench = "/home/u/.moadim/workbenches/my-routine-1700000000";
+    fs::write(
+        &claude_json,
+        format!(r#"{{"projects":{{"{workbench}":{{}}}}}}"#),
+    )
+    .unwrap();
+    fs::write(lock_path_for(&claude_json), "").unwrap();
+    fs::set_permissions(&dir, fs::Permissions::from_mode(0o555)).unwrap();
+
+    let result = prune_project_at(Some(claude_json), Path::new(workbench));
+
+    fs::set_permissions(&dir, fs::Permissions::from_mode(0o755)).unwrap();
+    assert!(result.is_err());
+    fs::remove_dir_all(&dir).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
 fn lock_exclusive_and_unlock_error_on_a_closed_fd() {
     use std::os::fd::AsRawFd as _;
 


### PR DESCRIPTION
## Problem

`src/utils/claude_json.rs`'s `prune_project_at`/`prune_locked` have four `?`-propagated error sites:

- `File::create(&lock_path)?` (lock-file creation)
- `lock_exclusive(&lock_file)?` (flock call-site)
- `fs::read_to_string(claude_json)?` (reading `~/.claude.json`)
- `atomic_write(claude_json, &bytes)?` (rewriting it)

`src/utils/claude_json_tests.rs` unit-tests `lock_exclusive`/`unlock` returning `Err` in isolation (`lock_exclusive_and_unlock_error_on_a_closed_fd`), but no test ever drives an `Err` through `prune_project_at`/`prune_locked` themselves — the line-coverage gate stays green (the line executes either way), but the error-handling branch at each of these sites is untested.

## Fix

Three new tests exercise three of the four sites end-to-end through the public-ish `prune_project_at` entry point:

- `prune_project_at_errors_when_lock_file_cannot_be_created` — read-only parent dir, no lock file yet, so `File::create` fails.
- `prune_project_at_errors_when_claude_json_is_a_directory` — `claude_json` is a directory (still `.exists()`), so `fs::read_to_string` fails.
- `prune_project_at_errors_when_atomic_write_cannot_create_its_temp_file` — lock file pre-created (so its `File::create` only truncates, no dir-write needed) but the dir is read-only, so `atomic_write`'s sibling temp file creation fails after the entry is removed in memory.

The fourth site (`lock_exclusive`'s call-site `Err`) isn't included — `flock` on a fresh, validly-opened fd doesn't have a reliable, non-racy way to fail in a test environment without duplicating the existing closed-fd trick at a level that no longer represents this call site.

No behavior change — test-only.

## Verification

- `cargo fmt --check` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — pass
- `cargo test --bin moadim` — 891/891 pass (3 new)
- `cargo llvm-cov --bin moadim --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — pass, 100% lines maintained

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.

cc @tupe12334