### PR TITLE
feat(routines): report total_bytes + truncated in the logs MCP tool

### DIFF
--- a/.changeset/log-metadata-truncated-flag.md
+++ b/.changeset/log-metadata-truncated-flag.md
@@ -1,0 +1,5 @@
+---
+"moadim": minor
+---
+
+Report `total_bytes` + `truncated` alongside log tail content in the logs MCP tool, so callers can tell a full log from a truncated window (#280).

--- a/src/routes/mcp.rs
+++ b/src/routes/mcp.rs
@@ -287,7 +287,11 @@ impl MoadimMcp {
         Parameters(IdInput { id }): Parameters<IdInput>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         Ok(match routines::svc_logs(&self.routines, &id) {
-            Ok(logs) => ok(serde_json::json!({ "logs": logs })),
+            Ok(logs) => ok(serde_json::json!({
+                "logs": logs.content,
+                "total_bytes": logs.total_bytes,
+                "truncated": logs.truncated,
+            })),
             Err(error) => err(error),
         })
     }

--- a/src/routines/handlers.rs
+++ b/src/routines/handlers.rs
@@ -294,7 +294,7 @@ pub async fn get_logs(
     State(store): State<RoutineStore>,
     Path(id): Path<String>,
 ) -> Result<String, AppError> {
-    svc_logs(&store, &id)
+    svc_logs(&store, &id).map(|logs| logs.content)
 }
 
 /// `GET /routines/{id}/runs` — list every run workbench for the routine, newest first.

--- a/src/routines/mod_agents_tests.rs
+++ b/src/routines/mod_agents_tests.rs
@@ -405,7 +405,7 @@ fn svc_logs_empty_when_no_workbench() {
     let mut routine = make_routine("logs-id");
     routine.title = "Unlikely Title For Logs 9988".into();
     store.lock().unwrap().insert("logs-id".into(), routine);
-    assert_eq!(svc_logs(&store, "logs-id").unwrap(), "");
+    assert_eq!(svc_logs(&store, "logs-id").unwrap().content, "");
 }
 
 #[test]
@@ -424,7 +424,7 @@ fn svc_logs_returns_newest_workbench_log() {
     std::fs::write(old.join("agent.log"), "old-log").unwrap();
     std::fs::write(new.join("agent.log"), "new-log").unwrap();
 
-    assert_eq!(svc_logs(&store, "logs-newest").unwrap(), "new-log");
+    assert_eq!(svc_logs(&store, "logs-newest").unwrap().content, "new-log");
 
     std::fs::remove_dir_all(&old).unwrap();
     std::fs::remove_dir_all(&new).unwrap();
@@ -440,7 +440,7 @@ fn svc_logs_empty_when_newest_has_no_log_file() {
 
     let dir = crate::paths::workbenches_dir().join(format!("{slug}-3000"));
     std::fs::create_dir_all(&dir).unwrap();
-    assert_eq!(svc_logs(&store, "logs-nofile").unwrap(), "");
+    assert_eq!(svc_logs(&store, "logs-nofile").unwrap().content, "");
     std::fs::remove_dir_all(&dir).unwrap();
 }
 
@@ -463,7 +463,7 @@ fn svc_logs_ignores_other_routine_with_shared_slug_prefix() {
     std::fs::write(mine.join("agent.log"), "mine").unwrap();
     std::fs::write(other.join("agent.log"), "not-mine").unwrap();
 
-    assert_eq!(svc_logs(&store, "logs-prefix").unwrap(), "mine");
+    assert_eq!(svc_logs(&store, "logs-prefix").unwrap().content, "mine");
 
     std::fs::remove_dir_all(&mine).unwrap();
     std::fs::remove_dir_all(&other).unwrap();

--- a/src/routines/service_log_tail.rs
+++ b/src/routines/service_log_tail.rs
@@ -6,6 +6,38 @@
 /// most recent bytes, since the tail is what matters for "what is this run doing right now".
 pub(crate) const MAX_LOG_TAIL_BYTES: u64 = 2 * 1024 * 1024;
 
+/// A log tail plus the metadata needed to tell "this is the whole file" from "this is a window"
+/// (#280) — `total_bytes` is the full on-disk size and `truncated` is whether `content` was
+/// capped to [`MAX_LOG_TAIL_BYTES`] rather than holding the complete file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LogWithMeta {
+    pub(crate) content: String,
+    pub(crate) total_bytes: u64,
+    pub(crate) truncated: bool,
+}
+
+impl LogWithMeta {
+    pub(crate) fn empty() -> Self {
+        Self {
+            content: String::new(),
+            total_bytes: 0,
+            truncated: false,
+        }
+    }
+}
+
+/// Same read as [`read_log_tail`], but reporting the full on-disk size and whether `content` is a
+/// truncated window rather than the complete file (see [`LogWithMeta`]).
+pub(crate) fn read_log_tail_with_meta(path: &std::path::Path) -> std::io::Result<LogWithMeta> {
+    let total_bytes = std::fs::metadata(path)?.len();
+    let content = read_log_tail(path)?;
+    Ok(LogWithMeta {
+        content,
+        total_bytes,
+        truncated: total_bytes > MAX_LOG_TAIL_BYTES,
+    })
+}
+
 /// Read `path`, returning only the last [`MAX_LOG_TAIL_BYTES`] when it's larger than that.
 ///
 /// The seek point is snapped forward to the next UTF-8 character boundary so a multi-byte

--- a/src/routines/service_log_tail.rs
+++ b/src/routines/service_log_tail.rs
@@ -11,12 +11,16 @@ pub(crate) const MAX_LOG_TAIL_BYTES: u64 = 2 * 1024 * 1024;
 /// capped to [`MAX_LOG_TAIL_BYTES`] rather than holding the complete file.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct LogWithMeta {
+    /// The (possibly truncated) tail content.
     pub(crate) content: String,
+    /// Full on-disk size of the log file, regardless of truncation.
     pub(crate) total_bytes: u64,
+    /// Whether `content` was capped to [`MAX_LOG_TAIL_BYTES`] rather than the complete file.
     pub(crate) truncated: bool,
 }
 
 impl LogWithMeta {
+    /// An empty log tail: no content, zero size, not truncated.
     pub(crate) fn empty() -> Self {
         Self {
             content: String::new(),

--- a/src/routines/service_logs_tests.rs
+++ b/src/routines/service_logs_tests.rs
@@ -83,7 +83,9 @@ fn svc_logs_returns_newest_workbench_log() {
     std::fs::write(newer.join("agent.log"), "new log contents").unwrap();
 
     let logs = svc_logs(&store, "logs-id").unwrap();
-    assert_eq!(logs, "new log contents");
+    assert_eq!(logs.content, "new log contents");
+    assert_eq!(logs.total_bytes, "new log contents".len() as u64);
+    assert!(!logs.truncated);
 }
 
 #[test]
@@ -121,7 +123,7 @@ fn svc_logs_skips_foreign_and_unparseable_workbenches() {
     std::fs::write(mine.join("agent.log"), "mine log contents").unwrap();
 
     let logs = svc_logs(&store, "logs-mixed-id").unwrap();
-    assert_eq!(logs, "mine log contents");
+    assert_eq!(logs.content, "mine log contents");
 }
 
 #[test]
@@ -140,7 +142,9 @@ fn svc_logs_empty_when_workbenches_dir_absent() {
     assert!(!crate::paths::workbenches_dir().exists());
 
     let logs = svc_logs(&store, "logs-empty-id").unwrap();
-    assert_eq!(logs, "");
+    assert_eq!(logs.content, "");
+    assert_eq!(logs.total_bytes, 0);
+    assert!(!logs.truncated);
 }
 
 #[test]
@@ -241,6 +245,11 @@ fn svc_logs_reads_through_the_size_cap() {
     std::fs::write(dir.join("agent.log"), &big).unwrap();
 
     let logs = svc_logs(&store, "logs-big-id").unwrap();
-    assert_ne!(logs, big, "an oversized log must not be served in full");
-    assert!(logs.contains("10 bytes omitted"), "got: {logs}");
+    assert_ne!(
+        logs.content, big,
+        "an oversized log must not be served in full"
+    );
+    assert!(logs.content.contains("10 bytes omitted"), "got: {logs:?}");
+    assert_eq!(logs.total_bytes, big.len() as u64);
+    assert!(logs.truncated);
 }

--- a/src/routines/service_slug_tests.rs
+++ b/src/routines/service_slug_tests.rs
@@ -424,5 +424,5 @@ fn svc_update_migrates_workbenches_on_rename() {
 
     // `svc_logs` (which looks up by the *current* slug) can still find the newest migrated run.
     let logs = svc_logs(&store, "rename-id").unwrap();
-    assert_eq!(logs, "prior run log");
+    assert_eq!(logs.content, "prior run log");
 }

--- a/src/routines/service_trigger.rs
+++ b/src/routines/service_trigger.rs
@@ -18,7 +18,7 @@ use crate::routines::model::{
 };
 use crate::routines::run_history::{read_exit_code, read_persisted_runs};
 
-use super::service_log_tail::read_log_tail;
+use super::service_log_tail::{read_log_tail, read_log_tail_with_meta, LogWithMeta};
 
 /// Record a manual trigger for `id` and spawn the same command the crontab would run.
 ///
@@ -282,8 +282,9 @@ pub(super) fn migrate_workbenches(old_slug: &str, new_slug: &str) {
     }
 }
 
-/// Return the contents of the newest workbench `agent.log` for routine `id`.
-pub fn svc_logs(store: &RoutineStore, id: &str) -> Result<String, AppError> {
+/// Return the contents of the newest workbench `agent.log` for routine `id`, plus whether that
+/// content is a truncated window rather than the complete file (see [`LogWithMeta`]).
+pub fn svc_logs(store: &RoutineStore, id: &str) -> Result<LogWithMeta, AppError> {
     let routine = store
         .lock_recover()
         .get(id)
@@ -309,13 +310,13 @@ pub fn svc_logs(store: &RoutineStore, id: &str) -> Result<String, AppError> {
         }
     }
     let Some((_, dir)) = newest else {
-        return Ok(String::new());
+        return Ok(LogWithMeta::empty());
     };
     let log_path = workbenches_dir().join(dir).join("agent.log");
     if !log_path.exists() {
-        return Ok(String::new());
+        return Ok(LogWithMeta::empty());
     }
-    read_log_tail(&log_path).map_err(|_| AppError::Internal)
+    read_log_tail_with_meta(&log_path).map_err(|_| AppError::Internal)
 }
 
 /// List every run for routine `id`, newest first: live (not-yet-reaped) workbenches, whose status


### PR DESCRIPTION
## Problem

`svc_logs()` serves a possibly-truncated `agent.log` tail as a bare `String`. The only signal that content was cut is a human-readable inline marker baked into the text (`"... [N bytes omitted...] ..."`). A caller consuming the response programmatically (e.g. an MCP client) has no structured way to tell "this is the whole file" from "this is a window onto a larger one" without parsing that text.

## Fix

- `service_log_tail.rs`: add `LogWithMeta { content, total_bytes, truncated }` and `read_log_tail_with_meta()`, which reads the file's on-disk size alongside the existing `read_log_tail()` tail read.
- `svc_logs()` now returns `LogWithMeta` instead of a bare `String`.
- The MCP `routine_logs` tool surfaces `total_bytes` and `truncated` alongside `logs` in its JSON response.
- The `GET /routines/{id}/logs` REST endpoint keeps its existing plain-text contract unchanged — it takes just `.content`.
- `svc_run_log`/`svc_run_summary` (which share the underlying `read_log_tail()`) are untouched, keeping this change scoped to `svc_logs`.

Existing tests updated to match the new return shape; a couple gained assertions on `total_bytes`/`truncated` for the empty and oversized cases.

## Note on local verification

This sandbox's disk ran out of space partway through a full `cargo test --workspace` run (the workspace's WASM/Yew UI dependency tree is large), so I could only verify `cargo fmt --check` locally (clean). The change itself is a small, type-checked refactor — every call site of `svc_logs`/`read_log_tail` was updated by hand and I re-grepped for any I might have missed. CI runs the full `fmt`/`clippy --workspace`/`test --workspace`/coverage gate on this PR with proper disk, so please treat that as authoritative before merging.

Closes #280