### PR TITLE
docs: prune shipped TODO.md entry

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,4 +5,3 @@
 This is a list of todos for consumption, in a pr remove the todo you have implemented and add any new ones you think of.
 
 - Add a day-detail popover to the routines calendar: clicking a day lists each fire time (HH:MM) with its routine, and a "run now" shortcut per routine
-- Have a commands folder for all the cli commands, we want to work with colocation of files


### PR DESCRIPTION
## Summary
- Removes the "have a commands folder for all the cli commands... colocation of files" entry from `TODO.md`.
- It was implemented by e065780 (#1088), which moved `cli.rs`/`cli_query.rs`/`cli_system.rs`/`cli_restart.rs` into `src/cli/{mod,query,system,restart}.rs`, but the TODO line was never pruned.
- `TODO.md`'s own convention (see its header) is "in a pr remove the todo you have implemented" — this repo has a recurring, repeatedly-merged pattern of exactly this cleanup (#989, #1055, #863, #796, #896, #911).

Docs-only, no `src/`/`ui/` touched — no changeset needed.

## Test plan
- [x] Confirmed `src/cli/` exists with the colocated files, verifying the TODO is shipped
- [x] Confirmed no other open PR touches `TODO.md`