### PR TITLE
chore(lint): enable clippy::trivially_copy_pass_by_ref

### DIFF
--- a/.changeset/enable-clippy-trivially-copy-pass-by-ref.md
+++ b/.changeset/enable-clippy-trivially-copy-pass-by-ref.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Enable `clippy::trivially_copy_pass_by_ref` (deny) to reject `&T` parameters where `T` is a small `Copy` type — pass-by-value is at least as cheap and states the callee doesn't need the caller's own reference. Codebase was already compliant, no code changes needed.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,3 +200,7 @@ items_after_statements = "deny"
 # dispatches every handler through `self.method(...)` uniformly, so `&self` there is a framework
 # requirement, not a mistake. The rest of the codebase is already clean, so `deny` locks that in.
 unused_self = "deny"
+# Reject a `&T` parameter where `T` is `Copy` and no bigger than a pointer — passing it by value is
+# at least as cheap and states the function doesn't need the caller's own reference. The codebase
+# is already clean, so `deny` locks that in.
+trivially_copy_pass_by_ref = "deny"


### PR DESCRIPTION
## What

Enables `clippy::trivially_copy_pass_by_ref` as `deny` in `Cargo.toml`'s `[lints.clippy]` section, following the established pattern of incrementally locking in pedantic clippy lints (see #1063, #1067).

## Why

The lint rejects a `&T` parameter where `T` is `Copy` and no bigger than a pointer — passing such a value by reference is never cheaper than by value, and the `&` needlessly implies the callee cares about the caller's own storage. Catching this keeps future signatures honest about ownership.

## Verification

- Codebase is already fully compliant — this is a `Cargo.toml`-only change plus a changeset, no source edits.
- `cargo clippy --workspace --all-targets --all-features` — clean.
- `cargo fmt --all -- --check` — clean.
- `cargo test --workspace` — 274 passed.

## Note

Given the backlog of stuck lint PRs tracked in #903 (many `chore(lint)` PRs conflict with each other on `Cargo.toml`), this PR is intentionally minimal (Cargo.toml + changeset only) to reduce merge-conflict surface with sibling lint PRs.