### PR TITLE
fix(ci): grant id-token: write to auto-release.yml so publish.yml's OIDC job isn't capped

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -29,6 +29,13 @@ on:
 
 permissions:
   contents: write
+  # `publish.yml`'s `publish` job requests `id-token: write` for crates.io
+  # Trusted Publishing (OIDC). A reusable-workflow chain is capped by the
+  # top-level caller's `permissions:` block — any scope not listed here is
+  # `none` for every job in the chain, regardless of what a called workflow
+  # requests. Omitting `id-token` made every run since 2026-07-02 fail with
+  # `startup_failure` before a single job was created (#1049).
+  id-token: write
 
 concurrency:
   group: auto-release


### PR DESCRIPTION
## Problem

`auto-release.yml` has failed with `startup_failure` (zero jobs ever created) on every run since 2026-07-02T13:07:08Z, silently blocking releases (v0.23.0/v0.24.0/v0.25.0 never got tagged/published through automation).

## Root cause

`publish.yml`'s `publish` job requests `id-token: write` (added in #888 for crates.io Trusted Publishing/OIDC). A reusable-workflow chain's effective token permissions are capped by the **top-level caller's** `permissions:` block — any scope not explicitly listed there is `none` for every job down the chain, no matter what a called workflow itself requests. `auto-release.yml` only granted `contents: write`, so `id-token: write` was capped to `none`, and GitHub rejects the entire run before creating a single job — exactly matching the observed zero-jobs `startup_failure`.

This is a workflow-file issue, not a repo Settings/admin problem (the issue's own writeup suspected the org's default Actions token permission, but that default only applies when a workflow omits `permissions:` entirely — this one doesn't).

## Fix

Add `id-token: write` to `auto-release.yml`'s top-level `permissions:` block, raising the ceiling so `publish.yml`'s job-level request is actually satisfiable.

## Verification

- `actionlint .github/workflows/auto-release.yml` — clean.
- YAML re-parses fine.
- Confirmed via `gh api .../check-runs` that every other push-triggered workflow (Lint, Test, Doc, cargo-deny) succeeded in the same window — isolated to this release chain, consistent with a permissions-escalation rejection rather than a general Actions outage.

## Not included here (needs a human)

Backfilling the stuck releases (tagging/publishing v0.23.0, v0.24.0, v0.25.0) is a separate, irreversible action — leaving that to a maintainer to do deliberately once this fix lands and a green run is confirmed.

Closes #1049