### PR TITLE
chore(lint): enable clippy::format_push_string, fix 3 violations

### DIFF
--- a/.changeset/enable-clippy-format-push-string.md
+++ b/.changeset/enable-clippy-format-push-string.md
@@ -1,0 +1,7 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::format_push_string`
+
+Fixes the 3 existing violations in `compose_prompt` (`src/routines/command.rs`), which built a repository/flag line with `format!` only to immediately copy it into the routine's prompt body via `push_str` — an unnecessary throwaway `String` allocation per line. Switches those to `write!`/`writeln!` directly into the existing buffer, and enables `format_push_string = "deny"` to lock in the zero-violation state going forward. No behavior change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,3 +179,8 @@ needless_collect = "deny"
 # "copy this value"; `.copied()` states the intent directly and optimizes
 # identically. The codebase is already clean, so `deny` locks that in.
 cloned_instead_of_copied = "deny"
+# Reject `.push_str(&format!(...))` in favour of `write!`/`writeln!` directly into the `String`.
+# The `format!` call allocates a throwaway `String` only to immediately copy its contents into
+# the target and drop it, so it's pure overhead that `write!` avoids by writing straight into the
+# existing buffer. The codebase is already clean, so `deny` locks that in.
+format_push_string = "deny"

--- a/src/routines/command.rs
+++ b/src/routines/command.rs
@@ -1,5 +1,7 @@
 //! Prompt composition, slug/shell helpers, and the single-line tmux launch command builder.
 
+use std::fmt::Write as _;
+
 use crate::paths::{routine_compiled_prompt_path, routine_scheduled_log_path};
 
 use super::agents::AgentCommand;
@@ -65,11 +67,17 @@ pub(crate) fn compose_prompt(routine: &Routine) -> String {
             "You are working in an empty directory. These repositories are relevant — clone any you need:\n",
         );
         for repo in &routine.repositories {
+            // `write!` into the existing `String` directly rather than `format!` + `push_str`,
+            // which would allocate a throwaway `String` per repository just to copy it into
+            // `body` immediately after. Writing to a `String` is infallible, so the `Result` is
+            // deliberately discarded.
             match &repo.branch {
                 Some(branch) => {
-                    body.push_str(&format!("- {} (branch {})\n", repo.repository, branch));
+                    let _ = writeln!(body, "- {} (branch {})", repo.repository, branch);
                 }
-                None => body.push_str(&format!("- {}\n", repo.repository)),
+                None => {
+                    let _ = writeln!(body, "- {}", repo.repository);
+                }
             }
         }
     }
@@ -96,10 +104,11 @@ pub(crate) fn compose_prompt(routine: &Routine) -> String {
                 FlagScope::General => "general",
                 FlagScope::Local => "local",
             };
-            body.push_str(&format!(
-                "- **{}** ({scope}): {}\n",
+            let _ = writeln!(
+                body,
+                "- **{}** ({scope}): {}",
                 flag.flag_type, flag.description
-            ));
+            );
         }
     }
     body


### PR DESCRIPTION
## Why

`compose_prompt()` (`src/routines/command.rs`) builds up the routine's `prompt.compiled.md` body by calling `format!(..)` for a repository line or an "Open flags" entry and immediately passing it to `push_str(&...)`. Each call allocates a throwaway `String` purely to copy its bytes into `body` and then drop it — pure overhead `write!`/`writeln!` avoids by writing straight into the existing buffer.

This repo has an established pattern (see #549, and the already-merged `clippy::cloned_instead_of_copied` / `clippy::needless_collect` lints) of incrementally enabling one clippy lint at a time, fixing whatever it flags, and denying it going forward so the fixed state can't regress. `clippy::format_push_string` was not yet enabled and had exactly 3 live violations, all in the same function, all mechanical and behavior-preserving.

## What

- Enabled `format_push_string = "deny"` in `Cargo.toml`'s `[lints.clippy]`, with the same rationale-comment style as the neighboring entries.
- Fixed the 3 violations in `compose_prompt`: two in the repositories-preamble loop (with/without a branch) and one in the "Open flags" loop, all converted from `body.push_str(&format!(...))` to `write!`/`writeln!(body, ...)`.
- Added a Changeset (`patch`), matching how the prior clippy-lint-enable PRs were released.

No behavior change — output strings are byte-for-byte identical. Existing tests in `src/routines/mod_tests.rs` (`compose_prompt_lists_repos_and_prompt`, `compose_prompt_repo_without_branch`, `compose_prompt_includes_open_flags_section`, etc.) already exercise every changed line, so no new tests were needed; `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` all pass locally.

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.