### PR TITLE
docs: fix validation findings

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -111,8 +111,13 @@ Middleware stack (outermost first): `CompressionLayer` → `logger` → `securit
 | `update_routine` | `routines::svc_update` |
 | `delete_routine` | `routines::svc_delete` |
 | `trigger_routine` | `routines::svc_trigger` |
+| `snooze_routine` | `routines::svc_snooze` |
+| `set_power_saving` | `routines::svc_set_power_saving` |
 | `cleanup_workbenches` | `routines::svc_cleanup` |
 | `list_agents` | `routines::available_agents` |
+| `create_flag` | `routines::svc_create_flag` |
+| `list_flags` | `routines::svc_list_flags` |
+| `resolve_flag` | `routines::svc_resolve_flag` |
 | `routine_logs` | `routines::svc_logs` |
 | `list_routine_runs` | `routines::svc_list_runs` |
 | `get_lock_status` | `global_lock::lock_status` |

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ git-trackable:
 | `schedule`     | string | yes      | Cron expression (`min hour dom month dow` or `@daily`, …), evaluated in the host's local timezone — **not** UTC. |
 | `title`        | string | yes      | Human name; slugified to name the run workbench and tmux session.                            |
 | `agent`        | string | yes      | Agent registry key (e.g. `claude`), resolved from `~/.config/moadim/agents/<agent>.toml`.    |
+| `model`        | string | no       | Model ID to run the agent with (e.g. `claude-sonnet-4-6`), passed as `--model` on the agent invocation. `None`/omitted uses the agent's own default. |
 | `goal`         | string | no       | A very short (≤5 lines) statement of the routine's goal — the "why" behind the prompt. Rendered into `prompt.md` as a `## Goal` preamble. |
 | `repositories` | list   | no       | Git repos listed in the prompt as context. Moadim does **not** clone them — the agent does.   |
 | `machines`     | list   | no       | Machine identities this routine runs on (matched against `machine.local.toml`). Defaults to empty — **an empty list runs nowhere**, so a new routine is dormant until explicitly assigned. |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -53,7 +53,7 @@ standalone, n8n, Temporal, Airflow, etc.
   offline against the host crontab.
 - **Three interfaces, one port** — UI + REST + MCP with no logic duplication. MCP
   means an agent can read, schedule, and re-fire its **own** routines.
-- **Unattended by design** — per-run throwaway workbench (reaped hourly), tmux
+- **Unattended by design** — per-run throwaway workbench (reaped on a 5-minute sweep), tmux
   session, pre-seeded Claude trust/MCP approvals so the session never blocks.
 - **Ops niceties** — `.ics` feed of fire times, `machines` targeting, run-now
   trigger, `max_runtime_secs` kill cap, `ttl_secs` retention.

--- a/docs/moadim.1
+++ b/docs/moadim.1
@@ -91,9 +91,6 @@ entry).
 .TP
 .B agents
 List available agent keys.
-.TP
-.B echo <message>
-Echo a message via the server.
 .SH OPTIONS
 .TP
 .B \-\-json


### PR DESCRIPTION
Weekly docs-validation pass. Doc-only changes, no source touched.

- `docs/moadim.1:95-96` — man page still documented `moadim echo <message>`, but the echo demo endpoint/tool/CLI passthrough was removed (see CHANGELOG.md #359, "Removed the vestigial `echo` demo endpoint/tool"). Removed the stale `.TP` entry.
- `Architecture.md:105-122` — the "Tools exposed" MCP table was missing 5 of the 21 tools actually defined in `src/routes/mcp.rs`: `snooze_routine`, `set_power_saving`, `create_flag`, `list_flags`, `resolve_flag`. Added rows for each.
- `README.md` (Routines field table) — the `model` field (`Option<String>`, e.g. `claude-sonnet-4-6`, exposed via `--model` on `create`/`update`/`replace` and the MCP tools) exists in `src/routines/model.rs` but was undocumented in the Field table. Added a row.
- `docs/comparison.md:56` — said workbenches are "reaped hourly"; the actual cleanup sweep runs every 5 minutes (`CLEANUP_INTERVAL` in `src/routines/cleanup/mod.rs`), matching what README.md and Architecture.md already say elsewhere. Fixed the wording to match.

Ran `scripts/check-readme-blocks.sh` (the repo's README markdown/JSON-block lint) — passes clean.