### PR TITLE
chore(lint): enable clippy::needless_pass_by_value

### DIFF
--- a/.changeset/needless-pass-by-value.md
+++ b/.changeset/needless-pass-by-value.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Enable `clippy::needless_pass_by_value` and fix its three violations: `cli::trigger` now takes `&str` instead of an owned `String`, `cli_query::status_json` takes `Option<&HealthInfo>` instead of an owned `Option<HealthInfo>`, and `LockScope` derives `Copy` (a fieldless enum tag) instead of `global_lock::set_lock` taking it by value under the lint. No behavior change; avoids needless clones/moves at call sites.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,3 +158,8 @@ redundant_else = "deny"
 # without a later, easy-to-forget follow-up PR. The codebase is already clean,
 # so `deny` locks that in.
 derive_partial_eq_without_eq = "deny"
+# Reject a by-value function argument that the body never consumes (never moves, mutates through
+# ownership, or otherwise needs to own) — it should take a reference instead. A needless owned
+# parameter forces every caller to clone or otherwise part with a value the callee never actually
+# needed to own. The codebase is already clean, so `deny` locks that in.
+needless_pass_by_value = "deny"

--- a/src/cli_json_tests.rs
+++ b/src/cli_json_tests.rs
@@ -187,7 +187,7 @@ fn readme_status_json_shape_matches_actual_keys() {
     };
     assert_eq!(
         documented,
-        actual_keys(&status_json(true, Some(7), Some(health))),
+        actual_keys(&status_json(true, Some(7), Some(&health))),
         "README `moadim status --json` shape has drifted from status_json's actual keys"
     );
 }
@@ -336,7 +336,7 @@ fn cleanup_errors_on_unexpected_status() {
 fn trigger_triggers_routine_when_server_responds() {
     let server = FakeServer::start(200, String::new());
     let _addr = EnvGuard::set(BIND_ADDR_ENV, &server.addr);
-    assert_eq!(trigger("some-id".to_string()).unwrap(), 0);
+    assert_eq!(trigger("some-id").unwrap(), 0);
 }
 
 #[test]
@@ -345,18 +345,18 @@ fn trigger_reports_unknown_routine_on_404() {
     // non-zero exit via the bubbled `Err`, distinct from "server not running".
     let server = FakeServer::start(404, String::new());
     let _addr = EnvGuard::set(BIND_ADDR_ENV, &server.addr);
-    assert!(trigger("missing".to_string()).is_err());
+    assert!(trigger("missing").is_err());
 }
 
 #[test]
 fn trigger_errors_on_unexpected_status() {
     let server = FakeServer::start(500, String::new());
     let _addr = EnvGuard::set(BIND_ADDR_ENV, &server.addr);
-    assert!(trigger("some-id".to_string()).is_err());
+    assert!(trigger("some-id").is_err());
 }
 
 #[test]
 fn trigger_reports_not_running_when_no_server() {
     let _addr = EnvGuard::set(BIND_ADDR_ENV, UNREACHABLE_ADDR);
-    assert_eq!(trigger("some-id".to_string()).unwrap(), EXIT_NOT_RUNNING);
+    assert_eq!(trigger("some-id").unwrap(), EXIT_NOT_RUNNING);
 }

--- a/src/cli_query.rs
+++ b/src/cli_query.rs
@@ -71,7 +71,7 @@ pub(super) fn humanize_bytes(bytes: u64) -> String {
 /// (`404`), and a "not running" hint when no server is reachable. Returns the process exit code to
 /// surface, mirroring the `status`/`cleanup` contract: `0` when the routine was triggered, and
 /// [`crate::cli::EXIT_NOT_RUNNING`] when no server is running, so scripts can branch on `$?`.
-pub fn trigger(id: String) -> anyhow::Result<i32> {
+pub fn trigger(id: &str) -> anyhow::Result<i32> {
     match http_request("POST", &format!("/api/v1/routines/{id}/trigger")) {
         Ok(200) => {
             println!("triggered routine {id}");
@@ -113,7 +113,7 @@ pub fn status(json: bool, wait_secs: Option<u64>) -> anyhow::Result<i32> {
         // `status --json` answers liveness *and* age/version without a second call. When the
         // server is down (or answers unparseably) these fields are emitted as null.
         let health = if running { fetch_health() } else { None };
-        println!("{}", status_json(running, pid, health));
+        println!("{}", status_json(running, pid, health.as_ref()));
         return Ok(liveness_exit_code(running));
     }
     if running {
@@ -142,9 +142,9 @@ pub(super) struct HealthInfo {
 /// `pid` is `null` when no pid file is present (or the server is down). `uptime_secs`/`version`
 /// carry the running server's self-reported `/health` details (via `health`), and are `null` when
 /// no server answers or its `/health` body could not be parsed.
-pub(super) fn status_json(running: bool, pid: Option<u32>, health: Option<HealthInfo>) -> String {
-    let uptime_secs = health.as_ref().map(|info| info.uptime_secs);
-    let version = health.as_ref().map(|info| info.version.as_str());
+pub(super) fn status_json(running: bool, pid: Option<u32>, health: Option<&HealthInfo>) -> String {
+    let uptime_secs = health.map(|info| info.uptime_secs);
+    let version = health.map(|info| info.version.as_str());
     serde_json::json!({
         "running": running,
         "pid": pid,

--- a/src/cli_query_tests.rs
+++ b/src/cli_query_tests.rs
@@ -10,7 +10,7 @@ fn status_json_reports_running_pid_and_address() {
         version: "1.2.3".to_string(),
     };
     let value: serde_json::Value =
-        serde_json::from_str(&status_json(true, Some(42), Some(health))).unwrap();
+        serde_json::from_str(&status_json(true, Some(42), Some(&health))).unwrap();
     assert_eq!(value["running"], serde_json::json!(true));
     assert_eq!(value["pid"], serde_json::json!(42));
     assert_eq!(value["address"], serde_json::json!(BIND_ADDR));

--- a/src/global_lock.rs
+++ b/src/global_lock.rs
@@ -12,6 +12,11 @@
 use std::io;
 
 /// Which lock sentinel to create or remove.
+///
+/// `Copy` because it is a plain tag with no payload — passing it by value (the natural way to
+/// pass an enum selector) then costs nothing, whereas passing it by reference would just add a
+/// pointless indirection at every call site.
+#[derive(Clone, Copy)]
 pub enum LockScope {
     /// The committed `.lock` file, shareable via version control.
     Shared,

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ async fn main() -> anyhow::Result<()> {
         }
         cli::Command::Cleanup { json } => std::process::exit(cli::cleanup(json)?),
         cli::Command::Stop { json, quiet } => std::process::exit(cli::stop(json, quiet)?),
-        cli::Command::Trigger { id } => std::process::exit(cli::trigger(id)?),
+        cli::Command::Trigger { id } => std::process::exit(cli::trigger(&id)?),
         cli::Command::Background => cli::run_background(),
         cli::Command::Restart {
             json,


### PR DESCRIPTION
## Why

This repo has an established pattern of incrementally locking in clean pedantic
clippy lints (`map_unwrap_or`, `use_self`, `match_same_arms`, `redundant_else`,
`derive_partial_eq_without_eq`, …) one at a time, each denied in `[lints.clippy]`
once the codebase already satisfies it. `clippy::needless_pass_by_value` flags a
function parameter taken by value that the body never actually needs to own —
every such call site pays for a clone/move the callee doesn't need. It wasn't
enabled yet, and the codebase had exactly three (harmless but avoidable) offenders:

- `cli::trigger(id: String)` only ever borrows `id` (via `format!`/`println!`);
  changed to `&str`, updating the one production caller in `main.rs` and the
  handful of test call sites.
- `cli_query::status_json(.., health: Option<HealthInfo>)` only reads through
  `health.as_ref()` internally; changed to `Option<&HealthInfo>`, updating the
  single call site (which already had an owned `Option<HealthInfo>` in hand) and
  two test call sites.
- `global_lock::set_lock(scope: LockScope, ..)` — `LockScope` is a fieldless
  2-variant enum tag, so the simplest fix (per clippy's own suggestion) is
  deriving `Copy` on it rather than threading a reference through every
  construction site.

No behavior change. Added a changeset since this touches `src/`.

## Testing

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 913 (root) + 259 (ui) passed
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% lines, gate passes
- `typos` — clean

---
This pull request was opened by the "Daemon + Landing auto-improve & auto-merge lint/docs PRs" routine of moadim.