### PR TITLE
chore(lint): enable clippy::items_after_statements, fix 3 violations

### DIFF
--- a/.changeset/enable-clippy-items-after-statements.md
+++ b/.changeset/enable-clippy-items-after-statements.md
@@ -1,0 +1,7 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::items_after_statements`
+
+Fixes the 3 existing violations — a `use` mid-function in `read_log_tail_of_len` (`src/routines/service_log_tail.rs`), a `use` mid-test in `service_overlap_guard_tests.rs`, and a `const` mid-test in `routines_sync_tests.rs` — by hoisting each item to the top of its block. Enables `items_after_statements = "deny"` to lock in the zero-violation state going forward. No behavior change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,3 +189,8 @@ format_push_string = "deny"
 # unused generality of `match`, keeping the two-way branch as readable as a plain `if`. The
 # codebase is already clean, so `deny` locks that in.
 single_match_else = "deny"
+# Reject an item (`use`, `const`, etc.) declared after a statement in the same block — items are
+# scoped to the whole block from the start regardless of where they're written, so placing one
+# mid-block after other code misleads the reader into thinking order matters here. Hoisting it to
+# the top of the block states that up front. The codebase is already clean, so `deny` locks that in.
+items_after_statements = "deny"

--- a/src/routines/service_log_tail.rs
+++ b/src/routines/service_log_tail.rs
@@ -64,10 +64,10 @@ pub(crate) fn read_log_tail(path: &std::path::Path) -> std::io::Result<String> {
 /// Shared implementation of [`read_log_tail`] for an already-known file length, so a caller that
 /// also needs the length for its own purposes (see [`read_log_tail_with_meta`]) can stat once.
 fn read_log_tail_of_len(path: &std::path::Path, len: u64) -> std::io::Result<String> {
+    use std::io::{Read, Seek, SeekFrom};
     if len <= MAX_LOG_TAIL_BYTES {
         return std::fs::read_to_string(path).map(|contents| strip_ansi_noise(&contents));
     }
-    use std::io::{Read, Seek, SeekFrom};
     let omitted = len - MAX_LOG_TAIL_BYTES;
     let mut file = std::fs::File::open(path)?;
     file.seek(SeekFrom::Start(omitted))?;

--- a/src/routines/service_overlap_guard_tests.rs
+++ b/src/routines/service_overlap_guard_tests.rs
@@ -59,7 +59,6 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
 
 #[test]
 fn svc_trigger_skips_spawn_when_a_previous_run_is_still_alive() {
-    let _home = TempHome::set();
     // The overlap guard (#514): a tmux stub reporting a live session under this routine's
     // `moadim-{slug}-` prefix must suppress the new fire instead of launching a second, concurrent
     // agent session. The trigger still records its timestamp and returns Ok, the same non-fatal
@@ -67,6 +66,7 @@ fn svc_trigger_skips_spawn_when_a_previous_run_is_still_alive() {
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt as _;
 
+    let _home = TempHome::set();
     let agent_name = "svc-trigger-overlap-agent-zzz";
     std::fs::create_dir_all(crate::paths::agents_dir()).unwrap();
     let cfg = crate::paths::agent_toml_path(agent_name);

--- a/src/sync/routines_sync_tests.rs
+++ b/src/sync/routines_sync_tests.rs
@@ -377,12 +377,13 @@ fn sync_routines_to_crontab_serializes_concurrent_calls() {
     // sleeps a fixed delay on every `crontab -` write, so two *unserialized* read-modify-write
     // round trips would overlap and finish in roughly one delay; serialized by the lock, they run
     // back to back and take roughly two.
+    const DELAY_MS: u64 = 150;
+
     let agent_name = "test-sync-agent-concurrent-lock";
     std::fs::create_dir_all(crate::paths::agents_dir()).unwrap();
     let cfg = crate::paths::agent_toml_path(agent_name);
     std::fs::write(&cfg, "command = \"claude\"\nargs = []\n").unwrap();
 
-    const DELAY_MS: u64 = 150;
     let shim = CronShim::new_with_write_delay(
         "# BEGIN MOADIM-ROUTINES\n# END MOADIM-ROUTINES\n",
         DELAY_MS,


### PR DESCRIPTION
## Summary
- Enables `clippy::items_after_statements` in the root package's lint config, following this repo's incremental-lint-adoption pattern (see `format_push_string`, `map_unwrap_or`, `cloned_instead_of_copied`, etc.).
- Fixes the 3 existing violations:
  - `read_log_tail_of_len` (`src/routines/service_log_tail.rs`): a `use std::io::{Read, Seek, SeekFrom};` declared after an early-return `if`.
  - `svc_trigger_skips_spawn_when_a_previous_run_is_still_alive` (`src/routines/service_overlap_guard_tests.rs`): a `#[cfg(unix)] use ...` declared after a `let` binding.
  - `sync_routines_to_crontab_serializes_concurrent_calls` (`src/sync/routines_sync_tests.rs`): a `const DELAY_MS` declared after several statements.
  Each item is hoisted to the top of its enclosing block — items are scoped to the whole block regardless of where they're written, so this only changes where the declaration is *read*, not what it does. No behavior change.

## Why
The repo already runs this exact playbook for lint after lint (`single_match_else`, `map_unwrap_or`, `cloned_instead_of_copied`, `format_push_string`, `needless_collect`, ...) as a deliberate, low-risk way to keep raising the clippy bar one lint at a time. `items_after_statements` was the next zero-violation-after-a-trivial-fix pedantic lint I found scanning `cargo clippy --workspace --all-targets -W clippy::pedantic`, so it locks in another slice of that bar without touching any runtime behavior.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (962 + 274 passed)
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (100% lines)
- [x] `linecheck --max-lines 500`
- [x] Full `.githooks/pre-push` run locally (all steps pass, including the changeset check)
- [x] Includes a `.changeset/enable-clippy-items-after-statements.md` (patch) per `CONTRIBUTING.md`