### PR TITLE
test(atomic): cover write_tmp's ENOSPC path via /dev/full

### DIFF
--- a/.changeset/atomic-write-enospc-regression-test.md
+++ b/.changeset/atomic-write-enospc-regression-test.md
@@ -1,0 +1,7 @@
+---
+"moadim": patch
+---
+
+### Added
+
+Regression test for `write_tmp`'s ENOSPC/EIO error path (via `/dev/full` on Linux), guarding the fix in #1019 where a full or failing disk during `atomic_write` now propagates the I/O error instead of panicking the whole daemon.

--- a/src/utils/atomic_tests.rs
+++ b/src/utils/atomic_tests.rs
@@ -87,6 +87,26 @@ fn tmp_path_falls_back_when_no_file_name() {
     assert!(tmp.to_string_lossy().contains(".tmp"));
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn write_tmp_propagates_a_write_failure_instead_of_panicking() {
+    // `/dev/full` always reports the device as full, so `write_all` fails with `ENOSPC` the same
+    // way a real full disk would — the realistic failure mode `write_tmp`'s doc comment calls out,
+    // and the reason its `?` propagation (rather than the `.expect()` this used to be) matters.
+    // `write_tmp` is private, so this calls it directly: `atomic_write`'s own tmp path embeds a
+    // fresh UUID per call, which can't be pointed at `/dev/full` from outside.
+    let dir = scratch_dir();
+    let tmp = dir.join("routine.toml.tmp");
+    std::os::unix::fs::symlink("/dev/full", &tmp).unwrap();
+
+    assert!(
+        write_tmp(&tmp, b"data").is_err(),
+        "write_tmp must return the write error instead of panicking"
+    );
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
 #[cfg(unix)]
 #[test]
 fn published_file_is_owner_only() {


### PR DESCRIPTION
## Summary
- #1019 changed `write_tmp`'s `write_all`/`sync_all` from `.expect(...)` to `?`, so a full or failing disk mid-write returns an `io::Error` instead of panicking the whole daemon. That specific propagation was untested — `cargo llvm-cov`'s line-coverage gate stayed green because the *outer* error-handling branch in `atomic_write` (temp-file cleanup + return) is already exercised by the existing `errors_when_temp_cannot_be_created` test, but the `write_all`/`sync_all` call sites themselves had zero region coverage.
- Adds a regression test that points `write_tmp`'s temp path at a symlink to `/dev/full` (a Linux virtual device that always reports "disk full"), so `write_all` deterministically fails with `ENOSPC` — the exact real-world failure mode the function's doc comment calls out — without any global process state (`setrlimit`, fd-closing) that could make other parallel tests flaky.
- Gated `#[cfg(target_os = "linux")]` since `/dev/full` has no macOS equivalent; runs on the existing Linux CI (`cargo test`).

## Why
`atomic_write` is the daemon's core durability primitive backing routine/agent config persistence. Its most realistic failure mode (ENOSPC/EIO on write) had a real bug until #1019 (a full disk would panic the daemon) and deserves a standing regression test, not just the type signature's promise.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace atomic` (new test correctly compiled out on macOS via the `target_os = "linux"` gate; existing atomic tests still pass)
- [x] Included a changeset (`.changeset/atomic-write-enospc-regression-test.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)