### PR TITLE
docs: add make readme-check to validate README's fenced json blocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,11 @@
 # .github/workflows/ — this only wraps the existing gates, it never redefines
 # them.
 
-.PHONY: spell
+.PHONY: spell readme-check
 
 spell:
 	@command -v typos >/dev/null 2>&1 || cargo install typos-cli
 	typos
+
+readme-check:
+	./scripts/check-readme-blocks.sh

--- a/TODO.md
+++ b/TODO.md
@@ -10,4 +10,4 @@ This is a list of todos for consumption, in a pr remove the todo you have implem
 - Add a TTL preset row (1h / 1d / 7d / 30d) under the WORKBENCH TTL input in the routine form, mirroring the cron schedule presets
 - Show a humanized retention countdown ("expires in 2d" / "expired") per finished run in the routine LOGS view, derived from the run's finish time and the routine's effective TTL
 - Auto-refresh the routine LOGS view (or show a removed badge) after a CLEANUP NOW sweep so stale run output isn't shown for reaped workbenches
-- Run the README's fenced `sh`/`json` blocks through a docs lint in CI (e.g. a `markdownlint`/`mdsh` check or a `--json | jq -e` smoke test) so the documented JSON shapes can't drift from the actual CLI output silently
+- Wire `make readme-check` (`scripts/check-readme-blocks.sh`) into `.github/workflows/lint.yml` as its own job — it validates README's fenced json blocks with jq but isn't CI-enforced yet, since adding it requires a token with the `workflow` OAuth scope

--- a/scripts/check-readme-blocks.sh
+++ b/scripts/check-readme-blocks.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Validate every fenced ```json block in README.md with `jq`, so a documented
+# JSON shape can't silently drift into invalid JSON as the README is edited.
+set -euo pipefail
+
+readme="README.md"
+status=0
+in_block=0
+block=""
+start_line=0
+lineno=0
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+  lineno=$((lineno + 1))
+  if [[ $in_block -eq 0 ]]; then
+    if [[ $line == '```json' ]]; then
+      in_block=1
+      block=""
+      start_line=$lineno
+    fi
+  elif [[ $line == '```' ]]; then
+    in_block=0
+    if ! jq -e . >/dev/null 2>/tmp/readme-block-err <<<"$block"; then
+      echo "::error file=$readme,line=$start_line::json block is not valid JSON: $(cat /tmp/readme-block-err)"
+      status=1
+    fi
+  else
+    block+="$line"$'\n'
+  fi
+done <"$readme"
+
+rm -f /tmp/readme-block-err
+exit "$status"


### PR DESCRIPTION
## Why

TODO.md carried an open item: lint README's fenced `sh`/`json` blocks so a documented JSON shape can't silently drift into something invalid as the README gets edited. There's one such block today (the `MOADIM_LOG_FORMAT=json` log line example); more will likely show up as CLI/API examples grow.

## What

- `scripts/check-readme-blocks.sh`: walks README.md, extracts every fenced ` ```json ` block, and validates it with `jq -e`.
- `make readme-check`: convenience wrapper, matching the existing `make spell` pattern.

Scoped to JSON only. I initially also syntax-checked ` ```sh ` blocks with `bash -n`, but README's shell examples use `<id>`-style placeholders (e.g. `moadim trigger <id>`), which `bash -n` parses as a redirection and rejects — a false positive, not a real bug. Dropped that half rather than special-case placeholder syntax.

## Not done here

Wiring this into `.github/workflows/lint.yml` as its own CI job — that edit needs a token with the `workflow` OAuth scope, which wasn't available when preparing this PR. Left a follow-up note in TODO.md; `make readme-check` runs the same check locally in the meantime.

## Test plan
- [x] `./scripts/check-readme-blocks.sh` exits 0 against current README.md
- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` pass (no src/ui changes, but ran anyway)