### PR TITLE
fix(routines): add a global cap on concurrently-running routine sessions

### DIFF
--- a/.changeset/global-concurrency-cap.md
+++ b/.changeset/global-concurrency-cap.md
@@ -1,0 +1,7 @@
+---
+"moadim": patch
+---
+
+### Added
+
+A shared cron minute (e.g. `*/5 * * * *`, `0 * * * *`) could launch an unbounded thundering herd of agent sessions: each routine fire spawns its own detached tmux session with no cap on how many may be alive across *all* routines at once — distinct from the existing per-routine overlap guard, which only stops one routine from stacking on its own still-running fire. `MOADIM_MAX_CONCURRENT_RUNS` (default `4`) now caps the number of concurrently-running routine agent sessions; a fire that would exceed it is skipped (logged, not queued) and picked up again on its next scheduled tick. The live count is derived from actual tmux session liveness, not an in-memory counter, so it stays correct across a daemon crash/restart.

--- a/Architecture.md
+++ b/Architecture.md
@@ -288,6 +288,17 @@ fires its `ShutdownSignal`, whichever comes first.
 - **Single Tokio runtime** (`#[tokio::main]`), all async.
 - **`RoutineStore`** is `Arc<Mutex<...>>` — synchronous lock, held only for the duration of the HashMap operation, then released before any disk I/O.
 - **MCP sessions** each get a cloned `Arc` of the same store, so mutations from REST and MCP are immediately visible to both.
+- **Global routine concurrency cap** (`routines::concurrency_cap`, #335): the per-routine overlap
+  guard described above only stops one routine from stacking on its own still-running fire — it
+  does nothing to bound how many *different* routines run at once. Since routines fire off the OS
+  crontab, many routines' schedules naturally align on the same minute boundary (e.g. `*/5 * * * *`,
+  `0 * * * *`), so without a cap a shared tick can launch an unbounded thundering herd of agent
+  sessions (CPU/RAM exhaustion, provider API rate-limit bursts). `spawn_routine_command` counts live
+  sessions sharing the `moadim-` prefix (`cleanup::tmux_session_count` — derived from actual tmux
+  session liveness, not an in-memory counter that could drift after a crash) and, at or over
+  `MOADIM_MAX_CONCURRENT_RUNS` (default `4`), skips the fire with a logged reason instead of
+  launching it or queueing it — the simpler, lower-risk policy, matching the overlap guard's own
+  skip-with-warning shape rather than adding new queueing infrastructure.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,17 @@ exceeded, the sweep also evicts finished workbenches oldest-first (regardless
 of their individual TTL) until back under it. A live session is never evicted.
 Unset or `0` (the default) keeps today's unbounded-by-size behavior.
 
+A routine already refuses to overlap with its own still-running fire, but
+nothing on its own bounds how many *different* routines run at once — the OS
+crontab naturally aligns fires from separate routines onto the same minute
+boundary (e.g. `*/5 * * * *`), so a shared tick can otherwise launch an
+unbounded thundering herd of agent sessions. Set `MOADIM_MAX_CONCURRENT_RUNS`
+to cap how many routine agent sessions may be alive at once (default `4`);
+once reached, a new fire is skipped — logging the reason — rather than
+launched, and is picked up again on its next scheduled tick. The count is
+derived from actual live tmux sessions, not an in-memory counter, so it stays
+correct across a daemon crash/restart.
+
 **REST** — under the `/api/v1` prefix:
 
 ```

--- a/src/routines/cleanup/cleanup_tmux_tests.rs
+++ b/src/routines/cleanup/cleanup_tmux_tests.rs
@@ -139,6 +139,64 @@ fn tmux_session_prefix_alive_false_when_tmux_bin_missing_or_fails() {
 }
 
 #[test]
+fn tmux_session_count_counts_every_session_starting_with_the_prefix() {
+    // The global concurrency cap (#335) needs a total *count* across every routine's sessions, not
+    // just any-vs-none, so this stubs `tmux list-sessions` with a mix of matching and unrelated
+    // session names and checks the count reflects only those starting with the given prefix.
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let dir = std::env::temp_dir().join(format!("moadim-tmux-count-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let stub = dir.join("tmux");
+    std::fs::write(
+        &stub,
+        "#!/bin/sh\nprintf 'moadim-foo-100_1\\nmoadim-bar-200_2\\nunrelated-session\\n'\nexit 0\n",
+    )
+    .unwrap();
+    #[cfg(unix)]
+    std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let previous = std::env::var_os("MOADIM_TMUX_BIN");
+    // SAFETY: tests in this crate run single-threaded (RUST_TEST_THREADS=1).
+    unsafe { std::env::set_var("MOADIM_TMUX_BIN", &stub) };
+
+    assert_eq!(
+        super::session::tmux_session_count("moadim-"),
+        2,
+        "both moadim-prefixed sessions count, regardless of which routine/slug spawned them"
+    );
+    assert_eq!(super::session::tmux_session_count("moadim-nonexistent-"), 0);
+
+    // SAFETY: single-threaded harness; restore the saved override.
+    unsafe {
+        match previous {
+            Some(value) => std::env::set_var("MOADIM_TMUX_BIN", value),
+            None => std::env::remove_var("MOADIM_TMUX_BIN"),
+        }
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn tmux_session_count_is_zero_when_tmux_bin_missing_or_fails() {
+    // No live server / no tmux at all must read as zero live sessions, not an error — mirrors
+    // `tmux_session_alive`'s and `tmux_session_prefix_alive`'s "no tmux" stance.
+    let previous = std::env::var_os("MOADIM_TMUX_BIN");
+    // SAFETY: single-threaded harness.
+    unsafe { std::env::set_var("MOADIM_TMUX_BIN", "/usr/bin/false") };
+    assert_eq!(super::session::tmux_session_count("moadim-"), 0);
+
+    // SAFETY: single-threaded harness; restore the saved override.
+    unsafe {
+        match previous {
+            Some(value) => std::env::set_var("MOADIM_TMUX_BIN", value),
+            None => std::env::remove_var("MOADIM_TMUX_BIN"),
+        }
+    }
+}
+
+#[test]
 fn note_forced_kill_is_silent_when_log_cannot_be_opened() {
     // The workbench directory does not exist, so opening `agent.log` (append+create) fails because
     // its parent is absent — exercising the `if let Ok` fall-through (the best-effort Err branch).

--- a/src/routines/cleanup/mod.rs
+++ b/src/routines/cleanup/mod.rs
@@ -37,6 +37,7 @@ use session::{note_forced_kill, tmux_kill_session, tmux_session_alive};
 
 pub(crate) use runtime::max_runtime_ceiling_secs;
 pub(crate) use session::tmux_session_alive as run_session_alive;
+pub(crate) use session::tmux_session_count;
 pub(crate) use session::tmux_session_prefix_alive;
 pub(crate) use ttl::ttl_ceiling_secs;
 

--- a/src/routines/cleanup/session.rs
+++ b/src/routines/cleanup/session.rs
@@ -64,6 +64,32 @@ pub(crate) fn tmux_session_prefix_alive(prefix: &str) -> bool {
         })
 }
 
+/// Count how many live tmux sessions have a name starting with `prefix`.
+///
+/// Backs the global concurrency cap (#335): every routine's fires share the one
+/// [`crate::routines::command::TMUX_SESSION_PREFIX`] (`"moadim-"`) regardless of which routine/slug
+/// spawned them, so — unlike [`tmux_session_prefix_alive`]'s per-routine-fire prefix (which further
+/// validates the trailing `$RID` shape) — a plain [`str::starts_with`] count over that shared prefix
+/// is the total number of routine agent sessions alive right now. Derived from the same
+/// `list-sessions` call each time it's needed (no cached/in-memory counter that could drift after a
+/// crash). A missing `tmux` binary or non-zero exit (no server running) reads as `0`, mirroring
+/// [`tmux_session_alive`]'s "no tmux, nothing running" stance.
+pub(crate) fn tmux_session_count(prefix: &str) -> usize {
+    std::process::Command::new(tmux_bin())
+        .arg("list-sessions")
+        .arg("-F")
+        .arg("#{session_name}")
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .map_or(0, |out| {
+            String::from_utf8_lossy(&out.stdout)
+                .lines()
+                .filter(|name| name.starts_with(prefix))
+                .count()
+        })
+}
+
 /// Return `true` if `name` is a tmux session name for *this* routine's `prefix`
 /// (`moadim-{slug}-`), not merely a different routine whose slug happens to be a string-prefix of
 /// this one's (e.g. slug `deploy` vs slug `deploy-staging`: `"moadim-deploy-"` is a literal prefix

--- a/src/routines/concurrency_cap.rs
+++ b/src/routines/concurrency_cap.rs
@@ -1,0 +1,37 @@
+//! Global cap on concurrently-running routine agent sessions (#335).
+//!
+//! Routines are driven by the OS crontab, so cron fires for many *different* routines naturally
+//! align on the same minute boundary (e.g. `*/5 * * * *`, `0 * * * *`, …) — nothing bounds how many
+//! agent sessions launch on the same tick, a thundering herd that can exhaust host CPU/RAM or burst
+//! past a provider's API rate limit. This is distinct from the per-routine overlap guard
+//! (`cleanup::tmux_session_prefix_alive`, #514): that only stops one routine from stacking on top of
+//! its own still-running fire, and does nothing to bound the total number of *different* routines
+//! running at once.
+//!
+//! `service_trigger::spawn_routine_command` checks [`max_concurrent_runs`] against the live session
+//! count (`cleanup::tmux_session_count`, keyed on the shared `moadim-` prefix every routine's tmux
+//! session name begins with) before launching, and skips the fire — logging a warning — rather than
+//! queueing it, the same non-fatal skip shape the overlap guard above already uses.
+
+/// Env var naming the global concurrency cap. Unset, empty, unparsable, or `0` falls back to
+/// [`DEFAULT_MAX_CONCURRENT_RUNS`] — unlike `MOADIM_MAX_WORKBENCH_DISK_BYTES`'s "0 means unbounded"
+/// convention, an unbounded fan-out is exactly the bug this cap exists to prevent, so there is no
+/// "off" setting here.
+pub(crate) const MAX_CONCURRENT_RUNS_ENV: &str = "MOADIM_MAX_CONCURRENT_RUNS";
+
+/// Sane default cap applied when [`MAX_CONCURRENT_RUNS_ENV`] is unset/unparsable/zero.
+const DEFAULT_MAX_CONCURRENT_RUNS: usize = 4;
+
+/// The configured global concurrency cap: how many routine agent sessions may be alive at once
+/// before a new fire is skipped instead of launched.
+pub(crate) fn max_concurrent_runs() -> usize {
+    std::env::var(MAX_CONCURRENT_RUNS_ENV)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|&cap| cap > 0)
+        .unwrap_or(DEFAULT_MAX_CONCURRENT_RUNS)
+}
+
+#[cfg(test)]
+#[path = "concurrency_cap_tests.rs"]
+mod concurrency_cap_tests;

--- a/src/routines/concurrency_cap_tests.rs
+++ b/src/routines/concurrency_cap_tests.rs
@@ -1,0 +1,63 @@
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and fixtures do not need doc comments"
+)]
+
+use super::*;
+
+/// Restore `MOADIM_MAX_CONCURRENT_RUNS` to whatever it was before the test ran.
+fn restore(prev: Option<std::ffi::OsString>) {
+    // SAFETY: tests in this crate run single-threaded (RUST_TEST_THREADS=1).
+    unsafe {
+        match prev {
+            Some(value) => std::env::set_var(MAX_CONCURRENT_RUNS_ENV, value),
+            None => std::env::remove_var(MAX_CONCURRENT_RUNS_ENV),
+        }
+    }
+}
+
+#[test]
+fn max_concurrent_runs_defaults_when_unset() {
+    let prev = std::env::var_os(MAX_CONCURRENT_RUNS_ENV);
+    // SAFETY: tests in this crate run single-threaded (RUST_TEST_THREADS=1); restored below.
+    unsafe {
+        std::env::remove_var(MAX_CONCURRENT_RUNS_ENV);
+    }
+    assert_eq!(max_concurrent_runs(), DEFAULT_MAX_CONCURRENT_RUNS);
+    restore(prev);
+}
+
+#[test]
+fn max_concurrent_runs_parses_a_valid_value() {
+    let prev = std::env::var_os(MAX_CONCURRENT_RUNS_ENV);
+    // SAFETY: tests in this crate run single-threaded (RUST_TEST_THREADS=1); restored below.
+    unsafe {
+        std::env::set_var(MAX_CONCURRENT_RUNS_ENV, "9");
+    }
+    assert_eq!(max_concurrent_runs(), 9);
+    restore(prev);
+}
+
+#[test]
+fn max_concurrent_runs_falls_back_to_default_on_garbage() {
+    let prev = std::env::var_os(MAX_CONCURRENT_RUNS_ENV);
+    // SAFETY: tests in this crate run single-threaded (RUST_TEST_THREADS=1); restored below.
+    unsafe {
+        std::env::set_var(MAX_CONCURRENT_RUNS_ENV, "not-a-number");
+    }
+    assert_eq!(max_concurrent_runs(), DEFAULT_MAX_CONCURRENT_RUNS);
+    restore(prev);
+}
+
+#[test]
+fn max_concurrent_runs_falls_back_to_default_on_zero() {
+    // Unlike the disk-cap env var, `0` is not "unbounded" here — an unbounded fan-out is exactly
+    // the bug this cap prevents, so `0` is rejected like any other unparsable value.
+    let prev = std::env::var_os(MAX_CONCURRENT_RUNS_ENV);
+    // SAFETY: tests in this crate run single-threaded (RUST_TEST_THREADS=1); restored below.
+    unsafe {
+        std::env::set_var(MAX_CONCURRENT_RUNS_ENV, "0");
+    }
+    assert_eq!(max_concurrent_runs(), DEFAULT_MAX_CONCURRENT_RUNS);
+    restore(prev);
+}

--- a/src/routines/mod.rs
+++ b/src/routines/mod.rs
@@ -18,6 +18,7 @@
 mod agents;
 mod cleanup;
 mod command;
+mod concurrency_cap;
 mod defaults;
 pub mod flags;
 mod handlers;
@@ -35,6 +36,8 @@ pub use model::*;
 pub use service::*;
 // `command` holds only crate-internal helpers (slugify, compose_prompt, build_routine_command, …).
 pub(crate) use command::*;
+// `concurrency_cap` is a crate-internal config knob for `service_trigger::spawn_routine_command`.
+pub(crate) use concurrency_cap::{max_concurrent_runs, MAX_CONCURRENT_RUNS_ENV};
 
 #[cfg(test)]
 #[path = "mod_tests.rs"]

--- a/src/routines/service_trigger.rs
+++ b/src/routines/service_trigger.rs
@@ -8,15 +8,18 @@ use crate::utils::time::now_secs;
 
 use crate::routines::agents::load_agent_command;
 use crate::routines::cleanup::{
-    cleanup_expired_workbenches, parse_workbench_name, run_session_alive, tmux_session_prefix_alive,
+    cleanup_expired_workbenches, parse_workbench_name, run_session_alive, tmux_session_count,
+    tmux_session_prefix_alive,
 };
 use crate::routines::command::{
     build_routine_command, inline_prompt_overflow, slugify, tmux_session_prefix,
+    TMUX_SESSION_PREFIX,
 };
 use crate::routines::model::{
     CleanupResponse, FleetRunSummary, Routine, RoutineStore, RunStatus, RunSummary,
 };
 use crate::routines::run_history::{read_exit_code, read_persisted_runs};
+use crate::routines::{max_concurrent_runs, MAX_CONCURRENT_RUNS_ENV};
 
 use super::service_log_tail::{read_log_tail_with_meta, LogWithMeta};
 
@@ -182,7 +185,8 @@ pub fn svc_set_power_saving(
 
 /// Spawn the launch command for `routine` under a login shell, logging (rather than failing) when
 /// the agent config cannot be loaded, the composed prompt won't fit in an inlined `{prompt}`
-/// argument, a previous fire of this routine is still running, or the process cannot be spawned.
+/// argument, a previous fire of this routine is still running, the global concurrency cap is
+/// already reached, or the process cannot be spawned.
 ///
 /// `sh -lc` sources the user's `~/.profile`, so the agent inherits their environment (`GH_TOKEN`,
 /// API keys, …) regardless of the minimal environment the daemon (or cron) runs under. Shared by the
@@ -217,6 +221,28 @@ fn spawn_routine_command(routine: &Routine) {
                      still active (overlap guard)",
                     routine.id,
                     session_prefix,
+                );
+                return;
+            }
+            // Global concurrency cap (#335): the overlap guard above only stops one routine from
+            // stacking on its own still-running fire — it does nothing to bound how many
+            // *different* routines run at once. Cron fires for every routine on a shared schedule
+            // (e.g. `*/5 * * * *`) naturally align on the same minute boundary, so an unbounded
+            // fan-out can thunder-herd the host (CPU/RAM exhaustion, provider API rate-limit
+            // bursts). Counted from actual tmux session liveness — not an in-memory counter, which
+            // would drift after a crash — via the same list-sessions seam the overlap guard above
+            // uses, just matched against every routine's shared `moadim-` prefix instead of one
+            // routine's own. Skips (rather than queues) this fire when at/over the cap: the
+            // simpler, lower-risk policy, and consistent with the overlap guard's own
+            // skip-with-warning shape above.
+            let live = tmux_session_count(TMUX_SESSION_PREFIX);
+            let cap = max_concurrent_runs();
+            if live >= cap {
+                log::warn!(
+                    "trigger: routine {:?} skipped — {live} routine session(s) already running, \
+                     at or over the global concurrency cap of {cap} (set {MAX_CONCURRENT_RUNS_ENV} \
+                     to raise it); this fire will be retried on its next scheduled tick",
+                    routine.id,
                 );
                 return;
             }

--- a/src/routines/service_trigger_tests.rs
+++ b/src/routines/service_trigger_tests.rs
@@ -379,3 +379,65 @@ fn svc_delete_syncs_crontab_on_success() {
         assert_eq!(deleted.routine.title, title);
     });
 }
+
+#[test]
+fn svc_trigger_skips_spawn_when_the_global_concurrency_cap_is_reached() {
+    // The global cap (#335) must trip even when the live sessions belong to *other* routines —
+    // unlike the per-routine overlap guard, it counts every `moadim-`-prefixed session regardless
+    // of slug. The stub reports one live session under an unrelated slug ("other"), so this
+    // routine's own overlap guard sees no match, but the cap (set to 1 below) is already at its
+    // limit and the fire must still be skipped.
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let _home = TempHome::set();
+
+    let agent_name = "svc-trigger-cap-agent-zzz";
+    std::fs::create_dir_all(crate::paths::agents_dir()).unwrap();
+    let cfg = crate::paths::agent_toml_path(agent_name);
+    std::fs::write(&cfg, "command = \"true\"\nargs = []\n").unwrap();
+
+    let title = "Svc Trigger Concurrency Cap ZZZ";
+    let dir = std::env::temp_dir().join(format!("moadim-svc-cap-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let stub = dir.join("tmux");
+    std::fs::write(
+        &stub,
+        "#!/bin/sh\nprintf 'moadim-other-1730000000_1\\n'\nexit 0\n",
+    )
+    .unwrap();
+    #[cfg(unix)]
+    std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let store = new_store();
+    let mut routine = make_routine("trig-cap-id", title, 1, 1);
+    routine.agent = agent_name.into();
+    crate::routine_storage::write_routine(&routine).unwrap();
+    store.lock().unwrap().insert("trig-cap-id".into(), routine);
+
+    let prev_tmux = std::env::var_os("MOADIM_TMUX_BIN");
+    let prev_cap = std::env::var_os("MOADIM_MAX_CONCURRENT_RUNS");
+    // SAFETY: tests in this crate run single-threaded (RUST_TEST_THREADS=1).
+    unsafe {
+        std::env::set_var("MOADIM_TMUX_BIN", &stub);
+        std::env::set_var("MOADIM_MAX_CONCURRENT_RUNS", "1");
+    }
+
+    let triggered = svc_trigger(&store, "trig-cap-id").unwrap();
+    // The trigger still records its own timestamp and returns Ok — the same non-fatal shape as the
+    // overlap guard's skip in `service_overlap_guard_tests.rs` — it's the *launch* that is skipped.
+    assert!(triggered.last_manual_trigger_at.is_some());
+
+    // SAFETY: single-threaded harness; restore the saved overrides.
+    unsafe {
+        match prev_tmux {
+            Some(value) => std::env::set_var("MOADIM_TMUX_BIN", value),
+            None => std::env::remove_var("MOADIM_TMUX_BIN"),
+        }
+        match prev_cap {
+            Some(value) => std::env::set_var("MOADIM_MAX_CONCURRENT_RUNS", value),
+            None => std::env::remove_var("MOADIM_MAX_CONCURRENT_RUNS"),
+        }
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## Problem

Every routine fire spawns its own agent run in a detached `tmux` session (`command::build_routine_command`), and nothing bounds how many may be alive across *all* routines at once. Since routines are driven by the OS crontab, many different routines' schedules naturally align on the same minute boundary (`*/5 * * * *`, `0 * * * *`, …), so a shared tick could launch an unbounded thundering herd of agent sessions — CPU/RAM exhaustion, provider API rate-limit bursts.

This is distinct from the existing per-routine overlap guard (#514, `cleanup::tmux_session_prefix_alive`): that only stops one routine from stacking on top of its own still-running fire — it does nothing to bound the total number of *different* routines running concurrently. This PR is scoped only to the new global cap; the per-routine guard is untouched.

## Fix

- New `MOADIM_MAX_CONCURRENT_RUNS` env var (`routines::concurrency_cap`), default `4`.
- `spawn_routine_command` (`routines::service_trigger`) now counts live tmux sessions sharing the `moadim-` prefix (`cleanup::tmux_session_count`, a new sibling of the existing `tmux_session_prefix_alive` seam) before launching. When the count is at or over the cap, the fire is skipped with a `log::warn!` instead of being launched.
- The live count is derived from actual tmux session liveness via `list-sessions` (the same seam the overlap guard already uses), **not** an in-memory counter — so it stays correct across a daemon crash/restart, per the issue's acceptance criteria.

## Queue vs. skip policy

Chose **skip-with-logged-reason** over queueing. The codebase's existing per-routine overlap guard already uses this exact shape (skip + `log::warn!`, fire retried on the routine's own next scheduled tick), and there's no existing queueing infrastructure anywhere in `routines/` to build on. Skip is also lower-risk: a queue would need its own eviction/ordering/starvation policy, none of which the issue's acceptance criteria require. A skipped scheduled fire is naturally retried on the next cron tick; a skipped manual trigger still returns success (the routine's own timestamp is recorded) so the caller isn't left guessing, mirroring the overlap guard's behavior exactly.

## Testing

- `routines::concurrency_cap::concurrency_cap_tests` — env var default/parse/garbage/zero-rejected (unlike `MOADIM_MAX_WORKBENCH_DISK_BYTES`, `0` is not treated as "unbounded" here, since unbounded fan-out is the bug this exists to prevent).
- `routines::cleanup::session::cleanup_tmux_tests` — new `tmux_session_count` counts only sessions matching a prefix, mocked via a `tmux` shim (no real tmux server), and reads as `0` when tmux is missing/fails.
- `routines::service::service_trigger_tests::svc_trigger_skips_spawn_when_the_global_concurrency_cap_is_reached` — end-to-end: a stubbed `tmux list-sessions` reports one live session under an *unrelated* routine's slug (so the per-routine overlap guard doesn't trip), the cap is set to 1, and the trigger is confirmed to skip the launch while still recording its own timestamp.

Verified locally:
- `cargo build` — clean
- `cargo test` — 969 passed, 0 failed
- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo llvm-cov --fail-under-lines 100` — 100% line coverage maintained
- `linecheck --max-lines 500` — all touched files under the repo's 500-line gate

## Docs

Documented `MOADIM_MAX_CONCURRENT_RUNS` and the skip policy in `README.md` (Routines section, alongside the existing disk-cap knob) and `Architecture.md`'s "Concurrency model" section.

Closes #335