### PR TITLE
fix(security): reject disallowed Host and cross-origin Origin on the HTTP API

### DIFF
--- a/.changeset/host-origin-validation.md
+++ b/.changeset/host-origin-validation.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Reject requests with a disallowed `Host` header, and state-changing requests with a cross-origin `Origin` header, closing the DNS-rebinding / browser cross-origin gap against the unauthenticated loopback API (#266). Extend the allowlist for reverse-proxy deployments with `MOADIM_ALLOWED_HOSTS`.

--- a/README.md
+++ b/README.md
@@ -446,6 +446,20 @@ Export the variable in your shell profile to make the change stick across comman
 `127.0.0.1:5784` addresses shown above and in the `--json` payloads reflect the default; they
 follow `MOADIM_BIND_ADDR` when it is set.
 
+Loopback isn't a full security boundary against a **browser**: any page you have open can still
+send requests to `http://127.0.0.1:5784`, and DNS rebinding can point an attacker-controlled domain
+at that same address. To close that off, every request's `Host` header is checked against an
+allowlist (`localhost`, `127.0.0.1`, `[::1]`, and the configured bind address), and a state-changing
+request (`POST`/`PUT`/`PATCH`/`DELETE`) carrying a cross-origin `Origin` header is rejected too — both
+with `403`. Non-browser clients (`curl`, the `moadim` CLI, the MCP transport) are unaffected, since
+they never send a forged `Origin` and always address the daemon by an allowlisted host. If you put
+the daemon behind a reverse proxy on another hostname, add it to the allowlist with
+`MOADIM_ALLOWED_HOSTS` (comma-separated `host[:port]` entries):
+
+```sh
+MOADIM_ALLOWED_HOSTS=moadim.example.internal moadim
+```
+
 ### Log format
 
 The server logs to stdout (foreground) or `~/.config/moadim/daemon.log` (background) using

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,8 @@ pub enum AppError {
     Conflict(String),
     /// 423 Locked — a global lock sentinel is preventing the operation.
     Locked(String),
+    /// 403 Forbidden — a request failed the `Host`/`Origin` allowlist check (issue #266).
+    Forbidden(String),
 }
 
 impl fmt::Display for AppError {
@@ -30,6 +32,7 @@ impl fmt::Display for AppError {
             Self::NotFound => write!(f, "not found"),
             Self::Conflict(msg) => write!(f, "conflict: {msg}"),
             Self::Locked(msg) => write!(f, "locked: {msg}"),
+            Self::Forbidden(msg) => write!(f, "forbidden: {msg}"),
         }
     }
 }
@@ -42,6 +45,7 @@ impl IntoResponse for AppError {
             Self::NotFound => StatusCode::NOT_FOUND,
             Self::Conflict(_) => StatusCode::CONFLICT,
             Self::Locked(_) => StatusCode::LOCKED,
+            Self::Forbidden(_) => StatusCode::FORBIDDEN,
         };
         (
             status,

--- a/src/error_tests.rs
+++ b/src/error_tests.rs
@@ -126,3 +126,27 @@ async fn into_response_body_carries_internal_message() {
         "internal server error"
     );
 }
+
+#[test]
+fn display_forbidden() {
+    assert_eq!(
+        AppError::Forbidden("host not allowed".into()).to_string(),
+        "forbidden: host not allowed"
+    );
+}
+
+#[test]
+fn into_response_forbidden_is_403() {
+    assert_eq!(
+        AppError::Forbidden("x".into()).into_response().status(),
+        StatusCode::FORBIDDEN
+    );
+}
+
+#[tokio::test]
+async fn into_response_body_carries_forbidden_message() {
+    assert_eq!(
+        response_error_field(AppError::Forbidden("nope".into())).await,
+        "forbidden: nope"
+    );
+}

--- a/src/middlewares/host_validation.rs
+++ b/src/middlewares/host_validation.rs
@@ -1,0 +1,108 @@
+use crate::error::AppError;
+use axum::{
+    extract::Request,
+    http::{header, Method},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use std::future::Future;
+use std::pin::Pin;
+
+/// Environment variable letting an operator extend [`allowed_hosts`] for a deliberate
+/// remote/proxy deployment (comma-separated `host[:port]` entries), documented next to
+/// `MOADIM_BIND_ADDR` in the README.
+const ALLOWED_HOSTS_ENV: &str = "MOADIM_ALLOWED_HOSTS";
+
+/// Build the allowlist of `Host`/`Origin` values [`host_validation`] trusts: `localhost` and
+/// `127.0.0.1`/`[::1]` (with and without the daemon's bound port), the raw bind address itself,
+/// and any operator-supplied extras from [`ALLOWED_HOSTS_ENV`].
+pub(crate) fn allowed_hosts() -> Vec<String> {
+    let bind = crate::cli::bind_addr();
+    let port = bind.rsplit_once(':').map(|(_, port)| port);
+    let mut hosts = vec![
+        "localhost".to_string(),
+        "127.0.0.1".to_string(),
+        "[::1]".to_string(),
+        bind.clone(),
+    ];
+    if let Some(port) = port {
+        hosts.push(format!("localhost:{port}"));
+        hosts.push(format!("[::1]:{port}"));
+    }
+    if let Ok(extra) = std::env::var(ALLOWED_HOSTS_ENV) {
+        hosts.extend(
+            extra
+                .split(',')
+                .map(str::trim)
+                .filter(|host| !host.is_empty())
+                .map(str::to_string),
+        );
+    }
+    hosts
+}
+
+/// Extract the `host[:port]` component from an `Origin` header value (`scheme://host[:port]`).
+fn origin_host(origin: &str) -> &str {
+    origin.split_once("://").map_or(origin, |(_, rest)| rest)
+}
+
+/// Future returned by the middleware closure built by [`host_validation`].
+type ValidationFuture = Pin<Box<dyn Future<Output = Response> + Send>>;
+
+/// Build a middleware guarding the unauthenticated loopback API against browser-borne
+/// cross-origin abuse (issue #266):
+///
+/// - A request whose `Host` header is not in `allowed` is rejected with `403`. This defeats DNS
+///   rebinding: a browser-borne request retargeted at the loopback socket still carries the
+///   attacker's domain in `Host`, even though the TCP connection itself lands on `127.0.0.1`.
+/// - A state-changing request (`POST`/`PUT`/`PATCH`/`DELETE`) whose `Origin` header names a host
+///   not in `allowed` is rejected with `403`, blocking a cross-origin page from driving the
+///   destructive API even without rebinding.
+///
+/// A request carrying **no** `Host`/`Origin` header is let through rather than rejected: every
+/// real HTTP client (browsers, `curl`, the `moadim` CLI's own loopback client, the MCP transport)
+/// always sends `Host`, so an absent header only happens when a test drives the `Router` directly
+/// in-process without a real TCP/HTTP round trip — rejecting that would break the whole in-process
+/// test suite for no security benefit. Likewise, a missing `Origin` means a non-browser client,
+/// which carries no forgeable origin to check in the first place.
+pub(crate) fn host_validation(
+    allowed: Vec<String>,
+) -> impl Fn(Request, Next) -> ValidationFuture + Clone + Send + Sync + 'static {
+    move |req: Request, next: Next| {
+        let allowed = allowed.clone();
+        Box::pin(async move {
+            if let Some(host) = req
+                .headers()
+                .get(header::HOST)
+                .and_then(|value| value.to_str().ok())
+            {
+                if !allowed.iter().any(|entry| entry.eq_ignore_ascii_case(host)) {
+                    return AppError::Forbidden(format!("host '{host}' is not allowed"))
+                        .into_response();
+                }
+            }
+            let is_state_changing = matches!(
+                *req.method(),
+                Method::POST | Method::PUT | Method::PATCH | Method::DELETE
+            );
+            if is_state_changing {
+                if let Some(origin) = req
+                    .headers()
+                    .get(header::ORIGIN)
+                    .and_then(|value| value.to_str().ok())
+                {
+                    let host = origin_host(origin);
+                    if !allowed.iter().any(|entry| entry.eq_ignore_ascii_case(host)) {
+                        return AppError::Forbidden(format!("origin '{origin}' is not allowed"))
+                            .into_response();
+                    }
+                }
+            }
+            next.run(req).await
+        })
+    }
+}
+
+#[cfg(test)]
+#[path = "host_validation_tests.rs"]
+mod host_validation_tests;

--- a/src/middlewares/host_validation_tests.rs
+++ b/src/middlewares/host_validation_tests.rs
@@ -1,0 +1,182 @@
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and fixtures do not need doc comments"
+)]
+
+use axum::{
+    body::Body,
+    http::{header, Request, StatusCode},
+    middleware,
+    routing::{get, post},
+    Router,
+};
+use tower::ServiceExt;
+
+use super::{allowed_hosts, host_validation};
+
+fn app() -> Router {
+    Router::new()
+        .route("/", get(|| async { "ok" }))
+        .route("/", post(|| async { "ok" }))
+        .layer(middleware::from_fn(host_validation(vec![
+            "example.com".to_string(),
+            "example.com:5784".to_string(),
+        ])))
+}
+
+#[tokio::test]
+async fn allowed_host_passes() {
+    let resp = app()
+        .oneshot(
+            Request::builder()
+                .uri("/")
+                .header(header::HOST, "example.com")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn disallowed_host_is_rejected() {
+    let resp = app()
+        .oneshot(
+            Request::builder()
+                .uri("/")
+                .header(header::HOST, "attacker.example")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn missing_host_header_passes() {
+    // No real HTTP client omits `Host`; this mirrors how in-process test requests are built
+    // elsewhere in the suite and must not be rejected (see the `host_validation` doc comment).
+    let resp = app()
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn cross_origin_post_is_rejected() {
+    let resp = app()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/")
+                .header(header::HOST, "example.com")
+                .header(header::ORIGIN, "http://attacker.example")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn same_origin_post_passes() {
+    let resp = app()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/")
+                .header(header::HOST, "example.com")
+                .header(header::ORIGIN, "http://example.com:5784")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn missing_origin_on_post_passes() {
+    // No `Origin` header means a non-browser client (curl, the CLI, MCP) with nothing to forge.
+    let resp = app()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/")
+                .header(header::HOST, "example.com")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn cross_origin_get_is_not_rejected() {
+    // Origin is only enforced on state-changing methods; a GET can't mutate anything.
+    let resp = app()
+        .oneshot(
+            Request::builder()
+                .uri("/")
+                .header(header::HOST, "example.com")
+                .header(header::ORIGIN, "http://attacker.example")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+struct EnvGuard {
+    name: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvGuard {
+    fn set(name: &'static str, value: &str) -> Self {
+        let previous = std::env::var_os(name);
+        // SAFETY: tests in this crate run single-threaded (`RUST_TEST_THREADS=1`, see
+        // `.cargo/config.toml`), so no other thread observes the env in between.
+        unsafe {
+            std::env::set_var(name, value);
+        }
+        Self { name, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: single-threaded test execution, see `set` above.
+        unsafe {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.name, value),
+                None => std::env::remove_var(self.name),
+            }
+        }
+    }
+}
+
+#[test]
+fn allowed_hosts_includes_loopback_defaults() {
+    let hosts = allowed_hosts();
+    assert!(hosts.iter().any(|host| host == "localhost"));
+    assert!(hosts.iter().any(|host| host == "127.0.0.1"));
+    assert!(hosts.iter().any(|host| host == "[::1]"));
+}
+
+#[test]
+fn allowed_hosts_extends_from_env_var() {
+    let _guard = EnvGuard::set(
+        "MOADIM_ALLOWED_HOSTS",
+        "reverse-proxy.internal, other.host:8080",
+    );
+    let hosts = allowed_hosts();
+    assert!(hosts.iter().any(|host| host == "reverse-proxy.internal"));
+    assert!(hosts.iter().any(|host| host == "other.host:8080"));
+}

--- a/src/middlewares/mod.rs
+++ b/src/middlewares/mod.rs
@@ -1,3 +1,5 @@
+/// Middleware that rejects browser-borne cross-origin requests (DNS rebinding, CSRF-style abuse).
+pub mod host_validation;
 /// Middleware that logs request method, path, status, and latency.
 pub mod logger;
 /// Middleware that adds defense-in-depth security response headers.

--- a/src/routes/http.rs
+++ b/src/routes/http.rs
@@ -342,6 +342,15 @@ pub(crate) fn build_app_with_shutdown(
         // SPA fallback: client-routed pages (`/routines`) and refreshes on them return the app
         // HTML so the Yew router can resolve the path on load.
         .fallback(get(index))
+        // Innermost of the cross-cutting layers (added first) so a rejected request's `403`
+        // still gets a security-headers pass and a logged inbound/outbound pair, while still
+        // running ahead of every route handler (issue #266: DNS rebinding / cross-origin abuse
+        // of the unauthenticated loopback API).
+        .layer(middleware::from_fn(
+            middlewares::host_validation::host_validation(
+                middlewares::host_validation::allowed_hosts(),
+            ),
+        ))
         .layer(middleware::from_fn(
             middlewares::security_headers::security_headers,
         ))


### PR DESCRIPTION
## Why

The daemon serves both a browser web UI and a state-changing JSON API from the same unauthenticated origin, wired up in `build_app` (`src/routes/http.rs`) with no `Host`/`Origin` validation anywhere. Binding to loopback (`127.0.0.1:5784`, the default) is correctly treated as safe against *other machines*, but loopback is **not** a security boundary against a **browser**: any page the operator has open can already issue requests to `http://127.0.0.1:5784`, and DNS rebinding (an attacker domain whose A record is repointed to `127.0.0.1`) can reach the daemon the same way even though it's bound only to loopback.

Because every route is unauthenticated, a browser-borne attacker could already drive the state-changing endpoints — `POST /api/v1/routines/{id}/trigger` fires an agent through a login shell that inherits the operator's environment (tokens, keys), `PUT/PATCH/DELETE` tamper with or delete scheduled work, and `POST /api/v1/shutdown` kills the daemon. This is closes #266.

## What

- New `src/middlewares/host_validation.rs`: a middleware that
  - rejects any request whose `Host` header isn't in an allowlist (`localhost`, `127.0.0.1`, `[::1]`, the configured bind address — extensible via the new `MOADIM_ALLOWED_HOSTS` env var for reverse-proxy deployments) with `403`, defeating DNS rebinding since the rebound request still carries the attacker's domain in `Host`;
  - additionally rejects a state-changing request (`POST`/`PUT`/`PATCH`/`DELETE`) whose `Origin` header names a disallowed host, blocking cross-origin pages from driving the destructive API even without rebinding.
  - lets a request with **no** `Host`/`Origin` header through: every real HTTP client (browsers, `curl`, the `moadim` CLI's own loopback client, the MCP transport) always sends `Host`, so a missing header only happens for in-process test requests that never go through a real TCP/HTTP round trip; a missing `Origin` means a non-browser client with nothing to forge.
- Wired in as the innermost cross-cutting layer in `build_app_with_shutdown`, so a rejected request still gets the security-headers pass and a logged inbound/outbound pair, while running ahead of every route handler.
- New `AppError::Forbidden` (403) variant, mirroring the existing `AppError` pattern.
- README: documents the new default guard and `MOADIM_ALLOWED_HOSTS`, next to the existing `MOADIM_BIND_ADDR` section.
- `.changeset/host-origin-validation.md` added per this repo's changelog convention.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (934 root + 259 ui, all passing)
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% line coverage maintained
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`
- [x] `make readme-check`
- [x] New unit tests cover: allowed Host passes, disallowed Host → 403, missing Host passes, cross-origin `Origin` on `POST` → 403, same-origin `POST` passes, missing `Origin` on `POST` passes, cross-origin `Origin` on `GET` is not rejected (only state-changing methods are checked), and `allowed_hosts()`'s defaults + `MOADIM_ALLOWED_HOSTS` extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)