### PR TITLE
feat(routines): add per-run work summary endpoint

### DIFF
--- a/.changeset/add-run-summary-endpoint.md
+++ b/.changeset/add-run-summary-endpoint.md
@@ -1,0 +1,5 @@
+---
+"moadim": minor
+---
+
+Add `GET /routines/{id}/runs/{workbench}/summary`, serving an agent-authored work summary (`summary.md`) for a specific run. Every routine's system prompt now instructs the agent to keep a running work log and write a final summary section to that file before exiting.

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -875,6 +875,43 @@
         }
       }
     },
+    "/routines/{id}/runs/{workbench}/summary": {
+      "get": {
+        "tags": [
+          "crate::routines"
+        ],
+        "summary": "`GET /routines/{id}/runs/{workbench}/summary` — return one specific run's agent-authored\n`summary.md` as plain text (empty when the agent hasn't written one).",
+        "operationId": "get_run_summary",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Routine UUID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "workbench",
+            "in": "path",
+            "description": "Workbench directory name (`{slug}-{unix_secs}`), from `GET /routines/{id}/runs`",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Summary file contents as plain text"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
     "/routines/{id}/scheduled-trigger": {
       "post": {
         "tags": [

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -34,6 +34,7 @@
         crate::routines::get_logs,
         crate::routines::get_runs,
         crate::routines::get_run_log,
+        crate::routines::get_run_summary,
         crate::routines::get_all_runs,
         crate::routines::ical_feed,
         crate::routines::create_flag,

--- a/src/routes/http.rs
+++ b/src/routes/http.rs
@@ -317,6 +317,10 @@ pub(crate) fn build_app_with_shutdown(
             "/routines/{id}/runs/{workbench}/log",
             get(routines::get_run_log),
         )
+        .route(
+            "/routines/{id}/runs/{workbench}/summary",
+            get(routines::get_run_summary),
+        )
         // Own fallback so unknown `/api/v1` paths return a JSON 404 instead of inheriting
         // the outer SPA fallback and answering with `index.html`/`200` (issue #270).
         .fallback(api_not_found)

--- a/src/routes/http_routing_tests.rs
+++ b/src/routes/http_routing_tests.rs
@@ -237,6 +237,20 @@ async fn router_routine_full_lifecycle() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 
+    // runs/{workbench}/summary for a workbench that doesn't exist -> 404
+    let resp = build_app(routines.clone())
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/api/v1/routines/{id}/runs/not-a-real-workbench-1/summary"
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
     // POST flag
     let resp = build_app(routines.clone())
         .oneshot(
@@ -398,6 +412,7 @@ async fn router_routine_not_found_paths() {
         ("GET", "/logs"),
         ("GET", "/runs"),
         ("GET", "/runs/some-workbench-1/log"),
+        ("GET", "/runs/some-workbench-1/summary"),
     ] {
         let resp = build_app(crate::routines::new_store())
             .oneshot(

--- a/src/routes/mcp.rs
+++ b/src/routes/mcp.rs
@@ -294,7 +294,7 @@ impl MoadimMcp {
 
     /// List a routine's runs (live workbenches plus durable history), newest first.
     #[tool(
-        description = "List a routine's runs, newest first — each run's workbench id (pass to the REST endpoint GET /routines/{id}/runs/{workbench}/log to fetch its log), start/finish time, status, and exit code"
+        description = "List a routine's runs, newest first — each run's workbench id (pass to the REST endpoints GET /routines/{id}/runs/{workbench}/log for its log or GET /routines/{id}/runs/{workbench}/summary for the agent's work summary), start/finish time, status, and exit code"
     )]
     fn list_routine_runs(
         &self,

--- a/src/routines/command.rs
+++ b/src/routines/command.rs
@@ -235,7 +235,14 @@ const MOADIM_SYSTEM_PROMPT: &str = "# Moadim Context\\n\
     > This section is managed by the moadim daemon. Do not edit it.\\n\
     \\n\
     You are running inside a moadim-managed agent session. \
-    Complete the task described in `prompt.md` and exit when done.";
+    Complete the task described in `prompt.md` and exit when done.\\n\
+    \\n\
+    ## Work log\\n\
+    \\n\
+    As you work, append short progress notes to `summary.md` in this workbench (create it if \
+    it doesn't exist) — what you're doing and why, each time you start a new step. Before you \
+    exit, write a `## Final summary` section to `summary.md` describing what was accomplished, \
+    what changed, and anything left unresolved.";
 
 /// Routine-origin disclosure appended to the moadim system prompt.
 ///

--- a/src/routines/handlers.rs
+++ b/src/routines/handlers.rs
@@ -19,8 +19,8 @@ use super::model::{
 };
 use super::service::{
     svc_cleanup, svc_create, svc_create_flag, svc_delete, svc_get, svc_list, svc_list_all_runs,
-    svc_list_flags, svc_list_runs, svc_logs, svc_resolve_flag, svc_run_log, svc_trigger,
-    svc_trigger_scheduled, svc_update,
+    svc_list_flags, svc_list_runs, svc_logs, svc_resolve_flag, svc_run_log, svc_run_summary,
+    svc_trigger, svc_trigger_scheduled, svc_update,
 };
 
 /// Request body for `POST /routines/{id}/flags`.
@@ -339,6 +339,21 @@ pub async fn get_run_log(
     Path((id, workbench)): Path<(String, String)>,
 ) -> Result<String, AppError> {
     svc_run_log(&store, &id, &workbench)
+}
+
+/// `GET /routines/{id}/runs/{workbench}/summary` — return one specific run's agent-authored
+/// `summary.md` as plain text (empty when the agent hasn't written one).
+#[utoipa::path(get, path = "/routines/{id}/runs/{workbench}/summary",
+    params(
+        ("id" = String, Path, description = "Routine UUID"),
+        ("workbench" = String, Path, description = "Workbench directory name (`{slug}-{unix_secs}`), from `GET /routines/{id}/runs`"),
+    ),
+    responses((status = 200, description = "Summary file contents as plain text"), (status = 404, description = "Not found")))]
+pub async fn get_run_summary(
+    State(store): State<RoutineStore>,
+    Path((id, workbench)): Path<(String, String)>,
+) -> Result<String, AppError> {
+    svc_run_summary(&store, &id, &workbench)
 }
 
 #[cfg(test)]

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -406,8 +406,8 @@ use service_trigger::migrate_workbenches;
 #[cfg(test)]
 pub(crate) use service_trigger::sh_bin;
 pub use service_trigger::{
-    svc_cleanup, svc_list_all_runs, svc_list_runs, svc_logs, svc_run_log, svc_set_power_saving,
-    svc_snooze, svc_trigger, svc_trigger_scheduled,
+    svc_cleanup, svc_list_all_runs, svc_list_runs, svc_logs, svc_run_log, svc_run_summary,
+    svc_set_power_saving, svc_snooze, svc_trigger, svc_trigger_scheduled,
 };
 
 #[path = "service_trigger_flags.rs"]

--- a/src/routines/service_runs_tests.rs
+++ b/src/routines/service_runs_tests.rs
@@ -266,6 +266,93 @@ fn svc_run_log_returns_specific_workbench_log() {
 }
 
 #[test]
+fn svc_run_summary_missing_routine_not_found() {
+    let _home = TempHome::set();
+    assert!(matches!(
+        svc_run_summary(&new_store(), "nope", "whatever-1"),
+        Err(AppError::NotFound)
+    ));
+}
+
+#[test]
+fn svc_run_summary_not_found_for_unparseable_workbench_name() {
+    let _home = TempHome::set();
+    let title = "Run Summary Bad Name ZZQ";
+    let store = new_store();
+    store
+        .lock()
+        .unwrap()
+        .insert("id".into(), make_routine("id", title));
+
+    assert!(matches!(
+        svc_run_summary(&store, "id", "not-a-workbench"),
+        Err(AppError::NotFound)
+    ));
+}
+
+#[test]
+fn svc_run_summary_not_found_for_foreign_workbench() {
+    let _home = TempHome::set();
+    let title = "Run Summary Foreign ZZQ";
+    let store = new_store();
+    store
+        .lock()
+        .unwrap()
+        .insert("id".into(), make_routine("id", title));
+
+    assert!(matches!(
+        svc_run_summary(&store, "id", "some-other-routine-9999"),
+        Err(AppError::NotFound)
+    ));
+}
+
+#[test]
+fn svc_run_summary_empty_when_summary_missing() {
+    let _home = TempHome::set();
+    let title = "Run Summary Missing File ZZQ";
+    let slug = slugify(title);
+    let store = new_store();
+    store
+        .lock()
+        .unwrap()
+        .insert("id".into(), make_routine("id", title));
+
+    let workbench = format!("{slug}-1000");
+    std::fs::create_dir_all(crate::paths::workbenches_dir().join(&workbench)).unwrap();
+
+    assert_eq!(svc_run_summary(&store, "id", &workbench).unwrap(), "");
+}
+
+#[test]
+fn svc_run_summary_returns_specific_workbench_summary() {
+    let _home = TempHome::set();
+    let title = "Run Summary Exact ZZQ";
+    let slug = slugify(title);
+    let store = new_store();
+    store
+        .lock()
+        .unwrap()
+        .insert("id".into(), make_routine("id", title));
+
+    let workbenches = crate::paths::workbenches_dir();
+    let older = format!("{slug}-1000");
+    let newer = format!("{slug}-2000");
+    std::fs::create_dir_all(workbenches.join(&older)).unwrap();
+    std::fs::create_dir_all(workbenches.join(&newer)).unwrap();
+    std::fs::write(workbenches.join(&older).join("summary.md"), "older summary").unwrap();
+    std::fs::write(workbenches.join(&newer).join("summary.md"), "newer summary").unwrap();
+
+    assert_eq!(
+        svc_run_summary(&store, "id", &older).unwrap(),
+        "older summary"
+    );
+    assert_eq!(
+        svc_run_summary(&store, "id", &newer).unwrap(),
+        "newer summary"
+    );
+}
+
+#[test]
 fn svc_list_all_runs_merges_across_routines_newest_first() {
     let _home = TempHome::set();
     let title_a = "Fleet Runs A ZZQ";

--- a/src/routines/service_trigger.rs
+++ b/src/routines/service_trigger.rs
@@ -445,12 +445,19 @@ fn run_summary(dir: &str, started_at: u64) -> RunSummary {
     }
 }
 
-/// Return the contents of a specific run's `agent.log`, by workbench directory name.
+/// Return the contents of `filename` inside a specific run's workbench, by workbench directory
+/// name.
 ///
 /// `workbench` must be an existing, exact `{slug}-{ts}` directory belonging to routine `id` — this
 /// guards both path traversal (a bare directory name, not an arbitrary path, is joined onto
 /// `workbenches_dir()`) and cross-routine leakage, mirroring the exact-slug check in [`svc_logs`].
-pub fn svc_run_log(store: &RoutineStore, id: &str, workbench: &str) -> Result<String, AppError> {
+/// Shared by [`svc_run_log`] (`agent.log`) and [`svc_run_summary`] (`summary.md`).
+fn svc_run_file(
+    store: &RoutineStore,
+    id: &str,
+    workbench: &str,
+    filename: &str,
+) -> Result<String, AppError> {
     let routine = store
         .lock_recover()
         .get(id)
@@ -463,9 +470,25 @@ pub fn svc_run_log(store: &RoutineStore, id: &str, workbench: &str) -> Result<St
     if dir_slug != slug {
         return Err(AppError::NotFound);
     }
-    let log_path = workbenches_dir().join(workbench).join("agent.log");
-    if !log_path.exists() {
+    let path = workbenches_dir().join(workbench).join(filename);
+    if !path.exists() {
         return Ok(String::new());
     }
-    read_log_tail(&log_path).map_err(|_| AppError::Internal)
+    read_log_tail(&path).map_err(|_| AppError::Internal)
+}
+
+/// Return the contents of a specific run's `agent.log`, by workbench directory name.
+pub fn svc_run_log(store: &RoutineStore, id: &str, workbench: &str) -> Result<String, AppError> {
+    svc_run_file(store, id, workbench, "agent.log")
+}
+
+/// Return the contents of a specific run's agent-authored `summary.md` (see the "Work log"
+/// instruction in [`crate::routines::command::system_prompt_stmts`]), by workbench directory
+/// name. Empty string when the agent hasn't written one (yet, or never did).
+pub fn svc_run_summary(
+    store: &RoutineStore,
+    id: &str,
+    workbench: &str,
+) -> Result<String, AppError> {
+    svc_run_file(store, id, workbench, "summary.md")
 }


### PR DESCRIPTION
## Summary
- Every routine's system prompt now instructs the agent to keep a running work log and write a final `## Final summary` section to `summary.md` in its workbench, before it exits.
- New `GET /routines/{id}/runs/{workbench}/summary` endpoint serves that file's contents, mirroring the existing per-run `.../log` endpoint (`agent.log`). Empty string when the agent hasn't written one.
- Shared workbench-file read/validation logic extracted into `svc_run_file`, used by both `svc_run_log` and the new `svc_run_summary`.
- `list_routine_runs` MCP tool description updated to mention both endpoints.
- No MCP tool added for the summary, following the existing precedent (`get_run_log` also has no MCP counterpart, only REST).

## Test plan
- [x] `cargo test --workspace` — 939 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main.rs'` — 100% line coverage
- [x] `linecheck --max-lines 500` — passes
- [x] `apis/openapi.json` regenerated and committed
- [x] `.changeset/add-run-summary-endpoint.md` added
- [x] Full `.githooks/pre-push` gate ran clean on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)