### PR TITLE
chore(lint): enable clippy::uninlined_format_args in the ui crate

### DIFF
--- a/.changeset/enable-clippy-uninlined-format-args-ui.md
+++ b/.changeset/enable-clippy-uninlined-format-args-ui.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Deny `clippy::uninlined_format_args` in the `ui` crate, matching the root crate's lint config. The `ui` crate has its own `[lints.clippy]` table that doesn't inherit the root's deny-list, so this lint never applied to `ui/src` despite CI's `clippy` job running `--workspace`. The crate is already clean, so this locks it in.

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -78,3 +78,9 @@ match_same_arms = "deny"
 # despite CI's `clippy` job running `--workspace`. The `ui` crate is already
 # clean, so `deny` locks that in.
 unused_async = "deny"
+# Reject a positional `format!`/`write!`/`println!` arg (`format!("{}", x)`) in favor of the
+# inlined form (`format!("{x}")`). Kept in lockstep with the same lint already enabled
+# workspace-root-side in Cargo.toml — the `ui` crate has its own `[lints]` table (no
+# `workspace = true` inheritance) so it was silently exempt despite `clippy --workspace`
+# covering it in CI. The `ui` crate is already clean, so `deny` locks that in.
+uninlined_format_args = "deny"


### PR DESCRIPTION
## Summary
- The `ui` crate has its own `[lints.clippy]` table and does not inherit the workspace root's extended deny-list, so `clippy::uninlined_format_args` (already `deny` at the root, `Cargo.toml:72`) never applied to `ui/src` despite CI's `clippy` job running `--workspace`.
- Adds the same lint to `ui/Cargo.toml`, mirroring the existing pattern used for `unused_self`, `wildcard_imports`, `map_unwrap_or`, `match_same_arms`, `unused_async`, etc. in the same file.
- The `ui` crate is already clean under this lint (verified with `cargo clippy --workspace --all-targets` — 0 new violations), so this is a pure lock-in with no source changes.

This pull request was opened by the "Daemon + Landing auto-improve & auto-merge lint/docs PRs" routine of moadim.

## Test plan
- [x] `cargo clippy --workspace --all-targets` — clean
- [x] `.changeset/enable-clippy-uninlined-format-args-ui.md` added (patch)