### PR TITLE
chore: lower linecheck gate from 700 to 500 lines

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -97,9 +97,9 @@ if ! command -v linecheck >/dev/null 2>&1; then
   exit 1
 fi
 
-echo "Checking .rs files do not exceed 700 lines..."
+echo "Checking .rs files do not exceed 500 lines..."
 # shellcheck disable=SC2046
-linecheck --max-lines 700 $(find src ui/src -name '*.rs')
+linecheck --max-lines 500 $(find src ui/src -name '*.rs')
 echo "Line-count check passed."
 
 if [ "${SKIP_CHANGELOG:-0}" != "1" ]; then


### PR DESCRIPTION
## Summary
Lowers the `linecheck --max-lines` gate in `.githooks/pre-push` from 700 to 500, per #941.

## Out of scope
This PR is config-only — it does not split any files. Splitting the 30 `.rs` files currently over 500 lines is a separate, larger effort left for follow-up PRs.

Files currently over the new 500-line gate (would fail local `linecheck --max-lines 500`, ordered by size):

- `src/routines/service_trigger_tests.rs` (742)
- `src/cli.rs` (679)
- `ui/src/routines/page.rs` (668)
- `ui/src/main.rs` (663)
- `ui/src/overview.rs` (661)
- `src/routines/service_tests.rs` (661)
- `src/routine_storage_tests.rs` (661)
- `src/routes/http_listener_tests.rs` (658)
- `ui/src/routines/filter_tests.rs` (650)
- `src/routines/service_trigger.rs` (650)
- `src/routes/http.rs` (637)
- `src/cli_tests.rs` (617)
- `src/routes/http_tests.rs` (613)
- `src/routine_storage.rs` (605)
- `src/routes/mcp_tests.rs` (595)
- `src/routines/command.rs` (591)
- `src/routines/service_sync_tests.rs` (590)
- `src/commands.rs` (559)
- `ui/src/command_palette.rs` (550)
- `ui/src/schedule_heatmap.rs` (547)
- `src/cli_spawn_tests.rs` (544)
- `src/routines/cleanup/cleanup_tests.rs` (543)
- `src/routines/service_flag_tests.rs` (542)
- `src/sync/mod_tests.rs` (534)
- `ui/src/routines/state_tests.rs` (533)
- `src/routines/service_slug_tests.rs` (532)
- `src/routine_storage_snooze_tests.rs` (530)
- `src/routine_storage_migration_tests.rs` (511)
- `ui/src/routines/filter.rs` (510)
- `src/routines/service_coverage_tests.rs` (508)

Note: this list has grown since #941 was filed (18 files listed there) — the codebase has added more files/lines in the interim. CI's `linecheck` job (and `.githooks/pre-push` locally) will start failing on these until they're split; that's expected and tracked as follow-up work, not fixed here per the issue's own request to keep this change config-only.

## Test plan
- [x] Ran `linecheck --max-lines 500 $(find src ui/src -name '*.rs')` locally to confirm the new gate rejects all 30 currently-oversized files and would pass once they're split.
- [x] Confirmed `.githooks/pre-push` is the only place the `700` threshold is configured (`linecheck.yml` only holds excludes; no CI workflow hardcodes the value).

Closes #941