### PR TITLE
fix(server): skip openapi.json write when the target dir doesn't exist

### DIFF
--- a/.changeset/openapi-spec-skip-missing-dir.md
+++ b/.changeset/openapi-spec-skip-missing-dir.md
@@ -1,0 +1,13 @@
+---
+"moadim": patch
+---
+
+fix(server): stop warning on every startup about the openapi.json write
+
+`write_openapi_spec` targets `CARGO_MANIFEST_DIR/apis/openapi.json`, a path
+baked in at compile time. For an installed binary (`cargo install`), that
+directory is wherever the crate happened to build and generally doesn't
+exist on the end user's machine, so every server startup logged a
+`could not write openapi spec: ...` warning for a file nobody expects to be
+writable there (#319). Skip the write when its parent directory doesn't
+exist instead of attempting and warning.

--- a/src/routes/http.rs
+++ b/src/routes/http.rs
@@ -471,7 +471,15 @@ pub(crate) fn build_app_with_shutdown(
 /// Best-effort: the spec is a development convenience (committed under `apis/`), so a write
 /// failure must not abort server startup. Extracted from [`run_with_listener_until`] so the
 /// failure branch can be exercised against an unwritable path.
+///
+/// `path` is `CARGO_MANIFEST_DIR/apis/openapi.json`, baked in at compile time. For an installed
+/// binary (`cargo install`), that directory is wherever the crate happened to build, which
+/// generally doesn't exist on the end user's machine — skip silently rather than warning on
+/// every startup for a path nobody expects to be writable (#319).
 pub(crate) fn write_openapi_spec(path: &std::path::Path) {
+    if !path.parent().is_some_and(std::path::Path::is_dir) {
+        return;
+    }
     if let Err(err) = std::fs::write(path, crate::openapi::ApiDoc::to_json()) {
         log::warn!("could not write openapi spec: {err}");
     }

--- a/src/routes/http_tests.rs
+++ b/src/routes/http_tests.rs
@@ -26,18 +26,35 @@ fn write_openapi_spec_writes_json_to_path() {
 
 #[test]
 fn write_openapi_spec_logs_on_write_failure() {
-    // The target's parent is a regular file, so writing the spec underneath it fails,
-    // exercising the best-effort `log::warn!` branch. The call must not panic.
+    // The parent directory exists (so the missing-parent skip doesn't fire), but the target path
+    // is itself a directory, so the write fails — exercising the best-effort `log::warn!` branch.
+    // The call must not panic.
     let dir = std::env::temp_dir().join(format!("moadim-openapi-fail-{}", uuid::Uuid::new_v4()));
-    std::fs::create_dir_all(&dir).unwrap();
-    let blocker = dir.join("blocker");
-    std::fs::write(&blocker, "i am a file").unwrap();
-    let unwritable = blocker.join("openapi.json");
+    let unwritable = dir.join("openapi.json");
+    std::fs::create_dir_all(&unwritable).unwrap();
 
     write_openapi_spec(&unwritable);
 
-    assert!(!unwritable.exists(), "the write should have failed");
+    assert!(
+        unwritable.is_dir(),
+        "the write should have failed, leaving the directory untouched"
+    );
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn write_openapi_spec_skips_when_parent_dir_is_missing() {
+    // Mirrors an installed binary: CARGO_MANIFEST_DIR was baked in at compile time on the build
+    // machine and doesn't exist here, so the write must be skipped, not attempted-and-warned.
+    let dir = std::env::temp_dir().join(format!("moadim-openapi-missing-{}", uuid::Uuid::new_v4()));
+    let path = dir.join("openapi.json");
+
+    write_openapi_spec(&path);
+
+    assert!(
+        !path.exists(),
+        "should not create the parent dir or the file"
+    );
 }
 
 // ── build_app / router smoke tests ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `write_openapi_spec` targets `CARGO_MANIFEST_DIR/apis/openapi.json`, a path baked in at compile time.
- For an installed binary (`cargo install`), that directory is wherever the crate happened to build — generally absent on the end user's machine — so every server startup logged a `could not write openapi spec: ...` warning for a file nobody expects to be writable there (#319).
- Skip the write when the parent directory doesn't exist instead of attempting it and warning; behavior for dev checkouts (where `apis/` exists) is unchanged.

## Test plan
- [x] `cargo test` — 892 passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Added `write_openapi_spec_skips_when_parent_dir_is_missing`; adjusted the existing write-failure test to still exercise the `log::warn!` branch (parent dir present, target path itself a directory) now that the missing-parent case is handled separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)