### PR TITLE
fix(lint): split mcp.rs input structs into mcp_types.rs

### DIFF
--- a/.changeset/split-mcp-types.md
+++ b/.changeset/split-mcp-types.md
@@ -1,0 +1,11 @@
+---
+"moadim": patch
+---
+
+### Fixed
+
+Split the MCP tool input structs out of `src/routes/mcp.rs` into a new
+`src/routes/mcp_types.rs` sibling module. `mcp.rs` had crept to 514 lines,
+tripping the pre-push hook's 500-line-per-file gate (`linecheck --max-lines
+500`) for every contributor who has `linecheck` installed, as CONTRIBUTING.md
+instructs. No behavior change.

--- a/src/routes/mcp.rs
+++ b/src/routes/mcp.rs
@@ -8,8 +8,13 @@ use rmcp::{
     model::{CallToolResult, ContentBlock},
     tool, tool_router,
 };
-use schemars::JsonSchema;
-use serde::Deserialize;
+
+#[path = "mcp_types.rs"]
+mod mcp_types;
+use mcp_types::{
+    CreateFlagInput, IdInput, ListRoutinesParam, LockRoutinesInput, ResolveFlagInput,
+    SetPowerSavingInput, SnoozeRoutineInput, UnlockRoutinesInput, UpdateRoutineInput,
+};
 
 /// MCP server handler that exposes routine management as MCP tools.
 #[derive(Clone)]
@@ -21,117 +26,6 @@ pub struct MoadimMcp {
     /// Notify handle that triggers a graceful server shutdown (the `shutdown` tool fires it,
     /// mirroring `POST /api/v1/shutdown` and `moadim stop`).
     shutdown: ShutdownSignal,
-}
-
-/// Input for tools that operate on a single routine by ID.
-#[derive(Deserialize, JsonSchema)]
-struct IdInput {
-    /// UUID of the target routine.
-    id: String,
-}
-
-/// Input for the `list_routines` MCP tool.
-#[derive(Deserialize, JsonSchema)]
-pub(super) struct ListRoutinesParam {
-    /// When `true` (the default), only return routines targeting the current machine.
-    /// Pass `false` to see routines from all machines.
-    local_only: Option<bool>,
-    /// When `true`, include each routine's `prompt` in the response. Defaults to `false` so listings stay compact; use `get_routine` to see a single routine's prompt.
-    include_prompts: Option<bool>,
-}
-
-/// Input for the `lock_routines` MCP tool.
-#[derive(Deserialize, JsonSchema)]
-struct LockRoutinesInput {
-    /// Which sentinel to create: `"shared"` (committed `.lock`) or `"local"` (gitignored `.local.lock`).
-    scope: String,
-}
-
-/// Input for the `unlock_routines` MCP tool.
-#[derive(Deserialize, JsonSchema)]
-struct UnlockRoutinesInput {
-    /// Which sentinel(s) to remove: `"shared"`, `"local"`, or `"all"` (both).
-    scope: String,
-}
-
-/// Input for the `create_flag` MCP tool.
-#[derive(Deserialize, JsonSchema)]
-struct CreateFlagInput {
-    /// UUID of the routine to flag.
-    id: String,
-    /// Free-text flag category. Common examples: "bug", "gap", `edge_case`, "question", "blocker"
-    /// — any string is accepted.
-    r#type: String,
-    /// Free-text description of what's unclear.
-    description: String,
-    /// `"general"` (committed, shared via git) or `"local"` (gitignored, machine-local).
-    scope: String,
-}
-
-/// Input for the `resolve_flag` MCP tool.
-#[derive(Deserialize, JsonSchema)]
-struct ResolveFlagInput {
-    /// UUID of the flagged routine.
-    id: String,
-    /// Flag filename, as returned by `create_flag`/`list_flags`.
-    filename: String,
-}
-
-/// Input for the `snooze_routine` MCP tool.
-#[derive(Deserialize, JsonSchema)]
-struct SnoozeRoutineInput {
-    /// UUID of the routine to snooze.
-    id: String,
-    /// Unix timestamp (seconds) to skip scheduled fires until, or omit/null. Mutually exclusive
-    /// with `skip_runs`.
-    snoozed_until: Option<u64>,
-    /// Number of upcoming scheduled fires to skip, or omit/null. Mutually exclusive with
-    /// `snoozed_until`.
-    skip_runs: Option<u32>,
-}
-
-/// Input for the `set_power_saving` MCP tool.
-#[derive(Deserialize, JsonSchema)]
-struct SetPowerSavingInput {
-    /// UUID of the routine to update.
-    id: String,
-    /// `true` to pause scheduled and manual firing for power saving, `false` to resume.
-    active: bool,
-}
-
-/// Input for the `update_routine` MCP tool.
-#[derive(Deserialize, JsonSchema)]
-struct UpdateRoutineInput {
-    /// UUID of the routine to update.
-    id: String,
-    /// New cron expression, or `None` to keep the existing value. Evaluated in the
-    /// host's local system timezone (the OS crontab timezone), not UTC.
-    schedule: Option<String>,
-    /// New title, or `None` to keep the existing value.
-    title: Option<String>,
-    /// New agent key, or `None` to keep the existing value.
-    agent: Option<String>,
-    /// New model ID, or `None` to keep the existing value. A blank/whitespace-only value clears
-    /// the model back to the agent's own default.
-    model: Option<String>,
-    /// New prompt, or `None` to keep the existing value.
-    prompt: Option<String>,
-    /// New goal (a very short, ≤5-line statement of the routine's purpose), or `None` to keep the
-    /// existing value. Send an empty string to clear it.
-    goal: Option<String>,
-    /// New repositories list, or `None` to keep the existing value.
-    repositories: Option<Vec<crate::routines::Repository>>,
-    /// New machines targeting list, or `None` to keep the existing value.
-    machines: Option<Vec<String>>,
-    /// New enabled state, or `None` to keep the existing value.
-    enabled: Option<bool>,
-    /// New workbench TTL (seconds) for finished runs, or `None` to keep the existing value.
-    ttl_secs: Option<u64>,
-    /// New max runtime (seconds) for a single run before the watchdog kills it, or `None` to keep
-    /// the existing value.
-    max_runtime_secs: Option<u64>,
-    /// New tags list, or `None` to keep the existing value.
-    tags: Option<Vec<String>>,
 }
 
 /// Wrap a serializable value in a successful `CallToolResult`.

--- a/src/routes/mcp_types.rs
+++ b/src/routes/mcp_types.rs
@@ -1,0 +1,116 @@
+//! Input structs for the MCP tools defined in `mcp.rs`, split out to keep that file under the
+//! repo's 500-line-per-file gate.
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+/// Input for tools that operate on a single routine by ID.
+#[derive(Deserialize, JsonSchema)]
+pub(super) struct IdInput {
+    /// UUID of the target routine.
+    pub(super) id: String,
+}
+
+/// Input for the `list_routines` MCP tool.
+#[derive(Deserialize, JsonSchema)]
+pub(super) struct ListRoutinesParam {
+    /// When `true` (the default), only return routines targeting the current machine.
+    /// Pass `false` to see routines from all machines.
+    pub(super) local_only: Option<bool>,
+    /// When `true`, include each routine's `prompt` in the response. Defaults to `false` so listings stay compact; use `get_routine` to see a single routine's prompt.
+    pub(super) include_prompts: Option<bool>,
+}
+
+/// Input for the `lock_routines` MCP tool.
+#[derive(Deserialize, JsonSchema)]
+pub(super) struct LockRoutinesInput {
+    /// Which sentinel to create: `"shared"` (committed `.lock`) or `"local"` (gitignored `.local.lock`).
+    pub(super) scope: String,
+}
+
+/// Input for the `unlock_routines` MCP tool.
+#[derive(Deserialize, JsonSchema)]
+pub(super) struct UnlockRoutinesInput {
+    /// Which sentinel(s) to remove: `"shared"`, `"local"`, or `"all"` (both).
+    pub(super) scope: String,
+}
+
+/// Input for the `create_flag` MCP tool.
+#[derive(Deserialize, JsonSchema)]
+pub(super) struct CreateFlagInput {
+    /// UUID of the routine to flag.
+    pub(super) id: String,
+    /// Free-text flag category. Common examples: "bug", "gap", `edge_case`, "question", "blocker"
+    /// — any string is accepted.
+    pub(super) r#type: String,
+    /// Free-text description of what's unclear.
+    pub(super) description: String,
+    /// `"general"` (committed, shared via git) or `"local"` (gitignored, machine-local).
+    pub(super) scope: String,
+}
+
+/// Input for the `resolve_flag` MCP tool.
+#[derive(Deserialize, JsonSchema)]
+pub(super) struct ResolveFlagInput {
+    /// UUID of the flagged routine.
+    pub(super) id: String,
+    /// Flag filename, as returned by `create_flag`/`list_flags`.
+    pub(super) filename: String,
+}
+
+/// Input for the `snooze_routine` MCP tool.
+#[derive(Deserialize, JsonSchema)]
+pub(super) struct SnoozeRoutineInput {
+    /// UUID of the routine to snooze.
+    pub(super) id: String,
+    /// Unix timestamp (seconds) to skip scheduled fires until, or omit/null. Mutually exclusive
+    /// with `skip_runs`.
+    pub(super) snoozed_until: Option<u64>,
+    /// Number of upcoming scheduled fires to skip, or omit/null. Mutually exclusive with
+    /// `snoozed_until`.
+    pub(super) skip_runs: Option<u32>,
+}
+
+/// Input for the `set_power_saving` MCP tool.
+#[derive(Deserialize, JsonSchema)]
+pub(super) struct SetPowerSavingInput {
+    /// UUID of the routine to update.
+    pub(super) id: String,
+    /// `true` to pause scheduled and manual firing for power saving, `false` to resume.
+    pub(super) active: bool,
+}
+
+/// Input for the `update_routine` MCP tool.
+#[derive(Deserialize, JsonSchema)]
+pub(super) struct UpdateRoutineInput {
+    /// UUID of the routine to update.
+    pub(super) id: String,
+    /// New cron expression, or `None` to keep the existing value. Evaluated in the
+    /// host's local system timezone (the OS crontab timezone), not UTC.
+    pub(super) schedule: Option<String>,
+    /// New title, or `None` to keep the existing value.
+    pub(super) title: Option<String>,
+    /// New agent key, or `None` to keep the existing value.
+    pub(super) agent: Option<String>,
+    /// New model ID, or `None` to keep the existing value. A blank/whitespace-only value clears
+    /// the model back to the agent's own default.
+    pub(super) model: Option<String>,
+    /// New prompt, or `None` to keep the existing value.
+    pub(super) prompt: Option<String>,
+    /// New goal (a very short, ≤5-line statement of the routine's purpose), or `None` to keep the
+    /// existing value. Send an empty string to clear it.
+    pub(super) goal: Option<String>,
+    /// New repositories list, or `None` to keep the existing value.
+    pub(super) repositories: Option<Vec<crate::routines::Repository>>,
+    /// New machines targeting list, or `None` to keep the existing value.
+    pub(super) machines: Option<Vec<String>>,
+    /// New enabled state, or `None` to keep the existing value.
+    pub(super) enabled: Option<bool>,
+    /// New workbench TTL (seconds) for finished runs, or `None` to keep the existing value.
+    pub(super) ttl_secs: Option<u64>,
+    /// New max runtime (seconds) for a single run before the watchdog kills it, or `None` to keep
+    /// the existing value.
+    pub(super) max_runtime_secs: Option<u64>,
+    /// New tags list, or `None` to keep the existing value.
+    pub(super) tags: Option<Vec<String>>,
+}


### PR DESCRIPTION
## Why

`src/routes/mcp.rs` had grown to 514 lines. The pre-push hook's line-count
gate (`linecheck --max-lines 500 $(find src ui/src -name '*.rs')`, added in
#1014 when the limit was lowered from 700 to 500) now fails on `main` for
anyone who has `linecheck` installed, exactly as CONTRIBUTING.md instructs:

```
$ linecheck --max-lines 500 $(find src ui/src -name '*.rs')
src/routes/mcp.rs: 514 lines (error threshold: 500)
```

That's a standing break on every clean clone's local pre-push run, independent
of whatever else a PR touches.

## What

Move the `#[derive(Deserialize, JsonSchema)]` MCP tool-input structs
(`IdInput`, `ListRoutinesParam`, `LockRoutinesInput`, `UnlockRoutinesInput`,
`CreateFlagInput`, `ResolveFlagInput`, `SnoozeRoutineInput`,
`SetPowerSavingInput`, `UpdateRoutineInput`) out of `mcp.rs` into a new
sibling module, `src/routes/mcp_types.rs`, following the same split pattern
already used elsewhere in the repo (`cli_query.rs`, `cli_system.rs`,
`routine_storage_migrations.rs`, etc). Pure move, no logic change — `mcp.rs`
is now 407 lines, `mcp_types.rs` is 116.

## Verification

Ran the full `.githooks/pre-push` gate end to end on this branch:

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 917 passed
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% lines
- `linecheck --max-lines 500 $(find src ui/src -name '*.rs')` — passes (previously failed on `main`)
- changeset present (`.changeset/split-mcp-types.md`)

This pull request was opened by the "Daemon + Landing auto-improve & auto-merge lint/docs PRs" routine of moadim.