### PR TITLE
feat(routines): surface is_running on GET /routines and GET /routines/{id}

### DIFF
--- a/.changeset/routine-is-running-field.md
+++ b/.changeset/routine-is-running-field.md
@@ -1,0 +1,12 @@
+---
+"moadim": minor
+---
+
+feat(routines): surface `is_running` on `GET /routines`/`GET /routines/{id}`
+
+Adds a derived, non-persisted `is_running: bool` field to the routine
+response, reporting whether any fire of the routine currently has a live
+tmux session. Reuses the existing overlap-guard tmux-prefix probe
+(`tmux_session_prefix_alive`, #514) that `svc_trigger` already relies on, so
+an operator (or the UI, in a follow-up) can finally tell "is this routine
+running right now?" from `GET /routines` instead of shelling in to `tmux ls`.

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -1514,7 +1514,8 @@
               "agent_registered",
               "agent_command_available",
               "file_path",
-              "flag_count"
+              "flag_count",
+              "is_running"
             ],
             "properties": {
               "agent_command_available": {
@@ -1533,6 +1534,10 @@
                 "type": "integer",
                 "description": "Number of open flags raised against this routine (see [`super::flags`]). Surfaced here so\nlistings can badge it without a separate `list_flags` round-trip per routine.",
                 "minimum": 0
+              },
+              "is_running": {
+                "type": "boolean",
+                "description": "`true` if any fire of this routine currently has a live tmux session — i.e. an agent is\nrunning right now. Derived by probing for a session under the routine's\n`moadim-{slug}-` prefix (the same overlap-guard check `svc_trigger` uses, #514), not\npersisted. `false` whenever no `tmux` binary is available, mirroring the probe's existing\nbest-effort \"no tmux, nothing running\" stance. See issue #438."
               },
               "next_run_at": {
                 "type": [

--- a/src/routines/model.rs
+++ b/src/routines/model.rs
@@ -8,7 +8,8 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use super::agents::load_agent_command;
-use super::command::{agent_command_available, slugify};
+use super::cleanup::tmux_session_prefix_alive;
+use super::command::{agent_command_available, slugify, tmux_session_prefix};
 use super::flags::list_flags;
 use crate::paths::routine_toml_path;
 
@@ -222,6 +223,12 @@ pub struct RoutineResponse {
     /// `None` when disabled, globally locked, or `schedule` is unparseable or has no upcoming
     /// fire (e.g. `@reboot`). See issue #369.
     pub next_run_at: Option<u64>,
+    /// `true` if any fire of this routine currently has a live tmux session — i.e. an agent is
+    /// running right now. Derived by probing for a session under the routine's
+    /// `moadim-{slug}-` prefix (the same overlap-guard check `svc_trigger` uses, #514), not
+    /// persisted. `false` whenever no `tmux` binary is available, mirroring the probe's existing
+    /// best-effort "no tmux, nothing running" stance. See issue #438.
+    pub is_running: bool,
 }
 
 /// The IANA name of the host's local timezone (e.g. `"Asia/Jerusalem"`).
@@ -277,6 +284,7 @@ impl RoutineResponse {
         let schedule_description = describe_schedule(&routine.schedule, timezone.as_deref());
         let flag_count = list_flags(&slug).len();
         let next_run_at = next_run_at(&routine.schedule, routine.enabled);
+        let is_running = tmux_session_prefix_alive(&tmux_session_prefix(&slug));
         Self {
             routine,
             agent_registered,
@@ -286,6 +294,7 @@ impl RoutineResponse {
             timezone,
             flag_count,
             next_run_at,
+            is_running,
         }
     }
 }

--- a/src/routines/model_tests.rs
+++ b/src/routines/model_tests.rs
@@ -212,6 +212,52 @@ fn from_routine_populates_derived_fields() {
     assert!(resp.file_path.contains("routine.toml"));
     assert_eq!(resp.flag_count, 0);
     assert!(resp.next_run_at.is_some());
+    // No `MOADIM_TMUX_BIN` stub set: the test-build fallback tmux binary doesn't exist, so no
+    // session can be reported alive.
+    assert!(!resp.is_running);
+}
+
+#[test]
+fn from_routine_is_running_true_when_a_fire_has_a_live_tmux_session() {
+    // Mirrors `svc_trigger_skips_spawn_when_a_previous_run_is_still_alive`
+    // (service_overlap_guard_tests.rs): a tmux stub that reports a session under this routine's
+    // `moadim-{slug}-` prefix must surface as `is_running: true`, the same overlap-guard probe
+    // `svc_trigger` uses (#514), now exposed on the read path too (#438).
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let title = "Model Test Is Running ZZZ";
+    let slug = slugify(title);
+    let dir = std::env::temp_dir().join(format!("moadim-model-running-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let stub = dir.join("tmux");
+    std::fs::write(
+        &stub,
+        format!("#!/bin/sh\nprintf 'moadim-{slug}-1730000000_4821\\n'\nexit 0\n"),
+    )
+    .unwrap();
+    #[cfg(unix)]
+    std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let mut routine = make_routine("claude");
+    routine.title = title.into();
+
+    let previous = std::env::var_os("MOADIM_TMUX_BIN");
+    // SAFETY: tests in this crate run single-threaded (RUST_TEST_THREADS=1).
+    unsafe { std::env::set_var("MOADIM_TMUX_BIN", &stub) };
+
+    let resp = RoutineResponse::from_routine(routine);
+
+    // SAFETY: single-threaded harness; restore the saved override.
+    unsafe {
+        match previous {
+            Some(value) => std::env::set_var("MOADIM_TMUX_BIN", value),
+            None => std::env::remove_var("MOADIM_TMUX_BIN"),
+        }
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert!(resp.is_running);
 }
 
 #[test]


### PR DESCRIPTION
## Why

`GET /routines` (and single-routine reads) already surface static and
scheduling facts about a routine — `enabled`, `agent_registered`,
`schedule_description`, `next_run_at`, etc. — but nothing about whether the
routine's agent is executing **right now**. The only way to know is to shell
into the host and run `tmux ls`. Closes #438.

The daemon already has the exact primitive needed: `tmux_session_prefix` +
`tmux_session_prefix_alive` (`src/routines/command.rs`,
`src/routines/cleanup/session.rs`) is the overlap-guard probe `svc_trigger`
uses (#514) to detect "is a previous fire of this routine still running" —
matching any live tmux session under the routine's `moadim-{slug}-` prefix,
not a single fixed name. It was already `pub(crate)` and used from
`service_trigger.rs`, just never surfaced on the read path.

## What changed

- `RoutineResponse` (`src/routines/model.rs`) gains a derived, non-persisted
  `is_running: bool` field, computed in `from_routine` by reusing the
  existing overlap-guard probe — no new tmux-probing logic.
- Regenerated `apis/openapi.json` via the repo's existing self-healing test
  (`committed_spec_is_current`).
- Added a changeset (`.changeset/routine-is-running-field.md`, `minor`,
  matching the precedent set by the sibling `next_run_at` field addition).

## Not in scope

The linked issue's acceptance criteria also ask for a UI "RUNNING" badge.
Keeping this PR to the backend field only, since the UI treatment is a
separate, independently reviewable change; the field is available on the
API today for anyone who wants to build that next.

## Testing

- `cargo build` — clean
- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 913 root + 259 `ui` tests pass (2 new: a
  `from_routine` regression asserting `is_running` is `false` with no tmux
  session, and one stubbing `MOADIM_TMUX_BIN` to report a live session under
  the routine's prefix, mirroring the existing overlap-guard test pattern in
  `service_overlap_guard_tests.rs`)
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main.rs'` — 100% line coverage, gate passes
- `typos` / `linecheck --max-lines 500` on touched files — clean

Investigated the ~70 other open PRs on this repo and the open issue list
before picking this: most auto-suggested issues I checked (docs drift #271,
request-timeout #402, PID reconciliation #315, correlation ids #354, README
`--json` contract #345, restart `-i` #308, stop-hang timeout #342, iCal
refresh interval #362, CI-lints-ui #412, and more) turned out to already be
fixed on `main` despite the issue staying open. #438 was the one I found
still genuinely unimplemented with a small, self-contained fix.

---

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.

Further attention can be directed to @tupe12334 if needed.