### PR TITLE
ci: wire make readme-check into lint.yml as its own job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,12 @@ name: Lint
 # (see CONTRIBUTING.md) — a PR could silently blow past the 500-line
 # convention and still go fully green. The `linecheck` job below closes
 # that gap the same way this file already does for fmt/clippy.
+#
+# `make readme-check` (scripts/check-readme-blocks.sh) validates every
+# ```json fence in README.md with `jq` but isn't run by any git hook either,
+# so it was previously exercised only when a contributor remembered to run
+# it by hand. The `readme-check` job below runs it on every PR so a
+# README example can't silently drift into invalid JSON.
 
 on:
   pull_request:
@@ -129,3 +135,16 @@ jobs:
         run: |
           # shellcheck disable=SC2046
           linecheck --max-lines 500 $(find src ui/src -name '*.rs')
+
+  readme-check:
+    name: readme-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Validate README's fenced json blocks
+        # jq ships preinstalled on the ubuntu-latest runner image, so no
+        # setup step is needed beyond checkout.
+        run: make readme-check

--- a/TODO.md
+++ b/TODO.md
@@ -10,4 +10,3 @@ This is a list of todos for consumption, in a pr remove the todo you have implem
 - Add a TTL preset row (1h / 1d / 7d / 30d) under the WORKBENCH TTL input in the routine form, mirroring the cron schedule presets
 - Show a humanized retention countdown ("expires in 2d" / "expired") per finished run in the routine LOGS view, derived from the run's finish time and the routine's effective TTL
 - Auto-refresh the routine LOGS view (or show a removed badge) after a CLEANUP NOW sweep so stale run output isn't shown for reaped workbenches
-- Wire `make readme-check` (`scripts/check-readme-blocks.sh`) into `.github/workflows/lint.yml` as its own job — it validates README's fenced json blocks with jq but isn't CI-enforced yet, since adding it requires a token with the `workflow` OAuth scope


### PR DESCRIPTION
## Why

`scripts/check-readme-blocks.sh` (added in #1035, wired as `make
readme-check`) validates every ```` ```json ```` fence in README.md with
`jq`, so a documented request/response shape can't silently drift into
invalid JSON as the README is edited. It wasn't run anywhere though —
not in CI, not in the pre-push hook — so it only caught a broken block
if a contributor remembered to run `make readme-check` by hand. TODO.md
carried this as a known follow-up ("isn't CI-enforced yet, since adding
it requires a token with the `workflow` OAuth scope").

## What

Adds a `readme-check` job to `.github/workflows/lint.yml` (the same
workflow that already runs `fmt`/`clippy`/`linecheck`) that checks out
the repo and runs `make readme-check`. `jq` ships preinstalled on the
`ubuntu-latest` runner image, so no extra setup step is needed. Removed
the now-implemented TODO.md entry per the repo's "remove the todo you
implement" convention.

Verified locally: `make readme-check` passes, `actionlint
.github/workflows/lint.yml` is clean, and `cargo fmt --check` / `cargo
clippy --workspace --all-targets -- -D warnings` / `cargo test
--workspace` / `cargo llvm-cov --fail-under-lines 100` all pass
unrelated to this change (workflow-only, no `src/`/`ui/` diff, so no
changeset is required).