### PR TITLE
fix(routines): stat agent.log once when reading its tail with metadata

### DIFF
--- a/.changeset/log-tail-single-stat.md
+++ b/.changeset/log-tail-single-stat.md
@@ -1,0 +1,14 @@
+---
+"moadim": patch
+---
+
+fix(routines): stat `agent.log` once when reading its tail with metadata
+
+`read_log_tail_with_meta` (backing the MCP `routine_logs` tool and the HTTP
+logs route) stated the log file twice: once for `total_bytes`/`truncated`,
+then again inside `read_log_tail` to size the actual read. For a log still
+being appended to by a live `tmux pipe-pane` capture, the file could grow
+between those two stats, so the reported `total_bytes`/`truncated` could
+describe a different moment in time than the `content` actually returned.
+Both callers now share a single stat, so the metadata always matches the
+content it describes.

--- a/src/routines/service_log_tail.rs
+++ b/src/routines/service_log_tail.rs
@@ -32,9 +32,15 @@ impl LogWithMeta {
 
 /// Same read as [`read_log_tail`], but reporting the full on-disk size and whether `content` is a
 /// truncated window rather than the complete file (see [`LogWithMeta`]).
+///
+/// Stats `path` exactly once and reuses that length for both the `content` read and the
+/// `total_bytes`/`truncated` fields. A file actively appended to by a live `tmux pipe-pane`
+/// capture can grow between two separate `metadata()` calls; stating twice risked reporting
+/// `total_bytes`/`truncated` for a different moment in time than the `content` actually read,
+/// which callers (the MCP `routine_logs` tool, the HTTP logs route) surface to clients verbatim.
 pub(crate) fn read_log_tail_with_meta(path: &std::path::Path) -> std::io::Result<LogWithMeta> {
     let total_bytes = std::fs::metadata(path)?.len();
-    let content = read_log_tail(path)?;
+    let content = read_log_tail_of_len(path, total_bytes)?;
     Ok(LogWithMeta {
         content,
         total_bytes,
@@ -52,6 +58,12 @@ pub(crate) fn read_log_tail_with_meta(path: &std::path::Path) -> std::io::Result
 /// don't clutter the served log.
 pub(crate) fn read_log_tail(path: &std::path::Path) -> std::io::Result<String> {
     let len = std::fs::metadata(path)?.len();
+    read_log_tail_of_len(path, len)
+}
+
+/// Shared implementation of [`read_log_tail`] for an already-known file length, so a caller that
+/// also needs the length for its own purposes (see [`read_log_tail_with_meta`]) can stat once.
+fn read_log_tail_of_len(path: &std::path::Path, len: u64) -> std::io::Result<String> {
     if len <= MAX_LOG_TAIL_BYTES {
         return std::fs::read_to_string(path).map(|contents| strip_ansi_noise(&contents));
     }


### PR DESCRIPTION
## Why

`read_log_tail_with_meta` (backing the MCP `routine_logs` tool and the HTTP
`/routines/{id}/logs` route) computes `total_bytes` via one `std::fs::metadata`
call, then calls `read_log_tail`, which internally does its own **second**
`std::fs::metadata` call to decide the read window and size the "N bytes
omitted" marker.

`agent.log` is actively appended to by a live `tmux pipe-pane` capture while a
routine is running. Between those two stats the file can grow past
`MAX_LOG_TAIL_BYTES`, so the `total_bytes`/`truncated` fields reported to a
client can describe a different moment in time than the `content` actually
returned — e.g. `truncated: false` while `content` already contains the
"bytes omitted" marker, or a `total_bytes` that doesn't match what the
truncation decision implies. Both fields are surfaced verbatim to MCP/HTTP
clients deciding whether to fetch more of the log, so the inconsistency is
externally visible, not just internal bookkeeping noise.

## What

Factored the shared truncate-and-read logic into a private
`read_log_tail_of_len(path, len)` that takes an already-known length.
`read_log_tail_with_meta` now stats once and passes that length through, so
`total_bytes`/`truncated`/`content` are always computed from the same
snapshot. `read_log_tail` (the public entry point, still used standalone by
`svc_run_log`) is unchanged in behavior — it still stats once, just via the
shared helper.

## Testing

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (962 passed)
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (100% line coverage, exit 0)
- `linecheck --max-lines 500 …`, `actionlint`, `typos` — all clean

No behavior change for existing callers/tests; this only removes a redundant
stat and closes the window where it could race.