### PR TITLE
docs: prune stale typos-tracking TODO already covered by dependabot

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,5 @@
 
 This is a list of todos for consumption, in a pr remove the todo you have implemented and add any new ones you think of.
 
-- Add a CI step (or weekly scheduled job) that checks whether a newer `crate-ci/typos` release exists than the pinned tag and opens/updates a tracking issue, so the pin gets bumped on a cadence instead of drifting silently
 - Add a day-detail popover to the routines calendar: clicking a day lists each fire time (HH:MM) with its routine, and a "run now" shortcut per routine
 - Have a commands folder for all the cli commands, we want to work with colocation of files


### PR DESCRIPTION
## Why

`TODO.md` had:

> Add a CI step (or weekly scheduled job) that checks whether a newer
> `crate-ci/typos` release exists than the pinned tag and opens/updates a
> tracking issue, so the pin gets bumped on a cadence instead of drifting
> silently

This is already solved. `.github/dependabot.yml`'s `github-actions` ecosystem
entry (added in #463/#471) runs weekly and groups minor/patch bumps of every
pinned GitHub Action — including `crate-ci/typos@<sha> # vX.Y.Z`, which is
pinned in exactly the SHA+version-comment format Dependabot recognizes.

I verified this isn't just theoretical: Dependabot has already merged bumps
for other pinned actions in this same group (`actions/cache` twice,
`actions/checkout`, `softprops/action-gh-release`), so the mechanism
demonstrably works for this pin format. A separate bespoke CI job to open a
tracking issue for a newer `crate-ci/typos` release would duplicate coverage
Dependabot already provides.

(One prior PR, #882, manually bumped the `crate-ci/typos` pin — but that was
this same auto-improve routine getting there first on a faster cadence than
Dependabot's weekly schedule, not evidence Dependabot can't do it; upstream is
still at the same `v1.48.0` it bumped to, so there's been no newer release to
test the weekly job against since.)

## Change

Removes the now-redundant TODO.md bullet. Docs-only — no `src/` or `ui/`
changes, so no changeset is needed.

## Verified

- Confirmed `.github/dependabot.yml` groups `github-actions` minor/patch
  updates weekly (`directory: "/"`, covers `.github/workflows`).
- Confirmed via `gh pr list` that Dependabot has merged multiple prior
  github-actions-group bumps (PRs #779, #638, #474, #472, #100).
- Confirmed upstream `crate-ci/typos` latest release is still `v1.48.0`
  (matches the currently pinned version), so no drift currently exists to fix.

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim. cc @tupe12334