### PR TITLE
fix(routines): cap agent.log reads to the last 2 MiB

### DIFF
--- a/.changeset/bound-log-read-size.md
+++ b/.changeset/bound-log-read-size.md
@@ -1,0 +1,14 @@
+---
+"moadim": patch
+---
+
+fix(routines): cap agent.log reads to the last 2 MiB
+
+`GET /routines/{id}/logs`, the run-detail log endpoint, and the `logs` MCP
+tool all read a run's `agent.log` in full via `read_to_string`. A
+long-running or noisy agent can grow that file without bound, so serving it
+whole risks an out-of-memory daemon and a multi-hundred-MB HTTP response for
+one request. Both now go through a shared `read_log_tail` helper that caps
+the read to the most recent 2 MiB, snapped to a UTF-8 character boundary so
+a multi-byte character split by the byte-offset seek isn't mangled, and
+prefixes a marker noting how many bytes were omitted.

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -644,6 +644,8 @@ mod service_trigger;
 use service_trigger::migrate_workbenches;
 #[cfg(test)]
 pub(crate) use service_trigger::sh_bin;
+#[cfg(test)]
+pub(crate) use service_trigger::{read_log_tail, MAX_LOG_TAIL_BYTES};
 pub use service_trigger::{
     svc_cleanup, svc_create_flag, svc_list_all_runs, svc_list_flags, svc_list_runs, svc_logs,
     svc_resolve_flag, svc_run_log, svc_set_power_saving, svc_snooze, svc_trigger,

--- a/src/routines/service_logs_tests.rs
+++ b/src/routines/service_logs_tests.rs
@@ -151,3 +151,85 @@ fn svc_logs_missing_routine_not_found() {
         Err(AppError::NotFound)
     ));
 }
+
+#[test]
+fn read_log_tail_returns_whole_file_under_the_cap() {
+    let dir = std::env::temp_dir().join(format!("moadim-logtail-small-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("agent.log");
+    std::fs::write(&path, "short log\n").unwrap();
+
+    assert_eq!(read_log_tail(&path).unwrap(), "short log\n");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn read_log_tail_truncates_and_notes_omitted_bytes() {
+    let dir = std::env::temp_dir().join(format!("moadim-logtail-big-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("agent.log");
+    // 3 bytes over the cap, so the tail drops exactly the first 3 leading "a"s.
+    let mut content = "a".repeat(MAX_LOG_TAIL_BYTES as usize);
+    content.push_str("END");
+    std::fs::write(&path, &content).unwrap();
+
+    let tail = read_log_tail(&path).unwrap();
+
+    assert_eq!(
+        tail,
+        format!(
+            "... [3 bytes omitted; showing the last {} bytes] ...\n{}END",
+            MAX_LOG_TAIL_BYTES,
+            "a".repeat(MAX_LOG_TAIL_BYTES as usize - 3),
+        )
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn read_log_tail_snaps_to_a_utf8_char_boundary() {
+    let dir = std::env::temp_dir().join(format!("moadim-logtail-utf8-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("agent.log");
+    // The file is exactly 1 byte over the cap, and its very first character is the 2-byte
+    // UTF-8 "é" straddling that 1-byte seek point. A naive byte-offset seek would land on
+    // é's stray continuation byte; the fix must skip it instead of emitting invalid UTF-8.
+    let content = format!("é{}", "a".repeat(MAX_LOG_TAIL_BYTES as usize - 1));
+    std::fs::write(&path, &content).unwrap();
+
+    let tail = read_log_tail(&path).unwrap();
+
+    assert_eq!(
+        tail,
+        format!(
+            "... [1 bytes omitted; showing the last {} bytes] ...\n{}",
+            MAX_LOG_TAIL_BYTES,
+            "a".repeat(MAX_LOG_TAIL_BYTES as usize - 1),
+        )
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn svc_logs_reads_through_the_size_cap() {
+    let _home = TempHome::set();
+    // End-to-end: svc_logs must go through read_log_tail, not a raw read_to_string, so an
+    // oversized agent.log doesn't get served in full.
+    let title = "Svc Logs Big ZZQ";
+    let slug = slugify(title);
+    let store = new_store();
+    store.lock().unwrap().insert(
+        "logs-big-id".into(),
+        make_routine("logs-big-id", title, 1, 1),
+    );
+
+    let workbenches = crate::paths::workbenches_dir();
+    let dir = workbenches.join(format!("{slug}-1"));
+    std::fs::create_dir_all(&dir).unwrap();
+    let big = "x".repeat(MAX_LOG_TAIL_BYTES as usize + 10);
+    std::fs::write(dir.join("agent.log"), &big).unwrap();
+
+    let logs = svc_logs(&store, "logs-big-id").unwrap();
+    assert_ne!(logs, big, "an oversized log must not be served in full");
+    assert!(logs.contains("10 bytes omitted"), "got: {logs}");
+}

--- a/src/routines/service_trigger.rs
+++ b/src/routines/service_trigger.rs
@@ -281,6 +281,42 @@ pub(super) fn migrate_workbenches(old_slug: &str, new_slug: &str) {
     }
 }
 
+/// Max bytes of `agent.log` returned by [`svc_logs`] / [`svc_run_log`]. A long-running or noisy
+/// agent can grow this file without bound; without a cap, serving the whole thing risks an
+/// out-of-memory daemon and a multi-hundred-MB HTTP response for one request. Keeps only the
+/// most recent bytes, since the tail is what matters for "what is this run doing right now".
+pub(crate) const MAX_LOG_TAIL_BYTES: u64 = 2 * 1024 * 1024;
+
+/// Read `path`, returning only the last [`MAX_LOG_TAIL_BYTES`] when it's larger than that.
+///
+/// The seek point is snapped forward to the next UTF-8 character boundary so a multi-byte
+/// character split by the byte-offset seek isn't silently mangled, and a truncated read is
+/// prefixed with a marker noting how many bytes were omitted rather than starting mid-line with
+/// no indication anything is missing.
+pub(crate) fn read_log_tail(path: &std::path::Path) -> std::io::Result<String> {
+    let len = std::fs::metadata(path)?.len();
+    if len <= MAX_LOG_TAIL_BYTES {
+        return std::fs::read_to_string(path);
+    }
+    use std::io::{Read, Seek, SeekFrom};
+    let omitted = len - MAX_LOG_TAIL_BYTES;
+    let mut file = std::fs::File::open(path)?;
+    file.seek(SeekFrom::Start(omitted))?;
+    let mut buf = Vec::with_capacity(MAX_LOG_TAIL_BYTES as usize);
+    file.read_to_end(&mut buf)?;
+    // A UTF-8 continuation byte is 10xxxxxx; skip up to 3 of them (the longest possible
+    // multi-byte sequence) to land on the next real character's leading byte.
+    let start = buf
+        .iter()
+        .take(4)
+        .position(|&byte| !(0x80..0xC0).contains(&byte))
+        .unwrap_or(0);
+    let tail = String::from_utf8_lossy(&buf[start..]);
+    Ok(format!(
+        "... [{omitted} bytes omitted; showing the last {MAX_LOG_TAIL_BYTES} bytes] ...\n{tail}"
+    ))
+}
+
 /// Return the contents of the newest workbench `agent.log` for routine `id`.
 pub fn svc_logs(store: &RoutineStore, id: &str) -> Result<String, AppError> {
     let routine = store
@@ -314,7 +350,7 @@ pub fn svc_logs(store: &RoutineStore, id: &str) -> Result<String, AppError> {
     if !log_path.exists() {
         return Ok(String::new());
     }
-    std::fs::read_to_string(&log_path).map_err(|_| AppError::Internal)
+    read_log_tail(&log_path).map_err(|_| AppError::Internal)
 }
 
 /// List every run for routine `id`, newest first: live (not-yet-reaped) workbenches, whose status
@@ -466,7 +502,7 @@ pub fn svc_run_log(store: &RoutineStore, id: &str, workbench: &str) -> Result<St
     if !log_path.exists() {
         return Ok(String::new());
     }
-    std::fs::read_to_string(&log_path).map_err(|_| AppError::Internal)
+    read_log_tail(&log_path).map_err(|_| AppError::Internal)
 }
 
 /// Reject a blank (empty/whitespace-only) flag `type` or `description`.


### PR DESCRIPTION
## Summary
- `svc_logs` (`GET /routines/{id}/logs`, MCP `logs` tool) and `svc_run_log` (run-detail log view) both read a run's `agent.log` in full via `read_to_string`.
- A long-running or noisy agent can grow that file without bound (see #278/#279/#280/#281), so serving it whole risks an out-of-memory daemon and a multi-hundred-MB HTTP response for one request.
- Both now go through a shared `read_log_tail` helper: caps the read to the most recent 2 MiB, snaps the seek point forward to a UTF-8 character boundary (so a multi-byte character split by the byte-offset seek isn't mangled), and prefixes a `... [N bytes omitted; showing the last 2097152 bytes] ...` marker so truncation is visible rather than silent.
- Small files (the common case) are unaffected — same `read_to_string` path when under the cap.

## Test plan
- [x] `cargo test` — 895 passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% lines maintained
- [x] New tests: whole-file-under-cap, truncation-with-marker, UTF-8 boundary snapping (character straddling the exact seek point), and an end-to-end `svc_logs` test confirming an oversized log isn't served in full

🤖 Generated with [Claude Code](https://claude.com/claude-code)