### PR TITLE
test(routines): cover next_run_at's no-future-fire branch

### DIFF
--- a/.changeset/next-run-at-no-future-fire-branch.md
+++ b/.changeset/next-run-at-no-future-fire-branch.md
@@ -1,0 +1,15 @@
+---
+"moadim": patch
+---
+
+test(routines): cover `next_run_at`'s "no future fire" branch in `model.rs`
+
+`next_run_at`'s doc comment documents three `None` cases — disabled, an
+unparseable schedule, and a schedule with no upcoming fire — but only the
+first two had tests. `cargo llvm-cov`'s region report showed the third
+branch (`cron.iter_after(Local::now()).next()?` returning `None`) was never
+exercised. Added a test using a parseable 7-field (`sec min hour dom month
+dow year`) schedule pinned to a year that has already passed, so parsing
+succeeds but the iterator yields no occurrence.
+
+No behavior change — regression test only.

--- a/src/routines/model_tests.rs
+++ b/src/routines/model_tests.rs
@@ -183,6 +183,15 @@ fn next_run_at_none_for_unparseable_schedule() {
 }
 
 #[test]
+fn next_run_at_none_for_a_schedule_with_no_future_fire() {
+    // A parseable 7-field (sec min hour dom month dow year) schedule pinned to a year that has
+    // already passed matches croner's own syntax, so `.parse()` succeeds, but `iter_after(now)`
+    // never yields an occurrence — covering the third documented `None` case (no upcoming fire)
+    // distinct from "unparseable" and "disabled".
+    assert!(next_run_at("0 0 0 1 1 * 2020", true).is_none());
+}
+
+#[test]
 fn from_routine_populates_derived_fields() {
     let routine = Routine {
         id: "rid".into(),


### PR DESCRIPTION
## Why

`next_run_at`'s doc comment in `src/routines/model.rs` documents three `None` cases:
- `enabled` is `false`
- the schedule can't be parsed
- the schedule parses but has no upcoming fire

Only the first two had tests (`next_run_at_none_when_disabled`,
`next_run_at_none_for_unparseable_schedule`). `cargo llvm-cov`'s region report
(region coverage isn't tracked by the repo's line-only 100% gate, so this kind
of gap is invisible to `--fail-under-lines`) showed the third branch —
`cron.iter_after(Local::now()).next()?` returning `None` — was never
exercised by any test.

## What changed

Added `next_run_at_none_for_a_schedule_with_no_future_fire`: a parseable
7-field (`sec min hour dom month dow year`) cron schedule pinned to a year
that has already passed. `.parse()` succeeds (croner supports the year
field), but `iter_after(now)` yields no occurrence, exercising the
previously-uncovered branch. Confirmed it resolves in ~2ms, not a slow crawl
toward croner's internal year ceiling.

No behavior change — regression test only. Verified locally: `cargo fmt --check`,
`cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`
(922 passed, up from 921), and `cargo llvm-cov --fail-under-lines 100
--ignore-filename-regex 'src/main\.rs'` all pass; `model.rs`'s missed-region
count dropped from 1 to 0 in the coverage report.

Added a changeset (`patch`) since this touches `src/`, matching the existing
"test-only, no behavior change" changeset precedent in this repo (e.g. the
`log-tail-branch-coverage` changeset).

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.