### PR TITLE
chore: add missing changesets

### DIFF
--- a/.changeset/add-cli-enable-disable-routine.md
+++ b/.changeset/add-cli-enable-disable-routine.md
@@ -1,0 +1,5 @@
+---
+"moadim": minor
+---
+
+Add `moadim enable`/`disable <routine>` CLI commands to toggle a routine's enabled state from the terminal (#820).

--- a/.changeset/enforce-linecheck-in-ci.md
+++ b/.changeset/enforce-linecheck-in-ci.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Enforce the 500-line-per-file gate in CI, not just the local pre-push hook (#1029).

--- a/.changeset/split-service-trigger-tests.md
+++ b/.changeset/split-service-trigger-tests.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Split service_trigger_tests.rs to satisfy the 500-line pre-push gate; no behavior change (#1018).


### PR DESCRIPTION
Adds the missing Changesets entries for 3 recently merged PRs that shipped without one:

- #820 — feat(cli): add `moadim enable`/`disable <routine>` (minor)
- #1018 — test(routines): split service_trigger_tests.rs to clear the 500-line gate (patch)
- #1029 — ci: run linecheck (500-line gate) in CI, not just the local hook (patch)

No code changes, only `.changeset/*.md` additions.