### PR TITLE
fix(pre-push): run cargo test --workspace so the ui crate's tests execute

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -54,7 +54,16 @@ cargo fmt --check
 # keep the two in lockstep so a green local push stays green in CI.
 cargo clippy --workspace --all-targets -- -D warnings
 
-# ── 4. Coverage ───────────────────────────────────────────────────────────────
+# ── 4. Test (workspace) ────────────────────────────────────────────────────────
+# `--workspace`, same reason as the clippy step above: this is a non-virtual
+# workspace (root Cargo.toml declares both a [package] and a [workspace]), so
+# a bare `cargo test` only runs the root `moadim` package's tests and
+# silently skips the `ui` member crate's ~250 tests. The coverage step below
+# also only instruments the root package (see its comment), so without this
+# step a broken `ui` unit test could pass the hook entirely.
+cargo test --workspace
+
+# ── 5. Coverage ───────────────────────────────────────────────────────────────
 # Requires: cargo install cargo-llvm-cov && rustup component add llvm-tools-preview
 if ! command -v cargo-llvm-cov >/dev/null 2>&1; then
   echo ""
@@ -65,9 +74,13 @@ if ! command -v cargo-llvm-cov >/dev/null 2>&1; then
 fi
 
 echo "Running coverage (100% line coverage required, excluding main.rs)..."
+# Deliberately scoped to the root package (no --workspace): the `ui` crate is
+# a Yew/WASM UI, and much of it is only meaningfully exercisable through a
+# browser, so it isn't held to this 100% line floor. Its own test suite still
+# runs above, via the workspace-wide `cargo test`.
 cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'
 
-# ── 5. Changelog ────────────────────────────────────────────────────────────────
+# ── 6. Changelog ────────────────────────────────────────────────────────────────
 # Mirror the CI `Changelog` workflow (.github/workflows/changelog.yml) locally so
 # pushes that would fail the `changeset status` check are caught before they hit
 # CI. If the commits being pushed touch `src/` or `ui/`, a new `.changeset/*.md`
@@ -75,7 +88,7 @@ cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'
 # local equivalent of the `skip-changelog` PR label) for deliberately
 # undocumented src/ui changes.
 
-# ── 6. Line-count gate ────────────────────────────────────────────────────────
+# ── 7. Line-count gate ────────────────────────────────────────────────────────
 # Requires: cargo install linecheck
 if ! command -v linecheck >/dev/null 2>&1; then
   echo ""

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,17 +31,18 @@ Run the checks the pre-push hook enforces before any push:
 ```sh
 cargo fmt --check
 cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
 cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'
 ```
 
-Use `--workspace --all-targets -- -D warnings` for clippy, exactly as the
-pre-push hook and the CI lint gate do — bare `cargo clippy` skips the `ui`
-member crate (this is a non-virtual workspace) as well as test/example/bench
-code, and only warns, so it can pass locally yet fail the hook and CI. The
-`cargo llvm-cov`
-command runs the test suite with instrumentation and enforces 100% line coverage
-(excluding `main.rs`); it subsumes a bare `cargo test`, so running it is enough
-to satisfy both the test and coverage gates in one pass.
+Use `--workspace` for both clippy and test, matching the pre-push hook —
+bare `cargo clippy`/`cargo test` skip the `ui` member crate entirely (this is
+a non-virtual workspace), so they can pass locally yet miss a real `ui`
+regression. `cargo llvm-cov` runs the test suite with instrumentation and
+enforces 100% line coverage (excluding `main.rs`), but is deliberately scoped
+to the root package only — the `ui` crate is a Yew/WASM UI that isn't held to
+that floor, so `cargo test --workspace` above is what actually exercises its
+own test suite.
 
 Enable the bundled git hooks once per clone:
 
@@ -100,8 +101,11 @@ Routines are persisted to the OS crontab so they run on schedule. See
 ## Tests
 
 ```sh
-cargo test
+cargo test --workspace
 ```
+
+`--workspace` matters here too: this is a non-virtual workspace, so a bare
+`cargo test` silently skips the `ui` member crate's tests.
 
 Tests must live in `*_tests.rs` sibling files, **not** inline
 `#[cfg(test)] mod foo { … }` blocks — the pre-push hook rejects inline blocks.


### PR DESCRIPTION
## Why

This is a non-virtual workspace (root `Cargo.toml` declares both a `[package]` and a `[workspace]` with member `ui`). The pre-push hook's lint step already learned this lesson and runs `cargo clippy --workspace` specifically because a bare `cargo clippy` silently skips the `ui` member crate — but the hook had no explicit test step at all. It relied on `cargo llvm-cov`, which (deliberately, per its own comment) only instruments the root package for the 100% line-coverage floor.

The result: the ~250 tests living in `ui/src/*_tests.rs` (`schedule`, `schedule_heatmap`, `routines::state`, `filter`, etc.) never actually ran as part of the pre-push hook. A broken `ui` unit test could pass a local push completely clean.

Verified locally:
- `cargo test` → 903 tests (root package only)
- `cargo test --workspace` → those same 903 **plus 255 more** from the `ui` crate

## What changed

- `.githooks/pre-push`: added an explicit `cargo test --workspace` step before the coverage step, with a comment explaining why `--workspace` is needed here (same root cause as the existing clippy fix) and why the coverage step below stays root-only on purpose (`ui` is a Yew/WASM UI not held to the 100% floor).
- `CONTRIBUTING.md`: updated both documented command lists (`Setup` and `Tests` sections) to use `cargo test --workspace`, keeping the docs in lockstep with the hook per this repo's own stated convention, and corrected a now-inaccurate claim that `cargo llvm-cov` "subsumes" a bare `cargo test`.

No `src/` or `ui/` code changed, so no changeset is needed (per the hook's own changeset-check logic).

## Known limitation

`.github/workflows/test.yml`'s CI "Run tests" job has the exact same bare `cargo test` gap and would benefit from the identical `--workspace` fix. I did not include that change here: pushing a change under `.github/workflows/` requires the OAuth `workflow` scope, which wasn't available in this environment. Flagging it in case a maintainer wants to apply the same one-line fix to that workflow file directly.

## Verification

Ran the full pre-push hook locally end-to-end (`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, the new `cargo test --workspace` step, `cargo llvm-cov --fail-under-lines 100`, `linecheck --max-lines 700`) — all green. Also ran `shellcheck` and `typos` against the changed files.

---

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.