### PR TITLE
chore(lint): enable clippy::derive_partial_eq_without_eq

### DIFF
--- a/.changeset/derive-eq-partial-eq-structs.md
+++ b/.changeset/derive-eq-partial-eq-structs.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Derive `Eq` alongside `PartialEq` on `Flag`, `RunSummary`, and `FleetRunSummary` (all fields are already `Eq`-safe), and enable `clippy::derive_partial_eq_without_eq` to lock that in for future types.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,3 +151,10 @@ manual_string_new = "deny"
 # for flat, early-return control flow (see `manual_let_else`, `if_not_else`
 # above). The codebase is already clean, so `deny` locks that in.
 redundant_else = "deny"
+# A type deriving `PartialEq` whose fields are all themselves `Eq` almost always
+# satisfies `Eq` too (reflexivity holds for everything but float fields, which
+# this codebase avoids in these structs). Deriving it costs nothing and unlocks
+# the type as a `HashSet`/`BTreeMap` key or `HashMap` value in `==`-free contexts
+# without a later, easy-to-forget follow-up PR. The codebase is already clean,
+# so `deny` locks that in.
+derive_partial_eq_without_eq = "deny"

--- a/src/routines/flags.rs
+++ b/src/routines/flags.rs
@@ -42,7 +42,7 @@ impl FlagScope {
 }
 
 /// A single flag raised against a routine.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, utoipa::ToSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, utoipa::ToSchema)]
 pub struct Flag {
     /// Filename on disk under the routine's `flags/` dir; the handle used to resolve it.
     pub filename: String,

--- a/src/routines/model.rs
+++ b/src/routines/model.rs
@@ -318,7 +318,7 @@ pub enum RunStatus {
 }
 
 /// One past (or in-progress) run of a routine, listed newest-first.
-#[derive(Debug, Clone, PartialEq, Serialize, JsonSchema, utoipa::ToSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema, utoipa::ToSchema)]
 pub struct RunSummary {
     /// Workbench directory name (`{slug}-{unix_secs}`); pass to `GET /routines/{id}/runs/{workbench}/log`.
     pub workbench: String,
@@ -334,7 +334,7 @@ pub struct RunSummary {
 
 /// One past (or in-progress) run, across every routine, listed newest-first — the fleet-wide
 /// counterpart to [`RunSummary`] backing an overview "recent runs" view.
-#[derive(Debug, Clone, PartialEq, Serialize, JsonSchema, utoipa::ToSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema, utoipa::ToSchema)]
 pub struct FleetRunSummary {
     /// The routine this run belongs to.
     pub routine_id: String,


### PR DESCRIPTION
## Why

`Flag`, `RunSummary`, and `FleetRunSummary` derive `PartialEq` but not `Eq`, even though every field they hold (`String`, `u64`, `Option<u64>`, `Option<i32>`, and the `FlagScope`/`RunStatus` enums, which already derive `Eq`) is itself `Eq`. Nothing in these types can fail reflexivity, so the missing `Eq` derive was just an oversight, and it silently blocks these types from being used as `HashSet`/`BTreeMap` keys or in other `Eq`-bound generic code until someone notices and back-fills it later.

## What

- Add `Eq` to the derive list on `Flag` (`src/routines/flags.rs`), `RunSummary`, and `FleetRunSummary` (`src/routines/model.rs`).
- Enable `clippy::derive_partial_eq_without_eq = "deny"` in the root `Cargo.toml`'s `[lints.clippy]` table (matching the existing pattern of locking in already-clean lints) so the next `PartialEq`-only, `Eq`-eligible type gets caught automatically instead of drifting.

## Verification

Ran the repo's own pre-push gates locally on this change:
- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 259 + 912 tests passing
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main.rs'` — 100% line coverage, exit 0

Added a changeset (`patch`) since this touches `src/`.

---

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.