### PR TITLE
chore(lint): enable clippy::redundant_else

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,3 +144,10 @@ needless_pass_by_ref_mut = "deny"
 # constructing an empty `String` — it says "empty string" directly instead of
 # making the reader infer it from an empty literal plus a conversion call.
 manual_string_new = "deny"
+# Reject an `else` branch after an `if` whose every path already diverges
+# (return/break/continue/panic) — the `else` adds a level of nesting for
+# nothing, since control flow never falls through to it. Dropping it keeps the
+# non-diverging code unindented, matching this codebase's existing preference
+# for flat, early-return control flow (see `manual_let_else`, `if_not_else`
+# above). The codebase is already clean, so `deny` locks that in.
+redundant_else = "deny"


### PR DESCRIPTION
## Summary

Adds `redundant_else = "deny"` to `[lints.clippy]` in `Cargo.toml`, following the same "lock in an already-clean pedantic lint" pattern as the prior `use_self` (#725) and `match_same_arms` (#720) additions.

`clippy::redundant_else` flags an `else` branch following an `if` whose every path already diverges (`return`/`break`/`continue`/`panic!`) — the `else` adds a needless nesting level since control flow can never fall through to it. This matches the codebase's existing preference for flat, early-return control flow, already enforced via `manual_let_else` and `if_not_else`.

The codebase is already 100% compliant with this lint (confirmed via `cargo clippy --workspace --all-targets -- -W clippy::redundant_else`, zero warnings), so this is a pure ratchet: it costs nothing today and prevents regression going forward.

## Why this, specifically

I audited the repo for a small, high-value gap: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo llvm-cov --fail-under-lines 100`, and `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items` all currently pass clean on `main` — so there was no broken gate to restore. Several open issues that looked like promising small fixes (e.g. #894 cargo doc broken link, #315 stale pid file, #293 untested CLI network paths, #362 iCal refresh interval, #402 per-request timeout) turned out to already be resolved on `main` but not yet closed. This lint addition is a genuinely small, safe, reviewable improvement that wasn't already covered by any open PR or fixed-but-unclosed issue.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (255 passed)
- No changeset needed — this PR only touches `Cargo.toml`'s lint configuration, not `src/` or `ui/`.

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.