### PR TITLE
fix(routines): anchor overlap guard's tmux prefix match to $RID's shape

### DIFF
--- a/.changeset/overlap-guard-slug-prefix-collision.md
+++ b/.changeset/overlap-guard-slug-prefix-collision.md
@@ -1,0 +1,7 @@
+---
+"moadim": patch
+---
+
+### Fixed
+
+The overlap guard (#514) matched a live tmux session by a plain string prefix (`moadim-<slug>-`), so a routine whose slug is itself a prefix of another routine's slug (e.g. `deploy` vs. `deploy-staging`) could have its own fire silently skipped by an unrelated routine's session — `"moadim-deploy-staging-<rid>".starts_with("moadim-deploy-")` read as "deploy is still running" even when deploy had no session of its own. The match now requires the text after the prefix to have the exact `$RID` shape the launcher emits (`<unix-ts>_<pid>`), so only a genuine fire of the same routine counts.

--- a/src/routines/cleanup/cleanup_tests.rs
+++ b/src/routines/cleanup/cleanup_tests.rs
@@ -105,9 +105,12 @@ fn tmux_session_prefix_alive_matches_any_session_starting_with_prefix() {
     let dir = std::env::temp_dir().join(format!("moadim-tmux-prefix-{}", uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&dir).unwrap();
     let stub = dir.join("tmux");
+    // Real `$RID` shape (`SESS="moadim-$SLUG-$RID"`, `RID="${TS}_$$"`): digits, `_`, digits.
+    // `moadim-baz-qux-300_3` is a *different* routine (slug `baz-qux`) whose session name is a
+    // literal string-prefix superset of slug `baz`'s own prefix — no genuine `baz` fire is listed.
     std::fs::write(
         &stub,
-        "#!/bin/sh\nprintf 'moadim-other-100\\nmoadim-foo-200\\n'\nexit 0\n",
+        "#!/bin/sh\nprintf 'moadim-other-100_1\\nmoadim-foo-200_2\\nmoadim-baz-qux-300_3\\n'\nexit 0\n",
     )
     .unwrap();
     #[cfg(unix)]
@@ -124,6 +127,11 @@ fn tmux_session_prefix_alive_matches_any_session_starting_with_prefix() {
     assert!(
         !super::session::tmux_session_prefix_alive("moadim-bar-"),
         "no listed session starts with this prefix"
+    );
+    assert!(
+        !super::session::tmux_session_prefix_alive("moadim-baz-"),
+        "a different routine's session name being a string-superset of the prefix (baz-qux vs. \
+         baz) must not read as baz's own fire still being alive"
     );
 
     // SAFETY: single-threaded harness; restore the saved override.

--- a/src/routines/cleanup/session.rs
+++ b/src/routines/cleanup/session.rs
@@ -60,8 +60,27 @@ pub(crate) fn tmux_session_prefix_alive(prefix: &str) -> bool {
             out.status.success()
                 && String::from_utf8_lossy(&out.stdout)
                     .lines()
-                    .any(|name| name.starts_with(prefix))
+                    .any(|name| is_fire_of_prefix(name, prefix))
         })
+}
+
+/// Return `true` if `name` is a tmux session name for *this* routine's `prefix`
+/// (`moadim-{slug}-`), not merely a different routine whose slug happens to be a string-prefix of
+/// this one's (e.g. slug `deploy` vs slug `deploy-staging`: `"moadim-deploy-"` is a literal prefix
+/// of `"moadim-deploy-staging-<rid>"`). A plain [`str::starts_with`] treated that as a match,
+/// falsely suppressing `deploy`'s own fire while an unrelated `deploy-staging` run was alive.
+///
+/// Requires the remainder after `prefix` to have the exact `$RID` shape `build_routine_command`
+/// emits (`${TS}_$$`, i.e. `<digits>_<digits>`) rather than any suffix at all.
+fn is_fire_of_prefix(name: &str, prefix: &str) -> bool {
+    name.strip_prefix(prefix).is_some_and(|rid| {
+        rid.split_once('_').is_some_and(|(ts, pid)| {
+            !ts.is_empty()
+                && !pid.is_empty()
+                && ts.bytes().all(|byte| byte.is_ascii_digit())
+                && pid.bytes().all(|byte| byte.is_ascii_digit())
+        })
+    })
 }
 
 /// Force-kill the tmux session named `session` (best-effort).
@@ -92,3 +111,7 @@ pub(super) fn note_forced_kill(workbench: &Path) {
         let _ = file.write_all(b"moadim: routine exceeded max runtime; killing session\n");
     }
 }
+
+#[cfg(test)]
+#[path = "session_tests.rs"]
+mod session_tests;

--- a/src/routines/cleanup/session_tests.rs
+++ b/src/routines/cleanup/session_tests.rs
@@ -1,0 +1,39 @@
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and fixtures do not need doc comments"
+)]
+
+use super::*;
+
+#[test]
+fn is_fire_of_prefix_matches_same_routine_rid() {
+    // Real shape emitted by `SESS="moadim-$SLUG-$RID"` where `RID="${TS}_$$"`.
+    assert!(is_fire_of_prefix(
+        "moadim-deploy-1730000000_4821",
+        "moadim-deploy-"
+    ));
+}
+
+#[test]
+fn is_fire_of_prefix_rejects_a_different_routine_whose_slug_is_a_prefix() {
+    // Regression for the overlap-guard false positive: slug `deploy` is a plain string-prefix of
+    // slug `deploy-staging`, so `"moadim-deploy-staging-<rid>".starts_with("moadim-deploy-")` used
+    // to read as "deploy's own fire is still alive" and silently skip deploy's launch.
+    assert!(!is_fire_of_prefix(
+        "moadim-deploy-staging-1730000000_4821",
+        "moadim-deploy-"
+    ));
+}
+
+#[test]
+fn is_fire_of_prefix_rejects_non_rid_suffix() {
+    assert!(!is_fire_of_prefix(
+        "moadim-deploy-not-a-rid",
+        "moadim-deploy-"
+    ));
+}
+
+#[test]
+fn is_fire_of_prefix_rejects_missing_prefix() {
+    assert!(!is_fire_of_prefix("other-session-1_2", "moadim-deploy-"));
+}

--- a/src/routines/service_overlap_guard_tests.rs
+++ b/src/routines/service_overlap_guard_tests.rs
@@ -77,9 +77,11 @@ fn svc_trigger_skips_spawn_when_a_previous_run_is_still_alive() {
     let dir = std::env::temp_dir().join(format!("moadim-svc-overlap-{}", uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&dir).unwrap();
     let stub = dir.join("tmux");
+    // Real `$RID` shape (`SESS="moadim-$SLUG-$RID"`, `RID="${TS}_$$"`): digits, `_`, digits —
+    // anything else no longer counts as a live fire of this routine (see `is_fire_of_prefix`).
     std::fs::write(
         &stub,
-        format!("#!/bin/sh\nprintf 'moadim-{slug}-1\\n'\nexit 0\n"),
+        format!("#!/bin/sh\nprintf 'moadim-{slug}-1730000000_4821\\n'\nexit 0\n"),
     )
     .unwrap();
     #[cfg(unix)]


### PR DESCRIPTION
## Problem

The per-routine overlap guard (#514) detects "is a previous fire of this routine still running" with a plain string-prefix match: `tmux_session_prefix_alive` lists live tmux sessions and checks `name.starts_with("moadim-{slug}-")`.

That prefix is not anchored to anything after the slug. So if one routine's slug is itself a string-prefix of another routine's slug — e.g. title "Deploy" (slug `deploy`) and title "Deploy Staging" (slug `deploy-staging`) — then while `deploy-staging`'s session `moadim-deploy-staging-<rid>` is alive, it also satisfies `starts_with("moadim-deploy-")`. `deploy`'s own scheduled/manual fire then gets silently skipped by the guard, logged only as "overlap guard" — even though `deploy` has no session of its own running. `slugify`'s rule (any run of non-alphanumeric characters collapses to one `-`) makes such prefix/suffix slug collisions easy to hit in practice ("Sync" / "Sync Prod", "Build" / "Build Frontend", etc).

## Fix

`build_routine_command` always emits the session name as `moadim-$SLUG-$RID` where `RID="${TS}_$$"` (a unix timestamp, `_`, and the launcher shell's PID). The guard now requires the text after the `moadim-{slug}-` prefix to have exactly that shape (`<digits>_<digits>`) instead of accepting any suffix, so a session only counts as "this routine's own fire" when it actually is one.

The matching logic is pulled out into a small, pure `is_fire_of_prefix` helper with direct unit tests (no tmux stub subprocess needed). Two existing tests used session-name fixtures that weren't actually shaped like a real `$RID` (e.g. `moadim-foo-200` with no underscore); under the old unanchored match this didn't matter, but it meant they happened to stop exercising the "guard triggers" branch once the match got stricter, so I updated those fixtures to a realistic `<ts>_<pid>` suffix and added a same-fixture regression case for the cross-slug collision.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 895 + 255 passing (4 new)
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% lines, exit 0
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items` — clean

Added a changeset (`moadim`: patch) per the repo's changesets setup.

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim. @tupe12334 feel free to tag me back in if you'd like changes.