### PR TITLE
fix(cleanup): lower workbench-reap sweep from hourly to 5 minutes

### DIFF
--- a/.changeset/faster-workbench-cleanup-sweep.md
+++ b/.changeset/faster-workbench-cleanup-sweep.md
@@ -1,0 +1,7 @@
+---
+"moadim": patch
+---
+
+### Fixed
+
+Lower the background workbench-cleanup sweep from hourly to every 5 minutes, so a high-frequency routine (e.g. an every-minute schedule, whose effective TTL can be as low as ~60s) no longer piles up dozens of expired, finished workbenches — full repo clones included — between sweeps (#170). The max-runtime watchdog is unaffected; it already runs on its own 30s cadence.

--- a/Architecture.md
+++ b/Architecture.md
@@ -179,7 +179,7 @@ instants so external calendars can subscribe without an embedded `VTIMEZONE`. Th
 `?routine=<id>` query param scopes the feed to a single routine (named after it via `X-WR-CALNAME`);
 an unknown or disabled id yields a well-formed empty calendar. See `src/routines/ical.rs`.
 
-Finished run workbenches are reaped automatically by an hourly background sweep
+Finished run workbenches are reaped automatically by a background sweep (every 5 minutes)
 (`routines::cleanup`, per-routine `ttl_secs`). `POST /routines/cleanup` (MCP tool
 `cleanup_workbenches`) runs that same sweep on demand and returns `{ "removed": N }`, so a caller
 need not wait for the next tick. A live tmux session within its run's max runtime is never touched;

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ install -Dm644 docs/moadim.1 "$HOME/.local/share/man/man1/moadim.1"
 - Routines created via REST or MCP are written into your OS crontab automatically
 - **Routines** schedule an AI agent — a prompt + schedule + agent, stored in `~/.config/moadim/routines/` (see [Routines](#routines)) — git-trackable, diff-friendly
 - **Agents** are a registry of coding agents (`claude`, …) under `~/.config/moadim/agents/<name>.toml`, referenced by routines
-- Each routine run executes in a throwaway **workbench** under `~/.moadim/workbenches/` (a separate tree from the config dir), reaped on an hourly cleanup sweep
+- Each routine run executes in a throwaway **workbench** under `~/.moadim/workbenches/` (a separate tree from the config dir), reaped on a periodic (5-minute) cleanup sweep
 - Same REST and MCP interface — no logic duplication between protocols
 - API spec auto-generated at build time into `apis/`
 
@@ -116,7 +116,7 @@ install -Dm644 docs/moadim.1 "$HOME/.local/share/man/man1/moadim.1"
 └── user_prompt.md             # optional — appended to every routine's prompt (see ## Routines)
 
 ~/.moadim/                     # runtime tree, separate from the config dir above
-└── workbenches/               # per-run throwaway dirs, reaped on the hourly sweep
+└── workbenches/               # per-run throwaway dirs, reaped on the periodic sweep
 ```
 
 ## Crontab sync
@@ -173,9 +173,9 @@ git-trackable:
 | `tags`         | list   | no       | Free-form labels for grouping/filtering routines (e.g. `"nightly"`). Defaults to empty; each entry is trimmed and must be non-blank. |
 
 **Workbenches and cleanup:** each run executes in a workbench under
-`~/.moadim/workbenches/`. Finished, expired workbenches are reaped on an
-hourly sweep so they don't accumulate; trigger a sweep on demand with
-`moadim cleanup`. Sessions still running are never reaped.
+`~/.moadim/workbenches/`. Finished, expired workbenches are reaped on a
+periodic (5-minute) sweep so they don't accumulate; trigger a sweep on demand
+with `moadim cleanup`. Sessions still running are never reaped.
 
 **REST** — under the `/api/v1` prefix:
 
@@ -315,7 +315,7 @@ moadim stop --json     # same, as a machine-readable JSON object
 | `moadim restart -i`, `--interactive` | interactive | Stops the running server (if any), same as `moadim restart`, but brings the fresh instance up in the foreground instead of backgrounding it — mirrors `moadim -i`. |
 | `moadim stop`      | —             | Sends `POST /shutdown` to the running server for a graceful stop. Add `--json` for `{"running":bool,"pid":N\|null,"address":"127.0.0.1:5784"}` (the `pid` is read before the shutdown request, since a graceful stop clears the pid file). Exits `0` when a running server was asked to shut down, `3` when none was reachable. |
 | `moadim status`    | —             | Prints whether a server is reachable on `127.0.0.1:5784`. Add `--json` for `{"running":bool,"pid":N\|null,"address":"127.0.0.1:5784","uptime_secs":N\|null,"version":S\|null}` — `uptime_secs`/`version` come from the server's `GET /health`, so a single call returns liveness **and** age/version (both `null` when no server answers). Add `--wait[=SECS]` to poll `GET /health` every 200ms until it answers or `SECS` elapse (default 30) instead of checking once, so a launch script can block on startup rather than sleeping blindly. Exits `0` when running, `3` when not (including a `--wait` timeout). |
-| `moadim cleanup`   | —             | Sends `POST /api/v1/routines/cleanup` to the running server and prints how many finished, expired routine workbenches were reaped and the disk space freed, e.g. `cleanup removed 3 workbenches (freed 12.4 MB)` (the on-demand version of the hourly sweep). Add `--json` for `{"running":bool,"removed":N,"freed_bytes":N,"address":"127.0.0.1:5784"}` (matching `status`/`stop --json`'s shape). Exits `0` when running, `3` when not. |
+| `moadim cleanup`   | —             | Sends `POST /api/v1/routines/cleanup` to the running server and prints how many finished, expired routine workbenches were reaped and the disk space freed, e.g. `cleanup removed 3 workbenches (freed 12.4 MB)` (the on-demand version of the periodic sweep). Add `--json` for `{"running":bool,"removed":N,"freed_bytes":N,"address":"127.0.0.1:5784"}` (matching `status`/`stop --json`'s shape). Exits `0` when running, `3` when not. |
 | `moadim trigger <id>` | —          | Sends `POST /api/v1/routines/{id}/trigger` to the running server, launching the routine immediately outside its schedule (the terminal equivalent of the REST/MCP on-demand trigger). Prints `triggered routine <id>` on success. Exits `0` when triggered, `3` when no server is reachable, and `1` with `no routine with id <id>` on a `404`. (`moadim run <id>` is kept as a hidden back-compat alias.) |
 
 `status`, `cleanup`, and `stop` follow a script-friendly exit-code contract so callers can branch

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -44,9 +44,9 @@ fn format_version(version: &str, sha: &str, date: &str) -> String {
 /// path differs from the one this process was started from (#167). A daemon left running across an
 /// in-place binary upgrade keeps executing the old compiled-in logic — including whatever it writes
 /// into a routine's generated agent instructions, such as the routine-origin disclosure — with no
-/// signal to the operator that a restart would pick up the newer build. Hourly matches the existing
-/// workbench-cleanup cadence ([`crate::routines::CLEANUP_INTERVAL`]); this is an operator nudge, not
-/// a time-critical check.
+/// signal to the operator that a restart would pick up the newer build. Hourly is plenty: this is
+/// an operator nudge, not a time-critical check, so it runs on its own cadence independent of
+/// [`crate::routines::CLEANUP_INTERVAL`].
 pub const VERSION_DRIFT_CHECK_INTERVAL: std::time::Duration =
     std::time::Duration::from_secs(60 * 60);
 

--- a/src/routes/http_listener.rs
+++ b/src/routes/http_listener.rs
@@ -109,10 +109,10 @@ pub async fn run_with_listener_until(
             .await;
         }
     });
-    // Force-kill hung runs on a much shorter cadence than the hourly reap above, so a sub-hour
-    // `max_runtime_secs` is enforced near its bound instead of waiting up to ~1h for the next sweep.
+    // Force-kill hung runs on a shorter cadence than the reap above, so a sub-minute
+    // `max_runtime_secs` is enforced near its bound instead of waiting for the next sweep.
     // This tick only evaluates the kill branch; TTL reaping of the killed workbench still happens in
-    // the hourly sweep.
+    // the sweep above.
     let watchdog_store = routines.clone();
     let watchdog_task = tokio::spawn(async move {
         let mut tick = tokio::time::interval(crate::routines::WATCHDOG_INTERVAL);

--- a/src/routines/cleanup/mod.rs
+++ b/src/routines/cleanup/mod.rs
@@ -40,15 +40,21 @@ pub(crate) use session::tmux_session_prefix_alive;
 pub(crate) use ttl::ttl_ceiling_secs;
 
 /// How often the background task scans for expired workbenches.
-pub const CLEANUP_INTERVAL: Duration = Duration::from_secs(60 * 60);
+///
+/// A routine's `effective_ttl_secs` can be as low as the cron interval (e.g. ~60s for an
+/// every-minute schedule, see [`ttl::MAX_TTL_SECS`]), well under an hour. This was previously a
+/// flat 1h, so a high-frequency routine's finished workbenches (full repo clones included) could
+/// pile up dozens deep between sweeps (#170). 5 minutes bounds that worst case to a handful of
+/// stale workbenches while keeping the sweep infrequent enough that its directory walk and
+/// `dir_size`/`remove_dir_all` work stay cheap.
+pub const CLEANUP_INTERVAL: Duration = Duration::from_secs(5 * 60);
 
 /// How often the lightweight watchdog scans for *hung* runs to force-kill.
 ///
-/// Decoupled from [`CLEANUP_INTERVAL`]: TTL-reaping finished workbenches can stay hourly, but the
-/// max-runtime watchdog must fire on a much shorter cadence or a sub-hour `max_runtime_secs` is
-/// unenforceable (a hung run would survive up to ~1h past its bound). At 30s the kill latency is
-/// `effective_max_runtime_secs + <=30s`, so even a routine bounded to a few minutes is reaped near
-/// its limit. This tick only evaluates the kill branch (no directory removal), so it stays cheap.
+/// Shorter than [`CLEANUP_INTERVAL`]: the max-runtime watchdog must fire on a cadence tight enough
+/// that a sub-minute `max_runtime_secs` is still enforceable near its bound. At 30s the kill
+/// latency is `effective_max_runtime_secs + <=30s`. This tick only evaluates the kill branch (no
+/// directory removal), so it stays cheap.
 pub const WATCHDOG_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Split a workbench directory name into its `(slug, trigger_timestamp)`.


### PR DESCRIPTION
## Why

Fixes #170.

A routine's `effective_ttl_secs` can be as low as ~60s — `min(MAX_TTL_SECS, cron_interval_secs)`, so an every-minute (`* * * * *`) routine gets an effective retention of about one minute. But the background reaper (`cleanup_expired_workbenches`, wired up in `src/routes/http_listener.rs`) only swept once an hour (`CLEANUP_INTERVAL`).

Each trigger creates a fresh workbench under `~/.moadim/workbenches/{slug}-{ts}` holding the prompt, logs, and any repos the agent cloned. For a sub-hour-schedule routine, up to ~60 already-expired, finished workbenches could accumulate on disk between hourly sweeps before any of them were reclaimed — the retention granularity the config implies (down to the cron interval) wasn't actually what got enforced.

## What

- `CLEANUP_INTERVAL` (`src/routines/cleanup/mod.rs`): 1 hour → 5 minutes. This is the "simpler interim fix" the issue itself proposes (vs. fully dynamic recomputation tracking the shortest TTL in play), and keeps the change to a one-line constant plus doc/comment updates.
- Updated the doc comments in `cleanup/mod.rs`, `http_listener.rs`, and `build_info.rs` that referenced the old hourly cadence (the latter's `VERSION_DRIFT_CHECK_INTERVAL` is an unrelated, independent hourly check — its comment previously (and now incorrectly would) claimed it "matches" the cleanup cadence).
- Updated `README.md`/`Architecture.md` mentions of "hourly sweep" to match.
- `WATCHDOG_INTERVAL` (30s, for force-killing hung runs) is untouched — it was already decoupled and on a shorter cadence.

Not attempted: the fully dynamic "recompute cadence from the shortest effective TTL across enabled routines" variant the issue also sketches — a fixed, small interval closes the vast majority of the gap (worst case now ~5 stale workbenches instead of ~60) without the added complexity of watching routine-store changes to retune a running `tokio::time::interval`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (921 + 259 passed)
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (100% lines)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`
- [x] `linecheck --max-lines 500` over `src` + `ui/src`
- [x] `typos`