### PR TITLE
fix(routines): strip ANSI escapes and \r-redraw noise from served logs

### DIFF
--- a/.changeset/strip-log-ansi-redraw-noise.md
+++ b/.changeset/strip-log-ansi-redraw-noise.md
@@ -1,0 +1,15 @@
+---
+"moadim": patch
+---
+
+fix(routines): strip ANSI escapes and `\r`-redraw noise from served logs
+
+`tmux pipe-pane -o` captures a routine's pane output verbatim, so `GET
+/routines/{id}/logs`, the run-detail log endpoint, and the `logs` MCP tool
+all served raw terminal escape sequences (color codes, cursor movement,
+screen clears) and every redraw frame of a spinner or progress bar as its
+own line, instead of the final state a real terminal would display (#278).
+`read_log_tail` now strips ANSI/VT escape sequences and collapses
+`\r`-based redraw overwrites down to the last write per line before
+returning content, so served logs read as the logical lines an operator
+would actually see in a terminal.

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -645,7 +645,7 @@ use service_trigger::migrate_workbenches;
 #[cfg(test)]
 pub(crate) use service_trigger::sh_bin;
 #[cfg(test)]
-pub(crate) use service_trigger::{read_log_tail, MAX_LOG_TAIL_BYTES};
+pub(crate) use service_trigger::{read_log_tail, strip_ansi_noise, MAX_LOG_TAIL_BYTES};
 pub use service_trigger::{
     svc_cleanup, svc_create_flag, svc_list_all_runs, svc_list_flags, svc_list_runs, svc_logs,
     svc_resolve_flag, svc_run_log, svc_set_power_saving, svc_snooze, svc_trigger,

--- a/src/routines/service_trigger.rs
+++ b/src/routines/service_trigger.rs
@@ -292,11 +292,13 @@ pub(crate) const MAX_LOG_TAIL_BYTES: u64 = 2 * 1024 * 1024;
 /// The seek point is snapped forward to the next UTF-8 character boundary so a multi-byte
 /// character split by the byte-offset seek isn't silently mangled, and a truncated read is
 /// prefixed with a marker noting how many bytes were omitted rather than starting mid-line with
-/// no indication anything is missing.
+/// no indication anything is missing. [`strip_ansi_noise`] runs over the returned content so
+/// terminal escape sequences and `\r`-redraw noise from the raw `tmux pipe-pane` capture (#278)
+/// don't clutter the served log.
 pub(crate) fn read_log_tail(path: &std::path::Path) -> std::io::Result<String> {
     let len = std::fs::metadata(path)?.len();
     if len <= MAX_LOG_TAIL_BYTES {
-        return std::fs::read_to_string(path);
+        return std::fs::read_to_string(path).map(|contents| strip_ansi_noise(&contents));
     }
     use std::io::{Read, Seek, SeekFrom};
     let omitted = len - MAX_LOG_TAIL_BYTES;
@@ -313,8 +315,75 @@ pub(crate) fn read_log_tail(path: &std::path::Path) -> std::io::Result<String> {
         .unwrap_or(0);
     let tail = String::from_utf8_lossy(&buf[start..]);
     Ok(format!(
-        "... [{omitted} bytes omitted; showing the last {MAX_LOG_TAIL_BYTES} bytes] ...\n{tail}"
+        "... [{omitted} bytes omitted; showing the last {MAX_LOG_TAIL_BYTES} bytes] ...\n{}",
+        strip_ansi_noise(&tail)
     ))
+}
+
+/// Strip raw `tmux pipe-pane` capture noise from `input`: ANSI/VT escape sequences (color codes,
+/// cursor movement, screen clears) and `\r`-based redraw overwrites from full-screen TUI agents.
+///
+/// `tmux pipe-pane -o` streams the pane's raw output verbatim, so a served log otherwise shows
+/// escape codes as literal garbage and every redraw frame of a spinner/progress bar as a separate
+/// line instead of the final, overwritten state a real terminal would display.
+pub(crate) fn strip_ansi_noise(input: &str) -> String {
+    let without_escapes = strip_escape_sequences(input);
+    collapse_carriage_returns(&without_escapes)
+}
+
+/// Remove ANSI escape sequences: CSI (`ESC [ … final-byte`), OSC (`ESC ] … BEL` or `ESC ] … ESC \`),
+/// and bare two-character escapes (e.g. `ESC c` full reset). A lone trailing `ESC` with no
+/// follow-up byte is dropped as-is.
+fn strip_escape_sequences(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(current) = chars.next() {
+        if current != '\u{1B}' {
+            out.push(current);
+            continue;
+        }
+        match chars.peek() {
+            Some('[') => {
+                chars.next();
+                for pc in chars.by_ref() {
+                    if ('@'..='~').contains(&pc) {
+                        break;
+                    }
+                }
+            }
+            Some(']') => {
+                chars.next();
+                loop {
+                    match chars.next() {
+                        Some('\u{7}') | None => break,
+                        Some('\u{1B}') => {
+                            if chars.peek() == Some(&'\\') {
+                                chars.next();
+                            }
+                            break;
+                        }
+                        Some(_) => {}
+                    }
+                }
+            }
+            Some(_) => {
+                chars.next();
+            }
+            None => {}
+        }
+    }
+    out
+}
+
+/// Collapse `\r`-based redraw overwrites: within each `\n`-delimited line, keep only the text
+/// after the final `\r`, mirroring what a real terminal would leave on screen after a spinner or
+/// progress bar repeatedly returns to the start of the line and overwrites itself.
+fn collapse_carriage_returns(input: &str) -> String {
+    input
+        .split('\n')
+        .map(|line| line.rsplit('\r').next().unwrap_or(line))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// Return the contents of the newest workbench `agent.log` for routine `id`.

--- a/src/routines/service_trigger_tests.rs
+++ b/src/routines/service_trigger_tests.rs
@@ -673,3 +673,70 @@ fn svc_delete_syncs_crontab_on_success() {
         assert_eq!(deleted.routine.title, title);
     });
 }
+
+#[test]
+fn strip_ansi_noise_leaves_plain_text_untouched() {
+    assert_eq!(
+        strip_ansi_noise("plain log line\nsecond line\n"),
+        "plain log line\nsecond line\n"
+    );
+}
+
+#[test]
+fn strip_ansi_noise_removes_csi_color_codes() {
+    assert_eq!(strip_ansi_noise("\u{1B}[31mred\u{1B}[0m\n"), "red\n");
+}
+
+#[test]
+fn strip_ansi_noise_removes_osc_sequence_terminated_by_bel() {
+    assert_eq!(
+        strip_ansi_noise("\u{1B}]0;window title\u{7}after\n"),
+        "after\n"
+    );
+}
+
+#[test]
+fn strip_ansi_noise_removes_osc_sequence_terminated_by_escape_backslash() {
+    assert_eq!(
+        strip_ansi_noise("\u{1B}]0;window title\u{1B}\\after\n"),
+        "after\n"
+    );
+}
+
+#[test]
+fn strip_ansi_noise_drops_bare_two_byte_escape() {
+    // `ESC c` is a full terminal reset with no CSI/OSC bracket.
+    assert_eq!(strip_ansi_noise("before\u{1B}cafter\n"), "beforeafter\n");
+}
+
+#[test]
+fn strip_ansi_noise_drops_trailing_lone_escape() {
+    assert_eq!(strip_ansi_noise("before\u{1B}"), "before");
+}
+
+#[test]
+fn strip_ansi_noise_collapses_carriage_return_redraws() {
+    assert_eq!(
+        strip_ansi_noise("progress: 10%\rprogress: 100%\ndone\n"),
+        "progress: 100%\ndone\n"
+    );
+}
+
+#[test]
+fn strip_ansi_noise_handles_combined_escape_and_redraw_noise() {
+    assert_eq!(
+        strip_ansi_noise("\u{1B}[2K\u{1B}[1Gspin .\rspin ..\rspin ...\ndone\u{1B}[0m\n"),
+        "spin ...\ndone\n"
+    );
+}
+
+#[test]
+fn read_log_tail_strips_ansi_noise_from_a_whole_file_read() {
+    let dir = std::env::temp_dir().join(format!("moadim-logtail-ansi-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("agent.log");
+    std::fs::write(&path, "\u{1B}[31mred\u{1B}[0m line\rreal line\n").unwrap();
+
+    assert_eq!(read_log_tail(&path).unwrap(), "real line\n");
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## What

`read_log_tail` (used by `GET /routines/{id}/logs`, the run-detail log endpoint, and the `logs` MCP tool) now strips ANSI/VT escape sequences (CSI color/cursor codes, OSC title sequences) and collapses `\r`-based redraw overwrites down to the last write per line, before returning agent.log content.

## Why

`tmux pipe-pane -o` captures a routine's pane output verbatim. Escape sequences and full-screen TUI-agent redraws (spinners, progress bars) previously came through as literal garbage / one line per redraw frame instead of the final on-screen state, cluttering every log view. Addresses the retrieval/rendering half of #278 (ingestion-side capping is already handled separately by #1006's 2 MiB tail cap and #999's daemon.log rotation).

## Testing

- `cargo test` — 908 passed, including 9 new unit tests for the stripping logic and its wiring into `read_log_tail`
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% line coverage maintained
- `cargo doc --workspace --no-deps --document-private-items` (`RUSTDOCFLAGS=-D warnings`) — clean

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.