### PR TITLE
fix(security): reject non-UTF-8 Host/Origin headers instead of allowing them

### DIFF
--- a/.changeset/host-validation-reject-non-utf8.md
+++ b/.changeset/host-validation-reject-non-utf8.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+`host_validation` middleware: a present-but-non-UTF-8 `Host` or `Origin` header is now rejected with `403` instead of being silently treated the same as a missing header. `HeaderValue::to_str()` only rejects non-ASCII bytes, which no legitimate client ever sends in these headers, so falling through to "allow" on that error let an attacker bypass the DNS-rebinding/cross-origin allowlist entirely by sending garbage bytes in `Host`/`Origin`. Adds regression tests for both headers.

--- a/src/middlewares/host_validation.rs
+++ b/src/middlewares/host_validation.rs
@@ -65,37 +65,56 @@ type ValidationFuture = Pin<Box<dyn Future<Output = Response> + Send>>;
 /// in-process without a real TCP/HTTP round trip — rejecting that would break the whole in-process
 /// test suite for no security benefit. Likewise, a missing `Origin` means a non-browser client,
 /// which carries no forgeable origin to check in the first place.
+///
+/// A `Host`/`Origin` header that **is present** but fails to parse as UTF-8 is rejected with
+/// `403`, not silently let through: `HeaderValue::to_str` only rejects non-ASCII bytes, which no
+/// legitimate client ever sends in these headers, so a present-but-unparseable value is treated
+/// as suspicious rather than being conflated with the benign "no header at all" case above.
 pub(crate) fn host_validation(
     allowed: Vec<String>,
 ) -> impl Fn(Request, Next) -> ValidationFuture + Clone + Send + Sync + 'static {
     move |req: Request, next: Next| {
         let allowed = allowed.clone();
         Box::pin(async move {
-            if let Some(host) = req
-                .headers()
-                .get(header::HOST)
-                .and_then(|value| value.to_str().ok())
-            {
-                if !allowed.iter().any(|entry| entry.eq_ignore_ascii_case(host)) {
-                    return AppError::Forbidden(format!("host '{host}' is not allowed"))
-                        .into_response();
-                }
+            match req.headers().get(header::HOST) {
+                None => {}
+                Some(value) => match value.to_str() {
+                    Err(_) => {
+                        return AppError::Forbidden("host header is not valid UTF-8".to_string())
+                            .into_response();
+                    }
+                    Ok(host) => {
+                        if !allowed.iter().any(|entry| entry.eq_ignore_ascii_case(host)) {
+                            return AppError::Forbidden(format!("host '{host}' is not allowed"))
+                                .into_response();
+                        }
+                    }
+                },
             }
             let is_state_changing = matches!(
                 *req.method(),
                 Method::POST | Method::PUT | Method::PATCH | Method::DELETE
             );
             if is_state_changing {
-                if let Some(origin) = req
-                    .headers()
-                    .get(header::ORIGIN)
-                    .and_then(|value| value.to_str().ok())
-                {
-                    let host = origin_host(origin);
-                    if !allowed.iter().any(|entry| entry.eq_ignore_ascii_case(host)) {
-                        return AppError::Forbidden(format!("origin '{origin}' is not allowed"))
+                match req.headers().get(header::ORIGIN) {
+                    None => {}
+                    Some(value) => match value.to_str() {
+                        Err(_) => {
+                            return AppError::Forbidden(
+                                "origin header is not valid UTF-8".to_string(),
+                            )
                             .into_response();
-                    }
+                        }
+                        Ok(origin) => {
+                            let host = origin_host(origin);
+                            if !allowed.iter().any(|entry| entry.eq_ignore_ascii_case(host)) {
+                                return AppError::Forbidden(format!(
+                                    "origin '{origin}' is not allowed"
+                                ))
+                                .into_response();
+                            }
+                        }
+                    },
                 }
             }
             next.run(req).await

--- a/src/middlewares/host_validation_tests.rs
+++ b/src/middlewares/host_validation_tests.rs
@@ -5,7 +5,7 @@
 
 use axum::{
     body::Body,
-    http::{header, Request, StatusCode},
+    http::{header, HeaderValue, Request, StatusCode},
     middleware,
     routing::{get, post},
     Router,
@@ -63,6 +63,44 @@ async fn missing_host_header_passes() {
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn non_utf8_host_header_is_rejected() {
+    // A real HTTP client's `Host` header is always ASCII; a present-but-unparseable value must
+    // not be conflated with "no Host header at all" (`missing_host_header_passes` above) — that
+    // would let an attacker bypass the allowlist entirely by sending garbage bytes.
+    let resp = app()
+        .oneshot(
+            Request::builder()
+                .uri("/")
+                .header(header::HOST, HeaderValue::from_bytes(b"\xff\xfe").unwrap())
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn non_utf8_origin_header_on_post_is_rejected() {
+    let resp = app()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/")
+                .header(header::HOST, "example.com")
+                .header(
+                    header::ORIGIN,
+                    HeaderValue::from_bytes(b"\xff\xfe").unwrap(),
+                )
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

`host_validation()` (added in #1040 to defend the unauthenticated loopback API against DNS rebinding and cross-origin abuse) checks `Host`/`Origin` headers like this:

```rust
if let Some(host) = req.headers().get(header::HOST).and_then(|v| v.to_str().ok()) {
    // allowlist check
}
```

`HeaderValue::to_str()` fails only when the header contains non-ASCII bytes — legal `obs-text` under the HTTP spec, but never sent by any real client (browser, curl, this daemon's own CLI, or the MCP transport). When it fails, `.ok()` swallows the error and the `if let Some` doesn't match, so the request falls through exactly like the *deliberately* permissive "no `Host` header at all" case (which exists only so in-process tests that build a `Router` without a real HTTP round trip keep working).

Net effect: sending a `Host`/`Origin` header with a few non-ASCII bytes bypasses the allowlist entirely, undermining the very rebinding/cross-origin protection the middleware exists to provide.

## Fix

Distinguish the three cases explicitly:
- header absent → let through (unchanged, still needed for the in-process test suite)
- header present and valid UTF-8 → check against the allowlist (unchanged)
- header present but **not** valid UTF-8 → reject with `403` (new)

Same treatment for both `Host` and `Origin`. Added two regression tests (`non_utf8_host_header_is_rejected`, `non_utf8_origin_header_on_post_is_rejected`) using `HeaderValue::from_bytes` to construct a header that fails `to_str()`.

## Testing

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (all passing, including the two new tests)
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (100% line floor holds)
- `linecheck --max-lines 500 $(find src ui/src -name '*.rs')`

No behavior change for any real client; only affects requests that were already sending a header a browser/curl would never produce.