### PR TITLE
test(ui): cover parse_cron/describe_cron_live in cron_utils.rs

### DIFF
--- a/.changeset/cron-utils-host-tests.md
+++ b/.changeset/cron-utils-host-tests.md
@@ -1,0 +1,17 @@
+---
+"moadim": patch
+---
+
+test(ui): cover `parse_cron`/`describe_cron_live` in `cron_utils.rs`
+
+`cron_utils.rs`'s field-count normalization (5-field passthrough, 6-field
+with seconds, 7-field seconds+year stripping, `@keyword`, and invalid input)
+and `describe_cron_live`'s validity/description pairing had no tests at
+all, unlike the sibling `schedule.rs`/`schedule_heatmap.rs` pure-logic
+modules which both have dedicated `*_tests.rs` files. Added
+`cron_utils_tests.rs` following that same host-tested convention.
+`reltime` is left untested — it calls `js_sys::Date::now()` and needs a
+wasm/DOM host, mirroring the pure/DOM split already documented in
+`refresh.rs`.
+
+No behavior change — regression tests only.

--- a/ui/src/cron_utils.rs
+++ b/ui/src/cron_utils.rs
@@ -53,3 +53,7 @@ pub(crate) fn reltime(ts: u64) -> String {
         format!("{}d ago", diff / 86_400)
     }
 }
+
+#[cfg(test)]
+#[path = "cron_utils_tests.rs"]
+mod cron_utils_tests;

--- a/ui/src/cron_utils_tests.rs
+++ b/ui/src/cron_utils_tests.rs
@@ -1,0 +1,66 @@
+//! Host-side unit tests for the pure cron helpers in [`super`]: `parse_cron`'s
+//! field-count normalization and `describe_cron_live`'s validity/description
+//! pairing. `reltime` is excluded — it calls `js_sys::Date::now()` and needs a
+//! wasm/DOM host, so it isn't host-testable (mirrors the `refresh.rs`/
+//! `schedule.rs` split between pure and DOM-touching logic).
+
+use super::*;
+
+#[test]
+fn parse_cron_rejects_empty_and_blank() {
+    assert!(parse_cron("").is_none());
+    assert!(parse_cron("   ").is_none());
+}
+
+#[test]
+fn parse_cron_accepts_5_field() {
+    assert!(parse_cron("0 * * * *").is_some());
+}
+
+#[test]
+fn parse_cron_accepts_6_field_with_seconds() {
+    // 6-field (sec min hour dom month dow) is valid croner syntax as-is, so it
+    // parses without normalization, keeping second-level detail in describe().
+    let cron = parse_cron("30 0 * * * *").expect("valid 6-field expression");
+    assert!(cron.describe().contains("second"));
+}
+
+#[test]
+fn parse_cron_normalizes_7_field_by_dropping_seconds_and_year() {
+    // 7-field (sec min hour dom month dow year) isn't valid croner syntax on
+    // its own; parse_cron must strip both the seconds and year fields before
+    // handing it to croner, matching the server's normalize_schedule.
+    let cron = parse_cron("30 0 12 * * * 2026").expect("normalized to a valid 5-field schedule");
+    assert_eq!(cron.describe(), "At 12:00.");
+}
+
+#[test]
+fn parse_cron_passes_through_at_keywords() {
+    assert!(parse_cron("@daily").is_some());
+}
+
+#[test]
+fn parse_cron_rejects_invalid_expression() {
+    assert!(parse_cron("not a cron").is_none());
+}
+
+#[test]
+fn describe_cron_live_reports_placeholder_for_blank_input() {
+    let (valid, description) = describe_cron_live("   ");
+    assert!(!valid);
+    assert_eq!(description, "— enter a cron expression —");
+}
+
+#[test]
+fn describe_cron_live_reports_invalid_for_bad_expression() {
+    let (valid, description) = describe_cron_live("not a cron");
+    assert!(!valid);
+    assert_eq!(description, "Invalid cron expression");
+}
+
+#[test]
+fn describe_cron_live_describes_valid_expression() {
+    let (valid, description) = describe_cron_live("0 * * * *");
+    assert!(valid);
+    assert!(!description.is_empty());
+}


### PR DESCRIPTION
## Summary

`ui/src/cron_utils.rs` holds the cron-expression parsing/formatting logic shared by the routines, schedule, and heatmap views (`parse_cron`, `describe_cron_live`, `reltime`). It had **zero** tests, unlike its two sibling pure-logic modules — `schedule.rs` (`schedule_tests.rs`) and `schedule_heatmap.rs` (`schedule_heatmap_tests.rs`) — which both follow a documented host-tested convention.

This PR adds `ui/src/cron_utils_tests.rs`, testing:
- `parse_cron`: empty/blank input, 5-field passthrough, 6-field-with-seconds (parses as-is via croner, preserving second-level detail), 7-field (seconds+year stripped to match the server's `normalize_schedule` in `src/utils/cron.rs`), `@keyword` schedules, and invalid input.
- `describe_cron_live`: the blank-input placeholder, the invalid-expression message, and the valid-expression description.

`reltime` is deliberately left untested — it calls `js_sys::Date::now()` and needs a wasm/DOM host to run, mirroring the pure/DOM split already documented in `refresh.rs` (`fmt_freshness` is host-tested, the DOM-touching parts aren't).

No behavior change — regression tests only. `ui` isn't held to the 100%-line-coverage gate (that's root-package-only per `CONTRIBUTING.md`), so this test gap was easy to miss; the diff is small and self-contained.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (268 passed, up from 259; 9 new tests added, 0 failed)
- [x] `linecheck --max-lines 500` over `src/` and `ui/src/`
- [x] Added `.changeset/cron-utils-host-tests.md` (patch, package `moadim`)

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.