### PR TITLE
chore(lint): enable clippy::match_same_arms in the ui crate

### DIFF
--- a/.changeset/enable-clippy-match-same-arms-ui.md
+++ b/.changeset/enable-clippy-match-same-arms-ui.md
@@ -1,0 +1,14 @@
+---
+"moadim": patch
+---
+
+### Changed
+
+chore(lint): enable `clippy::match_same_arms` in the `ui` crate
+
+Adds `match_same_arms = "deny"` to `ui/Cargo.toml`'s `[lints.clippy]` table, matching the lint
+already denied workspace-root-side in `Cargo.toml` — the `ui` crate has its own `[lints]` table (no
+`workspace = true` inheritance) so it silently escaped this despite CI's `clippy` job running
+`--workspace`. Fixes the 5 violations this surfaced in `routines/filter.rs`: each facet's explicit
+`Facet::All`/`Facet::Any` match arm did nothing that the trailing wildcard arm didn't already do, so
+they're removed as dead code. No behavior change.

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -63,3 +63,11 @@ needless_pass_by_ref_mut = "deny"
 # `log_viewer.rs`, `overview_recent_runs.rs`, `routines/form.rs`, `routines/history.rs`, and
 # `routines/hooks.rs`.
 map_unwrap_or = "deny"
+# Reject `match` arms with identical bodies — either the arm is dead code already covered by
+# another pattern, or the duplication is an unintentional bug where the bodies were meant to
+# differ. Kept in lockstep with the same lint already enabled workspace-root-side in Cargo.toml —
+# the `ui` crate has its own `[lints]` table (no `workspace = true` inheritance) so it was silently
+# exempt despite `clippy --workspace` covering it in CI. Fixes the 5 violations this surfaced in
+# `routines/filter.rs`, where each facet's explicit `Facet::All`/`Facet::Any` arm did nothing that
+# the trailing wildcard arm didn't already do.
+match_same_arms = "deny"

--- a/ui/src/routines/filter.rs
+++ b/ui/src/routines/filter.rs
@@ -217,7 +217,6 @@ impl RoutineFilter {
     #[must_use]
     pub fn matches(&self, r: &Routine, now: DateTime<Local>, window: Duration) -> bool {
         match self.status {
-            RoutineStatusFacet::All => {}
             RoutineStatusFacet::Enabled if !r.enabled => return false,
             RoutineStatusFacet::Disabled if r.enabled => return false,
             RoutineStatusFacet::Dormant if !(r.enabled && r.machines.is_empty()) => return false,
@@ -232,25 +231,21 @@ impl RoutineFilter {
             _ => {}
         }
         match &self.agent {
-            AgentFacet::All => {}
             AgentFacet::Named(a) if r.agent != *a => return false,
             _ => {}
         }
         match &self.machine {
-            RoutineMachineFacet::Any => {}
             RoutineMachineFacet::Unassigned if !r.machines.is_empty() => return false,
             RoutineMachineFacet::Machine(m) if !r.machines.iter().any(|x| x == m) => return false,
             _ => {}
         }
         match &self.repository {
-            RepositoryFacet::All => {}
             RepositoryFacet::Named(rp) if !r.repositories.iter().any(|x| x.repository == *rp) => {
                 return false
             }
             _ => {}
         }
         match &self.tag {
-            TagFacet::All => {}
             TagFacet::Named(t) if !r.tags.iter().any(|x| x == t) => return false,
             _ => {}
         }


### PR DESCRIPTION
## Summary

The workspace root (`Cargo.toml`) already denies `clippy::match_same_arms` (match arms with identical bodies are either dead code or an unintentional bug where the bodies were meant to differ). The `ui` crate has its own `[lints.clippy]` table with no `workspace = true` inheritance, so this lint was silently exempt for `ui/src` despite CI's `clippy` job running `--workspace`.

This PR:
- Adds `match_same_arms = "deny"` to `ui/Cargo.toml`'s `[lints.clippy]` table.
- Fixes the 5 violations it surfaced in `ui/src/routines/filter.rs`: each facet (`RoutineStatusFacet`, `AgentFacet`, `RoutineMachineFacet`, `RepositoryFacet`, `TagFacet`) had an explicit `Facet::All`/`Facet::Any => {}` arm whose body did nothing that the trailing wildcard `_ => {}` arm didn't already do, so they're removed as dead code. No behavior change — verified by the existing `filter.rs` unit tests, which continue to pass unchanged.

Checked the ~26 open PRs and recent git history first to confirm this specific lint isn't already covered by an open PR (only `clippy::unused_async` for the `ui` crate is currently open, in #1079) or already enabled in `ui/Cargo.toml`.

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (985 root + 274 ui tests, all passing)
- [x] `linecheck --max-lines 500` over `src/` and `ui/src/`
- [x] Added `.changeset/enable-clippy-match-same-arms-ui.md` (this PR only touches `ui/`, not root `src/`, so the 100%-coverage gate on the root package is unaffected)