### PR TITLE
test(ui): cover Esc/CloseModal reducer behavior for routine modals

### DIFF
--- a/ui/src/routines/state_tests.rs
+++ b/ui/src/routines/state_tests.rs
@@ -483,3 +483,51 @@ fn sort_by_last_fire_descending_puts_newest_first() {
     assert_eq!(sorted[0].id, "new");
     assert_eq!(sorted[1].id, "old");
 }
+
+// ── CloseModal (Esc dismissal) ────────────────────────────────────────────────
+// `install_search_hotkey` (routines/hooks.rs) dispatches this same action when
+// Escape is pressed and a modal is open. These tests pin the reducer behavior
+// it relies on: every modal variant resets to `None`, and no destructive/data
+// action (delete, bulk-delete) ever fires as a side effect.
+
+#[test]
+fn close_modal_from_edit_resets_to_none() {
+    let s = state_with_routines(&["a"]);
+    let s = s.reduce(RAction::OpenEdit("a".into()));
+    assert_eq!(s.modal, RModal::Edit("a".into()));
+    let s = s.reduce(RAction::CloseModal);
+    assert_eq!(s.modal, RModal::None);
+}
+
+#[test]
+fn close_modal_from_confirm_delete_resets_to_none_without_deleting() {
+    let s = state_with_routines(&["a", "b"]);
+    let s = s.reduce(RAction::OpenConfirmDelete {
+        id: "a".into(),
+        title: "a".into(),
+    });
+    let s = s.reduce(RAction::CloseModal);
+    assert_eq!(s.modal, RModal::None);
+    // Esc must not act like a confirmed delete: both routines are still present.
+    assert_eq!(s.routines.len(), 2);
+}
+
+#[test]
+fn close_modal_from_confirm_bulk_delete_resets_to_none_without_deleting() {
+    let s = state_with_routines(&["a", "b"]);
+    let s = s.reduce(RAction::SelectAll(vec!["a".into(), "b".into()]));
+    let s = s.reduce(RAction::OpenConfirmBulkDelete);
+    let s = s.reduce(RAction::CloseModal);
+    assert_eq!(s.modal, RModal::None);
+    // Esc must not act like a confirmed bulk delete: selection and routines survive.
+    assert_eq!(s.routines.len(), 2);
+    assert_eq!(s.selected.len(), 2);
+}
+
+#[test]
+fn close_modal_is_a_noop_when_no_modal_is_open() {
+    let s = state_with_routines(&["a"]);
+    assert_eq!(s.modal, RModal::None);
+    let s = s.reduce(RAction::CloseModal);
+    assert_eq!(s.modal, RModal::None);
+}


### PR DESCRIPTION
## Why

#283 asks that every modal/dialog in the UI (routine Edit, routine
delete-confirm, cron-job modals, and the shutdown-confirm `ShutdownDialog`)
dismiss on Esc without firing its destructive/confirm action.

Investigating, that wiring already exists on `main`:

- `ui/src/main.rs`'s `Shell` keydown listener already closes `show_shutdown`
  and `show_rename_machine` on Escape.
- `ui/src/routines/hooks.rs`'s `install_search_hotkey` already dispatches
  `RAction::CloseModal` on Escape whenever `RModal != None` (covering the
  routine Edit / ConfirmDelete / ConfirmBulkDelete modals).
- Both were shipped in #810, merged before this issue was picked up. That PR
  just never referenced #283, so the issue was left open.
- The "cron-job edit/confirm modals" mentioned in #283's body no longer
  exist — the cron-jobs feature (and `cron_jobs.rs`) was removed entirely in
  #842, after #810 landed. Nothing to wire there anymore.

What was actually still missing was #283's last acceptance criterion:
_"Tests ... cover: Esc closes each modal type and is a no-op when none is
open."_ There was no test exercising `RAction::CloseModal` at all.

## What

Add reducer-level tests to `ui/src/routines/state_tests.rs` (the existing
pattern this file already uses for every other `RAction`):

- `close_modal_from_edit_resets_to_none`
- `close_modal_from_confirm_delete_resets_to_none_without_deleting`
- `close_modal_from_confirm_bulk_delete_resets_to_none_without_deleting`
- `close_modal_is_a_noop_when_no_modal_is_open`

These pin exactly the behavior `install_search_hotkey` relies on when Esc
fires: every `RModal` variant resets to `None`, no delete/bulk-delete ever
executes as a side effect, and dispatching `CloseModal` with no modal open
is inert. No production code changed — the fix was already shipped; this
closes the test-coverage gap the issue called out.

## Testing

- `cargo test --workspace`: 912 + 259 passed, 0 failed.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo build --workspace` and `cargo check -p ui --target wasm32-unknown-unknown`: clean.
- Test-only change (no `ui/` runtime behavior touched), so `prebuilt.html`
  doesn't need regenerating; labeled `skip-changelog` per CONTRIBUTING.md
  for the same reason.

Closes #283