### PR TITLE
chore(lint): enable clippy::needless_collect

### DIFF
--- a/.changeset/enable-clippy-needless-collect.md
+++ b/.changeset/enable-clippy-needless-collect.md
@@ -1,0 +1,7 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::needless_collect`
+
+Locks in the codebase's existing zero-violation state for `clippy::needless_collect`, so a future PR that collects an iterator into a `Vec`/collection only to immediately re-iterate it (or check its length/emptiness) fails CI instead of shipping needless allocation overhead. No behavior change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,3 +169,8 @@ derive_partial_eq_without_eq = "deny"
 # parameter forces every caller to clone or otherwise part with a value the callee never actually
 # needed to own. The codebase is already clean, so `deny` locks that in.
 needless_pass_by_value = "deny"
+# Reject collecting an iterator into a `Vec`/collection only to immediately
+# iterate over it again (or check its length/emptiness) — the intermediate
+# collection is pure allocation overhead the iterator chain never needed. The
+# codebase is already clean, so `deny` locks that in.
+needless_collect = "deny"


### PR DESCRIPTION
## Why

Following the established pattern of incrementally locking in clippy pedantic lints once the codebase is already clean for them (see e.g. `needless_pass_by_value`, `explicit_into_iter_loop`, `map_unwrap_or`), this enables `clippy::needless_collect`.

The lint currently has **zero violations** in the workspace (`cargo clippy --workspace --all-targets -- -D clippy::needless_collect` passes as-is), so this is a pure lint-gate addition with no code changes — it just prevents a future regression where an iterator gets collected into a `Vec`/collection only to be immediately re-iterated or length-checked.

## What

- `Cargo.toml`: add `needless_collect = "deny"` to `[lints.clippy]`.
- `.changeset/enable-clippy-needless-collect.md`: changeset entry (patch).

## Validation

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean