### PR TITLE
docs: prune two TODO.md entries already shipped

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,5 +7,3 @@ This is a list of todos for consumption, in a pr remove the todo you have implem
 - Add a CI step (or weekly scheduled job) that checks whether a newer `crate-ci/typos` release exists than the pinned tag and opens/updates a tracking issue, so the pin gets bumped on a cadence instead of drifting silently
 - Add a day-detail popover to the routines calendar: clicking a day lists each fire time (HH:MM) with its routine, and a "run now" shortcut per routine
 - Have a commands folder for all the cli commands, we want to work with colocation of files
-- Show a humanized retention countdown ("expires in 2d" / "expired") per finished run in the routine LOGS view, derived from the run's finish time and the routine's effective TTL
-- Auto-refresh the routine LOGS view (or show a removed badge) after a CLEANUP NOW sweep so stale run output isn't shown for reaped workbenches


### PR DESCRIPTION
## Summary
- `TODO.md`'s "Show a humanized retention countdown ... in the routine LOGS view" is already implemented: `ui/src/routines/history.rs` has `fmt_retention` (with full test coverage in `history_tests.rs`) wired to the API's `retention_expires_at` field.
- `TODO.md`'s "Auto-refresh the routine LOGS view ... after a CLEANUP NOW sweep" is already implemented: `ui/src/routines/logs.rs` has an interval-based auto-refresh explicitly citing this exact scenario (#357).
- Per `TODO.md`'s own convention ("in a pr remove the todo you have implemented"), prune both stale entries so the backlog reflects what's actually left to do.
- Docs-only change (`TODO.md`), no `src/`/`ui/` touched, so no changeset is required.

## Test plan
- [x] Verified both features exist end-to-end on current `main` (backend field + frontend render + tests) before removing their TODO entries
- [x] No code changes, nothing to test at runtime

This pull request was opened by the "Daemon + Landing auto-improve & auto-merge lint/docs PRs" routine of moadim.