### PR TITLE
fix(routines): make Token Trim work in a temp clone, never mutate ~/.config/moadim

### DIFF
--- a/.changeset/token-trim-temp-clone.md
+++ b/.changeset/token-trim-temp-clone.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Fix the built-in "Token Trim" routine's PR step so it clones `~/.config/moadim`'s origin into a disposable `mktemp -d` temp dir and does all branch/commit/push work there, instead of checking out a branch directly inside `~/.config/moadim` — the live checkout the daemon reads routines from. This matches the fix already shipped for the sibling "The 1 Percent" routine (#916); "Token Trim" was never updated to the same pattern, so it still risked leaving the daemon's routines checkout parked on a stale branch mid-run.

--- a/src/routines/defaults/token_trim.rs
+++ b/src/routines/defaults/token_trim.rs
@@ -69,17 +69,23 @@ calls, same outputs, same decision logic. When in doubt, keep the instruction.
 
 ## Step 4: Open the PR
 
+**Never edit, checkout, or commit inside `~/.config/moadim` directly** — it is the live \
+checkout the daemon reads routines from. Do all work in a disposable temp clone instead:
+
 ```bash
-git -C ~/.config/moadim checkout -b token-trim/$(date +%Y%m%d-%H%M)
-# Edit the relevant <slug>/prompts/prompt.pure.md file(s) under ~/.config/moadim/routines/.
-# Only touch routine prompt files. Do NOT modify moadim daemon config.
-git -C ~/.config/moadim add -A
-git -C ~/.config/moadim commit -m \"routines: trim token cost in <routine-name>\"
-git -C ~/.config/moadim push -u origin HEAD
 origin=$(git -C ~/.config/moadim remote get-url origin)
+tmp=$(mktemp -d)
+git clone \"$origin\" \"$tmp\"
+git -C \"$tmp\" checkout -b token-trim/$(date +%Y%m%d-%H%M)
+# Edit the relevant <slug>/prompts/prompt.pure.md file(s) under $tmp/routines/.
+# Only touch routine prompt files. Do NOT modify moadim daemon config.
+git -C \"$tmp\" add -A
+git -C \"$tmp\" commit -m \"routines: trim token cost in <routine-name>\"
+git -C \"$tmp\" push -u origin HEAD
 gh pr create --repo \"$origin\" \
   --title \"token-trim: <short description>\" \
   --body \"$(printf '## What changed\\n<one paragraph>\\n\\n## Estimated token saving\\n~<N> tokens per run\\n\\n## Risk\\n<none|low|medium> — <one line>')\"
+rm -rf \"$tmp\"
 ```
 
 ## Report


### PR DESCRIPTION
## Why

The built-in "Token Trim" routine's Step 4 ("Open the PR") checks out a branch, commits, and pushes directly inside `~/.config/moadim` — the live checkout the daemon reads its own routines from. That's exactly the anti-pattern fixed for the sibling "The 1 Percent" routine in #916 (`fix(the-1-percent): work in a temp clone, never mutate ~/.config/moadim`), which switched to cloning into a disposable `mktemp -d` dir and doing all branch/commit/push work there.

Token Trim was simply never updated to match, so it still risks leaving the daemon's own routines checkout parked on a stale/half-merged branch while the daemon concurrently reads from it.

## What changed

`src/routines/defaults/token_trim.rs`: Step 4 of the prompt now clones the routines repo's origin into a temp dir and does all git operations (`checkout -b`, `add`, `commit`, `push`) there, then removes the temp dir — mirroring `the_1_percent.rs`'s already-fixed pattern exactly.

No test asserts on the exact prompt body text (`mod_tests.rs` only checks title/schedule/agent), so no test changes were needed.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (917 passed)
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — exit 0, unchanged from baseline (this file is a `const &str` prompt body, not executable lines)
- [x] Added a changeset (`.changeset/token-trim-temp-clone.md`)