### PR TITLE
ci: run cargo test with --workspace so ui crate tests aren't skipped

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,13 @@ jobs:
           shared-key: test
 
       - name: Run tests
-        run: cargo test
+        # Match the local pre-push hook and the `clippy` job in lint.yml:
+        # this is a non-virtual workspace (the root Cargo.toml declares both
+        # a [package] and a [workspace]), so a bare `cargo test` only runs
+        # the root `moadim` package's ~985 tests and silently skips the `ui`
+        # member crate's ~274 tests. Without `--workspace`, a PR could break
+        # every test in `ui/` and this job would still go green.
+        run: cargo test --workspace
 
   coverage:
     name: cargo llvm-cov (100% line floor)


### PR DESCRIPTION
## Why

The `test` job in [`test.yml`](.github/workflows/test.yml) runs bare
`cargo test`, which only exercises the root `moadim` package. This is a
non-virtual workspace (root `Cargo.toml` declares both `[package]` and
`[workspace]`), so a bare `cargo test` silently skips the `ui` member
crate's ~274 tests entirely — a PR that broke every test in `ui/` would
still go fully green in CI.

The sibling `clippy` job in `lint.yml` already got this exact fix (see its
comment there, added for the same reason: bare `cargo clippy` skips `ui`'s
`[lints.clippy] all = "deny"`). The `test` job never got the same
treatment. Both the local pre-push hook and CONTRIBUTING.md already
document `cargo test --workspace` as the correct invocation — CI's own
workflow just didn't follow it.

I confirmed the gap is real: `cargo test` on current `main` runs 985
tests, while `cargo test --workspace` runs 985 + 274 = 1259 (the `ui`
crate's suite is entirely absent from the smaller run).

## What

One-line fix: `cargo test` → `cargo test --workspace` in the `test` job,
with a comment mirroring the existing one in `lint.yml`.

CI-only change (`.github/workflows/test.yml`); no `src/`/`ui/` changes, so
no changeset is needed.

## Checks run locally

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 1259 passed, 0 failed
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — passes (no `src/`/`ui/` code touched)
- `linecheck --max-lines 500` — clean
- `actionlint .github/workflows/test.yml` — clean

---

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.