### PR TITLE
feat(routines): add read-only prompt-preview endpoint (#391)

### DIFF
--- a/.changeset/prompt-preview-endpoint.md
+++ b/.changeset/prompt-preview-endpoint.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Add `GET /routines/{id}/prompt-preview` (and the matching `preview_routine_prompt` MCP tool) to return the exact composed prompt body a routine's run would receive, computed in-memory with no workbench, `prompt.md` write, or agent launch. Lets operators verify repo clone bullets and prompt composition before a scheduled or manual run consumes a workbench.

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ PUT    /routines/{id}         # replace
 PATCH  /routines/{id}         # update fields
 DELETE /routines/{id}         # delete
 POST   /routines/{id}/trigger # run now, outside the schedule
+GET    /routines/{id}/prompt-preview # composed prompt body a run would receive, no run
 GET    /routines/{id}/logs    # run output
 POST   /routines/cleanup      # reap expired workbenches now
 GET    /agents                # list registered agents
@@ -213,8 +214,9 @@ GET    /routines.ics          # subscribe to fire times as a calendar feed
 ```
 
 **MCP** — the same operations are exposed as tools: `list_routines`,
-`get_routine`, `create_routine`, `update_routine`, `delete_routine`,
-`trigger_routine`, `routine_logs`, `list_agents`, and `cleanup_workbenches`.
+`get_routine`, `preview_routine_prompt`, `create_routine`, `update_routine`,
+`delete_routine`, `trigger_routine`, `routine_logs`, `list_agents`, and
+`cleanup_workbenches`.
 
 **Agents:** the `agent` field resolves to a config at
 `~/.config/moadim/agents/<agent>.toml`. API responses include

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -800,6 +800,34 @@
         }
       }
     },
+    "/routines/{id}/prompt-preview": {
+      "get": {
+        "tags": [
+          "crate::routines"
+        ],
+        "summary": "`GET /routines/{id}/prompt-preview` — the exact prompt body a run would receive, computed\nin-memory with no workbench, `prompt.md` write, or agent launch (issue #391). Does not include\nthe routine-origin disclosure written separately to `CLAUDE.md` at trigger time.",
+        "operationId": "get_prompt_preview",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Routine UUID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Composed prompt body as plain text"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
     "/routines/{id}/runs": {
       "get": {
         "tags": [

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -22,6 +22,7 @@
         crate::routines::list_agents,
         crate::routines::create,
         crate::routines::get,
+        crate::routines::get_prompt_preview,
         crate::routines::replace,
         crate::routines::update,
         crate::routines::delete,

--- a/src/routes/http.rs
+++ b/src/routes/http.rs
@@ -300,6 +300,10 @@ pub(crate) fn build_app_with_shutdown(
         )
         .route("/routines/{id}/trigger", post(routines::trigger))
         .route(
+            "/routines/{id}/prompt-preview",
+            get(routines::get_prompt_preview),
+        )
+        .route(
             "/routines/{id}/scheduled-trigger",
             post(routines::scheduled_trigger),
         )

--- a/src/routes/http_routing_tests.rs
+++ b/src/routes/http_routing_tests.rs
@@ -110,6 +110,27 @@ async fn router_routine_full_lifecycle() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
 
+    // prompt-preview (issue #391): the composed prompt body, computed with no workbench or agent
+    // launch.
+    let resp = build_app(routines.clone())
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/routines/{id}/prompt-preview"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let preview = String::from_utf8(bytes.to_vec()).unwrap();
+    // The routine's own prompt body and its declared repository both flow into the preview
+    // verbatim (see `compose_prompt`), same as they would in a real run's `prompt.md`.
+    assert!(preview.contains("- r (branch main)\n"));
+    assert!(preview.trim_end().ends_with('p'));
+
     // PATCH
     let resp = build_app(routines.clone())
         .oneshot(
@@ -409,6 +430,7 @@ async fn router_routine_not_found_paths() {
         ("DELETE", ""),
         ("POST", "/trigger"),
         ("POST", "/scheduled-trigger"),
+        ("GET", "/prompt-preview"),
         ("GET", "/logs"),
         ("GET", "/runs"),
         ("GET", "/runs/some-workbench-1/log"),

--- a/src/routes/mcp.rs
+++ b/src/routes/mcp.rs
@@ -437,5 +437,8 @@ mod mcp_lock_tests;
 #[path = "mcp_parity_tests.rs"]
 mod mcp_parity_tests;
 #[cfg(test)]
+#[path = "mcp_prompt_preview_tests.rs"]
+mod mcp_prompt_preview_tests;
+#[cfg(test)]
 #[path = "mcp_tests.rs"]
 mod mcp_tests;

--- a/src/routes/mcp.rs
+++ b/src/routes/mcp.rs
@@ -109,6 +109,23 @@ impl MoadimMcp {
         })
     }
 
+    /// Return the exact prompt body a routine's run would receive, without creating a workbench
+    /// or launching an agent.
+    #[tool(
+        description = "Preview the exact composed prompt body a routine's run would receive, without triggering a real run (no workbench, no agent launch). Does not include the routine-origin disclosure written separately to CLAUDE.md at trigger time."
+    )]
+    fn preview_routine_prompt(
+        &self,
+        Parameters(IdInput { id }): Parameters<IdInput>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        Ok(
+            match routines::svc_get_prompt_preview(&self.routines, &id) {
+                Ok(prompt) => ok(serde_json::json!({ "prompt": prompt })),
+                Err(error) => err(error),
+            },
+        )
+    }
+
     /// Validate and persist a new routine, returning the created record.
     #[tool(
         description = "Create a new routine (agent-driven job). The `schedule` cron expression is interpreted in the local system timezone of the host running the daemon, NOT UTC. The response includes a `timezone` field and a `schedule_description` annotated with that timezone — verify them to confirm the firing time."

--- a/src/routes/mcp_prompt_preview_tests.rs
+++ b/src/routes/mcp_prompt_preview_tests.rs
@@ -1,0 +1,108 @@
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and fixtures do not need doc comments"
+)]
+
+use rmcp::handler::server::wrapper::Parameters;
+
+use super::*;
+
+fn make_handler() -> MoadimMcp {
+    MoadimMcp::new(crate::routines::new_store(), 0, test_shutdown())
+}
+
+/// A throwaway shutdown signal for constructing a handler in tests; the `shutdown` tool fires it but
+/// nothing awaits it, so notifying is a harmless no-op.
+fn test_shutdown() -> crate::routes::http::ShutdownSignal {
+    std::sync::Arc::new(tokio::sync::Notify::new())
+}
+
+/// Point `MOADIM_HOME_OVERRIDE` at a fresh, empty temp home for the duration of a test, removing it
+/// on drop. With no agent TOMLs present, agent validation falls back to the built-in names (so
+/// `"claude"` is accepted) while `load_agent_command` finds no config. Tests in this crate run
+/// single-threaded per binary, so the global env mutation is safe.
+struct TempHome;
+
+impl TempHome {
+    fn set() -> Self {
+        let dir =
+            std::env::temp_dir().join(format!("moadim-mcp-preview-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).expect("create temp home");
+        // SAFETY: single-threaded test execution.
+        unsafe {
+            std::env::set_var("MOADIM_HOME_OVERRIDE", &dir);
+        }
+        Self
+    }
+}
+
+impl Drop for TempHome {
+    fn drop(&mut self) {
+        // SAFETY: single-threaded test execution.
+        unsafe {
+            std::env::remove_var("MOADIM_HOME_OVERRIDE");
+        }
+    }
+}
+
+/// `preview_routine_prompt`'s `Err` branch (issue #391): an unknown routine ID surfaces as an
+/// error `CallToolResult`, mirroring `get_routine_not_found_is_error`.
+#[test]
+fn preview_routine_prompt_not_found_is_error() {
+    let handler = make_handler();
+    let result = handler
+        .preview_routine_prompt(Parameters(IdInput {
+            id: "no-such".into(),
+        }))
+        .unwrap();
+    assert!(result.is_error.unwrap_or(false));
+}
+
+/// `preview_routine_prompt`'s `Ok` branch: the composed prompt body for a real routine, with no
+/// workbench created and no agent launched.
+#[test]
+fn preview_routine_prompt_success_contains_prompt() {
+    let _home = TempHome::set();
+    let handler = make_handler();
+
+    let create_result = handler
+        .create_routine(Parameters(crate::routines::CreateRoutineRequest {
+            model: None,
+            schedule: "@daily".into(),
+            title: "Preview Routine".into(),
+            agent: "claude".into(),
+            prompt: "do the thing".into(),
+            goal: None,
+            repositories: vec![],
+            machines: vec![crate::machine::current_machine()],
+            enabled: true,
+            ttl_secs: None,
+            max_runtime_secs: None,
+            tags: vec![],
+        }))
+        .unwrap();
+    assert!(!create_result.is_error.unwrap_or(false));
+    let text = match &create_result.content[0] {
+        rmcp::model::ContentBlock::Text(txt) => txt.text.clone(),
+        _ => panic!("expected text content"),
+    };
+    let id = serde_json::from_str::<serde_json::Value>(&text).unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let result = handler
+        .preview_routine_prompt(Parameters(IdInput { id }))
+        .unwrap();
+    assert!(!result.is_error.unwrap_or(false));
+    let text = match &result.content[0] {
+        rmcp::model::ContentBlock::Text(txt) => txt.text.clone(),
+        _ => panic!("expected text content"),
+    };
+    let preview: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert!(preview["prompt"]
+        .as_str()
+        .unwrap()
+        .trim_end()
+        .ends_with("do the thing"));
+}

--- a/src/routines/handlers.rs
+++ b/src/routines/handlers.rs
@@ -18,9 +18,9 @@ use super::model::{
     RoutineListQuery, RoutineResponse, RoutineStore, RunSummary, UpdateRoutineRequest,
 };
 use super::service::{
-    svc_cleanup, svc_create, svc_create_flag, svc_delete, svc_get, svc_list, svc_list_all_runs,
-    svc_list_flags, svc_list_runs, svc_logs, svc_resolve_flag, svc_run_log, svc_run_summary,
-    svc_trigger, svc_trigger_scheduled, svc_update,
+    svc_cleanup, svc_create, svc_create_flag, svc_delete, svc_get, svc_get_prompt_preview,
+    svc_list, svc_list_all_runs, svc_list_flags, svc_list_runs, svc_logs, svc_resolve_flag,
+    svc_run_log, svc_run_summary, svc_trigger, svc_trigger_scheduled, svc_update,
 };
 
 /// Request body for `POST /routines/{id}/flags`.
@@ -162,6 +162,19 @@ pub async fn get(
     Path(id): Path<String>,
 ) -> Result<Json<RoutineResponse>, AppError> {
     Ok(Json(svc_get(&store, &id)?))
+}
+
+/// `GET /routines/{id}/prompt-preview` — the exact prompt body a run would receive, computed
+/// in-memory with no workbench, `prompt.md` write, or agent launch (issue #391). Does not include
+/// the routine-origin disclosure written separately to `CLAUDE.md` at trigger time.
+#[utoipa::path(get, path = "/routines/{id}/prompt-preview",
+    params(("id" = String, Path, description = "Routine UUID")),
+    responses((status = 200, description = "Composed prompt body as plain text"), (status = 404, description = "Not found")))]
+pub async fn get_prompt_preview(
+    State(store): State<RoutineStore>,
+    Path(id): Path<String>,
+) -> Result<String, AppError> {
+    svc_get_prompt_preview(&store, &id)
 }
 
 /// `PATCH /routines/{id}` — partially update a routine.

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -412,7 +412,7 @@ pub use service_trigger::{
 
 #[path = "service_run_files.rs"]
 mod service_run_files;
-pub use service_run_files::{svc_run_log, svc_run_summary};
+pub use service_run_files::{svc_get_prompt_preview, svc_run_log, svc_run_summary};
 
 #[path = "service_trigger_flags.rs"]
 mod service_trigger_flags;

--- a/src/routines/service_prompt_preview_tests.rs
+++ b/src/routines/service_prompt_preview_tests.rs
@@ -1,0 +1,78 @@
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and fixtures do not need doc comments"
+)]
+
+use super::*;
+use crate::routines::model::{new_store, Repository, Routine};
+
+fn make_routine(id: &str, repositories: Vec<Repository>) -> Routine {
+    Routine {
+        model: None,
+        id: id.to_string(),
+        schedule: "@daily".to_string(),
+        title: "My Routine".to_string(),
+        agent: "claude".to_string(),
+        prompt: "do the thing".to_string(),
+        goal: None,
+        repositories,
+        machines: vec![crate::machine::current_machine()],
+        enabled: true,
+        source: "managed".to_string(),
+        created_at: 0,
+        updated_at: 0,
+        last_manual_trigger_at: None,
+        last_scheduled_trigger_at: None,
+        snoozed_until: None,
+        skip_runs: None,
+        power_saving: false,
+        tags: vec![],
+        ttl_secs: None,
+        max_runtime_secs: None,
+    }
+}
+
+#[test]
+fn preview_matches_compose_prompt_with_no_repositories() {
+    let routine = make_routine("no-repos", vec![]);
+    let store = new_store();
+    store
+        .lock_recover()
+        .insert(routine.id.clone(), routine.clone());
+
+    let preview = svc_get_prompt_preview(&store, "no-repos").expect("routine exists");
+    assert_eq!(preview, compose_prompt(&routine));
+    assert!(preview.contains("You are working in an empty directory.\n"));
+}
+
+#[test]
+fn preview_matches_compose_prompt_with_repositories() {
+    let routine = make_routine(
+        "with-repos",
+        vec![
+            Repository {
+                repository: "https://github.com/octocat/Hello-World".to_string(),
+                branch: None,
+            },
+            Repository {
+                repository: "https://github.com/octocat/Spoon-Knife".to_string(),
+                branch: Some("main".to_string()),
+            },
+        ],
+    );
+    let store = new_store();
+    store
+        .lock_recover()
+        .insert(routine.id.clone(), routine.clone());
+
+    let preview = svc_get_prompt_preview(&store, "with-repos").expect("routine exists");
+    assert_eq!(preview, compose_prompt(&routine));
+    assert!(preview.contains("- https://github.com/octocat/Hello-World\n"));
+    assert!(preview.contains("- https://github.com/octocat/Spoon-Knife (branch main)\n"));
+}
+
+#[test]
+fn preview_not_found_for_unknown_id() {
+    let store = new_store();
+    assert!(svc_get_prompt_preview(&store, "missing").is_err());
+}

--- a/src/routines/service_run_files.rs
+++ b/src/routines/service_run_files.rs
@@ -1,9 +1,10 @@
-//! Per-run file reads: a specific run's `agent.log` tail and agent-authored `summary.md`.
+//! Per-run file reads: a specific run's `agent.log` tail and agent-authored `summary.md`, plus a
+//! side-effect-free preview of the composed prompt a run would receive.
 
 use crate::error::AppError;
 use crate::paths::workbenches_dir;
 use crate::routines::cleanup::parse_workbench_name;
-use crate::routines::command::slugify;
+use crate::routines::command::{compose_prompt, slugify};
 use crate::routines::model::RoutineStore;
 use crate::utils::lock::LockRecover;
 
@@ -56,3 +57,22 @@ pub fn svc_run_summary(
 ) -> Result<String, AppError> {
     svc_run_file(store, id, workbench, "summary.md")
 }
+
+/// Compose the exact body an agent run would receive for routine `id`, without creating a
+/// workbench, writing `prompt.md`, or launching an agent (issue #391). Mirrors `svc_get`'s lookup,
+/// but returns the *derived* prompt body instead of the stored routine fields.
+///
+/// Does not include the routine-origin disclosure written separately to `CLAUDE.md` at trigger
+/// time — that isn't part of [`compose_prompt`], so it isn't part of this preview either.
+pub fn svc_get_prompt_preview(store: &RoutineStore, id: &str) -> Result<String, AppError> {
+    let routine = store
+        .lock_recover()
+        .get(id)
+        .cloned()
+        .ok_or(AppError::NotFound)?;
+    Ok(compose_prompt(&routine))
+}
+
+#[cfg(test)]
+#[path = "service_prompt_preview_tests.rs"]
+mod service_prompt_preview_tests;


### PR DESCRIPTION
## What

Adds `GET /routines/{id}/prompt-preview` and the matching MCP tool `preview_routine_prompt`, both returning `compose_prompt(routine)` — the exact body an agent run would receive — computed **in-memory**, with no workbench creation, `prompt.md` write, or agent launch.

## Why

Today the composed prompt body (the `# Workbench` preamble + per-repo clone bullets, prepended to the stored `routine.prompt`) is only materialized when a run actually fires. There is no way to see what an agent will receive without triggering a real run or reading `prompt.md` off disk on the host. This is exactly the surface where a class of already-fixed prompt-composition bugs manifested (#237 preamble emitted with no repos, #241 blank-repo clone bullet, #262 non-ASCII handling) — a side-effect-free preview turns prompt composition into something operators (and MCP-driving agents) can verify *before* a scheduled or manual run consumes a workbench and an agent session.

Closes #391 (REST + MCP surface; OpenAPI/README updated). The response is the `prompt.md` body only — it does not include the routine-origin disclosure written separately to `CLAUDE.md` at trigger time, which is called out explicitly in the doc comments.

## Implementation

- `svc_get_prompt_preview` in `src/routines/service_run_files.rs` — looks up the routine and calls the existing `compose_prompt`, mirroring `svc_get`'s lookup pattern. (Placed here rather than a new module/`service.rs` itself, since `service.rs` is already at the 500-line linecheck gate.)
- `GET /routines/{id}/prompt-preview` handler + route registration, following the exact pattern of `GET /routines/{id}/logs` (plain-text response, 404 on unknown id).
- `preview_routine_prompt` MCP tool, following the `get_routine`/`routine_logs` tool pattern.
- OpenAPI spec (`apis/openapi.json`, regenerated) and README (REST + MCP tool lists) updated.
- Tests: preview matches `compose_prompt` byte-for-byte for a routine with 0 repositories and with repositories (including a branch-qualified repo), plus a 404-on-unknown-id case.

## Verification

- `cargo fmt --check` — pass
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — pass
- `cargo test --workspace` — 988 + 274 passed, 0 failed (includes the openapi spec self-heal + re-verify round trip)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items` — pass
- `linecheck --max-lines 500` over `src/` + `ui/src/` — pass

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.