### PR TITLE
fix(routines): iCalendar feed skips power-saving and snoozed fires

### DIFF
--- a/.changeset/ical-feed-honors-snooze-and-power-saving.md
+++ b/.changeset/ical-feed-honors-snooze-and-power-saving.md
@@ -1,0 +1,13 @@
+---
+"moadim": patch
+---
+
+fix(routines): iCalendar feed now skips power-saving and snoozed fires
+
+`GET /routines.ics` only excluded disabled routines and unparseable schedules,
+so a routine in power-saving mode, snoozed via `snoozed_until`, or with
+`skip_runs` pending still advertised upcoming fire times that
+`svc_trigger_scheduled` would actually refuse to spawn — a subscribed calendar
+lied about what would run. The feed now filters/skips those fires the same way
+the trigger path does, so `.ics` subscribers never see a run that will
+silently no-op.

--- a/src/routines/ical.rs
+++ b/src/routines/ical.rs
@@ -113,8 +113,11 @@ fn fold_line(line: &str) -> String {
 /// Each enabled routine with a parseable schedule contributes one `VEVENT` per fire time in
 /// `(now, now + HORIZON_DAYS]`, capped at [`MAX_EVENTS_PER_ROUTINE`]. Fire times are evaluated in
 /// the host's local timezone (matching crontab semantics) and emitted as UTC instants so the feed
-/// needs no embedded `VTIMEZONE`. Disabled routines and unparseable schedules (e.g. `@reboot`)
-/// contribute nothing. The calendar is named [`DEFAULT_CAL_NAME`]; for a single-routine feed see
+/// needs no embedded `VTIMEZONE`. Disabled, power-saving, and unparseable-schedule (e.g. `@reboot`)
+/// routines contribute nothing. A snoozed routine (`snoozed_until` in the future, or `skip_runs`
+/// above zero) has its would-be-skipped fires filtered out too, mirroring the skip that
+/// `svc_trigger_scheduled` actually performs at fire time, so the feed never advertises a run that
+/// will silently no-op. The calendar is named [`DEFAULT_CAL_NAME`]; for a single-routine feed see
 /// [`build_ical_named`].
 ///
 /// When a routine fires more often than the cap allows within the horizon, the count cap is hit
@@ -158,7 +161,7 @@ fn build_ical_core(
     ];
     let globally_locked = crate::global_lock::is_globally_locked();
     for routine in routines {
-        if !routine.enabled || globally_locked {
+        if !routine.enabled || globally_locked || routine.power_saving {
             continue;
         }
         let Ok(cron) = routine.schedule.parse::<Cron>() else {
@@ -173,7 +176,18 @@ fn build_ical_core(
         // Fire times within the horizon, in order. Kept as a stateful iterator so that after the
         // per-routine cap is spent we can peek whether more fires remain inside the horizon and, if
         // so, surface the truncation rather than letting the feed silently stop short of 30 days.
-        let mut fires = cron.iter_after(now).take_while(|dt| *dt <= horizon);
+        //
+        // `snoozed_until`/`skip_runs` are mutually exclusive (enforced by `svc_snooze`): a fire is
+        // dropped either because it falls before the snooze deadline, or because it's among the
+        // next `skip_runs` fires that `svc_trigger_scheduled` will skip and decrement past. Both
+        // mirror the exact skip performed there so the feed matches what will actually run.
+        let snoozed_until = routine.snoozed_until;
+        let skip_runs = routine.skip_runs.unwrap_or(0) as usize;
+        let mut fires = cron
+            .iter_after(now)
+            .take_while(|dt| *dt <= horizon)
+            .filter(move |dt| snoozed_until.is_none_or(|until| dt.timestamp() as u64 >= until))
+            .skip(skip_runs);
         let mut emitted = 0usize;
         for fire in fires.by_ref().take(max_events) {
             let stamp = format_utc(fire.with_timezone(&Utc));

--- a/src/routines/ical_tests.rs
+++ b/src/routines/ical_tests.rs
@@ -112,6 +112,62 @@ fn unparseable_schedule_is_skipped() {
 }
 
 #[test]
+fn power_saving_routine_contributes_nothing() {
+    // power_saving is an independent signal from enabled (see svc_trigger_scheduled),
+    // and blocks a scheduled fire the same way; the feed must honor it too.
+    let mut routine = routine_with("r1", "@daily", true);
+    routine.power_saving = true;
+    let ics = build_ical(&[routine], fixed_now());
+    assert_eq!(count(&ics, "BEGIN:VEVENT"), 0);
+}
+
+#[test]
+fn snoozed_routine_skips_fires_before_the_deadline() {
+    // svc_trigger_scheduled refuses to spawn any fire before `snoozed_until`; the feed
+    // must not advertise those as real runs either.
+    let mut routine = routine_with("r1", "* * * * *", true);
+    let now = fixed_now();
+    let deadline = now + Duration::minutes(3);
+    routine.snoozed_until = Some(u64::try_from(deadline.timestamp()).unwrap());
+    let ics = build_ical_with_cap(&[routine], now, 5);
+    // The first two per-minute fires (00:01, 00:02) fall before the deadline and are
+    // dropped; the feed starts at the deadline itself (00:03).
+    assert!(ics.contains(&format!(
+        "DTSTART:{}\r\n",
+        format_utc(deadline.with_timezone(&Utc))
+    )));
+    let first_dropped = now + Duration::minutes(1);
+    assert!(!ics.contains(&format!(
+        "DTSTART:{}\r\n",
+        format_utc(first_dropped.with_timezone(&Utc))
+    )));
+    // 5 real VEVENTs (starting at the deadline) plus the truncation marker.
+    assert_eq!(count(&ics, "BEGIN:VEVENT"), 6);
+}
+
+#[test]
+fn skip_runs_drops_the_next_n_fires() {
+    // svc_trigger_scheduled decrements skip_runs once per skipped scheduled fire without
+    // spawning it; the feed must skip the same leading fires instead of showing them.
+    let mut routine = routine_with("r1", "* * * * *", true);
+    routine.skip_runs = Some(2);
+    let now = fixed_now();
+    let ics = build_ical_with_cap(&[routine], now, 3);
+    let first_kept = now + Duration::minutes(3);
+    let first_dropped = now + Duration::minutes(1);
+    assert!(ics.contains(&format!(
+        "DTSTART:{}\r\n",
+        format_utc(first_kept.with_timezone(&Utc))
+    )));
+    assert!(!ics.contains(&format!(
+        "DTSTART:{}\r\n",
+        format_utc(first_dropped.with_timezone(&Utc))
+    )));
+    // 3 real VEVENTs (starting after the 2 skipped fires) plus the truncation marker.
+    assert_eq!(count(&ics, "BEGIN:VEVENT"), 4);
+}
+
+#[test]
 fn high_frequency_schedule_is_capped() {
     let ics = build_ical(&[routine_with("r1", "* * * * *", true)], fixed_now());
     // 100 real events plus one trailing truncation-marker VEVENT (see below).


### PR DESCRIPTION
## What

`GET /routines.ics` (and the per-routine `?routine=<id>` variant) projects each enabled routine's upcoming cron fire times into an iCalendar feed. That skip check only looked at `enabled` and the global lock — it never accounted for a routine in **power-saving mode**, **snoozed** via `snoozed_until`, or with **`skip_runs`** pending, even though `svc_trigger_scheduled` (`src/routines/service_trigger.rs`) refuses to actually spawn any of those fires. A subscribed calendar therefore kept advertising run times that would silently no-op — misleading anyone relying on the feed to know when a routine will actually run.

## Fix

In `build_ical_core` (`src/routines/ical.rs`):
- Skip the whole routine when `power_saving` is true (same as the existing `enabled`/global-lock check).
- Filter out any projected fire before `snoozed_until`, mirroring the deadline check `svc_trigger_scheduled` performs.
- Skip the next `skip_runs` fires, mirroring the skip-and-decrement `svc_trigger_scheduled` performs.

`snoozed_until` and `skip_runs` are mutually exclusive (enforced by `svc_snooze`), so both can be applied unconditionally without a conflict.

## Tests

Added three tests to `src/routines/ical_tests.rs`:
- `power_saving_routine_contributes_nothing`
- `snoozed_routine_skips_fires_before_the_deadline`
- `skip_runs_drops_the_next_n_fires`

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (1233 passed), and `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (100% lines) all pass locally.

---

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.