### PR TITLE
fix(routines): run trigger/scheduled-trigger/cleanup handlers on spawn_blocking (#360)

### DIFF
--- a/.changeset/fix-blocking-trigger-cleanup-worker-threads.md
+++ b/.changeset/fix-blocking-trigger-cleanup-worker-threads.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Move `POST /routines/{id}/trigger`, `/scheduled-trigger`, and `/routines/cleanup` off the async worker thread. These handlers call `svc_trigger`/`svc_trigger_scheduled`/`svc_cleanup`, which shell out to `tmux`(1) and do blocking filesystem I/O; they previously ran inline on the Tokio worker thread instead of `spawn_blocking`, unlike the sibling create/update/delete/lock/unlock handlers. A hung `tmux` call (or a `*/N` scheduled-trigger herd) could stall unrelated requests such as `GET /health`.

--- a/src/routines/handlers.rs
+++ b/src/routines/handlers.rs
@@ -224,7 +224,13 @@ pub async fn trigger(
     State(store): State<RoutineStore>,
     Path(id): Path<String>,
 ) -> Result<Json<Routine>, AppError> {
-    Ok(Json(svc_trigger(&store, &id)?))
+    // `svc_trigger` shells out to `tmux`(1) (overlap guard, concurrency cap, session spawn) and
+    // does blocking fs I/O — keep that off the async worker thread (#360), same as create/update/
+    // delete above.
+    let resp = tokio::task::spawn_blocking(move || svc_trigger(&store, &id))
+        .await
+        .map_err(|_| AppError::Internal)??;
+    Ok(Json(resp))
 }
 
 /// `POST /routines/{id}/scheduled-trigger` — run a routine on its schedule.
@@ -239,7 +245,13 @@ pub async fn scheduled_trigger(
     State(store): State<RoutineStore>,
     Path(id): Path<String>,
 ) -> Result<Json<Routine>, AppError> {
-    Ok(Json(svc_trigger_scheduled(&store, &id)?))
+    // See `trigger` above: `svc_trigger_scheduled` shells out to `tmux`(1) too (#360). This is
+    // the endpoint the generated crontab line invokes, so a `*/N` herd of scheduled fires is
+    // exactly the thundering-herd case #360 is about.
+    let resp = tokio::task::spawn_blocking(move || svc_trigger_scheduled(&store, &id))
+        .await
+        .map_err(|_| AppError::Internal)??;
+    Ok(Json(resp))
 }
 
 /// `GET /routines.ics` — iCalendar feed of every enabled routine's upcoming fire times.
@@ -269,7 +281,17 @@ pub async fn ical_feed(
 #[utoipa::path(post, path = "/routines/cleanup",
     responses((status = 200, body = CleanupResponse, description = "Workbenches removed and bytes freed")))]
 pub async fn cleanup(State(store): State<RoutineStore>) -> Json<CleanupResponse> {
-    Json(svc_cleanup(&store))
+    // `svc_cleanup` does blocking fs scans and shells out to `tmux`(1) to kill hung sessions
+    // (#360) — the background hourly sweep (`http_listener::cleanup_task`) already runs this on
+    // `spawn_blocking`; this on-demand endpoint should not run it inline on the worker thread
+    // either.
+    tokio::task::spawn_blocking(move || svc_cleanup(&store))
+        .await
+        .unwrap_or(CleanupResponse {
+            removed: 0,
+            freed_bytes: 0,
+        })
+        .into()
 }
 
 /// `POST /routines/{id}/flags` — raise a new flag against a routine.


### PR DESCRIPTION
## Why

Issue #360 identified that several `async` HTTP handlers do blocking subprocess/fs I/O directly on the Tokio worker thread. The `POST /routines` (create), update, delete, lock, and unlock handlers were already fixed to use `spawn_blocking` (they even carry `#360` comments), but three sibling handlers were missed:

- `POST /routines/{id}/trigger` → `svc_trigger`
- `POST /routines/{id}/scheduled-trigger` → `svc_trigger_scheduled`
- `POST /routines/cleanup` → `svc_cleanup`

`svc_trigger`/`svc_trigger_scheduled` shell out to `tmux`(1) synchronously (overlap guard, global concurrency-cap check, session spawn) and `svc_cleanup` does blocking directory scans plus `tmux`(1) calls to kill hung sessions — all invoked inline in the `async fn` handler body.

`scheduled-trigger` is the exact endpoint the generated crontab line invokes (`moadim schedule trigger <id>`), so a `*/N` schedule firing many routines on the same minute is precisely the thundering-herd scenario #360's motivation describes: enough blocked worker threads could stall unrelated requests like `GET /health`.

Notably, the background hourly cleanup sweep (`http_listener::cleanup_task`) already wraps the identical `cleanup_expired_workbenches` call in `spawn_blocking` — the on-demand `POST /routines/cleanup` HTTP handler was the inconsistent one.

## What changed

Wrapped all three handlers' service calls in `tokio::task::spawn_blocking`, mirroring the exact pattern already used by `create`/`update`/`delete`/`lock`/`unlock` in the same file.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --bin moadim routines::handlers` (existing tests pass)
- [x] `cargo test --bin moadim service_trigger` (existing tests pass)
- [x] `cargo test --bin moadim http_routing` — including `router_routine_full_lifecycle` (exercises trigger) and `router_routines_cleanup_returns_removed_count` (exercises cleanup), both still pass end-to-end through the real router

No behavior change — same responses, just off the async worker thread.