### PR TITLE
fix(storage): propagate atomic_write I/O errors instead of panicking

### DIFF
--- a/.changeset/atomic-write-propagate-io-errors.md
+++ b/.changeset/atomic-write-propagate-io-errors.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Fix `atomic_write` panicking the whole daemon on a write/sync I/O error (e.g. disk full) instead of returning it. `File::create`/`open` reserve no disk space, so `write_all`/`sync_all` can still fail after that call succeeds; they now propagate via `?` like every other step in `atomic_write`, instead of `.expect(...)`.

--- a/src/utils/atomic.rs
+++ b/src/utils/atomic.rs
@@ -43,11 +43,11 @@ fn tmp_path(path: &Path) -> PathBuf {
 /// Create `tmp`, write all of `bytes`, and flush to disk so the rename publishes complete contents.
 fn write_tmp(tmp: &Path, bytes: &[u8]) -> io::Result<()> {
     let mut file = create_private(tmp)?;
-    // `write_all` and `sync_all` on a freshly-created local file descriptor cannot
-    // realistically fail once the `File::create` above succeeded; `.expect` avoids
-    // a branch that is impossible to exercise in tests.
-    file.write_all(bytes).expect("write to temp file failed");
-    file.sync_all().expect("sync temp file failed");
+    // `File::create`/`OpenOptions::open` reserve no disk space, so a full or failing
+    // disk can still make these fail (ENOSPC/EIO); propagate instead of panicking
+    // the whole daemon over one write.
+    file.write_all(bytes)?;
+    file.sync_all()?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- `write_tmp` used `.expect(...)` on `write_all`/`sync_all`, justified by a comment claiming they "cannot realistically fail once `File::create` succeeded." That's not true: `create`/`open` reserve no disk space, so a full or failing disk (`ENOSPC`/`EIO`) can still hit these calls.
- Today that panics the entire daemon process on every persistence path that goes through `atomic_write` (routine storage, machine config, `~/.claude.json` pruning, flags) — instead of surfacing the `io::Result` the callers already handle via `?`.
- Fix: propagate with `?` like the rest of `atomic_write`; the existing tmp-file cleanup on `Err` already covers this path, no other code changes needed.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features` (clean)
- [x] `cargo test atomic` (all existing atomic-write tests pass)