### PR TITLE
feat(routines): add a total-disk ceiling safety valve for workbenches (#398)

### DIFF
--- a/.changeset/workbench-disk-cap.md
+++ b/.changeset/workbench-disk-cap.md
@@ -1,0 +1,5 @@
+---
+"moadim": minor
+---
+
+Add `MOADIM_MAX_WORKBENCH_DISK_BYTES`, an optional total-disk ceiling for `~/.moadim/workbenches/`. The existing TTL sweep only reaps a workbench once it is old enough, so a handful of concurrent large runs (e.g. big repo clones) could exhaust the disk before any TTL elapsed (#398). Once set and exceeded, the same sweep now also evicts finished workbenches oldest-first — never a live session — until back under the cap. Unset or `0` keeps today's unbounded-by-size behavior.

--- a/Architecture.md
+++ b/Architecture.md
@@ -193,6 +193,12 @@ the same sweep includes a watchdog that force-kills any session whose run has ex
 recording the kill in the run's `agent.log`, after which the workbench is reaped under the normal
 `ttl_secs` rules.
 
+TTL reaping bounds age, not total size. `routines::cleanup::disk_cap` adds an optional safety valve
+on top of it: if `MOADIM_MAX_WORKBENCH_DISK_BYTES` is set and nonzero, the same sweep sums the whole
+`~/.moadim/workbenches/` tree and, once over that ceiling, evicts finished workbenches
+oldest-finished-first until back under it — a live session is never touched regardless of size or
+age. Unset or `0` preserves the unbounded-by-size behavior above.
+
 The agent command is resolved from a configurable registry at `~/.config/moadim/agents/<name>.toml`
 (`command`, `args`; placeholders `{prompt_file}` → `prompt.md`, `{workbench}` → `.`,
 `{prompt}` → `"$(cat prompt.md)"`).

--- a/README.md
+++ b/README.md
@@ -178,6 +178,13 @@ git-trackable:
 periodic (5-minute) sweep so they don't accumulate; trigger a sweep on demand
 with `moadim cleanup`. Sessions still running are never reaped.
 
+TTL is time-only, so a handful of concurrent large runs (e.g. big repo clones)
+can pile up disk before any TTL elapses. Set `MOADIM_MAX_WORKBENCH_DISK_BYTES`
+to a total byte ceiling for the whole `~/.moadim/workbenches/` tree; once
+exceeded, the sweep also evicts finished workbenches oldest-first (regardless
+of their individual TTL) until back under it. A live session is never evicted.
+Unset or `0` (the default) keeps today's unbounded-by-size behavior.
+
 **REST** — under the `/api/v1` prefix:
 
 ```

--- a/src/routines/cleanup/disk_cap.rs
+++ b/src/routines/cleanup/disk_cap.rs
@@ -1,0 +1,140 @@
+//! Size-based safety valve layered on top of the time-based TTL reaper (see the cleanup module).
+//!
+//! [`super::reap_dir`] only removes a workbench once it is *old enough*; nothing bounds how much
+//! disk `~/.moadim/workbenches/` may hold while runs are still within TTL (a handful of concurrent
+//! large repo clones can exhaust the disk long before any TTL elapses). This module adds an optional
+//! total ceiling: once the tree exceeds [`MAX_DISK_BYTES_ENV`], finished workbenches (never a live
+//! session) are evicted oldest-finished-first until back under it, regardless of their individual
+//! TTL. Unset or `0` preserves today's unbounded-by-size behavior.
+
+use std::path::{Path, PathBuf};
+
+use super::{dir_size, parse_workbench_name, prune_claude_json, ReapStats};
+
+/// Env var naming the total-disk ceiling for `~/.moadim/workbenches/`, in bytes. Unset, empty, or
+/// unparsable means unbounded (today's behavior) — this is purely an additional safety valve on top
+/// of TTL reaping, not a replacement for it.
+pub(super) const MAX_DISK_BYTES_ENV: &str = "MOADIM_MAX_WORKBENCH_DISK_BYTES";
+
+/// The configured ceiling, or `0` (unbounded) if [`MAX_DISK_BYTES_ENV`] is unset/unparsable.
+pub(super) fn max_disk_bytes() -> u64 {
+    std::env::var(MAX_DISK_BYTES_ENV)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(0)
+}
+
+/// One finished workbench eligible for cap-forced eviction.
+pub(super) struct EvictCandidate {
+    /// Workbench directory name (`{slug}-{ts}`), for logging.
+    pub name: String,
+    /// Absolute path to the workbench directory.
+    pub path: PathBuf,
+    /// Size in bytes of the workbench tree, as measured by [`super::dir_size`].
+    pub size: u64,
+    /// Best-effort finish time (unix seconds), oldest evicted first.
+    pub finish_ts: u64,
+}
+
+/// Given every finished workbench eligible for eviction and the tree's `total_bytes` (summed over
+/// *all* workbenches, live sessions included, since a live session still occupies disk even though
+/// it can never be evicted), pick the oldest-finished-first subset to remove so the tree drops back
+/// under `cap_bytes`. Returns an empty vec when `cap_bytes` is `0` (unbounded) or the tree is already
+/// at or under it.
+///
+/// Pure decision logic — no filesystem access — so it is unit-testable with injected sizes/totals,
+/// mirroring the injected-closure design of [`super::reap_dir`].
+pub(super) fn pick_for_eviction(
+    mut candidates: Vec<EvictCandidate>,
+    cap_bytes: u64,
+    total_bytes: u64,
+) -> Vec<EvictCandidate> {
+    if cap_bytes == 0 || total_bytes <= cap_bytes {
+        return Vec::new();
+    }
+    candidates.sort_by_key(|candidate| candidate.finish_ts);
+    let mut remaining = total_bytes;
+    let mut chosen = Vec::new();
+    for candidate in candidates {
+        if remaining <= cap_bytes {
+            break;
+        }
+        remaining = remaining.saturating_sub(candidate.size);
+        chosen.push(candidate);
+    }
+    chosen
+}
+
+/// Post-TTL-reap safety valve: if `cap_bytes` is nonzero (see [`max_disk_bytes`]) and the tree under
+/// `dir` still exceeds it, evict finished workbenches oldest-finished-first until back under the
+/// cap. A live session (per `is_alive`) is never touched, no matter its size or age — see
+/// [`pick_for_eviction`] for the pure selection logic this wraps with real directory/tmux/removal IO.
+/// Returns the count removed and bytes freed by this pass alone.
+pub(super) fn enforce(
+    dir: &Path,
+    cap_bytes: u64,
+    is_alive: &dyn Fn(&str) -> bool,
+    finished_at: &dyn Fn(&Path, u64) -> u64,
+) -> ReapStats {
+    if cap_bytes == 0 {
+        return ReapStats::default();
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return ReapStats::default();
+    };
+    let mut total_bytes = 0u64;
+    let mut candidates = Vec::new();
+    for entry in entries.flatten() {
+        if !entry.file_type().is_ok_and(|ft| ft.is_dir()) {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let Some((_slug, ts)) = parse_workbench_name(&name) else {
+            continue;
+        };
+        let size = dir_size(&entry.path());
+        total_bytes += size;
+        let session = format!("moadim-{name}");
+        if is_alive(&session) {
+            // Still occupies disk, but can never be evicted.
+            continue;
+        }
+        candidates.push(EvictCandidate {
+            name,
+            path: entry.path(),
+            size,
+            finish_ts: finished_at(&entry.path(), ts),
+        });
+    }
+    let mut stats = ReapStats::default();
+    for candidate in pick_for_eviction(candidates, cap_bytes, total_bytes) {
+        match std::fs::remove_dir_all(&candidate.path) {
+            Ok(()) => {
+                stats.removed += 1;
+                stats.freed_bytes += candidate.size;
+                log::warn!(
+                    "cleanup: evicted not-yet-expired workbench {:?} ({} bytes) — over the {} cap",
+                    candidate.name,
+                    candidate.size,
+                    MAX_DISK_BYTES_ENV
+                );
+                prune_claude_json(&candidate.path, &candidate.name);
+            }
+            Err(err) => {
+                log::warn!(
+                    "cleanup: failed to evict workbench {:?}: {err}",
+                    candidate.name
+                );
+            }
+        }
+    }
+    stats
+}
+
+#[cfg(test)]
+#[path = "disk_cap_tests.rs"]
+mod disk_cap_tests;
+
+#[cfg(test)]
+#[path = "enforce_disk_cap_tests.rs"]
+mod enforce_disk_cap_tests;

--- a/src/routines/cleanup/disk_cap_tests.rs
+++ b/src/routines/cleanup/disk_cap_tests.rs
@@ -1,0 +1,109 @@
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and fixtures do not need doc comments"
+)]
+
+use super::*;
+
+fn candidate(name: &str, size: u64, finish_ts: u64) -> EvictCandidate {
+    EvictCandidate {
+        name: name.to_string(),
+        path: std::path::PathBuf::from(name),
+        size,
+        finish_ts,
+    }
+}
+
+#[test]
+fn pick_for_eviction_is_noop_when_cap_unset() {
+    let candidates = vec![candidate("a", 100, 1)];
+    assert!(pick_for_eviction(candidates, 0, 100).is_empty());
+}
+
+#[test]
+fn pick_for_eviction_is_noop_when_under_cap() {
+    let candidates = vec![candidate("a", 100, 1)];
+    assert!(pick_for_eviction(candidates, 200, 100).is_empty());
+}
+
+#[test]
+fn pick_for_eviction_is_noop_when_exactly_at_cap() {
+    let candidates = vec![candidate("a", 100, 1)];
+    assert!(pick_for_eviction(candidates, 100, 100).is_empty());
+}
+
+#[test]
+fn pick_for_eviction_evicts_oldest_finished_first() {
+    // Total 300 over a 150 cap: the oldest-finished (ts 1) must go first; once evicting it alone
+    // (100 bytes) still leaves 200 > 150, the next-oldest (ts 2) also goes, dropping to 100 <= 150.
+    // The newest (ts 3) is never touched.
+    let candidates = vec![
+        candidate("newest", 100, 3),
+        candidate("oldest", 100, 1),
+        candidate("middle", 100, 2),
+    ];
+    let chosen = pick_for_eviction(candidates, 150, 300);
+    let names: Vec<&str> = chosen
+        .iter()
+        .map(|candidate| candidate.name.as_str())
+        .collect();
+    assert_eq!(names, vec!["oldest", "middle"]);
+}
+
+#[test]
+fn pick_for_eviction_stops_as_soon_as_under_cap() {
+    // Evicting just the oldest (200 bytes) already drops 500 total to 300 <= 300 cap, so the
+    // second-oldest must be left alone even though it exists.
+    let candidates = vec![candidate("oldest", 200, 1), candidate("newer", 100, 2)];
+    let chosen = pick_for_eviction(candidates, 300, 500);
+    assert_eq!(chosen.len(), 1);
+    assert_eq!(chosen[0].name, "oldest");
+}
+
+#[test]
+fn max_disk_bytes_defaults_to_zero_when_unset() {
+    let prev = std::env::var_os(MAX_DISK_BYTES_ENV);
+    // SAFETY: tests in this crate run single-threaded (RUST_TEST_THREADS=1); restored below.
+    unsafe {
+        std::env::remove_var(MAX_DISK_BYTES_ENV);
+    }
+    assert_eq!(max_disk_bytes(), 0);
+    unsafe {
+        match prev {
+            Some(value) => std::env::set_var(MAX_DISK_BYTES_ENV, value),
+            None => std::env::remove_var(MAX_DISK_BYTES_ENV),
+        }
+    }
+}
+
+#[test]
+fn max_disk_bytes_parses_a_valid_value() {
+    let prev = std::env::var_os(MAX_DISK_BYTES_ENV);
+    // SAFETY: tests in this crate run single-threaded (RUST_TEST_THREADS=1); restored below.
+    unsafe {
+        std::env::set_var(MAX_DISK_BYTES_ENV, "1234");
+    }
+    assert_eq!(max_disk_bytes(), 1234);
+    unsafe {
+        match prev {
+            Some(value) => std::env::set_var(MAX_DISK_BYTES_ENV, value),
+            None => std::env::remove_var(MAX_DISK_BYTES_ENV),
+        }
+    }
+}
+
+#[test]
+fn max_disk_bytes_falls_back_to_zero_on_garbage() {
+    let prev = std::env::var_os(MAX_DISK_BYTES_ENV);
+    // SAFETY: tests in this crate run single-threaded (RUST_TEST_THREADS=1); restored below.
+    unsafe {
+        std::env::set_var(MAX_DISK_BYTES_ENV, "not-a-number");
+    }
+    assert_eq!(max_disk_bytes(), 0);
+    unsafe {
+        match prev {
+            Some(value) => std::env::set_var(MAX_DISK_BYTES_ENV, value),
+            None => std::env::remove_var(MAX_DISK_BYTES_ENV),
+        }
+    }
+}

--- a/src/routines/cleanup/enforce_disk_cap_tests.rs
+++ b/src/routines/cleanup/enforce_disk_cap_tests.rs
@@ -1,0 +1,134 @@
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and fixtures do not need doc comments"
+)]
+
+use super::*;
+
+fn touch_dir(parent: &std::path::Path, name: &str) {
+    std::fs::create_dir_all(parent.join(name)).unwrap();
+}
+
+fn write_bytes(parent: &std::path::Path, name: &str, len: usize) {
+    std::fs::write(parent.join(name).join("agent.log"), vec![b'x'; len]).unwrap();
+}
+
+/// A `finished_at` that reports each run's trigger timestamp as its finish time, isolating cap
+/// eviction ordering from `agent.log` mtime.
+fn finish_at_trigger(_dir: &std::path::Path, trigger_ts: u64) -> u64 {
+    trigger_ts
+}
+
+#[test]
+fn enforce_disk_cap_is_noop_when_unset() {
+    let base =
+        std::env::temp_dir().join(format!("moadim-enforce-cap-unset-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&base).unwrap();
+    touch_dir(&base, "wb-100");
+
+    let stats = enforce(&base, 0, &|_| false, &finish_at_trigger);
+    assert_eq!(stats, ReapStats::default());
+    assert!(base.join("wb-100").exists());
+
+    std::fs::remove_dir_all(&base).unwrap();
+}
+
+#[test]
+fn enforce_disk_cap_is_noop_for_a_missing_dir() {
+    let missing = std::env::temp_dir().join(format!(
+        "moadim-enforce-cap-missing-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let _ = std::fs::remove_dir_all(&missing);
+    let stats = enforce(&missing, 100, &|_| false, &finish_at_trigger);
+    assert_eq!(stats, ReapStats::default());
+}
+
+#[test]
+fn enforce_disk_cap_evicts_oldest_finished_workbenches_over_cap() {
+    let base =
+        std::env::temp_dir().join(format!("moadim-enforce-cap-evict-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&base).unwrap();
+    touch_dir(&base, "oldest-1");
+    write_bytes(&base, "oldest-1", 40);
+    touch_dir(&base, "newest-2");
+    write_bytes(&base, "newest-2", 40);
+
+    // Total 80 bytes over a 50-byte cap: the oldest-finished must be evicted, dropping to 40 <= 50.
+    let stats = enforce(&base, 50, &|_| false, &finish_at_trigger);
+
+    assert_eq!(stats.removed, 1);
+    assert_eq!(stats.freed_bytes, 40);
+    assert!(!base.join("oldest-1").exists());
+    assert!(base.join("newest-2").exists());
+
+    std::fs::remove_dir_all(&base).unwrap();
+}
+
+#[test]
+fn enforce_disk_cap_never_evicts_a_live_session() {
+    let base =
+        std::env::temp_dir().join(format!("moadim-enforce-cap-live-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&base).unwrap();
+    touch_dir(&base, "alive-1");
+    write_bytes(&base, "alive-1", 100);
+
+    // Even though the tree is far over cap, the only candidate is a live session, so nothing moves.
+    let alive = |session: &str| session == "moadim-alive-1";
+    let stats = enforce(&base, 10, &alive, &finish_at_trigger);
+
+    assert_eq!(stats, ReapStats::default());
+    assert!(base.join("alive-1").exists());
+
+    std::fs::remove_dir_all(&base).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn enforce_disk_cap_counts_zero_when_remove_fails() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    // An over-cap, finished workbench whose removal fails (parent dir is read-only) is not
+    // counted, exercising the `Err` arm of the eviction remove match.
+    let base = std::env::temp_dir().join(format!(
+        "moadim-enforce-cap-removefail-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let _ = std::fs::remove_dir_all(&base);
+    std::fs::create_dir_all(&base).unwrap();
+    touch_dir(&base, "oldest-1");
+    write_bytes(&base, "oldest-1", 100);
+
+    // Strip write permission from the parent so removing the child directory fails.
+    let mut perms = std::fs::metadata(&base).unwrap().permissions();
+    perms.set_mode(0o555);
+    std::fs::set_permissions(&base, perms).unwrap();
+
+    let stats = enforce(&base, 10, &|_| false, &finish_at_trigger);
+    // A read-only parent makes `remove_dir_all` fail for an unprivileged user, so the directory
+    // survives and the Err arm runs (0 removed). Root bypasses the permission check; tolerate
+    // that by only asserting consistency.
+    if base.join("oldest-1").exists() {
+        assert_eq!(stats.removed, 0);
+    }
+
+    // Restore permissions so cleanup can proceed.
+    let mut perms = std::fs::metadata(&base).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&base, perms).unwrap();
+    std::fs::remove_dir_all(&base).unwrap();
+}
+
+#[test]
+fn enforce_disk_cap_skips_a_file_and_a_non_workbench_dir() {
+    let base =
+        std::env::temp_dir().join(format!("moadim-enforce-cap-skip-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&base).unwrap();
+    std::fs::write(base.join("stray-file"), b"x").unwrap();
+    touch_dir(&base, "notawb");
+
+    let stats = enforce(&base, 1, &|_| false, &finish_at_trigger);
+    assert_eq!(stats, ReapStats::default());
+
+    std::fs::remove_dir_all(&base).unwrap();
+}

--- a/src/routines/cleanup/mod.rs
+++ b/src/routines/cleanup/mod.rs
@@ -27,6 +27,7 @@ use crate::utils::time::now_secs;
 use super::model::{RoutineStore, RunStatus};
 use super::run_history::{append_persisted_run, has_persisted_run, read_exit_code, PersistedRun};
 
+mod disk_cap;
 mod runtime;
 mod session;
 mod snapshot;
@@ -305,7 +306,8 @@ fn reap_dir(
 /// Remove finished, expired workbenches under `~/.moadim/workbenches/`, using each routine's TTL.
 ///
 /// Returns the count of workbenches removed and the total bytes freed. Safe to call repeatedly; it
-/// only ever touches directories whose run has ended.
+/// only ever touches directories whose run has ended. Also enforces the optional total-disk safety
+/// valve (see [`disk_cap::enforce`]) once the normal TTL reap above has run.
 pub fn cleanup_expired_workbenches(store: &RoutineStore) -> ReapStats {
     let ttls = snapshot::snapshot_ttls(store);
     let max_runtimes = snapshot::snapshot_max_runtimes(store);
@@ -342,7 +344,7 @@ pub fn cleanup_expired_workbenches(store: &RoutineStore) -> ReapStats {
                 },
             );
         };
-    reap_dir(
+    let ttl_stats = reap_dir(
         &workbenches_dir(),
         now_secs(),
         &ttl_for,
@@ -351,7 +353,17 @@ pub fn cleanup_expired_workbenches(store: &RoutineStore) -> ReapStats {
         &tmux_kill_session,
         &agent_log_finish_time,
         &persist,
-    )
+    );
+    let cap_stats = disk_cap::enforce(
+        &workbenches_dir(),
+        disk_cap::max_disk_bytes(),
+        &tmux_session_alive,
+        &agent_log_finish_time,
+    );
+    ReapStats {
+        removed: ttl_stats.removed + cap_stats.removed,
+        freed_bytes: ttl_stats.freed_bytes + cap_stats.freed_bytes,
+    }
 }
 
 /// Force-kill hung run sessions under `~/.moadim/workbenches/` that have exceeded their routine's


### PR DESCRIPTION
## Problem

Workbench cleanup (`routines::cleanup`) is driven entirely by time — a workbench is reaped only once its run has finished **and** it is older than the routine's TTL. Nothing measures or caps the **size** of `~/.moadim/workbenches/`. A run can clone large repos, so a handful of concurrent (or many routines') runs can exhaust the disk long before any TTL elapses — see #398.

## Change

- Add `MOADIM_MAX_WORKBENCH_DISK_BYTES`: an optional total-disk ceiling for the workbench tree, in bytes. Unset or `0` preserves today's unbounded-by-size behavior.
- New `routines::cleanup::disk_cap` module: after the normal TTL sweep runs, if the ceiling is set and the tree still exceeds it, finished workbenches (never a live session) are evicted **oldest-finished-first** until back under the cap. This is a safety valve layered on top of the existing TTL reaper, not a replacement for it.
- Cap-forced evictions are logged distinctly (`over the MOADIM_MAX_WORKBENCH_DISK_BYTES cap`) from normal TTL reaps.
- Selection logic (`pick_for_eviction`) is pure and unit-tested with injected sizes/totals; the IO wrapper (`enforce`) is tested with a real tmpdir, mirroring the existing `reap_dir` test design (100% line coverage).
- Documented in README.md and Architecture.md.

## Test plan

- [x] `cargo test` (953 passed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`
- [x] `typos`
- [x] `linecheck --max-lines 500` over `src` + `ui/src`
- [x] `cargo llvm-cov` — 100% line coverage on the new module and `cleanup/mod.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)