### PR TITLE
fix(routines,cli): split files back under the 500-line pre-push gate

### DIFF
--- a/.changeset/split-cli-service-trigger-linecheck.md
+++ b/.changeset/split-cli-service-trigger-linecheck.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Split `src/routines/service_trigger.rs` (→ `service_run_files.rs`) and `src/cli.rs` (→ `cli_restart.rs`) to satisfy the 500-line pre-push gate, which two independently-passing PRs had combined to exceed (`linecheck` isn't a required status check on the branch ruleset, so neither merge was blocked by it). No behavior change.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -354,69 +354,6 @@ fn foreground_already_running_message(pid: Option<u32>) -> String {
     )
 }
 
-/// Stop a running background server (if any) and start a fresh detached instance. With `json`,
-/// emits a single machine-readable object (`{"old":N|null,"new":M}`) instead of the human-readable
-/// lines.
-///
-/// Unlike [`run_background`], which restarts only as a side effect of being asked to start while
-/// one is already up, this is the explicit "give me a clean process now" command: it stops the
-/// running server when present, otherwise just starts one.
-pub fn restart(json: bool, quiet: bool) -> anyhow::Result<()> {
-    // Only the bare command narrates the stop/start step and prints the hint block; `--json` emits a
-    // single object and `--quiet` prints just the rotation line.
-    let old_pid = stop_existing_for_restart(json || quiet)?;
-    let new_pid = spawn_detached()?;
-    if json {
-        println!("{}", restart_json(old_pid, new_pid));
-    } else {
-        // Headline the rotation so scripts/logs can see the process actually changed.
-        println!("{}", restart_rotation_line(old_pid, new_pid));
-        if !quiet {
-            report_endpoints();
-        }
-    }
-    Ok(())
-}
-
-/// Format the one-line PID rotation summary `restart` prints, e.g. `restarted: pid 123 -> 456`.
-/// `old` reads `none` when nothing was running (or its PID could not be read).
-fn restart_rotation_line(old: Option<u32>, new: u32) -> String {
-    let old = old.map_or_else(|| "none".to_string(), |pid| pid.to_string());
-    format!("restarted: pid {old} -> {new}")
-}
-
-/// Render the `restart` result as a one-line JSON object: `{"old":N|null,"new":N,"address":…}`.
-/// `old` is `null` when nothing was running (mirroring [`restart_rotation_line`]'s `none`); `new`
-/// is the freshly spawned PID; `address` is the bound [`BIND_ADDR`].
-fn restart_json(old: Option<u32>, new: u32) -> String {
-    serde_json::json!({
-        "old": old,
-        "new": new,
-        "address": bind_addr(),
-    })
-    .to_string()
-}
-
-/// Spawn a detached server process and print where to reach and manage it.
-///
-/// `verb` describes how the process came to be ("started" / "restarted") for the first line.
-fn start_detached_and_report(verb: &str) -> anyhow::Result<()> {
-    let pid = spawn_detached()?;
-    println!(
-        "moadim {verb} in the background (pid {pid}) at http://{}",
-        bind_addr()
-    );
-    report_endpoints();
-    Ok(())
-}
-
-/// Print the reach/manage hints (UI, stop, logs) shared by every detached-launch report.
-fn report_endpoints() {
-    println!("  UI    http://{}", bind_addr());
-    println!("  stop  moadim stop   (or use the STOP button in the UI)");
-    println!("  logs  {}", paths_daemon_log());
-}
-
 /// Ask a running server to stop via the `/shutdown` route. With `json`, emits a single
 /// machine-readable object (`{"running":bool,"pid":N|null,"address":…}`, matching `status --json`'s
 /// shape) instead of the human-readable line. With `quiet`, the human-readable line is suppressed
@@ -482,6 +419,13 @@ use cli_system::{
 };
 #[cfg(test)]
 pub(crate) use cli_system::{parse_body, parse_status_code, DAEMON_LOG_MAX_BYTES};
+
+#[path = "cli_restart.rs"]
+mod cli_restart;
+pub use cli_restart::restart;
+use cli_restart::start_detached_and_report;
+#[cfg(test)]
+use cli_restart::{restart_json, restart_rotation_line};
 
 #[cfg(test)]
 #[path = "cli_tests.rs"]

--- a/src/cli_restart.rs
+++ b/src/cli_restart.rs
@@ -1,0 +1,67 @@
+//! The `restart` command and its detached-spawn reporting, split out of `cli.rs` to stay under
+//! the repo's per-file line gate.
+
+use super::{bind_addr, paths_daemon_log, spawn_detached, stop_existing_for_restart};
+
+/// Stop a running background server (if any) and start a fresh detached instance. With `json`,
+/// emits a single machine-readable object (`{"old":N|null,"new":M}`) instead of the human-readable
+/// lines.
+///
+/// Unlike [`super::run_background`], which restarts only as a side effect of being asked to start
+/// while one is already up, this is the explicit "give me a clean process now" command: it stops
+/// the running server when present, otherwise just starts one.
+pub fn restart(json: bool, quiet: bool) -> anyhow::Result<()> {
+    // Only the bare command narrates the stop/start step and prints the hint block; `--json` emits a
+    // single object and `--quiet` prints just the rotation line.
+    let old_pid = stop_existing_for_restart(json || quiet)?;
+    let new_pid = spawn_detached()?;
+    if json {
+        println!("{}", restart_json(old_pid, new_pid));
+    } else {
+        // Headline the rotation so scripts/logs can see the process actually changed.
+        println!("{}", restart_rotation_line(old_pid, new_pid));
+        if !quiet {
+            report_endpoints();
+        }
+    }
+    Ok(())
+}
+
+/// Format the one-line PID rotation summary `restart` prints, e.g. `restarted: pid 123 -> 456`.
+/// `old` reads `none` when nothing was running (or its PID could not be read).
+pub(crate) fn restart_rotation_line(old: Option<u32>, new: u32) -> String {
+    let old = old.map_or_else(|| "none".to_string(), |pid| pid.to_string());
+    format!("restarted: pid {old} -> {new}")
+}
+
+/// Render the `restart` result as a one-line JSON object: `{"old":N|null,"new":N,"address":…}`.
+/// `old` is `null` when nothing was running (mirroring [`restart_rotation_line`]'s `none`); `new`
+/// is the freshly spawned PID; `address` is the bound [`super::BIND_ADDR`].
+pub(crate) fn restart_json(old: Option<u32>, new: u32) -> String {
+    serde_json::json!({
+        "old": old,
+        "new": new,
+        "address": bind_addr(),
+    })
+    .to_string()
+}
+
+/// Spawn a detached server process and print where to reach and manage it.
+///
+/// `verb` describes how the process came to be ("started" / "restarted") for the first line.
+pub(crate) fn start_detached_and_report(verb: &str) -> anyhow::Result<()> {
+    let pid = spawn_detached()?;
+    println!(
+        "moadim {verb} in the background (pid {pid}) at http://{}",
+        bind_addr()
+    );
+    report_endpoints();
+    Ok(())
+}
+
+/// Print the reach/manage hints (UI, stop, logs) shared by every detached-launch report.
+fn report_endpoints() {
+    println!("  UI    http://{}", bind_addr());
+    println!("  stop  moadim stop   (or use the STOP button in the UI)");
+    println!("  logs  {}", paths_daemon_log());
+}

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -406,9 +406,13 @@ use service_trigger::migrate_workbenches;
 #[cfg(test)]
 pub(crate) use service_trigger::sh_bin;
 pub use service_trigger::{
-    svc_cleanup, svc_list_all_runs, svc_list_runs, svc_logs, svc_run_log, svc_run_summary,
-    svc_set_power_saving, svc_snooze, svc_trigger, svc_trigger_scheduled,
+    svc_cleanup, svc_list_all_runs, svc_list_runs, svc_logs, svc_set_power_saving, svc_snooze,
+    svc_trigger, svc_trigger_scheduled,
 };
+
+#[path = "service_run_files.rs"]
+mod service_run_files;
+pub use service_run_files::{svc_run_log, svc_run_summary};
 
 #[path = "service_trigger_flags.rs"]
 mod service_trigger_flags;

--- a/src/routines/service_run_files.rs
+++ b/src/routines/service_run_files.rs
@@ -1,0 +1,58 @@
+//! Per-run file reads: a specific run's `agent.log` tail and agent-authored `summary.md`.
+
+use crate::error::AppError;
+use crate::paths::workbenches_dir;
+use crate::routines::cleanup::parse_workbench_name;
+use crate::routines::command::slugify;
+use crate::routines::model::RoutineStore;
+use crate::utils::lock::LockRecover;
+
+use super::service_log_tail::read_log_tail;
+
+/// Return the contents of `filename` inside a specific run's workbench, by workbench directory
+/// name.
+///
+/// `workbench` must be an existing, exact `{slug}-{ts}` directory belonging to routine `id` — this
+/// guards both path traversal (a bare directory name, not an arbitrary path, is joined onto
+/// `workbenches_dir()`) and cross-routine leakage, mirroring the exact-slug check in `svc_logs`.
+/// Shared by [`svc_run_log`] (`agent.log`) and [`svc_run_summary`] (`summary.md`).
+fn svc_run_file(
+    store: &RoutineStore,
+    id: &str,
+    workbench: &str,
+    filename: &str,
+) -> Result<String, AppError> {
+    let routine = store
+        .lock_recover()
+        .get(id)
+        .cloned()
+        .ok_or(AppError::NotFound)?;
+    let slug = slugify(&routine.title);
+    let Some((dir_slug, _)) = parse_workbench_name(workbench) else {
+        return Err(AppError::NotFound);
+    };
+    if dir_slug != slug {
+        return Err(AppError::NotFound);
+    }
+    let path = workbenches_dir().join(workbench).join(filename);
+    if !path.exists() {
+        return Ok(String::new());
+    }
+    read_log_tail(&path).map_err(|_| AppError::Internal)
+}
+
+/// Return the contents of a specific run's `agent.log`, by workbench directory name.
+pub fn svc_run_log(store: &RoutineStore, id: &str, workbench: &str) -> Result<String, AppError> {
+    svc_run_file(store, id, workbench, "agent.log")
+}
+
+/// Return the contents of a specific run's agent-authored `summary.md` (see the "Work log"
+/// instruction in [`crate::routines::command::system_prompt_stmts`]), by workbench directory
+/// name. Empty string when the agent hasn't written one (yet, or never did).
+pub fn svc_run_summary(
+    store: &RoutineStore,
+    id: &str,
+    workbench: &str,
+) -> Result<String, AppError> {
+    svc_run_file(store, id, workbench, "summary.md")
+}

--- a/src/routines/service_trigger.rs
+++ b/src/routines/service_trigger.rs
@@ -18,7 +18,7 @@ use crate::routines::model::{
 };
 use crate::routines::run_history::{read_exit_code, read_persisted_runs};
 
-use super::service_log_tail::{read_log_tail, read_log_tail_with_meta, LogWithMeta};
+use super::service_log_tail::{read_log_tail_with_meta, LogWithMeta};
 
 /// Record a manual trigger for `id` and spawn the same command the crontab would run.
 ///
@@ -454,52 +454,4 @@ fn run_summary(dir: &str, started_at: u64, effective_ttl_secs: Option<u64>) -> R
         exit_code,
         retention_expires_at,
     }
-}
-
-/// Return the contents of `filename` inside a specific run's workbench, by workbench directory
-/// name.
-///
-/// `workbench` must be an existing, exact `{slug}-{ts}` directory belonging to routine `id` — this
-/// guards both path traversal (a bare directory name, not an arbitrary path, is joined onto
-/// `workbenches_dir()`) and cross-routine leakage, mirroring the exact-slug check in [`svc_logs`].
-/// Shared by [`svc_run_log`] (`agent.log`) and [`svc_run_summary`] (`summary.md`).
-fn svc_run_file(
-    store: &RoutineStore,
-    id: &str,
-    workbench: &str,
-    filename: &str,
-) -> Result<String, AppError> {
-    let routine = store
-        .lock_recover()
-        .get(id)
-        .cloned()
-        .ok_or(AppError::NotFound)?;
-    let slug = slugify(&routine.title);
-    let Some((dir_slug, _)) = parse_workbench_name(workbench) else {
-        return Err(AppError::NotFound);
-    };
-    if dir_slug != slug {
-        return Err(AppError::NotFound);
-    }
-    let path = workbenches_dir().join(workbench).join(filename);
-    if !path.exists() {
-        return Ok(String::new());
-    }
-    read_log_tail(&path).map_err(|_| AppError::Internal)
-}
-
-/// Return the contents of a specific run's `agent.log`, by workbench directory name.
-pub fn svc_run_log(store: &RoutineStore, id: &str, workbench: &str) -> Result<String, AppError> {
-    svc_run_file(store, id, workbench, "agent.log")
-}
-
-/// Return the contents of a specific run's agent-authored `summary.md` (see the "Work log"
-/// instruction in [`crate::routines::command::system_prompt_stmts`]), by workbench directory
-/// name. Empty string when the agent hasn't written one (yet, or never did).
-pub fn svc_run_summary(
-    store: &RoutineStore,
-    id: &str,
-    workbench: &str,
-) -> Result<String, AppError> {
-    svc_run_file(store, id, workbench, "summary.md")
 }


### PR DESCRIPTION
## Summary
- `src/routines/service_trigger.rs` (505 lines) and `src/cli.rs` (508 lines) each independently passed their own PR's CI, but two separate PRs landing on `main` pushed both combined over the repo's 500-line-per-file convention — `linecheck` isn't in the branch ruleset's required status checks, so neither merge was blocked by it.
- This currently fails the local `pre-push` hook's line-count gate for anyone pushing from `main`, release included — found while validating a separate `auto-release.yml` fix (see #1049).
- Extracts `svc_run_log`/`svc_run_summary` (and their shared `svc_run_file` helper) from `service_trigger.rs` into a new `service_run_files.rs` sibling, and `restart`/`restart_rotation_line`/`restart_json`/`start_detached_and_report`/`report_endpoints` from `cli.rs` into a new `cli_restart.rs` sibling — mirroring the repo's existing `cli_query.rs`/`service_trigger_flags.rs` split pattern. No behavior change.

## Test plan
- [x] `cargo build`, `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` all clean.
- [x] `sh .githooks/pre-push` run locally twice: 957 tests passing, 100% line coverage, `linecheck --max-lines 500` passing, changeset present.