### PR TITLE
test(routines): cover two untested branches in service_log_tail.rs

### DIFF
--- a/.changeset/log-tail-branch-coverage.md
+++ b/.changeset/log-tail-branch-coverage.md
@@ -1,0 +1,21 @@
+---
+"moadim": patch
+---
+
+test(routines): cover two untested branches in `service_log_tail.rs`
+
+`cargo llvm-cov`'s region report (not the 100%-line gate, which region
+coverage doesn't affect) showed two real gaps in the routine log-tail /
+ANSI-sanitizing logic used by `svc_logs`/`svc_run_log`:
+
+- `read_log_tail` never had a test for its very first fallible step
+  (`std::fs::metadata(path)?`) — a workbench whose `agent.log` was removed
+  out from under it (e.g. a racing cleanup sweep) must surface an
+  `io::Error`, not panic.
+- `strip_ansi_noise`'s OSC-sequence parser only had a test for the
+  terminator `ESC \`; the other valid terminator, a bare `ESC` not
+  followed by `\`, was never exercised, and it has different behavior
+  (the character right after that `ESC` is not consumed, unlike the
+  `ESC \` case).
+
+No behavior change — regression tests only.

--- a/src/routines/service_ansi_tests.rs
+++ b/src/routines/service_ansi_tests.rs
@@ -35,6 +35,17 @@ fn strip_ansi_noise_removes_osc_sequence_terminated_by_escape_backslash() {
 }
 
 #[test]
+fn strip_ansi_noise_removes_osc_sequence_terminated_by_bare_escape() {
+    // A lone ESC not followed by `\` (a malformed/unusual string terminator) must still end
+    // the OSC sequence, and — unlike the ESC-backslash case above — the character right after
+    // that ESC is not part of the terminator, so it must survive in the output untouched.
+    assert_eq!(
+        strip_ansi_noise("\u{1B}]0;window title\u{1B}Xafter\n"),
+        "Xafter\n"
+    );
+}
+
+#[test]
 fn strip_ansi_noise_drops_bare_two_byte_escape() {
     // `ESC c` is a full terminal reset with no CSI/OSC bracket.
     assert_eq!(strip_ansi_noise("before\u{1B}cafter\n"), "beforeafter\n");

--- a/src/routines/service_logs_tests.rs
+++ b/src/routines/service_logs_tests.rs
@@ -153,6 +153,17 @@ fn svc_logs_missing_routine_not_found() {
 }
 
 #[test]
+fn read_log_tail_errors_when_file_is_missing() {
+    // The very first thing `read_log_tail` does is `std::fs::metadata(path)?`; a workbench
+    // whose `agent.log` was removed out from under it (e.g. a racing cleanup sweep) must
+    // surface an `io::Error` here instead of panicking.
+    let dir = std::env::temp_dir().join(format!("moadim-logtail-missing-{}", uuid::Uuid::new_v4()));
+    let path = dir.join("agent.log");
+
+    assert!(read_log_tail(&path).is_err());
+}
+
+#[test]
 fn read_log_tail_returns_whole_file_under_the_cap() {
     let dir = std::env::temp_dir().join(format!("moadim-logtail-small-{}", uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&dir).unwrap();


### PR DESCRIPTION
## Why

Surveyed the ~70 open PRs and the open issue backlog before picking this — most auto-suggested issues I sampled (docs drift, PID reconciliation, README `--json` contract, cargon doc intra-doc link, overlap guard, slug collisions, `ttl_secs`/`max_runtime_secs` validation, and more) turned out to already be fixed on `main` despite the issue staying open, and the UI feature requests (group-by, sortable columns, quick-trigger buttons, calendar popovers, etc.) are heavily oversubscribed across dozens of open PRs already. `cargo build`/`test`/`clippy`/`fmt`/`doc` and the 100%-line coverage gate all currently pass clean on `main`.

Digging one level deeper with `cargo llvm-cov`'s HTML report (region/branch coverage, not just the 100%-line gate CI already enforces) surfaced two real, currently-untested branches in `src/routines/service_log_tail.rs` (the tail-reading + ANSI-sanitizing logic behind `svc_logs`/`svc_run_log`):

- `read_log_tail`'s very first fallible step, `std::fs::metadata(path)?`, had no test — a workbench whose `agent.log` disappears out from under it (e.g. a racing cleanup sweep) needs to surface an `io::Error`, not panic.
- `strip_ansi_noise`'s OSC-sequence parser only had a test for the `ESC \` terminator. The other valid terminator — a bare `ESC` *not* followed by `\` — was never exercised, and it has genuinely different behavior: the character right after that `ESC` is not consumed by the terminator (unlike the `ESC \` case), so a wrong assumption here would silently corrupt or drop a character from a log line.

## What

- `src/routines/service_logs_tests.rs`: added `read_log_tail_errors_when_file_is_missing`.
- `src/routines/service_ansi_tests.rs`: added `strip_ansi_noise_removes_osc_sequence_terminated_by_bare_escape`.
- `.changeset/log-tail-branch-coverage.md`: patch changeset.

No production code changed — regression tests only, closing region-coverage gaps that the line-coverage gate can't see (a line can host multiple branches/regions).

## Verified locally

- `cargo test` — 914 passed (up from 912), 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main.rs'` — passes; `service_log_tail.rs` region misses dropped from 5 to 3 (the remaining 3 are the `File::open`/`seek`/`read_to_end` I/O-error arms inside the >2MB-log branch, which would need a contrived permission/race setup to hit meaningfully — left as-is rather than gold-plating)
- `linecheck --max-lines 500` across `src/` + `ui/src/` — clean
- `typos` — clean
- `cargo doc --workspace --no-deps --document-private-items` with `RUSTDOCFLAGS=-D warnings` — clean