### PR TITLE
fix(routines): guard write_routine against a stale on-disk slug collision (#188)

### DIFF
--- a/.changeset/fix-routine-slug-collision-guard.md
+++ b/.changeset/fix-routine-slug-collision-guard.md
@@ -1,0 +1,7 @@
+---
+"moadim": patch
+---
+
+fix(routines): guard `write_routine` against a stale on-disk slug collision (#188)
+
+Two distinct routine titles can slugify to the same folder name (e.g. `"Update deps!"` and `"Update deps?"` both become `update-deps`). The in-memory create/update handlers already reject that when both routines are loaded, but a slug could also collide with a stale `routine.toml` left on disk by something outside the in-memory store (e.g. a directory `remove_routine_dir` failed to clean up) — and `write_routine` would silently overwrite it, including the wrong `prompt.md` a scheduled run then executes. `write_routine` now checks the target slug's existing `routine.toml` id before writing and refuses to overwrite a different routine's files, surfaced as a 409 Conflict instead of a 500 at the `create`/`update` API handlers.

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -462,3 +462,7 @@ mod routine_storage_trigger_log_migration_tests;
 #[cfg(test)]
 #[path = "routine_storage_sidecar_state_tests.rs"]
 mod routine_storage_sidecar_state_tests;
+
+#[cfg(test)]
+#[path = "routine_storage_slug_collision_tests.rs"]
+mod routine_storage_slug_collision_tests;

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -235,9 +235,29 @@ fn ensure_routine_gitignore(path: &std::path::Path) -> std::io::Result<()> {
 /// stored inside `routine.toml` so it survives a rename. Daemon-written runtime state
 /// (`last_manual_trigger_at`) goes to the sidecar, not `routine.toml`, so a trigger never churns the
 /// version-controlled config file.
+///
+/// Two distinct titles can slugify to the same folder name (e.g. `"Update deps!"` and
+/// `"Update deps?"` both become `update-deps`). In-memory create/update handlers already reject
+/// that when both routines are loaded in the [`RoutineStore`], but a slug can also collide with a
+/// stale on-disk `routine.toml` that isn't (or is no longer) in memory — e.g. a directory left
+/// behind by a failed [`remove_routine_dir`]. Guard here too, as the last line of defense against
+/// silently overwriting another routine's files (#188): refuse to write when the target slug's
+/// `routine.toml` already exists and belongs to a different `id`.
 pub fn write_routine(routine: &Routine) -> std::io::Result<()> {
     let slug = slugify(&routine.title);
     let dir = routine_dir(&slug);
+    if let Some(existing_id) =
+        read_routine_toml(&routine_toml_path(&slug)).and_then(|existing| existing.id)
+    {
+        if existing_id != routine.id {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                format!(
+                    "slug \"{slug}\" is already used on disk by routine {existing_id}; refusing to overwrite it"
+                ),
+            ));
+        }
+    }
     crate::utils::fs_perms::create_private_dir_all(&dir)?;
     crate::utils::fs_perms::create_private_dir_all(&routine_prompts_dir(&slug))?;
 

--- a/src/routine_storage_slug_collision_tests.rs
+++ b/src/routine_storage_slug_collision_tests.rs
@@ -1,0 +1,94 @@
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and fixtures do not need doc comments"
+)]
+
+use super::*;
+use crate::routines::{slugify, Repository, Routine};
+
+fn scratch_dir(tag: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!("moadim-rs-{tag}-{}", uuid::Uuid::new_v4()))
+}
+
+fn with_override_home(body: impl FnOnce(&std::path::Path)) {
+    let home = scratch_dir("override-home");
+    std::fs::create_dir_all(&home).unwrap();
+    let previous = std::env::var_os("MOADIM_HOME_OVERRIDE");
+    // SAFETY: tests in this crate run single-threaded per binary.
+    unsafe {
+        std::env::set_var("MOADIM_HOME_OVERRIDE", &home);
+    }
+    body(&home);
+    unsafe {
+        match previous {
+            Some(value) => std::env::set_var("MOADIM_HOME_OVERRIDE", value),
+            None => std::env::remove_var("MOADIM_HOME_OVERRIDE"),
+        }
+    }
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+fn make_routine(id: &str, title: &str) -> Routine {
+    Routine {
+        model: None,
+        id: id.to_string(),
+        schedule: "@daily".to_string(),
+        title: title.to_string(),
+        agent: "claude".to_string(),
+        prompt: "task".to_string(),
+        goal: None,
+        repositories: vec![Repository {
+            repository: "https://example.com/r.git".to_string(),
+            branch: Some("main".to_string()),
+        }],
+        machines: vec![crate::machine::current_machine()],
+        enabled: true,
+        source: "managed".to_string(),
+        created_at: 5,
+        updated_at: 6,
+        last_manual_trigger_at: None,
+        last_scheduled_trigger_at: None,
+        snoozed_until: None,
+        skip_runs: None,
+        power_saving: false,
+        tags: vec![],
+        ttl_secs: None,
+        max_runtime_secs: None,
+    }
+}
+
+#[test]
+fn write_routine_rejects_slug_collision_with_a_different_id() {
+    // Two distinct titles that slugify to the same folder name (#188) must not let the second
+    // write silently clobber the first routine's on-disk files.
+    with_override_home(|_home| {
+        let title = "Update deps!";
+        let other_title = "Update deps?";
+        assert_eq!(slugify(title), slugify(other_title));
+
+        write_routine(&make_routine("rs-collision-a", title)).unwrap();
+        let err = write_routine(&make_routine("rs-collision-b", other_title)).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
+
+        // The first routine's file must be untouched.
+        let slug = slugify(title);
+        let loaded = load_routine_from_dir(&slug).unwrap();
+        assert_eq!(loaded.id, "rs-collision-a");
+    });
+}
+
+#[test]
+fn write_routine_allows_rewriting_its_own_slug() {
+    // The same routine (same id) writing to its own slug again — e.g. an update that doesn't
+    // change the title — must not trip the collision guard.
+    with_override_home(|_home| {
+        let title = "Rs Rewrite Routine";
+        let mut routine = make_routine("rs-rewrite-id", title);
+        write_routine(&routine).unwrap();
+        routine.updated_at = 99;
+        write_routine(&routine).unwrap();
+
+        let loaded = load_routine_from_dir(&slugify(title)).unwrap();
+        assert_eq!(loaded.updated_at, 99);
+    });
+}

--- a/src/routine_storage_tests.rs
+++ b/src/routine_storage_tests.rs
@@ -114,6 +114,42 @@ fn write_then_load_round_trips() {
 }
 
 #[test]
+fn write_routine_rejects_slug_collision_with_a_different_id() {
+    // Two distinct titles that slugify to the same folder name (#188) must not let the second
+    // write silently clobber the first routine's on-disk files.
+    with_override_home(|_home| {
+        let title = "Update deps!";
+        let other_title = "Update deps?";
+        assert_eq!(slugify(title), slugify(other_title));
+
+        write_routine(&make_routine("rs-collision-a", title)).unwrap();
+        let err = write_routine(&make_routine("rs-collision-b", other_title)).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
+
+        // The first routine's file must be untouched.
+        let slug = slugify(title);
+        let loaded = load_routine_from_dir(&slug).unwrap();
+        assert_eq!(loaded.id, "rs-collision-a");
+    });
+}
+
+#[test]
+fn write_routine_allows_rewriting_its_own_slug() {
+    // The same routine (same id) writing to its own slug again — e.g. an update that doesn't
+    // change the title — must not trip the collision guard.
+    with_override_home(|_home| {
+        let title = "Rs Rewrite Routine";
+        let mut routine = make_routine("rs-rewrite-id", title);
+        write_routine(&routine).unwrap();
+        routine.updated_at = 99;
+        write_routine(&routine).unwrap();
+
+        let loaded = load_routine_from_dir(&slugify(title)).unwrap();
+        assert_eq!(loaded.updated_at, 99);
+    });
+}
+
+#[test]
 fn tags_round_trip_through_routine_toml() {
     // Tags are persisted to the tracked `routine.toml` and read back on load.
     let title = "Rs Tags Routine";

--- a/src/routine_storage_tests.rs
+++ b/src/routine_storage_tests.rs
@@ -114,42 +114,6 @@ fn write_then_load_round_trips() {
 }
 
 #[test]
-fn write_routine_rejects_slug_collision_with_a_different_id() {
-    // Two distinct titles that slugify to the same folder name (#188) must not let the second
-    // write silently clobber the first routine's on-disk files.
-    with_override_home(|_home| {
-        let title = "Update deps!";
-        let other_title = "Update deps?";
-        assert_eq!(slugify(title), slugify(other_title));
-
-        write_routine(&make_routine("rs-collision-a", title)).unwrap();
-        let err = write_routine(&make_routine("rs-collision-b", other_title)).unwrap_err();
-        assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
-
-        // The first routine's file must be untouched.
-        let slug = slugify(title);
-        let loaded = load_routine_from_dir(&slug).unwrap();
-        assert_eq!(loaded.id, "rs-collision-a");
-    });
-}
-
-#[test]
-fn write_routine_allows_rewriting_its_own_slug() {
-    // The same routine (same id) writing to its own slug again — e.g. an update that doesn't
-    // change the title — must not trip the collision guard.
-    with_override_home(|_home| {
-        let title = "Rs Rewrite Routine";
-        let mut routine = make_routine("rs-rewrite-id", title);
-        write_routine(&routine).unwrap();
-        routine.updated_at = 99;
-        write_routine(&routine).unwrap();
-
-        let loaded = load_routine_from_dir(&slugify(title)).unwrap();
-        assert_eq!(loaded.updated_at, 99);
-    });
-}
-
-#[test]
 fn tags_round_trip_through_routine_toml() {
     // Tags are persisted to the tracked `routine.toml` and read back on load.
     let title = "Rs Tags Routine";

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -30,6 +30,16 @@ use service_validate::{
     validate_title,
 };
 
+/// Map a [`write_routine`] failure to an [`AppError`], turning the on-disk slug-collision guard
+/// (#188, `ErrorKind::AlreadyExists`) into a 409 the caller can act on instead of a generic 500.
+fn map_write_routine_err(err: &std::io::Error) -> AppError {
+    if err.kind() == std::io::ErrorKind::AlreadyExists {
+        AppError::Conflict(err.to_string())
+    } else {
+        AppError::Internal
+    }
+}
+
 /// Sort key placing routines with a repository before those without, then by
 /// the primary (first) repository URL alphabetically (case-insensitive).
 fn repo_sort_key(routine: &Routine) -> (bool, String) {
@@ -184,7 +194,7 @@ pub fn svc_create(
         max_runtime_secs: req.max_runtime_secs,
         tags,
     };
-    write_routine(&routine).map_err(|_| AppError::Internal)?;
+    write_routine(&routine).map_err(|err| map_write_routine_err(&err))?;
     store
         .lock_recover()
         .insert(routine.id.clone(), routine.clone());
@@ -317,7 +327,7 @@ pub fn svc_update(
     let routine = routine.clone();
     drop(lock);
     let new_slug = slugify(&routine.title);
-    write_routine(&routine).map_err(|_| AppError::Internal)?;
+    write_routine(&routine).map_err(|err| map_write_routine_err(&err))?;
     if new_slug != old_slug {
         migrate_workbenches(&old_slug, &new_slug);
         remove_routine_dir(&old_slug).map_err(|_| AppError::Internal)?;

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -25,20 +25,10 @@ mod service_validate;
 #[cfg(test)]
 use service_validate::MAX_TITLE_LEN;
 use service_validate::{
-    normalize_model, reject_blank, reject_over_ceiling, reject_zero_secs, validate_agent,
-    validate_goal, validate_machines, validate_prompt, validate_repositories, validate_tags,
-    validate_title,
+    map_write_routine_err, normalize_model, reject_blank, reject_over_ceiling, reject_zero_secs,
+    validate_agent, validate_goal, validate_machines, validate_prompt, validate_repositories,
+    validate_tags, validate_title,
 };
-
-/// Map a [`write_routine`] failure to an [`AppError`], turning the on-disk slug-collision guard
-/// (#188, `ErrorKind::AlreadyExists`) into a 409 the caller can act on instead of a generic 500.
-fn map_write_routine_err(err: &std::io::Error) -> AppError {
-    if err.kind() == std::io::ErrorKind::AlreadyExists {
-        AppError::Conflict(err.to_string())
-    } else {
-        AppError::Internal
-    }
-}
 
 /// Sort key placing routines with a repository before those without, then by
 /// the primary (first) repository URL alphabetically (case-insensitive).

--- a/src/routines/service_tests.rs
+++ b/src/routines/service_tests.rs
@@ -376,6 +376,29 @@ fn svc_create_rejects_agent_config_without_prompt_placeholder() {
 }
 
 #[test]
+fn svc_create_maps_an_on_disk_slug_collision_to_conflict() {
+    // #188: a stale `routine.toml` left on disk (e.g. by a directory `remove_routine_dir` failed
+    // to clean up) isn't in the in-memory store, so the store-level collision check above passes.
+    // `write_routine`'s own on-disk guard still catches it, and `svc_create` must surface that as
+    // a 409 `Conflict` (via `map_write_routine_err`), not a 500 `Internal`.
+    let _home = TempHome::set();
+    let title = "Svc Create Disk Collision ZZZ";
+    let stale = make_routine("stale-on-disk-id", title, 1, 1);
+    crate::routine_storage::write_routine(&stale).unwrap();
+
+    let store = new_store();
+    let mut req = valid_create_request();
+    req.title = title.into();
+    let result = svc_create(&store, req);
+    match result {
+        Err(AppError::Conflict(msg)) => {
+            assert!(msg.contains("stale-on-disk-id"), "{msg}");
+        }
+        other => panic!("expected Conflict, got {other:?}"),
+    }
+}
+
+#[test]
 fn svc_delete_tombstones_a_builtin_default_so_it_is_not_resurrected() {
     // #265: deleting a built-in default (title matches DEFAULT_ROUTINES[0]; kept as a literal
     // here since DEFAULT_ROUTINES is private to the `defaults` submodule) must stick — a later

--- a/src/routines/service_validate.rs
+++ b/src/routines/service_validate.rs
@@ -5,6 +5,17 @@ use crate::routines::agents::{available_agents, load_agent_command, AgentLoadErr
 use crate::routines::command::validate_placeholders;
 use crate::routines::model::Repository;
 
+/// Map a [`crate::routine_storage::write_routine`] failure to an [`AppError`], turning the
+/// on-disk slug-collision guard (#188, `ErrorKind::AlreadyExists`) into a 409 the caller can act
+/// on instead of a generic 500.
+pub(super) fn map_write_routine_err(err: &std::io::Error) -> AppError {
+    if err.kind() == std::io::ErrorKind::AlreadyExists {
+        AppError::Conflict(err.to_string())
+    } else {
+        AppError::Internal
+    }
+}
+
 /// Reject a blank (empty or whitespace-only) required text field.
 ///
 /// An empty `prompt` makes a routine fire forever with no task (#224); an empty


### PR DESCRIPTION
## Why

Routine folders are named solely by `slugify(&routine.title)`; the UUID `id` only lives inside `routine.toml`. Distinct titles can slugify to the same folder (`"Update deps!"` and `"Update deps?"` both become `update-deps`). `svc_create`/`svc_update` already reject that when both routines are loaded in the in-memory store, but nothing stopped `write_routine` itself from silently overwriting a *stale* on-disk `routine.toml` belonging to a different id — e.g. a directory a failed `remove_routine_dir` left behind, or any other route to an orphaned folder outside the in-memory guard's view. The clobber is silent: the surviving `prompt.md` can end up belonging to a different routine than the crontab entry and slug now point at, so a scheduled run can execute the wrong prompt (#188).

## What

- `write_routine` (`src/routine_storage.rs`) now peeks at the target slug's existing `routine.toml` (via the existing `read_routine_toml` helper) before writing. If it belongs to a different `id`, it returns `io::ErrorKind::AlreadyExists` instead of clobbering.
- `svc_create`/`svc_update` (`src/routines/service.rs`) map that specific error to `AppError::Conflict` (409) via a small `map_write_routine_err` helper, instead of the generic `AppError::Internal` (500) every other `write_routine` failure gets — giving the caller a clear, actionable signal.
- Writing the *same* routine (same `id`) to its own slug again — the ordinary update/re-persist path — is unaffected.
- Added two tests: a collision between two different ids sharing a slug is rejected and leaves the first routine's file untouched, and a routine rewriting its own slug still succeeds.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (993 + 274 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)