### PR TITLE
fix(routines): reconcile pristine built-in agent configs on startup

### DIFF
--- a/.changeset/reconcile-pristine-agent-configs.md
+++ b/.changeset/reconcile-pristine-agent-configs.md
@@ -1,0 +1,7 @@
+---
+"moadim": patch
+---
+
+fix(routines): reconcile pristine built-in agent configs on startup
+
+Built-in agent configs (`claude.toml`, `codex.toml`, `hermes.toml`) were only seeded when absent and never refreshed afterward — a shipped fix to a default agent config never reached an existing install. Startup now rewrites an existing config that is still pristine (unedited since the daemon wrote it) but stale, using a fingerprint header to distinguish pristine-but-stale from user-edited, mirroring the existing routine-defaults reconciliation. A user-edited config, or one with no managed header, is left untouched.

--- a/Architecture.md
+++ b/Architecture.md
@@ -205,6 +205,16 @@ The agent command is resolved from a configurable registry at `~/.config/moadim/
 The resolved values are baked into the crontab line at sync time, so editing an agent config requires
 re-syncing routines that use it. Routines with no matching agent config are skipped (with a warning).
 
+The daemon **owns** the content of a built-in agent config (`claude.toml`, `codex.toml`,
+`hermes.toml`), refreshing it from the built-in on every start — the same guarantee
+`routines::ensure_default_routines` gives built-in routines — so a shipped fix or improvement reaches
+existing installs, not just new ones. A user's edits are still never overwritten: each written config
+carries a fingerprint header recording the exact built-in content it was seeded from, and on startup
+only a file whose current content still matches that fingerprint (provably untouched since the daemon
+wrote it) is refreshed to the current built-in; anything else — an edited file, or one with no
+fingerprint at all (seeded before this mechanism existed) — is left alone. See
+`routines::agents::ensure_default_agents_in`.
+
 The only placeholders `args` may contain are `{workbench}`, `{prompt_file}`, and `{prompt}`, and at
 least one of `{prompt}` / `{prompt_file}` must appear so the agent actually receives the task.
 Creating or updating a routine validates the referenced agent's `args` against both rules: an unknown

--- a/src/routines/agents/agents_tests.rs
+++ b/src/routines/agents/agents_tests.rs
@@ -168,17 +168,17 @@ fn ensure_default_agents_in_returns_early_when_dir_is_uncreatable() {
 
 #[test]
 fn ensure_default_agents_in_logs_and_continues_on_write_failure() {
-    // Covers the `std::fs::write` error branch: a directory already occupies the
-    // path where the first agent's `.toml` file would be written, so the write
-    // fails while the loop continues to the next agent.
+    // Covers the `std::fs::read_to_string` non-`NotFound`-error branch: a directory already
+    // occupies the path where the first agent's `.toml` file would live, so reading it fails (it's
+    // a directory, not a file) and is logged while the loop continues to the next agent.
     let dir = unique_dir("write-fail");
     std::fs::create_dir_all(&dir).unwrap();
-    // Block the claude config path with a directory so writing the file fails.
+    // Block the claude config path with a directory so reading it fails.
     std::fs::create_dir_all(dir.join("claude.toml")).unwrap();
 
     ensure_default_agents_in(&dir);
 
-    // The blocked path remains a directory (write failed, was logged, ignored).
+    // The blocked path remains a directory (read failed, was logged, ignored).
     assert!(dir.join("claude.toml").is_dir());
     // The loop still seeded the second agent.
     assert!(dir.join("codex.toml").is_file());
@@ -224,6 +224,143 @@ fn ensure_default_agents_in_swallows_per_config_write_errors() {
     // Restore permissions so cleanup can proceed. (Root bypasses the read-only bit, in which case
     // the writes succeed; the call is exercised either way.)
     std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+// ── ensure_default_agents_in: reconciliation of an existing config (#428) ───────────────────────
+
+#[test]
+fn ensure_default_agents_in_seeds_with_a_managed_fingerprint_header() {
+    // Absent -> seeded case (unchanged from before), now also asserting the seeded file carries
+    // the managed header this reconciliation is built on.
+    let dir = unique_dir("seed-header");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    ensure_default_agents_in(&dir);
+
+    let written = std::fs::read_to_string(dir.join("claude.toml")).unwrap();
+    let (hash, body) = parse_managed(&written).expect("seeded file must carry the managed header");
+    assert_eq!(body, claude_code::CONFIG);
+    assert_eq!(hash, fingerprint(claude_code::CONFIG));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn ensure_default_agents_in_is_a_noop_when_already_current() {
+    // A managed file whose body already equals the current built-in must not be rewritten.
+    let dir = unique_dir("already-current");
+    std::fs::create_dir_all(&dir).unwrap();
+    ensure_default_agents_in(&dir);
+    let before = std::fs::read_to_string(dir.join("claude.toml")).unwrap();
+
+    ensure_default_agents_in(&dir);
+
+    let after = std::fs::read_to_string(dir.join("claude.toml")).unwrap();
+    assert_eq!(before, after);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn ensure_default_agents_in_upgrades_a_stale_pristine_config() {
+    // (a) stale-pristine -> upgraded: a managed file whose body is an old built-in (never edited,
+    // as proven by its body still hashing to its own recorded fingerprint) must be refreshed to the
+    // current built-in, with a fingerprint recorded for it in turn.
+    let dir = unique_dir("stale-pristine");
+    std::fs::create_dir_all(&dir).unwrap();
+    let stale_body = "command = \"old-claude\"\n";
+    std::fs::write(dir.join("claude.toml"), render_managed(stale_body)).unwrap();
+
+    ensure_default_agents_in(&dir);
+
+    let upgraded = std::fs::read_to_string(dir.join("claude.toml")).unwrap();
+    let (hash, body) = parse_managed(&upgraded).expect("still managed after upgrade");
+    assert_eq!(body, claude_code::CONFIG);
+    assert_eq!(hash, fingerprint(claude_code::CONFIG));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn ensure_default_agents_in_preserves_a_user_edited_config() {
+    // (b) user-edited -> preserved: a managed file whose current body no longer hashes to its
+    // recorded fingerprint (the user changed it after the daemon wrote it) must never be touched,
+    // even though its body also differs from the current built-in.
+    let dir = unique_dir("user-edited");
+    std::fs::create_dir_all(&dir).unwrap();
+    let managed = render_managed("command = \"old-claude\"\n");
+    let edited = format!("{managed}\n# a user note appended after seeding\n");
+    std::fs::write(dir.join("claude.toml"), &edited).unwrap();
+
+    ensure_default_agents_in(&dir);
+
+    assert_eq!(
+        std::fs::read_to_string(dir.join("claude.toml")).unwrap(),
+        edited,
+        "a user-edited config must never be overwritten"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn ensure_default_agents_in_leaves_a_legacy_unmanaged_config_untouched() {
+    // A config with no managed header at all (seeded before this mechanism existed, or hand-authored)
+    // has no provenance to trust, so it must be left strictly alone rather than guessed at.
+    let dir = unique_dir("legacy-no-header");
+    std::fs::create_dir_all(&dir).unwrap();
+    let legacy = "command = \"legacy-claude\"\n";
+    std::fs::write(dir.join("claude.toml"), legacy).unwrap();
+
+    ensure_default_agents_in(&dir);
+
+    assert_eq!(
+        std::fs::read_to_string(dir.join("claude.toml")).unwrap(),
+        legacy
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn ensure_default_agents_in_leaves_a_malformed_managed_header_untouched() {
+    // Covers `parse_managed`'s `split_once` returning `None`: the header prefix is present but
+    // there's no trailing newline/body, so the file can't be trusted as managed and is left alone.
+    let dir = unique_dir("malformed-header");
+    std::fs::create_dir_all(&dir).unwrap();
+    let malformed = format!("{MANAGED_HEADER_PREFIX}deadbeef");
+    std::fs::write(dir.join("claude.toml"), &malformed).unwrap();
+
+    ensure_default_agents_in(&dir);
+
+    assert_eq!(
+        std::fs::read_to_string(dir.join("claude.toml")).unwrap(),
+        malformed
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[cfg(unix)]
+#[test]
+fn ensure_default_agents_in_logs_when_rewriting_a_stale_pristine_config_fails() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    // Covers the rewrite-failure arm, distinct from the seed-failure arm covered by
+    // `ensure_default_agents_in_swallows_per_config_write_errors`: here the file already exists (a
+    // pristine-but-stale managed config) and its own permissions block the overwrite.
+    let dir = unique_dir("stale-write-fail");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("claude.toml");
+    std::fs::write(&path, render_managed("command = \"old-claude\"\n")).unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o444)).unwrap();
+
+    ensure_default_agents_in(&dir);
+
+    // Restore permissions so cleanup can proceed. (Root bypasses the read-only bit, in which case
+    // the rewrite succeeds; the call is exercised either way.)
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
     let _ = std::fs::remove_dir_all(&dir);
 }
 

--- a/src/routines/agents/mod.rs
+++ b/src/routines/agents/mod.rs
@@ -182,7 +182,10 @@ fn fingerprint(data: &str) -> String {
 /// Render `contents` as a daemon-managed file: [`MANAGED_HEADER_PREFIX`] plus its fingerprint, then
 /// `contents` verbatim.
 fn render_managed(contents: &str) -> String {
-    format!("{MANAGED_HEADER_PREFIX}{}\n{contents}", fingerprint(contents))
+    format!(
+        "{MANAGED_HEADER_PREFIX}{}\n{contents}",
+        fingerprint(contents)
+    )
 }
 
 /// Split a daemon-written file's `text` into its recorded fingerprint and body.

--- a/src/routines/agents/mod.rs
+++ b/src/routines/agents/mod.rs
@@ -1,7 +1,19 @@
-//! The agent registry: resolving `~/.config/moadim/agents/<name>.toml` and seeding built-in defaults.
+//! The agent registry: resolving `~/.config/moadim/agents/<name>.toml`, seeded and kept current on
+//! startup.
 //!
 //! Each supported agent contributes its registry key and default config from its own
 //! `<agent>/setup.rs` module; [`DEFAULT_AGENT_CONFIGS`] assembles them for [`ensure_default_agents`].
+//!
+//! Mirrors [`super::defaults::ensure_default_routines`]: the daemon owns the content of a built-in
+//! agent config and refreshes it from [`DEFAULT_AGENT_CONFIGS`] on every start, so a shipped fix or
+//! improvement reaches existing installs, not just new ones. Unlike a routine's structured fields,
+//! an agent config is an opaque TOML blob, so drift can't be detected field-by-field; instead each
+//! written file carries a [`MANAGED_HEADER_PREFIX`] line fingerprinting the exact built-in content it
+//! was written from. On startup, a file whose current body still matches its recorded fingerprint is
+//! provably untouched since the daemon wrote it (pristine, even if stale) and is safely refreshed to
+//! the current built-in; a file whose body has drifted from its fingerprint — or one with no
+//! fingerprint at all, e.g. seeded before this mechanism existed — is left strictly alone, preserving
+//! the existing "user edits are never overwritten" guarantee.
 
 use serde::Deserialize;
 use std::io::ErrorKind;
@@ -92,7 +104,8 @@ pub fn load_agent_command(name: &str) -> Result<AgentCommand, AgentLoadError> {
     toml::from_str(&text).map_err(|err| AgentLoadError::Parse(err.to_string()))
 }
 
-/// Built-in default agent configs `(name, toml)`, written on startup if the file does not exist.
+/// Built-in default agent configs `(name, toml)`, seeded on startup if absent and reconciled onto a
+/// still-pristine copy of an older default. See [`ensure_default_agents_in`].
 const DEFAULT_AGENT_CONFIGS: &[(&str, &str)] = &[
     (claude_code::NAME, claude_code::CONFIG),
     (codex::NAME, codex::CONFIG),
@@ -143,15 +156,57 @@ pub(crate) fn available_agents_in(dir: &Path) -> Vec<String> {
     names
 }
 
-/// Write any missing built-in agent configs into `~/.config/moadim/agents/`.
+/// First line of a daemon-written agent config, recording an FNV-1a [`fingerprint`] of the built-in
+/// body it was written from. See the module docs for why this is how a pristine-but-stale default is
+/// told apart from a user's edit.
+const MANAGED_HEADER_PREFIX: &str = "# moadim:managed ";
+
+/// A non-cryptographic 64-bit fingerprint of `data`, rendered as lowercase hex.
 ///
-/// Existing files are never overwritten, so user edits are preserved. Best-effort: directory or
-/// write failures are logged and ignored rather than aborting startup.
+/// ponytail: FNV-1a, not a cryptographic hash — fine here since this only tells "pristine" content
+/// apart from "edited" content, not a security boundary. Deterministic across Rust versions (unlike
+/// `std::collections::hash_map::DefaultHasher`, whose algorithm is not guaranteed stable), which
+/// matters because a fingerprint written by one daemon build is compared against one computed by a
+/// later build.
+fn fingerprint(data: &str) -> String {
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0100_0000_01b3;
+    let mut hash = FNV_OFFSET;
+    for byte in data.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    format!("{hash:016x}")
+}
+
+/// Render `contents` as a daemon-managed file: [`MANAGED_HEADER_PREFIX`] plus its fingerprint, then
+/// `contents` verbatim.
+fn render_managed(contents: &str) -> String {
+    format!("{MANAGED_HEADER_PREFIX}{}\n{contents}", fingerprint(contents))
+}
+
+/// Split a daemon-written file's `text` into its recorded fingerprint and body.
+///
+/// Returns `None` for text with no (well-formed) [`MANAGED_HEADER_PREFIX`] line — a config seeded
+/// before this mechanism existed, or never written by the daemon at all — which
+/// [`ensure_default_agents_in`] treats as foreign and never touches.
+fn parse_managed(text: &str) -> Option<(&str, &str)> {
+    let rest = text.strip_prefix(MANAGED_HEADER_PREFIX)?;
+    rest.split_once('\n')
+}
+
+/// Write any missing built-in agent configs into `~/.config/moadim/agents/`, and refresh any
+/// existing one that is still pristine (unedited since the daemon wrote it) but stale.
+///
+/// A user-modified config is never overwritten — only a file whose current content still matches the
+/// fingerprint recorded when the daemon wrote it is refreshed. Best-effort: directory, read, or write
+/// failures are logged and ignored rather than aborting startup.
 pub fn ensure_default_agents() {
     ensure_default_agents_in(&agents_dir());
 }
 
-/// Write missing built-in agent configs into `dir`. See [`ensure_default_agents`].
+/// Write missing / refresh stale-pristine built-in agent configs into `dir`. See
+/// [`ensure_default_agents`].
 pub(crate) fn ensure_default_agents_in(dir: &Path) {
     if let Err(err) = crate::utils::fs_perms::create_private_dir_all(dir) {
         log::warn!(
@@ -162,14 +217,47 @@ pub(crate) fn ensure_default_agents_in(dir: &Path) {
     }
     for (name, contents) in DEFAULT_AGENT_CONFIGS {
         let path = dir.join(format!("{name}.toml"));
-        if path.exists() {
-            continue;
-        }
-        if let Err(err) = std::fs::write(&path, contents) {
-            log::warn!(
-                "ensure_default_agents: failed to write {}: {err}",
-                path.display()
-            );
+        match std::fs::read_to_string(&path) {
+            Err(err) if err.kind() == ErrorKind::NotFound => {
+                if let Err(err) = std::fs::write(&path, render_managed(contents)) {
+                    log::warn!(
+                        "ensure_default_agents: failed to write {}: {err}",
+                        path.display()
+                    );
+                }
+            }
+            Err(err) => {
+                log::warn!(
+                    "ensure_default_agents: failed to read {}: {err}",
+                    path.display()
+                );
+            }
+            Ok(existing) => {
+                let Some((recorded_fingerprint, body)) = parse_managed(&existing) else {
+                    // No managed header: a foreign file, or one seeded before this mechanism
+                    // existed. Its provenance is unknown, so it's left strictly alone.
+                    continue;
+                };
+                if body == *contents {
+                    continue; // Already current; nothing to do.
+                }
+                if fingerprint(body) != recorded_fingerprint {
+                    // Edited since the daemon last wrote it: never overwrite a user's edit.
+                    continue;
+                }
+                // A pristine copy of a stale default: safe to refresh to the current built-in.
+                if let Err(err) = std::fs::write(&path, render_managed(contents)) {
+                    log::warn!(
+                        "ensure_default_agents: failed to rewrite stale default {}: {err}",
+                        path.display()
+                    );
+                } else {
+                    log::info!(
+                        "ensure_default_agents: upgraded stale default {} to the current built-in",
+                        path.display()
+                    );
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

Built-in agent configs (`claude.toml`, `codex.toml`, `hermes.toml`) were seeded only when the file was absent and never touched again — asymmetric with built-in routines, which the daemon explicitly reconciles onto disk on every startup (`routines::ensure_default_routines`). A shipped fix or improvement to a default agent config never reached an existing install; the only "upgrade path" was manually deleting the file.

## Fix

`ensure_default_agents_in` (`src/routines/agents/mod.rs`) now also refreshes an existing config that is still **pristine** (unedited since the daemon wrote it) but **stale** — mirroring the routine-defaults reconciliation, adapted for the fact that an agent config is an opaque TOML blob rather than a struct with fields to diff.

### Fingerprinting approach

Each config the daemon writes now starts with a header line:

```toml
# moadim:managed <16-hex-char fingerprint>
command = "claude"
...
```

The fingerprint is a 64-bit FNV-1a hash of the body that follows (`fingerprint()` in `mod.rs`). On startup, for each built-in config file:

- **Absent** → seeded with the current built-in + a fresh fingerprint header (unchanged from before).
- **Present, body already equals the current built-in** → no-op.
- **Present, header's recorded fingerprint matches the current body's fingerprint, body != current built-in** → the file is *provably* untouched since the daemon wrote it (pristine), just stale — rewritten to the current built-in with an updated fingerprint. Logged at `info`.
- **Present, body's fingerprint no longer matches the recorded one** → the user edited it after the daemon wrote it — left strictly alone.
- **Present, no (well-formed) managed header at all** → a config seeded before this mechanism existed, or a hand-authored one — no provenance to trust, so it's also left strictly alone. (This is the one deliberate limitation: an already-existing, never-edited install won't auto-upgrade until it's re-seeded from scratch, since there's no historical fingerprint to check it against. Safety — never clobbering a real edit — was prioritized over closing this one-time gap.)

Why FNV-1a over a crypto hash (e.g. sha2) or `DefaultHasher`: this only needs to distinguish "pristine" from "edited" content, not resist tampering, so a cheap non-cryptographic hash is enough and avoids a new dependency. `DefaultHasher`'s algorithm isn't guaranteed stable across Rust releases, which matters here since a fingerprint written by one daemon build has to compare correctly against one computed by a later build — FNV-1a is simple arithmetic, deterministic forever.

The header is a plain `#` TOML comment, so `load_agent_command`'s `toml::from_str` parses the file exactly as before; no reader-side changes needed.

All of this is best-effort, matching the existing seeding behavior: a read or write failure is logged and skipped, and startup never blocks on it.

## Tests

Added to `src/routines/agents/agents_tests.rs`:
- `ensure_default_agents_in_seeds_with_a_managed_fingerprint_header` — absent → seeded (asserts the new header shape)
- `ensure_default_agents_in_is_a_noop_when_already_current` — no rewrite when nothing drifted
- `ensure_default_agents_in_upgrades_a_stale_pristine_config` — (a) stale-pristine → upgraded
- `ensure_default_agents_in_preserves_a_user_edited_config` — (b) user-edited → preserved
- `ensure_default_agents_in_leaves_a_legacy_unmanaged_config_untouched` — no header at all → left alone
- `ensure_default_agents_in_leaves_a_malformed_managed_header_untouched` — malformed header → left alone
- `ensure_default_agents_in_logs_when_rewriting_a_stale_pristine_config_fails` — rewrite failure is logged, not fatal

Also updated one pre-existing test's comment (`ensure_default_agents_in_logs_and_continues_on_write_failure`) since blocking the config path with a directory now hits the new read-error branch rather than the write-error branch.

## Docs

`Architecture.md`'s agent-registry section now states that built-in agent configs are daemon-owned and reconciled on upgrade, mirroring the existing routine-defaults wording. `mod.rs`'s module doc comment explains the fingerprinting scheme in full.

## Verification

- `cargo build`, `cargo test` (969 passed), `cargo clippy --workspace --all-targets -- -D warnings` all clean.
- `cargo llvm-cov`: `routines/agents/mod.rs` is 100% line-covered; total repo coverage is unchanged from the `main` baseline (99.63%, pre-existing gap in unrelated files, not introduced by this change).

Closes #428