### PR TITLE
chore(lint): enable clippy::case_sensitive_file_extension_comparisons

### DIFF
--- a/.changeset/enable-clippy-case-sensitive-file-extension-comparisons.md
+++ b/.changeset/enable-clippy-case-sensitive-file-extension-comparisons.md
@@ -1,0 +1,7 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::case_sensitive_file_extension_comparisons`
+
+Locks in the codebase's existing (near-)zero-violation state for `clippy::case_sensitive_file_extension_comparisons`, so a future case-sensitive `.ends_with(".ext")` file-extension check fails CI instead of silently disagreeing with the case-insensitive filesystems (macOS, Windows) this daemon runs on. Fixes the two existing violations in `src/routines/flags.rs` and its tests by switching `is_safe_flag_filename` (and the test asserting its shape) from `ends_with(".md")` to `Path::extension()` compared with `eq_ignore_ascii_case`. No behavior change on case-sensitive filesystems (Linux); on case-insensitive ones, a flag file named e.g. `bug-123.MD` is now correctly recognized instead of rejected.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,3 +208,9 @@ trivially_copy_pass_by_ref = "deny"
 # judge magnitude at a glance instead of counting digits one by one. The codebase is already
 # clean, so `deny` locks that in.
 unreadable_literal = "deny"
+# Reject a case-sensitive `.ends_with(".ext")`/`.starts_with(...)` file-extension check in favour
+# of `Path::extension()` compared with `eq_ignore_ascii_case`. A literal `.md` check silently
+# mismatches an uppercase or mixed-case extension even though macOS's and Windows' default
+# filesystems treat the two names as the same file, so the check's pass/fail result can disagree
+# with what's actually on disk. The codebase is already clean, so `deny` locks that in.
+case_sensitive_file_extension_comparisons = "deny"

--- a/src/routines/flags.rs
+++ b/src/routines/flags.rs
@@ -64,7 +64,9 @@ fn is_safe_flag_filename(filename: &str) -> bool {
     !filename.is_empty()
         && !filename.contains(['/', '\\'])
         && !filename.contains("..")
-        && filename.ends_with(".md")
+        && std::path::Path::new(filename)
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
 }
 
 /// Split a flag filename into its `(created_at, scope)`, or `None` if it doesn't match the

--- a/src/routines/flags_tests.rs
+++ b/src/routines/flags_tests.rs
@@ -37,7 +37,9 @@ fn create_flag_writes_general_file_with_md_suffix() {
     let _home = TempHome::set();
     let flag = create_flag("r1", "bug", "the thing is broken", FlagScope::General).unwrap();
     assert!(flag.filename.starts_with("bug-"));
-    assert!(flag.filename.ends_with(".md"));
+    assert!(std::path::Path::new(&flag.filename)
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("md")));
     assert!(!flag.filename.ends_with(".local.md"));
     assert_eq!(flag.flag_type, "bug");
     assert_eq!(flag.description, "the thing is broken");


### PR DESCRIPTION
## Summary
- Enables `clippy::case_sensitive_file_extension_comparisons` at `deny` in `[lints.clippy]`, matching this repo's existing one-lint-at-a-time convention.
- Fixes the two existing violations, both in flag filename handling: `is_safe_flag_filename` in `src/routines/flags.rs` and the corresponding assertion in `src/routines/flags_tests.rs`, switching from a literal `.ends_with(".md")` check to `Path::extension()` compared with `eq_ignore_ascii_case`.
- Adds a changeset describing the change, matching prior clippy-lint PRs in this repo.

## Why
A case-sensitive extension check disagrees with macOS/Windows default (case-insensitive) filesystems: a flag file could exist on disk under a different-case extension yet be rejected by `is_safe_flag_filename`, which guards `resolve_flag` against a caller-supplied filename escaping the flags directory. No behavior change on Linux (case-sensitive); on case-insensitive filesystems, this fixes a false-negative rejection.

Closes #1089

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (274 passed)