### PR TITLE
ci: run linecheck (500-line gate) in CI, not just the local hook

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,13 @@ name: Lint
 # member crate is linted too; `ui`'s deps (yew/gloo/web-sys) build fine on the
 # host target for clippy's purposes, so no wasm32 target install is required
 # here either.
+#
+# The pre-push hook's file-size gate (`linecheck --max-lines 500` over
+# `src/` and `ui/src/`) has no CI equivalent, so it's a no-op for any
+# contributor who hasn't opted into `git config core.hooksPath .githooks`
+# (see CONTRIBUTING.md) — a PR could silently blow past the 500-line
+# convention and still go fully green. The `linecheck` job below closes
+# that gap the same way this file already does for fmt/clippy.
 
 on:
   pull_request:
@@ -95,3 +102,30 @@ jobs:
         # never enforced here, so a PR could lint-regress the dashboard and
         # still go fully green.
         run: cargo clippy --workspace --all-targets -- -D warnings
+
+  linecheck:
+    name: linecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+
+      - name: Cache cargo registry and target/
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: linecheck
+
+      - name: Install linecheck
+        run: cargo install linecheck --locked
+
+      - name: Check .rs files do not exceed 500 lines
+        # Match the local pre-push hook exactly (same paths, same limit).
+        run: |
+          # shellcheck disable=SC2046
+          linecheck --max-lines 500 $(find src ui/src -name '*.rs')


### PR DESCRIPTION
## Why

The pre-push hook (`.githooks/pre-push`) enforces a 500-line-per-file cap via
`linecheck` across `src/` and `ui/src/`, and the repo's history is full of PRs
splitting files to satisfy it (e.g. #1020, #1018, #1017, #1008, #997, #996,
#976). But that gate has never had a CI equivalent, and enabling the hooks is
opt-in (`git config core.hooksPath .githooks`, per CONTRIBUTING.md). A PR from
a contributor who hasn't installed the hooks — or a `--no-verify` push —
could blow past the 500-line convention and still go fully green through
`lint.yml`/`test.yml`.

This mirrors exactly what `lint.yml` already does for `cargo fmt`/`cargo
clippy`: give the hook-only gate a CI job so it's enforced for everyone,
regardless of local setup.

## What

Adds a `linecheck` job to `.github/workflows/lint.yml` that installs the same
`linecheck` crate used locally and runs the identical command the pre-push
hook runs (`linecheck --max-lines 500` over every `.rs` file under `src/` and
`ui/src/`).

Verified locally:
- `linecheck --max-lines 500 $(find src ui/src -name '*.rs')` passes on `main` (repo is currently compliant).
- `actionlint` (with shellcheck) passes clean on the updated workflow.
- `cargo fmt --check` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace` all still pass — no source changes, CI-only.

No changeset needed: this only touches `.github/workflows/`, not `src/` or `ui/`.

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.