### PR TITLE
fix(ci): gate manual v* tag publish/release on lint/test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,14 @@ name: Publish to crates.io
 
 # Publish the crate. Triggered two ways:
 #   * `workflow_call` from auto-release.yml on a version bump (automated path).
-#   * a manual `v*` tag push (escape hatch for hotfixes cut by hand).
+#     That commit already passed lint/test before landing on main (via
+#     cut-release.yml's `needs: [version, lint, test]` gate and/or PR branch
+#     protection), so re-running here would be redundant — skipped below.
+#   * a manual `v*` tag push (escape hatch for hotfixes cut by hand). Unlike
+#     the automated path, this can tag *any* commit, verified or not, so this
+#     is where the gap was (see #260): publish ran without ever checking
+#     cargo test/fmt/clippy. Fixed by calling lint.yml/test.yml (already
+#     workflow_call-callable) and gating `publish` on them via `needs:`.
 
 on:
   push:
@@ -22,8 +29,26 @@ permissions:
   contents: read
 
 jobs:
+  # Gate for the manual `push: tags` escape hatch only — see #260. Skipped
+  # entirely on the `workflow_call` path since that commit is already verified
+  # (see header comment above).
+  lint:
+    name: Lint tagged commit
+    if: github.event_name == 'push'
+    uses: ./.github/workflows/lint.yml
+
+  test:
+    name: Test tagged commit
+    if: github.event_name == 'push'
+    uses: ./.github/workflows/test.yml
+
   publish:
     name: Publish
+    needs: [lint, test]
+    # Run if lint/test passed (push path) or were skipped (workflow_call path).
+    # Do NOT use the default `success()` here: a skipped need would otherwise
+    # make this job skip too.
+    if: always() && (needs.lint.result == 'success' || needs.lint.result == 'skipped') && (needs.test.result == 'success' || needs.test.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       id-token: write # required for crates.io Trusted Publishing (OIDC)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,16 @@ name: GitHub Release
 
 # Cut a GitHub Release for a version. Triggered two ways:
 #   * `workflow_call` from auto-release.yml, right after it pushes the tag on a
-#     version bump (the automated path — see auto-release.yml).
-#   * a manual `v*` tag push (escape hatch for hotfixes cut by hand).
+#     version bump (the automated path — see auto-release.yml). That commit
+#     already passed lint/test before landing on main (via cut-release.yml's
+#     `needs: [version, lint, test]` gate and/or PR branch protection), so
+#     re-running here would be redundant — skipped below.
+#   * a manual `v*` tag push (escape hatch for hotfixes cut by hand). Unlike
+#     the automated path, this can tag *any* commit, verified or not, so this
+#     is where the gap was (see #260): a release could be cut without ever
+#     checking cargo test/fmt/clippy. Fixed by calling lint.yml/test.yml
+#     (already workflow_call-callable) and gating `release` on them via
+#     `needs:`.
 # Release notes are extracted from the matching version section in CHANGELOG.md
 # so the published notes stay in sync with the changelog. Runs independently of
 # publish.yml — neither blocks the other.
@@ -23,8 +31,26 @@ permissions:
   contents: write
 
 jobs:
+  # Gate for the manual `push: tags` escape hatch only — see #260. Skipped
+  # entirely on the `workflow_call` path since that commit is already verified
+  # (see header comment above).
+  lint:
+    name: Lint tagged commit
+    if: github.event_name == 'push'
+    uses: ./.github/workflows/lint.yml
+
+  test:
+    name: Test tagged commit
+    if: github.event_name == 'push'
+    uses: ./.github/workflows/test.yml
+
   release:
     name: Create GitHub Release
+    needs: [lint, test]
+    # Run if lint/test passed (push path) or were skipped (workflow_call path).
+    # Do NOT use the default `success()` here: a skipped need would otherwise
+    # make this job skip too.
+    if: always() && (needs.lint.result == 'success' || needs.lint.result == 'skipped') && (needs.test.result == 'success' || needs.test.result == 'skipped')
     runs-on: ubuntu-latest
     env:
       TAG: ${{ inputs.tag || github.ref_name }}


### PR DESCRIPTION
## Problem

`publish.yml` (crates.io publish) and `release.yml` (GitHub Release) both trigger on `push: tags: ['v*']`, but `test.yml`/`lint.yml` trigger only on `pull_request` and `push: branches: [main]`. A manually pushed `v*` tag (the documented escape hatch for hand-cut hotfixes) can therefore run `cargo publish` and cut a GitHub Release on **any** commit without ever running `cargo test`, `cargo fmt --check`, or `cargo clippy`. `publish.yml` only checks that `prebuilt.html` exists and that the tag matches `Cargo.toml`'s version — never that the suite is green. A bad tag ships to crates.io irreversibly.

## Fix

Add `lint`/`test` jobs to `publish.yml` and `release.yml` that reuse the existing, already `workflow_call`-callable `lint.yml`/`test.yml` workflows, and gate the `publish`/`release` job on them via `needs:`. These gate jobs run **only** when triggered by `push` (i.e. the manual tag-push escape hatch):

```yaml
lint:
  if: github.event_name == 'push'
  uses: ./.github/workflows/lint.yml
test:
  if: github.event_name == 'push'
  uses: ./.github/workflows/test.yml

publish: # (or `release`)
  needs: [lint, test]
  if: always() && (needs.lint.result == 'success' || needs.lint.result == 'skipped') && (needs.test.result == 'success' || needs.test.result == 'skipped')
```

### Why the automated `auto-release.yml` path is unaffected

`publish.yml`/`release.yml` are also invoked via `workflow_call` from `auto-release.yml` on every version-bump push to `main`. That commit is already verified before it ever reaches `main`: `cut-release.yml`'s `land` job requires `needs: [version, lint, test]` before fast-forwarding the bump commit onto `main` (and/or ordinary PRs are gated by `lint.yml`/`test.yml` on `pull_request`). Re-running lint/test again in the `workflow_call` path would be redundant, so the new `lint`/`test` jobs above are skipped (`if: github.event_name == 'push'` is false for `workflow_call`), and the `if:` on `publish`/`release` treats `skipped` the same as `success` so the automated path runs exactly as it did before — no regression, no added latency.

### Manual tag-push path (the actual gap)

Now runs the full `lint.yml` (fmt + clippy) and `test.yml` (test + coverage) suites against the tagged commit first. If either fails, `publish`/`release` does not run — no crates.io publish, no GitHub Release. If both pass, publish/release proceeds exactly as before.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open(...))"` — both edited files parse.
- `actionlint .github/workflows/publish.yml .github/workflows/release.yml .github/workflows/auto-release.yml .github/workflows/cut-release.yml .github/workflows/lint.yml .github/workflows/test.yml` — clean, no findings (this repo already vendors actionlint locally).
- Manually traced the job graph in both files: no cycles, `needs: [lint, test]` refer to jobs defined in the same file, `auto-release.yml`'s `workflow_call` wiring re-checked against the new `if:` conditions.

Closes #260