### PR TITLE
docs(routines): document the ttl_secs/max_runtime_secs > 0 minimum

### DIFF
--- a/.changeset/issue-233-ttl-max-runtime-doc-minimum.md
+++ b/.changeset/issue-233-ttl-max-runtime-doc-minimum.md
@@ -1,0 +1,12 @@
+---
+"moadim": patch
+---
+
+docs(routines): note the `> 0` requirement on `ttl_secs`/`max_runtime_secs`
+
+`svc_create`/`svc_update` already reject `ttl_secs: 0` and `max_runtime_secs: 0`
+with `400 Bad Request` (#239), but the REST/MCP field docs (and the generated
+OpenAPI spec) never said so, leaving the constraint undiscoverable to callers
+until they hit the error. Documents the minimum on `Routine`,
+`CreateRoutineRequest`, `UpdateRoutineRequest`, and the MCP `update_routine`
+input, closing the last unchecked box on #233.

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -1091,7 +1091,7 @@
               "null"
             ],
             "format": "int64",
-            "description": "Max wall-clock seconds a run may execute before the watchdog kills its hung\nsession. `None` uses the default cap (`MAX_RUNTIME_SECS`).",
+            "description": "Max wall-clock seconds a run may execute before the watchdog kills its hung\nsession. `None` uses the default cap (`MAX_RUNTIME_SECS`). Must be greater\nthan zero when set; `0` is rejected (#233).",
             "minimum": 0
           },
           "model": {
@@ -1133,7 +1133,7 @@
               "null"
             ],
             "format": "int64",
-            "description": "Workbench retention in seconds for finished runs; caps the cron-derived\nretention lower. `None` uses `min(MAX_TTL_SECS, cron interval)`.",
+            "description": "Workbench retention in seconds for finished runs; caps the cron-derived\nretention lower. `None` uses `min(MAX_TTL_SECS, cron interval)`. Must be\ngreater than zero when set; `0` is rejected (#233).",
             "minimum": 0
           }
         }
@@ -1460,7 +1460,7 @@
               "null"
             ],
             "format": "int64",
-            "description": "Maximum wall-clock seconds a single run may execute before the cleanup watchdog force-kills\nits (hung) tmux session, after which the workbench is reaped under the normal TTL rules.\n`None` uses `min(MAX_RUNTIME_SECS, cron interval)`; an explicit value can only lower that. A\nsession still within this bound is never touched. The cap and\n[`Routine::effective_max_runtime_secs`] live in the cleanup module.",
+            "description": "Maximum wall-clock seconds a single run may execute before the cleanup watchdog force-kills\nits (hung) tmux session, after which the workbench is reaped under the normal TTL rules.\n`None` uses `min(MAX_RUNTIME_SECS, cron interval)`; an explicit value can only lower that. A\nsession still within this bound is never touched. The cap and\n[`Routine::effective_max_runtime_secs`] live in the cleanup module. Must be greater than\nzero when set; `0` is rejected by `svc_create`/`svc_update` (#233).",
             "minimum": 0
           },
           "model": {
@@ -1528,7 +1528,7 @@
               "null"
             ],
             "format": "int64",
-            "description": "How long (seconds) a finished run's workbench is retained before auto-cleanup removes it.\nCaps the cron-derived retention (`min(MAX_TTL_SECS, cron interval)`) lower; it can only\nshorten, never extend it. `None` uses the cron-derived value. Sessions still running are\nnever reaped. The cap and [`Routine::effective_ttl_secs`] live in the cleanup module.",
+            "description": "How long (seconds) a finished run's workbench is retained before auto-cleanup removes it.\nCaps the cron-derived retention (`min(MAX_TTL_SECS, cron interval)`) lower; it can only\nshorten, never extend it. `None` uses the cron-derived value. Sessions still running are\nnever reaped. The cap and [`Routine::effective_ttl_secs`] live in the cleanup module. Must\nbe greater than zero when set; `0` is rejected by `svc_create`/`svc_update` (#233).",
             "minimum": 0
           },
           "updated_at": {
@@ -1763,7 +1763,7 @@
               "null"
             ],
             "format": "int64",
-            "description": "New max runtime (seconds) for a single run, or `None` to keep the existing value.",
+            "description": "New max runtime (seconds) for a single run, or `None` to keep the existing value. Must be\ngreater than zero when set; `0` is rejected (#233).",
             "minimum": 0
           },
           "model": {
@@ -1820,7 +1820,7 @@
               "null"
             ],
             "format": "int64",
-            "description": "New workbench TTL (seconds), or `None` to keep the existing value.",
+            "description": "New workbench TTL (seconds), or `None` to keep the existing value. Must be\ngreater than zero when set; `0` is rejected (#233).",
             "minimum": 0
           }
         }

--- a/src/routes/mcp_types.rs
+++ b/src/routes/mcp_types.rs
@@ -106,10 +106,11 @@ pub(super) struct UpdateRoutineInput {
     pub(super) machines: Option<Vec<String>>,
     /// New enabled state, or `None` to keep the existing value.
     pub(super) enabled: Option<bool>,
-    /// New workbench TTL (seconds) for finished runs, or `None` to keep the existing value.
+    /// New workbench TTL (seconds) for finished runs, or `None` to keep the existing value. Must
+    /// be greater than zero when set; `0` is rejected (#233).
     pub(super) ttl_secs: Option<u64>,
     /// New max runtime (seconds) for a single run before the watchdog kills it, or `None` to keep
-    /// the existing value.
+    /// the existing value. Must be greater than zero when set; `0` is rejected (#233).
     pub(super) max_runtime_secs: Option<u64>,
     /// New tags list, or `None` to keep the existing value.
     pub(super) tags: Option<Vec<String>>,

--- a/src/routines/model.rs
+++ b/src/routines/model.rs
@@ -172,14 +172,16 @@ pub struct Routine {
     /// How long (seconds) a finished run's workbench is retained before auto-cleanup removes it.
     /// Caps the cron-derived retention (`min(MAX_TTL_SECS, cron interval)`) lower; it can only
     /// shorten, never extend it. `None` uses the cron-derived value. Sessions still running are
-    /// never reaped. The cap and [`Routine::effective_ttl_secs`] live in the cleanup module.
+    /// never reaped. The cap and [`Routine::effective_ttl_secs`] live in the cleanup module. Must
+    /// be greater than zero when set; `0` is rejected by `svc_create`/`svc_update` (#233).
     #[serde(default)]
     pub ttl_secs: Option<u64>,
     /// Maximum wall-clock seconds a single run may execute before the cleanup watchdog force-kills
     /// its (hung) tmux session, after which the workbench is reaped under the normal TTL rules.
     /// `None` uses `min(MAX_RUNTIME_SECS, cron interval)`; an explicit value can only lower that. A
     /// session still within this bound is never touched. The cap and
-    /// [`Routine::effective_max_runtime_secs`] live in the cleanup module.
+    /// [`Routine::effective_max_runtime_secs`] live in the cleanup module. Must be greater than
+    /// zero when set; `0` is rejected by `svc_create`/`svc_update` (#233).
     #[serde(default)]
     pub max_runtime_secs: Option<u64>,
     /// Free-form labels for grouping and filtering routines (e.g. `"triage"`, `"nightly"`).
@@ -409,11 +411,13 @@ pub struct CreateRoutineRequest {
     #[serde(default = "bool_true")]
     pub enabled: bool,
     /// Workbench retention in seconds for finished runs; caps the cron-derived
-    /// retention lower. `None` uses `min(MAX_TTL_SECS, cron interval)`.
+    /// retention lower. `None` uses `min(MAX_TTL_SECS, cron interval)`. Must be
+    /// greater than zero when set; `0` is rejected (#233).
     #[serde(default)]
     pub ttl_secs: Option<u64>,
     /// Max wall-clock seconds a run may execute before the watchdog kills its hung
-    /// session. `None` uses the default cap (`MAX_RUNTIME_SECS`).
+    /// session. `None` uses the default cap (`MAX_RUNTIME_SECS`). Must be greater
+    /// than zero when set; `0` is rejected (#233).
     #[serde(default)]
     pub max_runtime_secs: Option<u64>,
     /// Free-form labels for the routine (defaults to empty). Each entry is trimmed
@@ -445,9 +449,11 @@ pub struct UpdateRoutineRequest {
     pub machines: Option<Vec<String>>,
     /// New enabled state, or `None` to keep the existing value.
     pub enabled: Option<bool>,
-    /// New workbench TTL (seconds), or `None` to keep the existing value.
+    /// New workbench TTL (seconds), or `None` to keep the existing value. Must be
+    /// greater than zero when set; `0` is rejected (#233).
     pub ttl_secs: Option<u64>,
-    /// New max runtime (seconds) for a single run, or `None` to keep the existing value.
+    /// New max runtime (seconds) for a single run, or `None` to keep the existing value. Must be
+    /// greater than zero when set; `0` is rejected (#233).
     pub max_runtime_secs: Option<u64>,
     /// New tags list, or `None` to keep the existing value.
     pub tags: Option<Vec<String>>,


### PR DESCRIPTION
## Why

Closes #233.

The actual bug — `ttl_secs: 0` reaping a finished run's logs instantly, and `max_runtime_secs: 0` making the watchdog self-kill a run the moment it starts — was already fixed by #239, merged the same day #233 was filed (`reject_zero_secs` in `src/routines/service_validate.rs`, wired into both `svc_create` and `svc_update`, with rejection tests in `service_tests.rs`). #239's body named `#233` without a `Closes` keyword, so the issue was never auto-closed and stayed open.

Checking #233's acceptance criteria against current `main`:

- [x] `svc_create`/`svc_update` reject `ttl_secs == 0` / `max_runtime_secs == 0` with `400 Bad Request` — done in #239.
- [x] Minimum documented as `>= 1` (any positive value) — behavior already matches, but wasn't written down anywhere a caller could see it.
- [x] Validation happens before persistence — `reject_zero_secs` runs up front in both service functions.
- [x] Tests cover `ttl_secs = 0` / `max_runtime_secs = 0` rejected on create and update, and a valid positive value round-tripping — already in `service_tests.rs`.
- [ ] **OpenAPI/MCP schema and field docs in `model.rs` note the minimum** — this was the one box left unchecked. This PR closes it.

## What

- `src/routines/model.rs`: add "must be greater than zero when set; `0` is rejected" to the doc comments on `Routine::ttl_secs`/`max_runtime_secs`, `CreateRoutineRequest::ttl_secs`/`max_runtime_secs`, and `UpdateRoutineRequest::ttl_secs`/`max_runtime_secs`.
- `src/routes/mcp_types.rs`: same note on `UpdateRoutineInput::ttl_secs`/`max_runtime_secs` (the MCP `create_routine` tool reuses `CreateRoutineRequest` directly, so no separate MCP create-side struct needed the note).
- `apis/openapi.json`: regenerated (`utoipa`/`schemars` derive the schema `description` straight from these doc comments) via `cargo test`'s `committed_spec_is_current` self-check, which fails the build on drift.

No behavior change — the `0`-rejection logic and its tests are untouched. This purely makes the existing, already-enforced constraint discoverable via the REST/MCP schema instead of only via a 400 at request time.

## Test plan

- [x] `cargo build`
- [x] `cargo test` — 959 passed, 0 failed (including the `apis/openapi.json` staleness self-check)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Added a `.changeset/` entry per this repo's changelog-gate convention