### PR TITLE
docs(architecture): document agent.log fidelity-vs-readability goal

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -172,6 +172,15 @@ diagnostics for the steps that get the session running in the first place. Only 
 the `mkdir` itself precede the redirect — a failure that early means `$WB` may not exist yet, so
 there's nowhere to write a launch log to.
 
+`agent.log` capture optimizes for **operator readability** over raw audit fidelity: `svc_logs` /
+`svc_run_log` (`src/routines/service_log_tail.rs`) strip ANSI/VT escape sequences and collapse
+`\r`-based redraw overwrites down to the final on-screen line before serving a tail, and cap the
+served window to `MAX_LOG_TAIL_BYTES` (2 MiB, UTF-8-boundary-safe) with a `"N bytes omitted"` marker
+rather than the full file. The on-disk file itself is untouched — this is a read-time view, not a
+write-time transform — so the raw `pipe-pane` capture remains available on disk for anyone who needs
+the byte-exact record; the served view just optimizes for "what is a human looking at right now"
+over "what did the terminal literally emit."
+
 Before either path launches, the daemon checks for a live tmux session under the routine's
 `moadim-<slug>-` prefix (any `$TS` suffix) and skips the fire — logging a warning instead of
 spawning — if one is still running. This overlap guard prevents a run that outlives its schedule


### PR DESCRIPTION
## Summary
- Adds a short paragraph to `Architecture.md` recording the decision #282 asked for: `agent.log` capture optimizes for **operator readability** over raw audit fidelity.
- Cites the concrete mechanism already implementing that choice: `src/routines/service_log_tail.rs`'s ANSI-escape stripping, `\r`-redraw collapsing, and the `MAX_LOG_TAIL_BYTES` (2 MiB, UTF-8-safe) tail cap with an omitted-bytes marker.
- Notes the on-disk file is untouched — this is a read-time view, not a write-time transform — so the raw record is still recoverable on disk.

No code changes; the behavior already exists (see `service_log_tail.rs`), it just wasn't written down anywhere.

Closes #282

## Test plan
- [x] Doc-only change; `Architecture.md` is outside `src/`/`ui/`, so no changeset is required by the repo's changelog gate.
- [x] Re-read the referenced source (`service_log_tail.rs`) to confirm the description matches current behavior exactly.