### PR TITLE
fix(routines): run crontab sync via spawn_blocking, not inline (#360)

### DIFF
--- a/.changeset/spawn-blocking-crontab-sync.md
+++ b/.changeset/spawn-blocking-crontab-sync.md
@@ -1,0 +1,7 @@
+---
+"moadim": patch
+---
+
+### Fixed
+
+Run crontab sync (`lock`/`unlock`/`create`/`update`/`delete` on `/routines`) via `tokio::task::spawn_blocking` instead of inline on the async handler. These calls shell out to `crontab`(1); without `spawn_blocking` a slow or hung `crontab` invocation pins a Tokio worker thread indefinitely, and the per-request 30s timeout (`middlewares/timeout.rs`) can't preempt it since the thread is synchronously blocked, not polling a future (#360).

--- a/src/routines/handlers.rs
+++ b/src/routines/handlers.rs
@@ -66,10 +66,17 @@ pub async fn lock(
     Json(body): Json<LockRequest>,
 ) -> Result<Json<LockStatus>, AppError> {
     let scope = parse_lock_scope(&body.scope)?;
-    crate::global_lock::set_lock(scope, true).map_err(|_| AppError::Internal)?;
-    if let Err(sync_err) = crate::sync::routines::sync_routines_to_crontab(&store) {
-        log::warn!("crontab sync after HTTP lock failed: {sync_err}");
-    }
+    // Crontab sync shells out to `crontab`(1); run it on the blocking pool so a slow or
+    // hung invocation can't pin a Tokio worker thread (#360).
+    tokio::task::spawn_blocking(move || {
+        crate::global_lock::set_lock(scope, true).map_err(|_| AppError::Internal)?;
+        if let Err(sync_err) = crate::sync::routines::sync_routines_to_crontab(&store) {
+            log::warn!("crontab sync after HTTP lock failed: {sync_err}");
+        }
+        Ok::<_, AppError>(())
+    })
+    .await
+    .map_err(|_| AppError::Internal)??;
     Ok(Json(crate::global_lock::lock_status()))
 }
 
@@ -86,12 +93,18 @@ pub async fn unlock(
     } else {
         vec![parse_lock_scope(&query.scope)?]
     };
-    for scope in scopes {
-        crate::global_lock::set_lock(scope, false).map_err(|_| AppError::Internal)?;
-    }
-    if let Err(sync_err) = crate::sync::routines::sync_routines_to_crontab(&store) {
-        log::warn!("crontab sync after HTTP unlock failed: {sync_err}");
-    }
+    // See `lock` above: crontab sync must not run inline on the async worker thread (#360).
+    tokio::task::spawn_blocking(move || {
+        for scope in scopes {
+            crate::global_lock::set_lock(scope, false).map_err(|_| AppError::Internal)?;
+        }
+        if let Err(sync_err) = crate::sync::routines::sync_routines_to_crontab(&store) {
+            log::warn!("crontab sync after HTTP unlock failed: {sync_err}");
+        }
+        Ok::<_, AppError>(())
+    })
+    .await
+    .map_err(|_| AppError::Internal)??;
     Ok(Json(crate::global_lock::lock_status()))
 }
 
@@ -114,7 +127,12 @@ pub async fn create(
     State(store): State<RoutineStore>,
     Json(body): Json<CreateRoutineRequest>,
 ) -> Result<(StatusCode, Json<RoutineResponse>), AppError> {
-    Ok((StatusCode::CREATED, Json(svc_create(&store, body)?)))
+    // `svc_create` syncs the crontab, which shells out to `crontab`(1) (#360) — keep that
+    // off the async worker thread.
+    let resp = tokio::task::spawn_blocking(move || svc_create(&store, body))
+        .await
+        .map_err(|_| AppError::Internal)??;
+    Ok((StatusCode::CREATED, Json(resp)))
 }
 
 /// `GET /routines` — list routines, optionally filtered and sorted by repository.
@@ -156,7 +174,11 @@ pub async fn update(
     Path(id): Path<String>,
     Json(body): Json<UpdateRoutineRequest>,
 ) -> Result<Json<RoutineResponse>, AppError> {
-    Ok(Json(svc_update(&store, &id, body)?))
+    // See `create` above: `svc_update` syncs the crontab (#360).
+    let resp = tokio::task::spawn_blocking(move || svc_update(&store, &id, body))
+        .await
+        .map_err(|_| AppError::Internal)??;
+    Ok(Json(resp))
 }
 
 /// `PUT /routines/{id}` — alias for `PATCH`: a partial-merge update, not a full replace.
@@ -184,7 +206,11 @@ pub async fn delete(
     State(store): State<RoutineStore>,
     Path(id): Path<String>,
 ) -> Result<Json<RoutineResponse>, AppError> {
-    Ok(Json(svc_delete(&store, &id)?))
+    // See `create` above: `svc_delete` syncs the crontab (#360).
+    let resp = tokio::task::spawn_blocking(move || svc_delete(&store, &id))
+        .await
+        .map_err(|_| AppError::Internal)??;
+    Ok(Json(resp))
 }
 
 /// `POST /routines/{id}/trigger` — manually run a routine outside its schedule.


### PR DESCRIPTION
## Why

`lock`, `unlock`, `create`, `update`, and `delete` on `/routines` all end up calling `sync_routines_to_crontab`, which shells out to `crontab`(1) (`src/sync/mod.rs`) synchronously, inline on the async Tokio worker thread handling the request.

This is a real, currently-live gap: `middlewares/timeout.rs`'s 30s per-request deadline comment explicitly calls it out —

> Bounds the blast radius of a wedged handler — e.g. blocking `crontab`/`tmux`/filesystem I/O that runs with no `spawn_blocking` (#360)

A slow or hung `crontab` invocation pins that worker thread indefinitely. The request timeout can't help here: `tokio::time::timeout` races a *future*, but a thread synchronously blocked inside a subprocess call isn't polling anything — it just doesn't return until the subprocess does, timeout or not.

The codebase already has this exact pattern established for other blocking work — the cleanup/watchdog/version-drift background tasks in `routes/http_listener.rs` all wrap their blocking calls in `tokio::task::spawn_blocking`. This PR applies the same idiom to the 5 HTTP handler call sites that were missing it.

## What changed

- `src/routines/handlers.rs`: `lock`, `unlock`, `create`, `update`, `delete` now run their crontab-touching work inside `tokio::task::spawn_blocking`, with the `JoinError` mapped to `AppError::Internal` (a panic/cancel on the blocking task is already a 500 in spirit — there's no more specific error to report).
- No behavior change from the caller's perspective (same responses, same error mapping) — purely moves where the blocking work executes.

## Testing

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (934 + 259 passed), and `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (100.00% lines) all pass locally — existing tests already exercise these handlers end-to-end so no new tests were needed for full coverage.
- Added a changeset (`.changeset/spawn-blocking-crontab-sync.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)