### PR TITLE
chore(lint): enable clippy::explicit_into_iter_loop

### DIFF
--- a/.changeset/clippy-explicit-into-iter-loop.md
+++ b/.changeset/clippy-explicit-into-iter-loop.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::explicit_into_iter_loop`
+
+Companion to the already-enabled `clippy::explicit_iter_loop`: rejects
+`for x in collection.into_iter()` in favor of the equivalent, shorter
+`for x in collection`. The workspace was already clean against this lint
+(zero violations), so `deny` just locks that in. No behavior change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,12 @@ unwrap_used = "deny"
 # reader having to confirm that `.iter()` isn't secretly `.into_iter()` (which
 # would move). It states "borrow and iterate" at a glance.
 explicit_iter_loop = "deny"
+# Companion to `explicit_iter_loop` above: reject `for x in collection.into_iter()`
+# in favour of the equivalent `for x in collection`. `.into_iter()` here is
+# redundant — a plain `for` loop already calls it implicitly — so spelling it
+# out adds noise without adding meaning. The codebase is already clean, so
+# `deny` locks that in.
+explicit_into_iter_loop = "deny"
 # Reject `use some::module::*;` glob imports. Explicit imports make it clear
 # at the call site which module a name comes from, avoid silent breakage or
 # ambiguity when the globbed module adds a new item, and keep `rust-analyzer`


### PR DESCRIPTION
## Why

`clippy::explicit_iter_loop` is already enabled (denies `for x in collection.iter()` in favor of `for x in &collection`), but its `.into_iter()` companion wasn't locked in yet. `for x in collection.into_iter()` is exactly equivalent to `for x in collection` — a plain `for` loop already calls `.into_iter()` implicitly — so spelling it out is pure noise.

The workspace (`src/` and `ui/`) is already clean against this lint: zero violations. This PR only adds the lint to `Cargo.toml`'s `[lints.clippy]` table (with the same rationale-comment style as its neighbors) plus a changeset entry; no other files change.

## Verification

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (917 + 259 passed)
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (100% lines)

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.