### PR TITLE
fix(routines): rotate a routine's runs.log instead of letting it grow forever

### DIFF
--- a/.changeset/rotate-run-history-log.md
+++ b/.changeset/rotate-run-history-log.md
@@ -1,0 +1,14 @@
+---
+"moadim": patch
+---
+
+fix(routines): rotate a routine's `runs.log` instead of letting it grow forever
+
+The reaper appends one durable [`PersistedRun`] record to a routine's
+`runs.log` right before reaping its workbench, with no other trim point —
+the same unbounded-growth shape already fixed for `daemon.log` (#316), just
+scoped per routine instead of per daemon. A long-lived, frequently-firing
+routine's history would otherwise grow without bound. `append_persisted_run`
+now rotates `runs.log` to a sibling `runs.log.1` (replacing any previous one)
+once it exceeds 1 MiB, mirroring `DAEMON_LOG_MAX_BYTES`'s rotate-and-replace
+approach.

--- a/src/routines/run_history.rs
+++ b/src/routines/run_history.rs
@@ -40,15 +40,40 @@ pub(crate) fn read_exit_code(workbench_path: &Path) -> Option<i32> {
         .and_then(|text| text.trim().parse::<i32>().ok())
 }
 
+/// Size at which a routine's `runs.log` is rotated to a sibling `.log.1` file (replacing any
+/// previous one) on the next append. The reaper appends one record here per finished run for the
+/// whole life of the daemon with no other trim point, so a long-lived, frequently-firing routine's
+/// history would otherwise grow unbounded — the same shape already fixed for `daemon.log` (see
+/// [`crate::cli_system::DAEMON_LOG_MAX_BYTES`], #316). A routine's `runs.log` is far smaller per
+/// entry and per-routine, so it gets a smaller cap.
+const RUN_HISTORY_MAX_BYTES: u64 = 1024 * 1024;
+
+/// Rotate `path` to a sibling `.1` file (overwriting any previous one) if it has grown past
+/// [`RUN_HISTORY_MAX_BYTES`]. Best-effort: a failed rotation (permissions, race) falls through to
+/// the caller's own `append(true)` open rather than blocking the reap sweep that triggered it.
+fn rotate_run_history_if_oversized(path: &Path) {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return;
+    };
+    if metadata.len() <= RUN_HISTORY_MAX_BYTES {
+        return;
+    }
+    let rotated_path = path.with_extension("log.1");
+    let _ = std::fs::rename(path, rotated_path);
+}
+
 /// Append `run` as one NDJSON line to routine `id`'s `runs.log`.
 ///
-/// Best-effort: a write failure (creating the routine's directory, opening the log, or the write
-/// itself — collapsed into a single chain so there is one failure path to reason about, not three)
-/// is logged and swallowed rather than blocking the reap sweep that triggered it — losing one
-/// history entry is far cheaper than a stuck cleanup loop.
+/// Rotates the log first if it's grown past [`RUN_HISTORY_MAX_BYTES`] (see
+/// [`rotate_run_history_if_oversized`]), then the append itself is best-effort: a write failure
+/// (creating the routine's directory, opening the log, or the write itself — collapsed into a
+/// single chain so there is one failure path to reason about, not three) is logged and swallowed
+/// rather than blocking the reap sweep that triggered it — losing one history entry is far
+/// cheaper than a stuck cleanup loop.
 pub(crate) fn append_persisted_run(id: &str, run: &PersistedRun) {
     let line = serde_json::to_string(run).expect("PersistedRun always serializes");
     let path = routine_run_history_path(id);
+    rotate_run_history_if_oversized(&path);
     let parent = path
         .parent()
         .expect("routine run-history path has a parent dir");

--- a/src/routines/run_history.rs
+++ b/src/routines/run_history.rs
@@ -44,7 +44,7 @@ pub(crate) fn read_exit_code(workbench_path: &Path) -> Option<i32> {
 /// previous one) on the next append. The reaper appends one record here per finished run for the
 /// whole life of the daemon with no other trim point, so a long-lived, frequently-firing routine's
 /// history would otherwise grow unbounded — the same shape already fixed for `daemon.log` (see
-/// [`crate::cli_system::DAEMON_LOG_MAX_BYTES`], #316). A routine's `runs.log` is far smaller per
+/// `DAEMON_LOG_MAX_BYTES` in `cli_system`, #316). A routine's `runs.log` is far smaller per
 /// entry and per-routine, so it gets a smaller cap.
 const RUN_HISTORY_MAX_BYTES: u64 = 1024 * 1024;
 

--- a/src/routines/run_history_tests.rs
+++ b/src/routines/run_history_tests.rs
@@ -147,6 +147,87 @@ fn has_persisted_run_true_only_for_matching_workbench() {
     assert!(!has_persisted_run("other-id", "my-routine-1000"));
 }
 
+#[test]
+fn rotate_run_history_if_oversized_is_a_no_op_when_file_is_missing() {
+    let path = std::env::temp_dir().join(format!("moadim-runs-missing-{}", uuid::Uuid::new_v4()));
+    rotate_run_history_if_oversized(&path);
+    assert!(!path.exists());
+}
+
+#[test]
+fn rotate_run_history_if_oversized_leaves_small_files_in_place() {
+    let base = std::env::temp_dir().join(format!("moadim-runs-small-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&base).unwrap();
+    let path = base.join("runs.log");
+    std::fs::write(&path, b"a few bytes").unwrap();
+
+    rotate_run_history_if_oversized(&path);
+
+    assert!(path.exists(), "file under the cap must not be rotated");
+    assert!(!path.with_extension("log.1").exists());
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[test]
+fn rotate_run_history_if_oversized_rolls_the_file_past_the_cap() {
+    let base = std::env::temp_dir().join(format!("moadim-runs-big-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&base).unwrap();
+    let path = base.join("runs.log");
+    std::fs::write(&path, vec![b'x'; (RUN_HISTORY_MAX_BYTES + 1) as usize]).unwrap();
+
+    rotate_run_history_if_oversized(&path);
+
+    assert!(
+        !path.exists(),
+        "the oversized file must be moved out of the way"
+    );
+    assert!(
+        path.with_extension("log.1").exists(),
+        "the oversized file must land at the .1 sibling"
+    );
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[test]
+fn rotate_run_history_if_oversized_replaces_a_previous_1_file() {
+    let base = std::env::temp_dir().join(format!("moadim-runs-replace-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&base).unwrap();
+    let path = base.join("runs.log");
+    std::fs::write(&path, vec![b'y'; (RUN_HISTORY_MAX_BYTES + 1) as usize]).unwrap();
+    let rotated = path.with_extension("log.1");
+    std::fs::write(&rotated, b"stale rotated content").unwrap();
+
+    rotate_run_history_if_oversized(&path);
+
+    assert!(rotated.exists());
+    assert_eq!(
+        std::fs::metadata(&rotated).unwrap().len(),
+        RUN_HISTORY_MAX_BYTES + 1,
+        "rotation must replace a stale .1 file with the freshly-rolled one"
+    );
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[test]
+fn append_persisted_run_rotates_an_oversized_log_before_appending() {
+    let _home = TempHome::set();
+    let path = crate::paths::routine_run_history_path("big-id");
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, vec![b'z'; (RUN_HISTORY_MAX_BYTES + 1) as usize]).unwrap();
+
+    append_persisted_run("big-id", &sample_run("my-routine-1000", 1000));
+
+    assert!(
+        path.with_extension("log.1").exists(),
+        "the oversized log must be rotated aside"
+    );
+    assert_eq!(
+        read_persisted_runs("big-id"),
+        vec![sample_run("my-routine-1000", 1000)],
+        "the fresh log must contain only the newly appended run, not the rotated-away content"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn append_persisted_run_creates_owner_only_log_and_dir() {


### PR DESCRIPTION
## Why

`append_persisted_run` (`src/routines/run_history.rs`) appends one durable
`PersistedRun` record to a routine's `runs.log` right before the reaper
removes its workbench, so the run's outcome survives past TTL reaping. That
log is pure append with no cap or rotation, so a long-lived daemon with a
routine that fires frequently grows `runs.log` without bound until it fills
the disk — the exact same shape already fixed for `daemon.log` in #316
(`rotate_daemon_log_if_oversized` / `DAEMON_LOG_MAX_BYTES` in
`src/cli_system.rs`), just scoped per-routine instead of per-daemon and never
applied here.

`read_persisted_runs`/`has_persisted_run` also fully read and re-parse this
file on every call (every `GET /routines/{id}/runs` and `GET /routines/runs`
request, plus once per expiring workbench during a reap sweep), so letting it
grow unbounded compounds into repeated, growing I/O — not just disk usage.

## What

Mirrors the existing `daemon.log` rotation approach: `append_persisted_run`
now checks `runs.log`'s size before appending and, once it exceeds 1 MiB,
renames it to a sibling `runs.log.1` (replacing any previous one) so the next
append starts a fresh file. Rotation is best-effort — a failed rename falls
through to the normal append rather than blocking the reap sweep that
triggered it, matching the daemon.log precedent's failure handling.

1 MiB is a generous cap relative to what's actually surfaced (the UI/API only
ever show the last ~20 runs per routine), while keeping the file bounded for
routines that run very frequently over a long-lived daemon.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (274 + 980 tests pass, including 5 new tests
      covering: no-op on missing file, no-op under the cap, rotation past the
      cap, replacing a stale `.1` file, and an end-to-end
      `append_persisted_run` rotation)
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main.rs'` — still 100%
- [x] `linecheck --max-lines 500` — both touched files stay well under the cap
- [x] Added a changeset (`.changeset/rotate-run-history-log.md`)