### PR TITLE
chore(lint): enable clippy::cloned_instead_of_copied

### DIFF
--- a/.changeset/enable-clippy-cloned-instead-of-copied.md
+++ b/.changeset/enable-clippy-cloned-instead-of-copied.md
@@ -1,0 +1,7 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::cloned_instead_of_copied`
+
+Locks in the codebase's existing zero-violation state for `clippy::cloned_instead_of_copied`, so a future `.cloned()` call on an iterator/`Option` of a `Copy` type fails CI instead of shipping a needlessly indirect clone where `.copied()` says the same thing more directly. No behavior change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,3 +174,8 @@ needless_pass_by_value = "deny"
 # collection is pure allocation overhead the iterator chain never needed. The
 # codebase is already clean, so `deny` locks that in.
 needless_collect = "deny"
+# Prefer `.copied()` over `.cloned()` when iterating `Copy` items (e.g.
+# `&i32`, `&bool`) — cloning a `Copy` type is a needlessly indirect way to say
+# "copy this value"; `.copied()` states the intent directly and optimizes
+# identically. The codebase is already clean, so `deny` locks that in.
+cloned_instead_of_copied = "deny"


### PR DESCRIPTION
## Summary

Enables the `clippy::cloned_instead_of_copied` pedantic lint (`deny`) and adds a changeset, continuing this repo's existing pattern of picking off one zero-violation clippy lint per PR (see `needless_collect`, `explicit_into_iter_loop`, `needless_pass_by_value`, etc. already in `Cargo.toml`).

## Why

`clippy::cloned_instead_of_copied` flags `.cloned()` on an iterator/`Option` of a `Copy` type (e.g. `&i32`, `&bool`) where `.copied()` says the same thing more directly and compiles to identical code — an unnecessarily indirect way to express a trivial copy. It's a **pedantic** lint, so it is *not* already covered by this crate's `clippy::all = "deny"` — enabling it is a real new gate, not a restatement of an existing one (verified by isolating the lint outside the repo: it does not fire under `clippy::all` alone, only when explicitly enabled).

Verified zero current violations across the workspace before adding the `deny`, so this is a pure lock-in with no behavior change.

## Verification (all run locally, matching CONTRIBUTING.md / CI exactly)

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 962 + 274 passed, 0 failed
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% line coverage maintained
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items` — clean
- No `src/` or `ui/src/` files touched, so the 500-line `linecheck` gate doesn't apply to this diff

Also confirmed HEAD's fmt/clippy/test/doc/coverage gates are currently all green (a prior local run showed two spurious test failures, traced to running two `cargo test`/`cargo llvm-cov` processes concurrently against the same un-overridden real `$HOME` test paths — an artifact of my own test methodology, not a repo bug; a clean sequential run of everything passes).

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim. cc @tupe12334