### PR TITLE
chore(lint): enable clippy::unused_self, fix 3 violations

### DIFF
--- a/.changeset/enable-clippy-unused-self.md
+++ b/.changeset/enable-clippy-unused-self.md
@@ -1,0 +1,11 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::unused_self`
+
+Enables `unused_self = "deny"` to reject a `&self` method that never reads `self`. The 3 existing
+violations — `list_agents`, `get_lock_status`, and `restart` in `src/routes/mcp.rs` — are `#[tool_router]`
+MCP tool handlers whose `&self` receiver is dictated by the framework's uniform `self.method(...)`
+dispatch, not by need, so each gets a documented `#[allow(clippy::unused_self, reason = "...")]` instead
+of a signature change. No behavior change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,3 +194,9 @@ single_match_else = "deny"
 # mid-block after other code misleads the reader into thinking order matters here. Hoisting it to
 # the top of the block states that up front. The codebase is already clean, so `deny` locks that in.
 items_after_statements = "deny"
+# Reject a `&self` method that never reads `self` — it should be an associated function instead, so
+# the signature doesn't overstate what the method needs from its receiver. The handful of MCP tool
+# handlers that don't touch `self` are exempted with a documented `#[allow]`: `#[tool_router]`
+# dispatches every handler through `self.method(...)` uniformly, so `&self` there is a framework
+# requirement, not a mistake. The rest of the codebase is already clean, so `deny` locks that in.
+unused_self = "deny"

--- a/src/routes/mcp.rs
+++ b/src/routes/mcp.rs
@@ -225,6 +225,10 @@ impl MoadimMcp {
 
     /// List the available agent registry keys a routine can launch.
     #[tool(description = "List the available agent registry keys a routine can launch")]
+    #[allow(
+        clippy::unused_self,
+        reason = "tool_router dispatches every handler through self.method(...) uniformly"
+    )]
     fn list_agents(&self) -> Result<CallToolResult, rmcp::ErrorData> {
         Ok(ok(routines::available_agents()))
     }
@@ -314,6 +318,10 @@ impl MoadimMcp {
     #[tool(
         description = "Get the global routine lock status. Returns `shared` (committed .lock file), `local` (gitignored .local.lock), and `locked` (either is present)."
     )]
+    #[allow(
+        clippy::unused_self,
+        reason = "tool_router dispatches every handler through self.method(...) uniformly"
+    )]
     fn get_lock_status(&self) -> Result<CallToolResult, rmcp::ErrorData> {
         Ok(ok(crate::global_lock::lock_status()))
     }
@@ -392,6 +400,10 @@ impl MoadimMcp {
     /// `moadim restart`. Delegates to a detached helper process that performs the swap.
     #[tool(
         description = "Restart the server: stop it and start a fresh instance. Mirrors the POST /api/v1/restart route and `moadim restart`."
+    )]
+    #[allow(
+        clippy::unused_self,
+        reason = "tool_router dispatches every handler through self.method(...) uniformly"
     )]
     fn restart(&self) -> Result<CallToolResult, rmcp::ErrorData> {
         log::info!("restart requested via MCP");


### PR DESCRIPTION
## Summary

Enables `clippy::unused_self = "deny"` (continuing this repo's one-lint-per-PR pattern already used for `items_after_statements`, `format_push_string`, `single_match_else`, etc.) and fixes the 3 existing violations.

All 3 hits are `#[tool_router]` MCP tool handlers in `src/routes/mcp.rs` (`list_agents`, `get_lock_status`, `restart`) that don't read `self` in their body — but the `&self` receiver is required by the `tool_router` macro's uniform `self.method(...)` dispatch, not by the method itself. Rather than break that contract, each gets a documented `#[allow(clippy::unused_self, reason = "...")]`, consistent with this repo's `allow_attributes_without_reason = "deny"` policy.

No behavior change. Includes a `.changeset/*.md` patch note.

This pull request was opened by the "Daemon + Landing auto-improve & auto-merge lint/docs PRs" routine of moadim.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test` (962 passed)