### PR TITLE
fix(routines): rename prompt.compiled.md sidecar to prompt.compiled.local.md

### DIFF
--- a/.changeset/rename-compiled-prompt-to-local.md
+++ b/.changeset/rename-compiled-prompt-to-local.md
@@ -1,0 +1,19 @@
+---
+"moadim": patch
+---
+
+fix(routines): rename the compiled-prompt sidecar to prompt.compiled.local.md
+
+`prompts/prompt.compiled.md` is fully derived from `prompt.pure.md` + `routine.toml`
+and rewritten on every save, so it should never be tracked — but relying on an
+explicit `.gitignore` entry (added in #1050) only stopped *new* writes from being
+tracked; it did nothing for installs where the file had already been `git add`-ed
+before that fix landed. Renamed it to `prompt.compiled.local.md` so it matches the
+`*.local.*` pattern the same way `state.local.toml` does, and dropped the now-redundant
+explicit `.gitignore` entry (#1046).
+
+A new startup migration (`migrate_compiled_prompt_filename`) renames the file on disk
+for existing routines. This does not touch git history or the index — the daemon has
+no git integration — so an install with `prompt.compiled.md` already committed will
+still need a manual `git rm --cached prompts/prompt.compiled.md` (or just let the next
+commit record the rename) after upgrading.

--- a/Architecture.md
+++ b/Architecture.md
@@ -26,7 +26,7 @@ Moadim is a Rust daemon that manages scheduled AI-agent routines and exposes the
                ~/.config/moadim/routines/
                ├── <uuid>/routine.toml                  (tracked)
                ├── <uuid>/prompts/prompt.pure.md         (tracked)
-               ├── <uuid>/prompts/prompt.compiled.md     (tracked)
+               ├── <uuid>/prompts/prompt.compiled.local.md (gitignored)
                └── <uuid>/.gitignore                    (generated)
 ```
 
@@ -143,7 +143,7 @@ and a `title`. Routines have their own store (`RoutineStore`), REST endpoints
 (`/routines`), MCP tools (`create_routine`, …), and crontab block.
 
 When a routine fires there is **no moadim process in the loop and no clone step**. At create/update
-time moadim writes the raw prompt to `prompts/prompt.pure.md` and composes `prompts/prompt.compiled.md`
+time moadim writes the raw prompt to `prompts/prompt.pure.md` and composes `prompts/prompt.compiled.local.md`
 (a repositories-as-context preamble + the prompt) into `~/.config/moadim/routines/<id>/`, then writes a
 single self-contained shell command into a dedicated crontab block:
 
@@ -151,7 +151,7 @@ single self-contained shell command into a dedicated crontab block:
 # BEGIN MOADIM-ROUTINES
 # Managed by moadim — routines (agent tmux sessions)
 <sched> TS=$(date +\%s); WB=…/workbenches/<slug>-$TS; mkdir -p $WB; \
-  { cp …/prompts/prompt.compiled.md $WB/prompt.md; \
+  { cp …/prompts/prompt.compiled.local.md $WB/prompt.md; \
     tmux new-session -d -s moadim-<slug>-$TS -c $WB '<agent-cmd>'; \
     tmux pipe-pane -o -t … "cat >> $WB/agent.log"; } >> $WB/launch.log 2>&1   # moadim-routine:<id>
 # END MOADIM-ROUTINES
@@ -212,7 +212,7 @@ Creating or updating a routine validates the referenced agent's `args` against b
 time, rather than silently launching the agent with a garbage or empty task at fire time.
 
 Modules: `src/routines/` (model + service + command builder + handlers), `src/routine_storage.rs`
-(`routine.toml` + `prompts/prompt.pure.md` + `prompts/prompt.compiled.md` persistence),
+(`routine.toml` + `prompts/prompt.pure.md` + `prompts/prompt.compiled.local.md` persistence),
 `src/sync/routines.rs` (the `MOADIM-ROUTINES` block).
 Reverse sync (crontab → store) is not implemented for routines.
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ install -Dm644 docs/moadim.1 "$HOME/.local/share/man/man1/moadim.1"
 │       ├── routine.toml       # tracked — schedule, agent, repositories
 │       ├── prompts/
 │       │   ├── prompt.pure.md      # tracked — the raw, user-authored prompt
-│       │   └── prompt.compiled.md  # tracked — the rendered prompt handed to the agent
+│       │   └── prompt.compiled.local.md  # gitignored — derived, rendered prompt
 │       └── .gitignore         # generated — excludes *.local.* and *.log
 ├── agents/                    # registered coding agents referenced by routines
 │   └── claude.toml
@@ -155,7 +155,7 @@ git-trackable:
     ├── routine.toml   # tracked — schedule, agent, repositories
     ├── prompts/
     │   ├── prompt.pure.md      # tracked — the raw, user-authored prompt
-    │   └── prompt.compiled.md  # tracked — the rendered prompt handed to the agent
+    │   └── prompt.compiled.local.md  # gitignored — derived, rendered prompt
     └── .gitignore     # generated — excludes *.local.* and *.log
 ```
 

--- a/src/cli_system.rs
+++ b/src/cli_system.rs
@@ -66,9 +66,10 @@ Each subdirectory here is one routine (a prompt + schedule + agent, run on a cro
 
 - `<id>/routine.toml` — the schedule, agent, and repositories.
 - `<id>/prompts/prompt.pure.md` — the prompt you wrote.
-- `<id>/prompts/prompt.compiled.md` — the composed prompt (repositories preamble + pure
-  prompt) copied into each run's workbench. Gitignored: it's fully derived from
-  `prompt.pure.md` + `routine.toml` and rewritten on every save.
+- `<id>/prompts/prompt.compiled.local.md` — the composed prompt (repositories preamble +
+  pure prompt) copied into each run's workbench. Gitignored (`.local.` matches the
+  `*.local.*` pattern): it's fully derived from `prompt.pure.md` + `routine.toml` and
+  rewritten on every save.
 - `<id>/flags/` — open questions an agent raised mid-run: a gap, bug, edge case, or question
   it couldn't resolve.
 - `<id>/state.local.toml` — gitignored sidecar holding snooze/skip-runs state.

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,15 +136,21 @@ async fn run_server() -> anyhow::Result<()> {
     }
     routines::ensure_default_agents();
     // Rename any prompt.txt sidecars to prompt.md before the crontab resync; otherwise the first
-    // cron trigger after upgrade would fail on the launch command's `cp prompt.compiled.md` step.
+    // cron trigger after upgrade would fail on the launch command's `cp prompt.compiled.local.md`
+    // step.
     routine_storage::migrate_prompt_files();
     // Move each routine's prompt file(s) into its prompts/ subfolder, and extract the raw prompt
     // out of routine.toml into prompts/prompt.pure.md. Must run before migrate_routine_dirs and
     // load_store, which both read the prompt from the new sidecar location.
     routine_storage::migrate_prompts_to_subfolder();
+    // Rename the compiled-prompt sidecar from the legacy prompt.compiled.md to
+    // prompt.compiled.local.md so it matches the *.local.* gitignore pattern instead of relying on
+    // an explicit entry (issue #1046). Must run after migrate_prompts_to_subfolder (which is what
+    // lands the legacy filename in prompts/) and before load_store.
+    routine_storage::migrate_compiled_prompt_filename();
     // Move legacy UUID-named routine dirs to the current slug-based layout before loading, so the
     // store reflects the canonical dirs the crontab sync and the launch command's
-    // `cp prompt.compiled.md` both target.
+    // `cp prompt.compiled.local.md` both target.
     routine_storage::migrate_routine_dirs();
     // Migrate per-routine trigger timestamps from legacy TOML sidecars (scheduled.local.toml,
     // last_manual_trigger_at in state.local.toml) into the new append-only log files
@@ -158,7 +164,7 @@ async fn run_server() -> anyhow::Result<()> {
     routines::ensure_default_routines(&routines);
     // Re-persist so every routine has its routine.toml + prompts/ sidecars in the slug dir (and any
     // stale legacy run.sh is removed), healing dirs left without a prompt (otherwise the launch
-    // command's `cp prompt.compiled.md` fails and the agent launches with an empty prompt).
+    // command's `cp prompt.compiled.local.md` fails and the agent launches with an empty prompt).
     routine_storage::repersist_routines(&routines);
     // Re-sync routines to the crontab on startup; otherwise a block that went stale (e.g. emptied
     // by an earlier run before agent configs existed) would never be regenerated until the next

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -101,11 +101,15 @@ pub fn routine_pure_prompt_path(id: &str) -> PathBuf {
     routine_prompts_dir(id).join("prompt.pure.md")
 }
 
-/// Returns the path to `{routines_dir}/{id}/prompts/prompt.compiled.md`, the composed prompt
+/// Returns the path to `{routines_dir}/{id}/prompts/prompt.compiled.local.md`, the composed prompt
 /// (repositories preamble + pure prompt) that the launch command copies into the workbench.
+///
+/// `.local.` keeps it matching the routine `.gitignore`'s `*.local.*` pattern: it is fully derived
+/// from `prompt.pure.md` + `routine.toml` and rewritten on every [`crate::routine_storage::write_routine`]
+/// call, so (unlike `prompt.pure.md`) it should never be tracked (issue #1046).
 #[must_use]
 pub fn routine_compiled_prompt_path(id: &str) -> PathBuf {
-    routine_prompts_dir(id).join("prompt.compiled.md")
+    routine_prompts_dir(id).join("prompt.compiled.local.md")
 }
 
 /// Returns the path to `{routines_dir}/{id}/.gitignore`.

--- a/src/paths/mod_tests.rs
+++ b/src/paths/mod_tests.rs
@@ -74,7 +74,7 @@ fn routine_compiled_prompt_path_filename() {
     let path = routine_compiled_prompt_path("abc");
     assert_eq!(
         path.file_name().unwrap().to_str().unwrap(),
-        "prompt.compiled.md"
+        "prompt.compiled.local.md"
     );
     assert_eq!(path.parent().unwrap(), routine_prompts_dir("abc"));
 }

--- a/src/routes/mcp.rs
+++ b/src/routes/mcp.rs
@@ -229,7 +229,7 @@ impl MoadimMcp {
         Ok(ok(routines::available_agents()))
     }
 
-    /// Raise a new flag against a routine, refreshing its `prompt.compiled.md` so the next run's
+    /// Raise a new flag against a routine, refreshing its `prompt.compiled.local.md` so the next run's
     /// "Open flags" section includes it.
     #[tool(
         description = "Flag something unclear about a routine mid-run — a gap, bug, edge case, or question the agent hit with no other channel to surface it (the run happens unattended inside tmux). `type` is free text (common examples: \"bug\", \"gap\", \"edge_case\", \"question\", \"blocker\"); `scope` is \"general\" (committed, shared via git) or \"local\" (gitignored, machine-local). Unresolved flags are shown back to the agent in the routine's prompt on its next run."
@@ -263,7 +263,7 @@ impl MoadimMcp {
         })
     }
 
-    /// Resolve (delete) a flag by filename, refreshing `prompt.compiled.md` so it stops appearing
+    /// Resolve (delete) a flag by filename, refreshing `prompt.compiled.local.md` so it stops appearing
     /// in the next run's prompt.
     #[tool(
         description = "Resolve a routine flag by filename (as returned by create_flag/list_flags), removing it"

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -1,5 +1,5 @@
 //! TOML-backed persistence for routines, plus the `prompts/prompt.pure.md` (raw) and
-//! `prompts/prompt.compiled.md` (composed) sidecar files.
+//! `prompts/prompt.compiled.local.md` (composed) sidecar files.
 
 use crate::utils::lock::LockRecover;
 use std::collections::HashMap;
@@ -195,11 +195,10 @@ fn load_routine_from_dir(dir_name: &str) -> Option<Routine> {
     })
 }
 
-/// Patterns every routine's `.gitignore` must carry: machine-local runtime state, logs, the
-/// obsolete per-routine launch script, and `prompts/prompt.compiled.md` — the composed prompt is
-/// fully derived from `prompts/prompt.pure.md` + `routine.toml` and rewritten on every
-/// [`write_routine`] call, so (unlike `prompt.pure.md`) it should never be tracked (issue #1046).
-const ROUTINE_GITIGNORE_REQUIRED: &[&str] = &["*.local.*", "*.log", "run.sh", "prompt.compiled.md"];
+/// Patterns every routine's `.gitignore` must carry: machine-local runtime state, logs, and the
+/// obsolete per-routine launch script. `prompts/prompt.compiled.local.md` needs no entry of its
+/// own — its `.local.` filename already matches `*.local.*` (issue #1046).
+const ROUTINE_GITIGNORE_REQUIRED: &[&str] = &["*.local.*", "*.log", "run.sh"];
 
 /// Ensure `path` (a routine's `.gitignore`) contains every pattern in [`ROUTINE_GITIGNORE_REQUIRED`],
 /// appending whichever are missing and leaving the rest of the file (including user additions)
@@ -229,7 +228,7 @@ fn ensure_routine_gitignore(path: &std::path::Path) -> std::io::Result<()> {
 }
 
 /// Write `routine` to disk: `routine.toml` (tracked config), the `prompts/prompt.pure.md` (raw) and
-/// `prompts/prompt.compiled.md` (composed) sidecars, the gitignored `state.local.toml` runtime
+/// `prompts/prompt.compiled.local.md` (composed) sidecars, the gitignored `state.local.toml` runtime
 /// sidecar, and `.gitignore` (created or reconciled — see [`ensure_routine_gitignore`]).
 ///
 /// The folder is named after the slugified title (`slugify(&routine.title)`). The UUID `id` is
@@ -344,11 +343,12 @@ pub fn remove_routine_dir(slug: &str) -> std::io::Result<()> {
 }
 
 /// Re-persist every loaded routine to disk, recreating `routine.toml`, `prompts/prompt.pure.md`,
-/// `prompts/prompt.compiled.md`, and `.gitignore` in its canonical slug directory.
+/// `prompts/prompt.compiled.local.md`, and `.gitignore` in its canonical slug directory.
 ///
 /// Nothing else rewrites the prompt sidecars on startup, so a slug dir missing its
-/// `prompts/prompt.compiled.md` (e.g. after the UUID→slug migration, or if the sidecar was lost)
-/// would fail the launch command's `cp prompt.compiled.md`. Re-persisting from the in-memory store
+/// `prompts/prompt.compiled.local.md` (e.g. after the UUID→slug migration, or if the sidecar was
+/// lost) would fail the launch command's `cp prompt.compiled.local.md`. Re-persisting from the
+/// in-memory store
 /// heals those dirs (and removes any stale legacy `run.sh`). Idempotent; safe to call on every
 /// startup after [`load_store`].
 pub fn repersist_routines(store: &RoutineStore) {
@@ -401,12 +401,14 @@ pub(crate) fn load_store_from_dir(dir: &std::path::Path) -> RoutineStore {
 #[path = "routine_storage_migrations.rs"]
 mod routine_storage_migrations;
 pub use routine_storage_migrations::{
-    migrate_prompt_files, migrate_prompts_to_subfolder, migrate_routine_dirs, migrate_trigger_logs,
+    migrate_compiled_prompt_filename, migrate_prompt_files, migrate_prompts_to_subfolder,
+    migrate_routine_dirs, migrate_trigger_logs,
 };
 #[cfg(test)]
 pub(crate) use routine_storage_migrations::{
-    migrate_prompt_files_from_dir, migrate_prompts_to_subfolder_from_dir,
-    migrate_routine_dirs_from_dir, migrate_trigger_logs_from_dir,
+    migrate_compiled_prompt_filename_from_dir, migrate_prompt_files_from_dir,
+    migrate_prompts_to_subfolder_from_dir, migrate_routine_dirs_from_dir,
+    migrate_trigger_logs_from_dir,
 };
 
 #[cfg(test)]
@@ -424,6 +426,10 @@ mod routine_storage_migration_tests;
 #[cfg(test)]
 #[path = "routine_storage_prompt_file_migration_tests.rs"]
 mod routine_storage_prompt_file_migration_tests;
+
+#[cfg(test)]
+#[path = "routine_storage_compiled_prompt_migration_tests.rs"]
+mod routine_storage_compiled_prompt_migration_tests;
 
 #[cfg(test)]
 #[path = "routine_storage_snooze_tests.rs"]

--- a/src/routine_storage_compiled_prompt_migration_tests.rs
+++ b/src/routine_storage_compiled_prompt_migration_tests.rs
@@ -1,0 +1,112 @@
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and fixtures do not need doc comments"
+)]
+
+use super::*;
+
+/// A unique, not-yet-created scratch directory under the system temp dir.
+fn scratch_dir(tag: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!("moadim-rs-{tag}-{}", uuid::Uuid::new_v4()))
+}
+
+/// Run `body` with `MOADIM_HOME_OVERRIDE` pointed at a fresh temp home, restoring the previous value
+/// and removing the temp home afterwards. Mirrors the seam used by the agent registry tests.
+fn with_override_home(body: impl FnOnce(&std::path::Path)) {
+    let home = scratch_dir("override-home");
+    std::fs::create_dir_all(&home).unwrap();
+    let previous = std::env::var_os("MOADIM_HOME_OVERRIDE");
+    // SAFETY: tests in this crate run single-threaded per binary; we set and immediately restore the
+    // override around this call.
+    unsafe {
+        std::env::set_var("MOADIM_HOME_OVERRIDE", &home);
+    }
+    body(&home);
+    unsafe {
+        match previous {
+            Some(value) => std::env::set_var("MOADIM_HOME_OVERRIDE", value),
+            None => std::env::remove_var("MOADIM_HOME_OVERRIDE"),
+        }
+    }
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+#[test]
+fn migrate_compiled_prompt_filename_from_dir_missing_dir_returns() {
+    // The scan directory does not exist, so `read_dir` errors and the function returns early.
+    let missing = scratch_dir("compiled-prompt-missing");
+    migrate_compiled_prompt_filename_from_dir(&missing);
+    assert!(!missing.exists());
+}
+
+#[test]
+fn migrate_compiled_prompt_filename_from_dir_renames_and_skips_non_dirs_and_existing() {
+    let dir = scratch_dir("compiled-prompt-rename");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    // A plain file in the scan dir exercises the non-directory `continue` branch.
+    std::fs::write(dir.join("loose.txt"), "ignore me").unwrap();
+
+    // A routine dir with only the legacy `prompt.compiled.md`: it should be renamed to
+    // `prompt.compiled.local.md`.
+    let renameable = dir.join("renameable");
+    let renameable_prompts = renameable.join("prompts");
+    std::fs::create_dir_all(&renameable_prompts).unwrap();
+    std::fs::write(renameable_prompts.join("prompt.compiled.md"), "old body").unwrap();
+
+    // A routine dir that already has the new filename: the rename is skipped, leaving both intact.
+    let already = dir.join("already");
+    let already_prompts = already.join("prompts");
+    std::fs::create_dir_all(&already_prompts).unwrap();
+    std::fs::write(already_prompts.join("prompt.compiled.md"), "stale").unwrap();
+    std::fs::write(already_prompts.join("prompt.compiled.local.md"), "current").unwrap();
+
+    migrate_compiled_prompt_filename_from_dir(&dir);
+
+    assert!(!renameable_prompts.join("prompt.compiled.md").exists());
+    assert_eq!(
+        std::fs::read_to_string(renameable_prompts.join("prompt.compiled.local.md")).unwrap(),
+        "old body"
+    );
+    // Pre-existing prompt.compiled.local.md is untouched; the stale prompt.compiled.md stays put.
+    assert!(already_prompts.join("prompt.compiled.md").exists());
+    assert_eq!(
+        std::fs::read_to_string(already_prompts.join("prompt.compiled.local.md")).unwrap(),
+        "current"
+    );
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn migrate_compiled_prompt_filename_from_dir_logs_on_rename_failure() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // A routine's `prompts/` dir holding the legacy file but made read-only: renaming within it
+    // fails because the directory cannot be modified, exercising the `log::warn!` failure branch.
+    let dir = scratch_dir("compiled-prompt-rename-fail");
+    std::fs::create_dir_all(&dir).unwrap();
+    let prompts = dir.join("locked").join("prompts");
+    std::fs::create_dir_all(&prompts).unwrap();
+    std::fs::write(prompts.join("prompt.compiled.md"), "body").unwrap();
+    std::fs::set_permissions(&prompts, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+    migrate_compiled_prompt_filename_from_dir(&dir);
+
+    // The rename could not happen: the legacy file remains and the new one was never created.
+    std::fs::set_permissions(&prompts, std::fs::Permissions::from_mode(0o755)).unwrap();
+    assert!(prompts.join("prompt.compiled.md").exists());
+    assert!(!prompts.join("prompt.compiled.local.md").exists());
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[test]
+fn migrate_compiled_prompt_filename_public_wrapper_runs() {
+    // Exercises the public wrapper, which simply delegates to the inner variant scanning an empty
+    // override home (no routines dir yet, so it returns without doing anything).
+    with_override_home(|_home| {
+        migrate_compiled_prompt_filename();
+    });
+}

--- a/src/routine_storage_migrations.rs
+++ b/src/routine_storage_migrations.rs
@@ -57,10 +57,13 @@ pub(crate) fn migrate_prompt_files_from_dir(dir: &std::path::Path) {
 /// of `routine.toml` into `prompts/prompt.pure.md`.
 ///
 /// Call once at startup, after [`migrate_prompt_files`] (which renames `prompt.txt` to `prompt.md`)
-/// and before [`migrate_routine_dirs`] / `load_store`. Older daemons wrote a single top-level
-/// `prompt.md` (the composed prompt) and kept the raw prompt inside `routine.toml`'s `prompt` field;
-/// this daemon reads the raw prompt from `prompts/prompt.pure.md` and the composed prompt from
-/// `prompts/prompt.compiled.md`, so an un-migrated dir would launch with an empty prompt.
+/// and before [`migrate_compiled_prompt_filename`] / [`migrate_routine_dirs`] / `load_store`. Older
+/// daemons wrote a single top-level `prompt.md` (the composed prompt) and kept the raw prompt inside
+/// `routine.toml`'s `prompt` field; this daemon reads the raw prompt from `prompts/prompt.pure.md`
+/// and the composed prompt from `prompts/prompt.compiled.local.md`, so an un-migrated dir would
+/// launch with an empty prompt. This step lands the composed prompt at the intermediate
+/// `prompts/prompt.compiled.md` name; [`migrate_compiled_prompt_filename`] renames it the rest of the
+/// way to `prompt.compiled.local.md`.
 pub fn migrate_prompts_to_subfolder() {
     migrate_prompts_to_subfolder_from_dir(&routines_dir());
 }
@@ -122,9 +125,9 @@ pub(crate) fn migrate_prompts_to_subfolder_from_dir(dir: &std::path::Path) {
 ///
 /// Early daemon versions stored each routine under `{routines_dir}/{id}/` (the UUID). The current
 /// layout uses `{routines_dir}/{slugify(title)}/`. After an upgrade the legacy dir still holds the
-/// real `routine.toml` + `prompts/prompt.compiled.md`, while the crontab sync creates a *fresh* slug
-/// dir containing only `run.sh` — so the cron `cp prompt.compiled.md` reads an empty dir and the
-/// agent launches task-less.
+/// real `routine.toml` + `prompts/prompt.compiled.local.md`, while the crontab sync creates a *fresh*
+/// slug dir containing only `run.sh` — so the cron `cp prompt.compiled.local.md` reads an empty dir
+/// and the agent launches task-less.
 ///
 /// For every on-disk routine whose directory name does not already equal its slug, this re-persists
 /// it into the slug dir (preserving any `run.sh` already there) and removes the stale legacy dir.
@@ -163,6 +166,45 @@ pub(crate) fn migrate_routine_dirs_from_dir(dir: &std::path::Path) {
         }
         if let Err(err) = remove_routine_dir(&dir_name) {
             log::warn!("migrate_routine_dirs: failed to remove legacy dir {dir_name:?}: {err}");
+        }
+    }
+}
+
+/// Rename each routine's compiled-prompt sidecar from the legacy `prompt.compiled.md` to
+/// `prompt.compiled.local.md`, so it matches the `*.local.*` `.gitignore` pattern instead of relying
+/// on the (now removed) explicit `prompt.compiled.md` entry.
+///
+/// Call once at startup, after [`migrate_prompts_to_subfolder`] (which moves the sidecar into
+/// `prompts/`) and before `load_store`. This only renames the file on disk; it does not touch git
+/// history or the index — the daemon has no git integration, so an install where
+/// `prompt.compiled.md` was already `git add`-ed/committed before this rename must `git rm --cached`
+/// it manually (or let the next commit record the rename itself) (issue #1046).
+pub fn migrate_compiled_prompt_filename() {
+    migrate_compiled_prompt_filename_from_dir(&routines_dir());
+}
+
+/// Inner variant of [`migrate_compiled_prompt_filename`] that scans `dir` instead of [`routines_dir`].
+///
+/// Extracted so tests can drive the migration against a controlled scratch directory, including the
+/// `read_dir` error-return branch and the per-entry rename-failure branch.
+pub(crate) fn migrate_compiled_prompt_filename_from_dir(dir: &std::path::Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if !entry.file_type().is_ok_and(|ft| ft.is_dir()) {
+            continue;
+        }
+        let prompts_dir = entry.path().join("prompts");
+        let old = prompts_dir.join("prompt.compiled.md");
+        let new = prompts_dir.join("prompt.compiled.local.md");
+        if old.exists() && !new.exists() {
+            if let Err(err) = std::fs::rename(&old, &new) {
+                log::warn!(
+                    "migrate_compiled_prompt_filename: failed to rename {}: {err}",
+                    old.display()
+                );
+            }
         }
     }
 }

--- a/src/routine_storage_prompt_sidecar_tests.rs
+++ b/src/routine_storage_prompt_sidecar_tests.rs
@@ -75,7 +75,7 @@ fn prompt_file_contains_composed_prompt() {
 fn write_routine_persists_composed_prompt_sidecar_with_repos() {
     // Focused coverage for the `atomic_write(routine_compiled_prompt_path, compose_prompt(..))`
     // call in `write_routine`: a routine with a non-empty prompt AND repositories runs
-    // `compose_prompt` fully, and the composed body lands in prompts/prompt.compiled.md on disk.
+    // `compose_prompt` fully, and the composed body lands in prompts/prompt.compiled.local.md on disk.
     with_override_home(|_home| {
         let id = "rs-prompt-sidecar-id";
         let title = "Rs Prompt Sidecar Routine";
@@ -140,14 +140,14 @@ fn write_routine_errors_when_prompt_sidecar_write_fails() {
 fn write_routine_errors_when_compiled_prompt_sidecar_write_fails() {
     // Covers the error-propagation (`?`) on the compiled-prompt `atomic_write` in `write_routine`:
     // routine.toml and the pure-prompt sidecar both write successfully, but a non-empty directory
-    // occupies the `prompt.compiled.md` path, so the atomic rename over it fails.
+    // occupies the `prompt.compiled.local.md` path, so the atomic rename over it fails.
     with_override_home(|_home| {
         let id = "rs-compiled-prompt-write-fail-id";
         let title = "Rs Compiled Prompt Write Fail Routine";
         let slug = slugify(title);
         let dir = crate::paths::routine_dir(&slug);
         std::fs::create_dir_all(&dir).unwrap();
-        // Block prompt.compiled.md with a *non-empty* directory so the atomic rename over it fails.
+        // Block prompt.compiled.local.md with a *non-empty* directory so the atomic rename over it fails.
         let prompt_dir = crate::paths::routine_compiled_prompt_path(&slug);
         std::fs::create_dir_all(&prompt_dir).unwrap();
         std::fs::write(prompt_dir.join("occupant"), "keep me non-empty").unwrap();

--- a/src/routine_storage_tests.rs
+++ b/src/routine_storage_tests.rs
@@ -404,7 +404,7 @@ fn repersist_routines_recreates_missing_prompt_sidecar() {
         let title = "Rs Repersist Routine";
         let slug = slugify(title);
         write_routine(&make_routine(id, title)).unwrap();
-        // Simulate the sync-only state: prompt.compiled.md gone, only run.sh-style dir remains.
+        // Simulate the sync-only state: prompt.compiled.local.md gone, only run.sh-style dir remains.
         std::fs::remove_file(crate::paths::routine_compiled_prompt_path(&slug)).unwrap();
         assert!(!crate::paths::routine_compiled_prompt_path(&slug).exists());
 
@@ -429,7 +429,7 @@ fn write_routine_seeds_gitignore_with_all_required_patterns() {
         write_routine(&make_routine(id, title)).unwrap();
 
         let content = std::fs::read_to_string(crate::paths::routine_gitignore_path(&slug)).unwrap();
-        for pattern in ["*.local.*", "*.log", "run.sh", "prompt.compiled.md"] {
+        for pattern in ["*.local.*", "*.log", "run.sh"] {
             assert!(
                 content.lines().any(|line| line == pattern),
                 "missing required pattern {pattern:?} in {content:?}"
@@ -449,25 +449,25 @@ fn write_routine_seeds_gitignore_with_all_required_patterns() {
 }
 
 #[test]
-fn write_routine_heals_a_legacy_gitignore_missing_prompt_compiled_md() {
+fn write_routine_heals_a_legacy_gitignore_missing_required_patterns() {
     with_override_home(|_home| {
         let id = "rs-gitignore-heal-id";
         let title = "Rs Gitignore Heal Routine";
         let slug = slugify(title);
         std::fs::create_dir_all(crate::paths::routine_dir(&slug)).unwrap();
-        // Simulate an install from before `prompt.compiled.md` was added to the required patterns,
-        // plus a user-added custom entry that reconciliation must preserve. No trailing newline,
+        // Simulate an install from before `run.sh` was added to the required patterns, plus a
+        // user-added custom entry that reconciliation must preserve. No trailing newline,
         // exercising the "append one before the new patterns" branch too.
         std::fs::write(
             crate::paths::routine_gitignore_path(&slug),
-            "*.local.*\n*.log\nrun.sh\nmy-custom-pattern",
+            "*.local.*\n*.log\nmy-custom-pattern",
         )
         .unwrap();
 
         write_routine(&make_routine(id, title)).unwrap();
 
         let content = std::fs::read_to_string(crate::paths::routine_gitignore_path(&slug)).unwrap();
-        assert!(content.lines().any(|line| line == "prompt.compiled.md"));
+        assert!(content.lines().any(|line| line == "run.sh"));
         assert!(
             content.lines().any(|line| line == "my-custom-pattern"),
             "user-added pattern must survive reconciliation: {content:?}"

--- a/src/routines/command.rs
+++ b/src/routines/command.rs
@@ -50,7 +50,7 @@ pub(crate) fn tmux_session_prefix(slug: &str) -> String {
     format!("{TMUX_SESSION_PREFIX}{slug}-")
 }
 
-/// Compose the `prompt.compiled.md` body: a repositories-as-context preamble, an optional `## Goal`
+/// Compose the `prompt.compiled.local.md` body: a repositories-as-context preamble, an optional `## Goal`
 /// section, the prompt, and — when the routine has any — an "Open flags" section listing
 /// gaps/bugs/edge cases the agent raised on a previous run (see [`super::flags`]) that no one has
 /// resolved yet.

--- a/src/routines/service_flag_tests.rs
+++ b/src/routines/service_flag_tests.rs
@@ -105,7 +105,7 @@ fn svc_create_flag_persists_and_refreshes_prompt() {
     assert_eq!(flag.flag_type, "bug");
     assert_eq!(flag.description, "broken thing");
 
-    // prompt.compiled.md is refreshed with the new open flag so the next run sees it.
+    // prompt.compiled.local.md is refreshed with the new open flag so the next run sees it.
     let slug = slugify(title);
     let prompt =
         std::fs::read_to_string(crate::paths::routine_compiled_prompt_path(&slug)).unwrap();

--- a/src/routines/service_trigger_flags.rs
+++ b/src/routines/service_trigger_flags.rs
@@ -42,7 +42,7 @@ fn routine_and_slug(store: &RoutineStore, id: &str) -> Result<(Routine, String),
 
 /// Raise a new flag against routine `id`. `flag_type` and `description` must be non-blank;
 /// `scope` is `"general"` (committed) or `"local"` (gitignored). Refreshes the routine's
-/// `prompts/prompt.compiled.md` afterward so the next run's "Open flags" section (see
+/// `prompts/prompt.compiled.local.md` afterward so the next run's "Open flags" section (see
 /// `compose_prompt`) includes it.
 pub fn svc_create_flag(
     store: &RoutineStore,
@@ -70,7 +70,7 @@ pub fn svc_list_flags(store: &RoutineStore, id: &str) -> Result<Vec<Flag>, AppEr
 /// Resolve (delete) the flag named `filename` under routine `id`.
 ///
 /// `NotFound` when the routine does not exist, `filename` is unsafe, or names no existing flag.
-/// Refreshes `prompts/prompt.compiled.md` afterward so a resolved flag stops appearing in the next
+/// Refreshes `prompts/prompt.compiled.local.md` afterward so a resolved flag stops appearing in the next
 /// run's prompt.
 pub fn svc_resolve_flag(store: &RoutineStore, id: &str, filename: &str) -> Result<(), AppError> {
     let (routine, slug) = routine_and_slug(store, id)?;

--- a/src/routines/service_validate.rs
+++ b/src/routines/service_validate.rs
@@ -93,7 +93,7 @@ pub(super) fn validate_agent(agent: &str) -> Result<(), AppError> {
 /// Reject a prompt that is empty or whitespace-only with `400 Bad Request`.
 ///
 /// The prompt is the one field that defines what a routine actually does. A blank
-/// prompt still produces a valid `prompt.compiled.md` (just the moadim preamble + repo list),
+/// prompt still produces a valid `prompt.compiled.local.md` (just the moadim preamble + repo list),
 /// so the routine fires on every cron tick and launches an agent with no task —
 /// silently burning scheduled runs and the user's agent/API budget (issue #224).
 /// Shared by the create and update paths so the REST and MCP surfaces reject it
@@ -143,7 +143,7 @@ pub(super) fn validate_title(title: &str) -> Result<(), AppError> {
 /// Reject `repositories` entries whose URL (or set branch) is empty/whitespace-only, and return a
 /// normalized copy with surrounding whitespace trimmed.
 ///
-/// `repository` is a free-form string rendered verbatim into the agent's `prompt.compiled.md` preamble by
+/// `repository` is a free-form string rendered verbatim into the agent's `prompt.compiled.local.md` preamble by
 /// `compose_prompt` (see #241), so a blank or padded entry yields a broken `- ` clone bullet. An
 /// empty list is valid — this only guards the contents of non-empty entries. Mirrors the
 /// `validate_cron` / `validate_agent` boundary checks for the other routine fields (#224/#226).


### PR DESCRIPTION
## Why

`prompts/prompt.compiled.md` is fully derived from `prompts/prompt.pure.md` + `routine.toml` and rewritten on every `write_routine` call — it carries no information a user authored, so it should never be tracked in git.

#1050 already addressed part of this by adding an explicit `prompt.compiled.md` entry to the required `.gitignore` patterns, but its own PR description explicitly scoped out the rename:

> Deliberately does *not* rename `prompt.compiled.md` itself (the fuller fix floated in #1046) — that needs a migration path for installs that already have it tracked, which is a separate, larger change. This PR only stops new/healed installs from tracking it going forward.

That means:
- The filename is still inconsistent with the `*.local.*` convention `state.local.toml` already follows.
- Any install where `prompt.compiled.md` was already `git add`-ed/committed *before* #1050's `.gitignore` fix landed still has it tracked forever — a `.gitignore` addition never untracks an already-tracked file.

This PR does the actual rename #1046 asked for.

## What

- Renamed the sidecar from `prompt.compiled.md` to `prompt.compiled.local.md` (`routine_compiled_prompt_path` in `src/paths/mod.rs`), so it matches `*.local.*` directly.
- Dropped the now-redundant explicit `prompt.compiled.md` entry from `ROUTINE_GITIGNORE_REQUIRED` in `src/routine_storage.rs`.
- Added a new startup migration, `migrate_compiled_prompt_filename` (`src/routine_storage_migrations.rs`), that renames the on-disk file for existing routines — same shape as the existing `migrate_prompt_files` (prompt.txt → prompt.md) migration: scan each routine dir, rename the legacy file to the new name if the new one doesn't already exist, log and continue on a rename failure. Wired into the startup migration chain in `src/main.rs`, right after `migrate_prompts_to_subfolder` (which is what lands the legacy filename in `prompts/` for pre-subfolder installs) and before `load_store`.
- Updated every touch point that referenced the literal filename: the launch command's `cp` step derives its path from `routine_compiled_prompt_path` already, so no logic change was needed there beyond doc comments; updated comments/docs in `src/main.rs`, `src/routines/command.rs`, `src/routes/mcp.rs`, `src/routines/service_trigger_flags.rs`, `src/routines/service_validate.rs`, `src/cli_system.rs` (the seeded `routines/README.md` text), `README.md`, `Architecture.md`.
- Updated tests: `src/paths/mod_tests.rs` (new filename), `src/routine_storage_tests.rs` (dropped `prompt.compiled.md` from the required-pattern test; replaced the now-obsolete "heal legacy gitignore missing prompt.compiled.md" test with an equivalent covering the still-required patterns), `src/routine_storage_prompt_sidecar_tests.rs` (comments only — these tests already resolve the path via `routine_compiled_prompt_path` so no assertion changes were needed). Added `src/routine_storage_compiled_prompt_migration_tests.rs`, mirroring the existing `routine_storage_prompt_file_migration_tests.rs` test shape (missing-dir, rename + skip-existing, rename-failure log branch, public wrapper).
- Left `migrate_prompts_to_subfolder` itself untouched — it still lands the pre-subfolder legacy file at the intermediate `prompts/prompt.compiled.md` name, and the new migration (run right after it in the startup chain) carries it the rest of the way to `prompt.compiled.local.md`. Kept each migration doing one thing, consistent with the existing chain.

## Migration-path limitation

The new migration only renames the file **on disk**. It does **not** touch git history or the index — this daemon has no git integration anywhere in the codebase (verified: no `git` subprocess calls exist). So an install where `prompt.compiled.md` was already `git add`-ed/committed before this change lands will still show it as tracked after upgrading; the operator needs to run `git rm --cached prompts/prompt.compiled.md` in that routine's directory themselves (or just let their next commit record it as a rename). This is called out in the migration's doc comment and the changeset.

## Testing

- `cargo build`
- `cargo test` — 966 passed, 0 failed (up from 960; 6 new tests)
- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% line coverage maintained
- `linecheck --max-lines 500 $(find src ui/src -name '*.rs')` — clean
- `typos`, `actionlint` — clean
- `pnpm exec changeset status --since=origin/main` — clean (changeset added)

Closes #1046