### PR TITLE
fix(githooks): extend test-file convention check to ui/src

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -5,6 +5,9 @@ set -e
 # Tests must live in *_tests.rs files, not inline #[cfg(test)] blocks.
 # A colocated reference is fine: `#[cfg(test)] mod foo_tests;` (semicolon).
 # Inline blocks have the form `#[cfg(test)] mod foo {` (opening brace).
+# Scans `ui/src` too (same reason as the clippy/test/linecheck steps below):
+# this is a non-virtual workspace and `ui` has its own ~250 tests, so limiting
+# this scan to `src` let an inline test block in `ui/src` slip past silently.
 echo "Checking test-file convention (tests must be in *_tests.rs files)..."
 fail=0
 
@@ -31,7 +34,7 @@ check_file() {
   return 0
 }
 
-for f in $(find src -name '*.rs' | grep -v '_tests\.rs$'); do
+for f in $(find src ui/src -name '*.rs' | grep -v '_tests\.rs$'); do
   if ! check_file "$f"; then
     fail=1
   fi


### PR DESCRIPTION
## Why

The pre-push hook's inline-`#[cfg(test)]`-block scan (`.githooks/pre-push`, step 1) only walked `find src -name '*.rs'` — it never looked at `ui/src`. This repo is a non-virtual workspace and the `ui` (Yew/WASM) crate has its own ~250 tests using the same `*_tests.rs`-sibling convention documented in CONTRIBUTING.md, but an inline `#[cfg(test)] mod foo { ... }` block landing in `ui/src` would slip past this check silently.

This is the same class of gap the clippy/test/linecheck steps immediately below it in the same script already guard against — each of those was previously scoped to `src` only and later widened to `src ui/src` for exactly this reason (see the existing comments on the lint/test/linecheck steps).

## What

- `.githooks/pre-push`: scan `find src ui/src -name '*.rs'` instead of `find src -name '*.rs'` for the test-file-convention check, with a comment explaining why.

No violations exist in `ui/src` today — verified by running the updated check (passes), then injecting a throwaway inline test block under `ui/src`, confirming the check now fails on it, then removing the injected file. Also ran the full `.githooks/pre-push` hook end-to-end locally (fmt, clippy --workspace --all-targets, test --workspace, 100%-line coverage, linecheck, changeset check) — all green.

Tooling-only change (`.githooks/`), doesn't touch `src/` or `ui/`, so no changeset is required by the changelog gate.

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.