### PR TITLE
fix(security): warn at startup when binding to a non-loopback address

### DIFF
--- a/.changeset/warn-non-loopback-bind.md
+++ b/.changeset/warn-non-loopback-bind.md
@@ -1,0 +1,7 @@
+---
+"moadim": patch
+---
+
+### Fixed
+
+Warn at startup when the server binds to a non-loopback address. The REST/MCP API has no authentication (#504), so exposing it beyond `127.0.0.1`/`::1` grants anyone who can reach that address unauthenticated routine CRUD; the daemon now logs a loud warning at launch, matching the existing tmux/python3 startup checks, instead of leaving this risk silent.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,6 +19,16 @@ pub fn bind_addr() -> String {
     std::env::var(BIND_ADDR_ENV).unwrap_or_else(|_| BIND_ADDR.to_string())
 }
 
+/// Returns `true` if `addr` (as returned by [`bind_addr`]) resolves to a loopback interface.
+///
+/// The REST/MCP API has no authentication (issue #504): binding to a non-loopback address
+/// exposes unauthenticated routine CRUD to the network. An address this can't parse is treated
+/// as non-loopback so callers warn rather than stay silent.
+pub fn bind_addr_is_loopback(addr: &str) -> bool {
+    addr.parse::<std::net::SocketAddr>()
+        .is_ok_and(|socket| socket.ip().is_loopback())
+}
+
 /// Environment marker set on the backgrounded child so it knows it was spawned by the launcher.
 const DAEMONIZED_ENV: &str = "MOADIM_DAEMONIZED";
 

--- a/src/cli_tests.rs
+++ b/src/cli_tests.rs
@@ -15,6 +15,19 @@ fn no_args_defaults_to_background() {
 }
 
 #[test]
+fn bind_addr_is_loopback_true_for_v4_and_v6_loopback() {
+    assert!(bind_addr_is_loopback("127.0.0.1:5784"));
+    assert!(bind_addr_is_loopback("[::1]:5784"));
+}
+
+#[test]
+fn bind_addr_is_loopback_false_for_non_loopback_or_unparsable() {
+    assert!(!bind_addr_is_loopback("0.0.0.0:5784"));
+    assert!(!bind_addr_is_loopback("192.168.1.10:5784"));
+    assert!(!bind_addr_is_loopback("not-an-address"));
+}
+
+#[test]
 fn interactive_flags_select_foreground() {
     for flag in ["-i", "--interactive", "-f", "--foreground"] {
         assert_eq!(parse(argv(&[flag])), Command::Foreground, "flag {flag}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,18 @@ async fn run_server() -> anyhow::Result<()> {
     if let Err(err) = sync::routines::sync_routines_to_crontab(&routines) {
         log::warn!("startup crontab sync failed: {err}");
     }
-    let listener = tokio::net::TcpListener::bind(cli::bind_addr()).await?;
+    // The REST/MCP API has no authentication (issue #504): binding to a non-loopback address
+    // exposes unauthenticated routine CRUD to anyone who can reach it. Warn loudly at startup,
+    // same as the tmux/python3 checks above, rather than letting this go unnoticed.
+    let bind_addr = cli::bind_addr();
+    if !cli::bind_addr_is_loopback(&bind_addr) {
+        log::warn!(
+            "moadim is binding to {bind_addr}, which is not loopback-only; the REST/MCP API has \
+             no authentication, so anyone who can reach this address can create, modify, or \
+             delete routines. Restrict network access to this port (see issue #504)."
+        );
+    }
+    let listener = tokio::net::TcpListener::bind(bind_addr).await?;
     cli::write_pid_file()?;
     let result =
         routes::http::run_with_listener_until(routines, listener, termination_signal()).await;


### PR DESCRIPTION
## Why

The REST/MCP API has no authentication (#504): setting `MOADIM_BIND_ADDR` to a non-loopback address silently exposes unauthenticated routine CRUD to anyone who can reach that address. Full auth is a much larger change tracked separately in #504. Until that lands, this risk should at least be visible.

## What

- Adds `cli::bind_addr_is_loopback(addr: &str) -> bool`, a small helper that parses the configured bind address and checks `IpAddr::is_loopback` (treats an unparsable address as non-loopback, so callers warn rather than stay silent).
- `run_server()` in `main.rs` now logs a `log::warn!` at startup when the bind address isn't loopback-only, matching the existing tmux/python3 startup-check pattern already in that function.
- Two unit tests for the new helper (IPv4/IPv6 loopback, non-loopback, and unparsable input).

## Not in scope

This is a visibility fix, not authentication. Implementing real auth for the REST/MCP surface is tracked in #504 and is intentionally left out of this small PR.

## Testing

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 924 passed (was 922; +2 new tests), 0 failed
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% line coverage (the new warning branch lives in `main.rs`, which is excluded from the floor; the new testable helper in `cli.rs` is fully covered)
- `typos` — clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)