### PR TITLE
fix(build): inline compiled CSS into prebuilt.html, not just JS/WASM

### DIFF
--- a/.changeset/fix-prebuilt-ui-css-not-inlined.md
+++ b/.changeset/fix-prebuilt-ui-css-not-inlined.md
@@ -1,0 +1,22 @@
+---
+"moadim": patch
+---
+
+fix(build): inline the compiled CSS into `prebuilt.html`, not just JS/WASM
+
+`src/build/ui.rs`'s `inline_into_html` folded trunk's compiled JS and WASM
+into a single self-contained `index.html`, but left the CSS as an external
+`<link rel="stylesheet" href="./styles-<hash>.css">` — a file that never
+gets embedded or shipped alongside `prebuilt.html` (only the HTML itself is
+copied to the package root and committed). Every `cargo install moadim`
+user hit this: the server's catch-all route serves `index.html` for that
+missing CSS request, the browser gets `text/html` back for a `.css`
+request, and strict MIME checking refuses to apply it — the control panel
+rendered completely unstyled. Present since CSS inlining was never added
+alongside JS/WASM inlining (reproduces on the v0.26.0 tag too); this is the
+first release to carry the fix.
+
+`find_dist_assets` now also locates the `.css` file in trunk's `dist/`,
+and `assemble_html` inlines it into a `<style>` block in `<head>` the same
+way the WASM bytes are inlined into the boot script, so the served bundle
+makes zero external asset requests.

--- a/prebuilt.html
+++ b/prebuilt.html
@@ -1,3 +1,1714 @@
+<style>    :root {
+      --bg:           #050905;
+      --bg-2:         #0b130a;
+      --bg-3:         #111d10;
+      --border:       #19291a;
+      --border-hi:    #2a4229;
+      --text-ghost:   #2a4d28;
+      --text-dim:     #3e6e3a;
+      --text-mid:     #5f9e58;
+      --text:         #9fd494;
+      --text-hi:      #c5eabc;
+      --accent:       #4ade80;
+      --accent-dim:   #0d2919;
+      --red:          #f87171;
+      --red-dim:      #270f0f;
+      --amber:        #fbbf24;
+      --amber-dim:    #271b06;
+      --mono:         'Share Tech Mono', 'Courier New', monospace;
+    }
+
+    /* ── Light theme — full CSS-variable override so every component inherits ── */
+    html.theme-light {
+      --bg:           #f5f5f0;
+      --bg-2:         #ebebе6;
+      --bg-3:         #e0e0db;
+      --border:       #cccccc;
+      --border-hi:    #aaaaaa;
+      --text-ghost:   #999999;
+      --text-dim:     #666666;
+      --text-mid:     #444444;
+      --text:         #1a1a1a;
+      --text-hi:      #000000;
+      --accent:       #187a3d;
+      --accent-dim:   #e0f5e8;
+      --red:          #b91c1c;
+      --red-dim:      #fee2e2;
+      --amber:        #b45309;
+      --amber-dim:    #fef3c7;
+    }
+    /* Remove terminal eye-candy in bright surroundings */
+    html.theme-light body::before,
+    html.theme-light body::after { opacity: 0; }
+
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    html, body {
+      height: 100%;
+      background: var(--bg);
+      color: var(--text);
+      font-family: var(--mono);
+      font-size: 13px;
+      line-height: 1.6;
+    }
+
+    /* scanlines */
+    body::before {
+      content: '';
+      position: fixed; inset: 0;
+      background: repeating-linear-gradient(
+        0deg,
+        transparent, transparent 2px,
+        rgba(0,0,0,0.04) 2px, rgba(0,0,0,0.04) 4px
+      );
+      pointer-events: none;
+      z-index: 9999;
+    }
+
+    /* grain noise */
+    body::after {
+      content: '';
+      position: fixed; inset: 0;
+      opacity: 0.025;
+      background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+      background-size: 128px 128px;
+      pointer-events: none;
+      z-index: 9998;
+    }
+
+    /* ── Header ── */
+    header {
+      border-bottom: 1px solid var(--border);
+      padding: 0 28px;
+      height: 54px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      background: var(--bg-2);
+      position: sticky; top: 0;
+      z-index: 100;
+    }
+
+    .logo {
+      display: flex;
+      align-items: baseline;
+      gap: 10px;
+      font-weight: 400;
+      font-size: 17px;
+      letter-spacing: 0.3em;
+      color: var(--accent);
+    }
+
+    .logo-sub {
+      font-size: 10px;
+      letter-spacing: 0.2em;
+      color: var(--text-dim);
+    }
+
+    .logo-version {
+      font-size: 10px;
+      letter-spacing: 0.1em;
+      color: var(--text-dim);
+    }
+
+    .header-right { display: flex; align-items: center; gap: 16px; }
+
+    /* ── Health ── */
+    .health {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 5px 12px;
+      border: 1px solid var(--border);
+      background: var(--bg-3);
+      font-size: 11px;
+    }
+
+    .health-dot {
+      width: 7px; height: 7px;
+      border-radius: 50%;
+      background: var(--text-ghost);
+      flex-shrink: 0;
+    }
+    .health-dot.ok    { background: var(--accent); animation: glow 2.4s ease-in-out infinite; }
+    .health-dot.error { background: var(--red); }
+
+    @keyframes glow {
+      0%,100% { box-shadow: 0 0 0 0 rgba(74,222,128,0.5); }
+      50%      { box-shadow: 0 0 0 5px rgba(74,222,128,0); }
+    }
+
+    .health-status { color: var(--text-mid); letter-spacing: 0.06em; }
+    .health-uptime  { color: var(--text-ghost); }
+
+    /* ── Buttons ── */
+    .btn {
+      font-family: var(--mono);
+      font-size: 11px;
+      letter-spacing: 0.06em;
+      padding: 6px 14px;
+      border: 1px solid;
+      cursor: pointer;
+      background: transparent;
+      transition: background 0.12s, color 0.12s;
+    }
+    .btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+    .btn-primary { border-color: var(--accent); color: var(--accent); }
+    .btn-primary:not(:disabled):hover { background: var(--accent); color: var(--bg); }
+
+    .btn-danger  { border-color: var(--red); color: var(--red); }
+    .btn-danger:not(:disabled):hover  { background: var(--red); color: var(--bg); }
+
+    .btn-ghost   { border-color: var(--border-hi); color: var(--text-mid); }
+    .btn-ghost:not(:disabled):hover   { border-color: var(--text-dim); color: var(--text); }
+
+    .btn-sm { padding: 4px 10px; }
+
+    /* ── Machine badge (header) ── */
+    .machine-badge {
+      background: none;
+      border: 1px solid var(--border);
+      color: var(--text-dim);
+      font-family: var(--mono);
+      font-size: 11px;
+      letter-spacing: 0.06em;
+      padding: 4px 10px;
+      cursor: pointer;
+      transition: color 0.12s, border-color 0.12s;
+      white-space: nowrap;
+      max-width: 160px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .machine-badge::before { content: "@ "; color: var(--text-ghost); }
+    .machine-badge:hover { color: var(--accent); border-color: var(--border-hi); }
+
+    /* ── Dependency warning badge (header) ── */
+    .dep-warn {
+      font-family: var(--mono);
+      font-size: 10px;
+      letter-spacing: 0.1em;
+      padding: 4px 8px;
+      border: 1px solid var(--red);
+      color: var(--red);
+      background: var(--red-dim);
+      cursor: default;
+      white-space: nowrap;
+      animation: dep-pulse 2s ease-in-out infinite;
+    }
+    .dep-warn-soft {
+      border-color: var(--amber);
+      color: var(--amber);
+      background: var(--amber-dim);
+      animation: none;
+    }
+    @keyframes dep-pulse {
+      0%,100% { opacity: 1; }
+      50%      { opacity: 0.65; }
+    }
+
+    .btn-refresh {
+      background: none;
+      border: 1px solid var(--border);
+      color: var(--text-dim);
+      font-family: var(--mono);
+      font-size: 14px;
+      padding: 4px 10px;
+      cursor: pointer;
+      transition: color 0.12s, border-color 0.12s;
+      line-height: 1;
+    }
+    .btn-refresh:hover { color: var(--accent); border-color: var(--border-hi); }
+    .btn-refresh.spinning { animation: spin 0.6s linear infinite; }
+
+    .btn-cmdk {
+      background: none;
+      border: 1px solid var(--border);
+      color: var(--text-dim);
+      font-family: var(--mono);
+      font-size: 11px;
+      letter-spacing: 0.08em;
+      padding: 4px 9px;
+      cursor: pointer;
+      transition: color 0.12s, border-color 0.12s;
+      line-height: 1;
+    }
+    .btn-cmdk:hover { color: var(--accent); border-color: var(--border-hi); }
+
+    .btn-theme {
+      background: none;
+      border: 1px solid var(--border);
+      color: var(--text-dim);
+      font-family: var(--mono);
+      font-size: 13px;
+      padding: 4px 9px;
+      cursor: pointer;
+      transition: color 0.12s, border-color 0.12s;
+      line-height: 1;
+    }
+    .btn-theme:hover { color: var(--accent); border-color: var(--border-hi); }
+
+    /* ── Command palette (⌘K) ── */
+    .cmdk {
+      align-self: flex-start;
+      margin-top: 11vh;
+      width: clamp(280px, 90vw, 560px);
+      background: var(--bg-2);
+      border: 1px solid var(--border-hi);
+      box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
+      transform: translateY(10px);
+      transition: transform 0.18s;
+      display: flex;
+      flex-direction: column;
+      max-height: 70vh;
+    }
+    .overlay.open .cmdk { transform: translateY(0); }
+
+    .cmdk-search {
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      padding: 12px 14px;
+      border-bottom: 1px solid var(--border);
+    }
+    .cmdk-prompt { color: var(--accent); font-size: 15px; line-height: 1; }
+    .cmdk-input {
+      flex: 1;
+      background: none;
+      border: none;
+      outline: none;
+      color: var(--text-hi);
+      font-family: var(--mono);
+      font-size: 14px;
+    }
+    .cmdk-input::placeholder { color: var(--text-ghost); }
+    .cmdk-hint {
+      font-size: 9px;
+      letter-spacing: 0.12em;
+      color: var(--text-ghost);
+      border: 1px solid var(--border);
+      padding: 2px 5px;
+    }
+
+    .cmdk-list {
+      list-style: none;
+      margin: 0;
+      padding: 6px;
+      overflow-y: auto;
+    }
+    .cmdk-row {
+      display: flex;
+      align-items: center;
+      gap: 11px;
+      padding: 8px 10px;
+      cursor: pointer;
+      border: 1px solid transparent;
+    }
+    .cmdk-row.active { background: var(--bg-3); border-color: var(--border-hi); }
+    .cmdk-row-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+    .cmdk-row-title {
+      color: var(--text-hi);
+      font-size: 13px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .cmdk-row-sub {
+      color: var(--text-dim);
+      font-size: 10px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .kind-badge.nav { border-color: var(--border-hi); color: var(--accent); }
+    .kind-badge.action { border-color: var(--amber); color: var(--amber); }
+
+    .cmdk-empty { padding: 30px 18px; text-align: center; }
+
+    .cmdk-foot {
+      display: flex;
+      gap: 16px;
+      padding: 9px 14px;
+      border-top: 1px solid var(--border);
+      font-size: 10px;
+      color: var(--text-ghost);
+    }
+    .cmdk-key {
+      color: var(--text-mid);
+      border: 1px solid var(--border);
+      padding: 1px 5px;
+      margin-right: 4px;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+
+    .btn-stop {
+      background: none;
+      border: 1px solid var(--border);
+      color: var(--text-dim);
+      font-family: var(--mono);
+      font-size: 12px;
+      letter-spacing: 0.05em;
+      padding: 4px 10px;
+      cursor: pointer;
+      transition: color 0.12s, border-color 0.12s, background 0.12s;
+      line-height: 1;
+    }
+    .btn-stop:hover:not(:disabled) { color: var(--red); border-color: var(--red); }
+    .btn-stop:disabled { opacity: 0.4; cursor: not-allowed; }
+
+    /* ── Tabs ── */
+    .tabs {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 0 28px;
+      display: flex;
+      gap: 4px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .tab-btn {
+      font-family: var(--mono);
+      font-size: 11px;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      padding: 12px 18px;
+      border: none;
+      border-bottom: 2px solid transparent;
+      margin-bottom: -1px;
+      background: transparent;
+      color: var(--text-dim);
+      cursor: pointer;
+      transition: color 0.12s, border-color 0.12s;
+    }
+    .tab-btn:hover  { color: var(--text-mid); }
+    .tab-btn.active { color: var(--accent); border-bottom-color: var(--accent); }
+
+    /* ── Main ── */
+    main { max-width: 1100px; margin: 0 auto; padding: 32px 28px; }
+
+    /* ── Stats ── */
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(5, 1fr);
+      gap: 10px;
+      margin-bottom: 36px;
+    }
+
+    @media (max-width: 800px) {
+      .stats { grid-template-columns: repeat(3, 1fr); }
+    }
+
+    @media (max-width: 520px) {
+      .stats { grid-template-columns: repeat(2, 1fr); }
+    }
+
+    .stat-card {
+      border: 1px solid var(--border);
+      border-left-width: 3px;
+      background: var(--bg-2);
+      padding: 14px 18px;
+      display: flex; flex-direction: column; gap: 4px;
+    }
+    .stat-card.all      { border-left-color: var(--border-hi); }
+    .stat-card.enabled  { border-left-color: var(--accent); }
+    .stat-card.disabled { border-left-color: var(--amber); }
+    .stat-card.due      { border-left-color: var(--red); }
+    .stat-card.unreg    { border-left-color: var(--red); }
+    .stat-card.attention { border-left-color: var(--red); }
+    .stat-card.dormant  { border-left-color: var(--border-hi); }
+    .stat-card.has-dormant { border-left-color: var(--amber); }
+    .stat-card.has-dormant .stat-val { color: var(--amber); }
+    .stat-card.flags    { border-left-color: var(--border-hi); }
+    .stat-card.has-flags { border-left-color: var(--red); }
+    .stat-card.has-flags .stat-val { color: var(--red); }
+    .stat-card.has-unreg { border-left-color: var(--amber); }
+    .stat-card.has-unreg .stat-val { color: var(--amber); }
+    .stat-card.system   { border-left-color: #7c8fc9; }
+
+    .stat-label {
+      font-size: 9px;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      color: var(--text-dim);
+    }
+
+    .stat-val { font-size: 30px; color: var(--text-hi); line-height: 1.1; }
+    .stat-val.c-accent { color: var(--accent); }
+
+    /* Cross-filtering KPI tiles: the cron StatsBar renders each card as a button
+       that applies its status facet. Reset native button chrome and add a
+       pressed/active state; non-clickable StatsBars (overview/routines) keep the
+       plain <div>. */
+    button.stat-card {
+      font: inherit;
+      color: inherit;
+      text-align: left;
+      cursor: pointer;
+      transition: background 0.12s, border-color 0.12s;
+    }
+    button.stat-card:hover { border-color: var(--border-hi); background: var(--bg-3); }
+    button.stat-card:focus-visible { outline: 1px solid var(--accent); outline-offset: 2px; }
+    .stat-card.active { background: var(--accent-dim); }
+    .stat-card.active .stat-label { color: var(--text-mid); }
+    .stat-val.c-amber  { color: var(--amber); }
+    .stat-val.c-red    { color: var(--red); }
+    /* Time strings ("in 4m", "tomorrow 09:00") are textual, not a single
+       glyph, so the NEXT RUN tile uses a smaller, baseline-aligned size. */
+    .stat-val.stat-val-sm { font-size: 18px; color: var(--text-hi); padding-top: 8px; }
+
+    /* ── Overview: type badge + name link ── */
+    .kind-badge {
+      display: inline-block;
+      font-size: 9px;
+      letter-spacing: 0.14em;
+      padding: 2px 7px;
+      border: 1px solid var(--border-hi);
+      color: var(--text-mid);
+    }
+    .kind-badge.cron    { border-color: var(--border-hi); color: var(--text-mid); }
+    .kind-badge.routine { border-color: #3a4d7c; color: #9fb0e0; }
+
+    /* ── Overview: NEEDS ATTENTION triage panel ── */
+    .section-label.attn { color: var(--red); }
+    /* Red-accented frame + faint wash so broken items read as urgent. */
+    .attn-wrap {
+      border-color: var(--red);
+      box-shadow: inset 3px 0 0 var(--red);
+    }
+    .attn-wrap table thead th { color: var(--red); }
+    .attn-badge {
+      display: inline-block;
+      font-size: 9px;
+      letter-spacing: 0.14em;
+      padding: 2px 7px;
+      border: 1px solid var(--red);
+      color: var(--red);
+      background: var(--red-dim);
+      white-space: nowrap;
+    }
+    .attn-detail { color: var(--text-mid); }
+
+    /* ── Routine health badge (per-row status indicator in the Routines table) ── */
+    .health-badge {
+      display: inline-block;
+      font-size: 8px;
+      font-weight: 600;
+      letter-spacing: 0.1em;
+      padding: 2px 5px;
+      border: 1px solid var(--border-hi);
+      color: var(--text-mid);
+      white-space: nowrap;
+      vertical-align: middle;
+    }
+    .health-badge.dormant       { border-color: var(--amber); color: var(--amber); background: var(--amber-dim); }
+    .health-badge.dead          { border-color: var(--red);   color: var(--red);   background: var(--red-dim); }
+    .health-badge.agent-missing { border-color: var(--amber); color: var(--amber); background: var(--amber-dim); }
+    .health-badge.disabled      { border-color: var(--border-hi); color: var(--text-dim); }
+    .health-badge.power-saving  { border-color: var(--text-mid); color: var(--text-mid); background: var(--border); }
+    .health-badge.snoozed       { border-color: var(--amber); color: var(--amber); background: var(--amber-dim); }
+    .health-badge.healthy       { border-color: var(--accent); color: var(--accent); }
+
+    .ov-name-link {
+      color: var(--text-hi);
+      text-decoration: none;
+      border-bottom: 1px solid transparent;
+      transition: color 0.1s, border-color 0.1s;
+    }
+    .ov-name-link:hover { color: var(--accent); border-bottom-color: var(--accent-dim); }
+    .ov-flag-badge {
+      display: inline-block;
+      margin-left: 6px;
+      font-size: 9px;
+      letter-spacing: 0.06em;
+      color: var(--red);
+      opacity: 0.85;
+      vertical-align: middle;
+    }
+
+    /* ── Section header ── */
+    .section-hd {
+      display: flex; align-items: center; justify-content: space-between;
+      margin-bottom: 14px;
+    }
+
+    .section-label {
+      font-size: 9px;
+      letter-spacing: 0.22em;
+      text-transform: uppercase;
+      color: var(--text-dim);
+    }
+
+    .section-actions { display: flex; gap: 8px; align-items: center; }
+
+    /* ── Table ── */
+    .table-wrap {
+      border: 1px solid var(--border);
+      overflow-x: auto;
+      overflow-y: hidden;
+    }
+
+    table { width: 100%; border-collapse: collapse; }
+
+    thead th {
+      font-size: 9px;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--text-ghost);
+      text-align: left;
+      padding: 9px 14px;
+      border-bottom: 1px solid var(--border);
+      background: var(--bg-3);
+      font-weight: 400;
+    }
+
+    .th-sort { cursor: pointer; user-select: none; }
+    .th-sort:hover { color: var(--text); }
+    .th-sort-active { color: var(--accent); }
+
+    tbody tr {
+      border-bottom: 1px solid var(--border);
+      transition: background 0.08s;
+    }
+    tbody tr:last-child { border-bottom: none; }
+    tbody tr:hover      { background: var(--bg-2); }
+
+    tbody td { padding: 11px 14px; vertical-align: middle; }
+
+    .cell-id {
+      font-size: 10px;
+      color: var(--text-ghost);
+      font-family: var(--mono);
+      letter-spacing: 0.03em;
+    }
+
+    .cell-schedule       { color: var(--text-hi); font-size: 12px; }
+    .cell-schedule-human { font-size: 10px; color: var(--text-mid); margin-top: 1px; }
+
+    .cell-handler { color: var(--accent); font-size: 12px; display: flex; align-items: center; gap: 6px; }
+
+    .handler-dot {
+      width: 6px; height: 6px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+    .handler-dot.ok   { background: var(--accent); box-shadow: 0 0 4px rgba(74,222,128,0.5); }
+    .handler-dot.warn { background: var(--amber); }
+
+    .cell-meta {
+      font-size: 10px;
+      color: var(--text-dim);
+      max-width: 130px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .cell-no-machines { color: var(--amber); }
+
+    .cell-time { font-size: 10px; color: var(--text-ghost); }
+
+    /* ── Next run ── */
+    .cell-next            { line-height: 1.25; }
+    .cell-next-when       { color: var(--text-hi); font-size: 12px; }
+    .cell-next-until      { font-size: 10px; color: var(--text-mid); margin-top: 1px; }
+    .cell-next-until.soon { color: var(--red); }
+    .cell-next.muted      { font-size: 12px; color: var(--text-ghost); }
+
+    /* ── Toggle ── */
+    .toggle { position: relative; width: 34px; height: 18px; cursor: pointer; display: block; }
+    .toggle input { opacity: 0; width: 0; height: 0; position: absolute; }
+
+    .toggle-track {
+      position: absolute; inset: 0;
+      border: 1px solid var(--border-hi);
+      background: var(--bg-3);
+      transition: border-color 0.15s, background 0.15s;
+    }
+    .toggle-track::after {
+      content: '';
+      position: absolute;
+      top: 2px; left: 2px;
+      width: 12px; height: 12px;
+      background: var(--text-dim);
+      transition: transform 0.15s, background 0.15s;
+    }
+
+    .toggle input:checked + .toggle-track              { border-color: var(--accent); background: var(--accent-dim); }
+    .toggle input:checked + .toggle-track::after       { transform: translateX(16px); background: var(--accent); }
+
+    /* ── Multiselect ── */
+    .th-select, .td-select { width: 28px; text-align: center; padding-right: 0; }
+    tbody tr.row-selected { background: var(--accent-dim); }
+    tbody tr.row-selected:hover { background: var(--accent-dim); }
+
+    .row-check {
+      appearance: none;
+      -webkit-appearance: none;
+      width: 14px; height: 14px;
+      border: 1px solid var(--border-hi);
+      background: var(--bg-3);
+      cursor: pointer;
+      position: relative;
+      vertical-align: middle;
+      transition: border-color 0.1s, background 0.1s;
+    }
+    .row-check:hover { border-color: var(--accent-dim); }
+    .row-check:checked { border-color: var(--accent); background: var(--accent-dim); }
+    .row-check:checked::after {
+      content: '✓';
+      position: absolute;
+      top: -2px; left: 1px;
+      font-size: 11px;
+      color: var(--accent);
+    }
+    .row-check:focus-visible { outline: 1px solid var(--accent); outline-offset: 1px; }
+
+    .bulk-bar {
+      display: flex; align-items: center; justify-content: space-between;
+      gap: 12px;
+      padding: 8px 14px;
+      margin-bottom: 10px;
+      border: 1px solid var(--accent-dim);
+      background: var(--bg-2);
+    }
+    .bulk-count {
+      font-size: 10px;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--accent);
+    }
+    .bulk-acts { display: flex; gap: 8px; align-items: center; }
+
+    /* ── Global lock banner ── */
+    .lock-banner {
+      display: flex; align-items: center; justify-content: space-between;
+      gap: 12px;
+      padding: 8px 14px;
+      margin-bottom: 10px;
+      border: 1px solid var(--amber);
+      background: var(--amber-dim);
+    }
+    .lock-banner-msg {
+      display: flex; align-items: center; gap: 10px;
+      font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase;
+      color: var(--amber);
+    }
+    .lock-scope-tag {
+      font-size: 9px; letter-spacing: 0.1em; padding: 1px 6px;
+      border: 1px solid var(--amber); color: var(--amber);
+      opacity: 0.7;
+    }
+    .lock-banner-acts { display: flex; gap: 8px; }
+
+    /* ── Row actions ── */
+    .row-actions { display: flex; gap: 4px; align-items: center; }
+
+    .act-btn {
+      font-family: var(--mono);
+      font-size: 10px;
+      letter-spacing: 0.04em;
+      padding: 2px 8px;
+      border: 1px solid transparent;
+      cursor: pointer;
+      background: transparent;
+      transition: color 0.1s, border-color 0.1s;
+    }
+    .act-btn.run  { color: var(--text-ghost); }
+    .act-btn.run:hover  { color: var(--accent); border-color: var(--accent-dim); }
+    .act-btn.edit { color: var(--text-mid); border-color: var(--border); }
+    .act-btn.edit:hover { color: var(--text-hi); border-color: var(--border-hi); }
+    .act-btn.del  { color: var(--text-ghost); }
+    .act-btn.del:hover  { color: var(--red); border-color: var(--red-dim); }
+    .cell-triggered { font-size: 10px; color: var(--text-ghost); margin-top: 2px; }
+
+    /* ── Empty state ── */
+    .empty {
+      padding: 72px 40px;
+      text-align: center;
+      color: var(--text-ghost);
+    }
+    .empty-icon { font-size: 36px; margin-bottom: 14px; opacity: 0.4; }
+    .empty-msg  { font-size: 13px; letter-spacing: 0.22em; text-transform: uppercase; }
+    .empty-sub  { font-size: 10px; color: var(--text-ghost); margin-top: 6px; opacity: 0.7; }
+
+    /* ── Modal ── */
+    .overlay {
+      position: fixed; inset: 0;
+      background: rgba(4, 8, 4, 0.87);
+      z-index: 200;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.18s;
+    }
+    .overlay.open { opacity: 1; pointer-events: all; }
+
+    .modal {
+      background: var(--bg-2);
+      border: 1px solid var(--border-hi);
+      width: clamp(280px, 90vw, 540px);
+      max-height: 88vh;
+      overflow-y: auto;
+      transform: translateY(10px);
+      transition: transform 0.18s;
+    }
+    .overlay.open .modal { transform: translateY(0); }
+
+    .modal-hd {
+      padding: 14px 18px;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .modal-title {
+      font-size: 11px;
+      color: var(--text-hi);
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+    }
+    .modal-x {
+      background: none; border: none;
+      color: var(--text-dim); cursor: pointer;
+      font-family: var(--mono); font-size: 15px;
+      line-height: 1; padding: 2px 4px;
+    }
+    .modal-x:hover { color: var(--text); }
+
+    .modal-body { padding: 18px; }
+    .modal-ft {
+      padding: 14px 18px;
+      border-top: 1px solid var(--border);
+      display: flex; gap: 8px; justify-content: flex-end;
+    }
+
+    /* ── Form ── */
+    .form-group { margin-bottom: 18px; }
+
+    .form-label {
+      display: block;
+      font-size: 9px;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--text-dim);
+      margin-bottom: 5px;
+    }
+    .form-required { color: var(--red); }
+
+    .form-input {
+      width: 100%;
+      background: var(--bg-3);
+      border: 1px solid var(--border);
+      color: var(--text);
+      font-family: var(--mono);
+      font-size: 13px;
+      padding: 7px 11px;
+      outline: none;
+      transition: border-color 0.12s;
+    }
+    .form-input:focus         { border-color: var(--accent); }
+    .form-input.invalid       { border-color: var(--red); }
+    .form-input::placeholder  { color: var(--text-ghost); }
+    textarea.form-input       { resize: vertical; min-height: 90px; }
+
+    /* ── Settings page ── */
+    .settings-page { padding: 0 18px 24px; }
+    .settings-card {
+      max-width: 640px;
+      border: 1px solid var(--border);
+      background: var(--bg-2);
+      padding: 16px;
+      margin-top: 12px;
+    }
+    .settings-card-hd {
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      color: var(--text-hi);
+      text-transform: uppercase;
+      margin-bottom: 6px;
+    }
+    .settings-card-sub { font-size: 12px; color: var(--text-dim); margin: 0 0 12px; line-height: 1.5; }
+    .settings-textarea { font-size: 12px; min-height: 220px; }
+    .settings-card-acts { display: flex; align-items: center; gap: 10px; margin-top: 10px; }
+    .settings-dirty-hint { font-size: 11px; color: var(--amber); }
+
+    /* cron presets */
+    .cron-presets { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 5px; }
+
+    /* workbench TTL presets */
+    .ttl-presets { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 5px; }
+
+    .preset-btn {
+      font-family: var(--mono);
+      font-size: 9px;
+      padding: 2px 7px;
+      border: 1px solid var(--border);
+      color: var(--text-dim);
+      cursor: pointer;
+      background: transparent;
+      transition: all 0.1s;
+      letter-spacing: 0.04em;
+    }
+    .preset-btn:hover { border-color: var(--accent); color: var(--accent); }
+
+    /* machines picker */
+    .machine-chips { display: flex; flex-wrap: wrap; gap: 5px; margin-bottom: 6px; }
+    .machine-chip {
+      font-family: var(--mono);
+      font-size: 10px;
+      padding: 3px 9px;
+      border: 1px solid var(--border);
+      color: var(--text-dim);
+      cursor: pointer;
+      background: transparent;
+      transition: all 0.1s;
+      letter-spacing: 0.04em;
+    }
+    .machine-chip:hover { border-color: var(--accent); color: var(--accent); }
+    .machine-chip.on {
+      border-color: var(--accent);
+      color: var(--bg-1);
+      background: var(--accent);
+    }
+    .machine-empty { font-size: 10px; color: var(--text-ghost); margin-bottom: 6px; }
+    .machine-add { display: flex; gap: 6px; align-items: stretch; }
+    .machine-add .form-input { flex: 1; }
+
+    /* cron preview */
+    .cron-preview {
+      margin-top: 6px;
+      padding: 6px 10px;
+      font-size: 11px;
+      border-left: 2px solid var(--border-hi);
+      color: var(--text-dim);
+      background: var(--bg-3);
+      min-height: 26px;
+      transition: border-color 0.12s, color 0.12s;
+    }
+    .cron-preview.ok    { border-left-color: var(--accent); color: var(--accent); }
+    .cron-preview.bad   { border-left-color: var(--red); color: var(--red); }
+
+    /* json error */
+    .field-err { font-size: 10px; color: var(--red); margin-top: 3px; }
+
+    /* enabled toggle row */
+    .toggle-row {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 7px 11px;
+      background: var(--bg-3);
+      border: 1px solid var(--border);
+    }
+    .toggle-row-label {
+      font-size: 9px;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: var(--text-dim);
+    }
+
+    /* ── Confirm dialog ── */
+    .confirm-dialog {
+      background: var(--bg-2);
+      border: 1px solid var(--red);
+      padding: 22px;
+      width: clamp(240px, 90vw, 350px);
+      transform: translateY(8px);
+      transition: transform 0.15s;
+    }
+    .overlay.open .confirm-dialog { transform: translateY(0); }
+
+    .confirm-title { font-size: 12px; color: var(--red); letter-spacing: 0.06em; margin-bottom: 8px; }
+    .confirm-msg   { font-size: 11px; color: var(--text-mid); line-height: 1.5; margin-bottom: 18px; }
+    .confirm-acts  { display: flex; gap: 8px; justify-content: flex-end; }
+
+    /* ── Toast ── */
+    .toast-wrap {
+      position: fixed; bottom: 22px; right: 22px;
+      z-index: 500;
+      display: flex; flex-direction: column; gap: 6px; align-items: flex-end;
+    }
+
+    .toast {
+      font-family: var(--mono);
+      font-size: 11px;
+      padding: 9px 14px;
+      border: 1px solid;
+      max-width: 300px;
+      animation: toast-in 0.18s ease-out;
+      letter-spacing: 0.03em;
+    }
+    .toast.ok  { border-color: var(--accent); color: var(--accent); background: var(--accent-dim); }
+    .toast.err { border-color: var(--red);    color: var(--red);    background: var(--red-dim); }
+    @keyframes toast-in { from { opacity:0; transform: translateX(12px); } to { opacity:1; transform:none; } }
+
+    /* ── Loader ── */
+    .spinner {
+      display: inline-block;
+      width: 11px; height: 11px;
+      border: 1px solid var(--text-ghost);
+      border-top-color: var(--accent);
+      border-radius: 50%;
+      animation: spin 0.55s linear infinite;
+    }
+
+    /* ── System section ── */
+    .system-section { margin-top: 48px; }
+
+    .badge-readonly {
+      display: inline-block;
+      font-size: 8px;
+      letter-spacing: 0.16em;
+      padding: 2px 6px;
+      border: 1px solid #3a4a7a;
+      color: #7c8fc9;
+      background: #0c1020;
+      vertical-align: middle;
+      margin-left: 8px;
+      text-transform: uppercase;
+    }
+
+    .sys-source {
+      font-size: 9px;
+      color: #7c8fc9;
+      letter-spacing: 0.06em;
+    }
+
+    tbody tr.sys-row { opacity: 0.85; }
+    tbody tr.sys-row:hover { background: #0c1420; }
+
+    /* ── Create page ── */
+    .create-page { max-width: 640px; margin: 0 auto; padding: 32px 28px; }
+
+    .page-hd {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      margin-bottom: 24px;
+      padding-bottom: 14px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .page-title {
+      font-size: 11px;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--text-hi);
+    }
+
+    .page-freshness {
+      font-size: 10px;
+      color: var(--text-ghost);
+      margin-left: auto;
+    }
+
+    .cell-goal {
+      font-size: 10px;
+      color: var(--text-ghost);
+      margin-top: 2px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 220px;
+    }
+
+    .page-card {
+      background: var(--bg-2);
+      border: 1px solid var(--border-hi);
+    }
+
+    /* ── Logs page ── */
+    .logs-page { max-width: 1100px; margin: 0 auto; padding: 32px 28px; }
+
+    .logs-wrap {
+      border: 1px solid var(--border);
+      background: var(--bg-2);
+      min-height: 300px;
+      max-height: 70vh;
+      overflow-y: auto;
+      position: relative;
+    }
+
+    .logs-content {
+      display: block;
+      padding: 16px 18px;
+      font-family: var(--mono);
+      font-size: 12px;
+      line-height: 1.7;
+      color: var(--text-mid);
+      white-space: pre-wrap;
+      word-break: break-all;
+      margin: 0;
+    }
+
+    .logs-empty {
+      padding: 48px;
+      text-align: center;
+      font-size: 11px;
+      color: var(--text-ghost);
+      letter-spacing: 0.12em;
+    }
+
+    .logs-error {
+      padding: 24px 18px;
+      font-size: 11px;
+      color: var(--red);
+      border-left: 2px solid var(--red);
+      margin: 16px;
+      background: var(--red-dim);
+    }
+
+    .act-btn.logs { color: var(--text-ghost); }
+    .act-btn.logs:hover { color: var(--text-mid); border-color: var(--border-hi); }
+
+    .act-btn.flags { color: var(--text-ghost); display: inline-flex; align-items: center; gap: 4px; }
+    .act-btn.flags:hover { color: var(--text-mid); border-color: var(--border-hi); }
+
+    .act-btn.history { color: var(--text-ghost); }
+    .act-btn.history:hover { color: var(--text-mid); border-color: var(--border-hi); }
+
+    /* ── Run history status badge (HISTORY page per-run status) ── */
+    .run-status {
+      display: inline-block;
+      font-size: 8px;
+      font-weight: 600;
+      letter-spacing: 0.1em;
+      padding: 2px 5px;
+      border: 1px solid var(--border-hi);
+      color: var(--text-mid);
+      white-space: nowrap;
+    }
+    .run-status.running { border-color: var(--amber); color: var(--amber); background: var(--amber-dim); }
+    .run-status.success { border-color: var(--accent); color: var(--accent); background: var(--accent-dim); }
+    .run-status.failed  { border-color: var(--red);   color: var(--red);   background: var(--red-dim); }
+    .run-status.unknown { border-color: var(--border-hi); color: var(--text-dim); }
+    .flag-badge {
+      display: inline-block;
+      min-width: 14px;
+      padding: 0 4px;
+      border-radius: 8px;
+      background: var(--accent);
+      color: var(--bg);
+      font-size: 9px;
+      line-height: 14px;
+      text-align: center;
+    }
+
+    .flags-list { display: flex; flex-direction: column; gap: 1px; margin: 16px; }
+    .flags-count { font-size: 10px; color: var(--text-ghost); margin-bottom: 8px; }
+    .flag-item { padding: 12px 16px; border: 1px solid var(--border); background: var(--bg-2); }
+    .flag-item-hd { display: flex; align-items: center; gap: 8px; }
+    .flag-type { font-family: var(--mono); font-size: 11px; color: var(--text-hi); text-transform: uppercase; }
+    .flag-scope { font-size: 10px; color: var(--text-ghost); border: 1px solid var(--border); border-radius: 3px; padding: 0 4px; }
+    .flag-age { font-size: 10px; color: var(--text-dim); }
+    .flag-item-hd .btn { margin-left: auto; }
+    .flag-desc { margin-top: 6px; font-size: 12px; color: var(--text-mid); white-space: pre-wrap; }
+
+    /* ── Schedule fire preview ── */
+    .sched-preview-btn {
+      display: inline-block;
+      margin-top: 4px;
+      font-family: var(--mono);
+      font-size: 9px;
+      letter-spacing: 0.1em;
+      padding: 1px 6px;
+      border: 1px solid var(--border);
+      color: var(--text-ghost);
+      cursor: pointer;
+      background: transparent;
+      transition: color 0.1s, border-color 0.1s;
+    }
+    .sched-preview-btn:hover { color: var(--text-mid); border-color: var(--border-hi); }
+    .sched-preview-btn.open  { color: var(--accent); border-color: var(--accent); }
+
+    .fires-panel {
+      margin-top: 6px;
+      border: 1px solid var(--border-hi);
+      background: var(--bg-3);
+      padding: 7px 10px;
+    }
+    .fires-hd {
+      font-size: 8px;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      color: var(--text-ghost);
+      margin-bottom: 5px;
+    }
+    .fires-item {
+      display: flex;
+      gap: 8px;
+      align-items: baseline;
+      padding: 2px 0;
+    }
+    .fires-when  { font-size: 11px; color: var(--text-hi); }
+    .fires-until { font-size: 10px; color: var(--text-dim); }
+    .fires-empty { font-size: 10px; color: var(--text-ghost); }
+
+    /* ── View toggle ── */
+    .section-acts { display: flex; align-items: center; gap: 10px; }
+
+    /* ── Auto-refresh control ── */
+    .refresh-control { display: flex; align-items: center; gap: 7px; }
+    .refresh-lbl {
+      font-family: var(--mono);
+      font-size: 9px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--text-dim);
+    }
+    .refresh-select {
+      background: var(--bg-3);
+      border: 1px solid var(--border);
+      color: var(--text);
+      font-family: var(--mono);
+      font-size: 11px;
+      padding: 4px 8px;
+      outline: none;
+      cursor: pointer;
+      transition: border-color 0.12s;
+    }
+    .refresh-select:focus { border-color: var(--accent); }
+    .refresh-fresh {
+      font-family: var(--mono);
+      font-size: 10px;
+      letter-spacing: 0.04em;
+      color: var(--text-ghost);
+      white-space: nowrap;
+    }
+
+    .view-toggle { display: flex; border: 1px solid var(--border); }
+
+    .view-btn {
+      font-family: var(--mono);
+      font-size: 9px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      padding: 5px 11px;
+      border: none;
+      background: transparent;
+      color: var(--text-dim);
+      cursor: pointer;
+      transition: color 0.12s, background 0.12s;
+    }
+    .view-btn + .view-btn { border-left: 1px solid var(--border); }
+    .view-btn:hover  { color: var(--text-mid); }
+    .view-btn.active { color: var(--accent); background: var(--accent-dim); }
+
+    /* ── Filter & sort bar ── */
+    .filter-bar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-bottom: 10px;
+    }
+    .filter-field { display: flex; align-items: center; gap: 8px; }
+    .filter-input {
+      background: var(--bg-3);
+      border: 1px solid var(--border);
+      color: var(--text);
+      font-family: var(--mono);
+      font-size: 12px;
+      padding: 6px 10px;
+      min-width: clamp(140px, 40vw, 240px);
+      outline: none;
+      transition: border-color 0.12s;
+    }
+    .filter-input:focus       { border-color: var(--accent); }
+    .filter-input::placeholder { color: var(--text-ghost); }
+    .filter-label {
+      font-family: var(--mono);
+      font-size: 9px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--text-dim);
+    }
+    .filter-select {
+      background: var(--bg-3);
+      border: 1px solid var(--border);
+      color: var(--text);
+      font-family: var(--mono);
+      font-size: 12px;
+      padding: 6px 10px;
+      outline: none;
+      cursor: pointer;
+      transition: border-color 0.12s;
+    }
+    .filter-select:focus { border-color: var(--accent); }
+    .filter-count {
+      font-family: var(--mono);
+      font-size: 11px;
+      letter-spacing: 0.04em;
+      color: var(--text-dim);
+      white-space: nowrap;
+    }
+
+    /* ── Group-by selector ── */
+    .group-by-ctrl { display: flex; align-items: center; gap: 6px; }
+
+    /* ── Table group header rows ── */
+    tr.group-hd td {
+      padding: 5px 10px;
+      background: var(--bg-3);
+      border-top: 1px solid var(--border);
+      border-bottom: 1px solid var(--border);
+    }
+    tr.group-hd:first-child td { border-top: none; }
+    .group-label {
+      font-family: var(--mono);
+      font-size: 10px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--text-hi);
+      font-weight: 600;
+    }
+    .group-count {
+      margin-left: 6px;
+      font-family: var(--mono);
+      font-size: 10px;
+      letter-spacing: 0.06em;
+      color: var(--text-dim);
+    }
+
+    /* ── Calendar ── */
+    .cal-wrap {
+      border: 1px solid var(--border);
+      background: var(--bg-2);
+      overflow: hidden;
+    }
+
+    .cal-nav {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 14px;
+      border-bottom: 1px solid var(--border);
+      background: var(--bg-3);
+    }
+    .cal-month {
+      font-size: 12px;
+      letter-spacing: 0.14em;
+      color: var(--text-hi);
+      min-width: clamp(90px, 30vw, 150px);
+      text-align: center;
+    }
+    .cal-nav .btn-ghost { margin-left: auto; }
+
+    .cal-weekdays,
+    .cal-grid {
+      display: grid;
+      grid-template-columns: repeat(7, 1fr);
+    }
+
+    .cal-weekday {
+      padding: 7px 8px;
+      font-size: 9px;
+      letter-spacing: 0.16em;
+      color: var(--text-ghost);
+      text-align: center;
+      border-bottom: 1px solid var(--border);
+      background: var(--bg-3);
+    }
+
+    .cal-day {
+      min-height: 92px;
+      padding: 6px;
+      border-right: 1px solid var(--border);
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      overflow: hidden;
+    }
+    .cal-day:nth-child(7n) { border-right: none; }
+    .cal-grid > .cal-day:nth-last-child(-n+7) { border-bottom: none; }
+    .cal-day.other-month { background: var(--bg); opacity: 0.55; }
+    .cal-day.today { background: var(--accent-dim); }
+
+    .cal-daynum { font-size: 11px; color: var(--text-mid); }
+    .cal-day.today .cal-daynum { color: var(--accent); }
+
+    .cal-hits { display: flex; flex-direction: column; gap: 3px; }
+
+    .cal-chip {
+      font-size: 9px;
+      letter-spacing: 0.02em;
+      padding: 2px 5px;
+      background: var(--bg-3);
+      border-left: 2px solid var(--accent);
+      color: var(--text);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .cal-more { font-size: 9px; color: var(--text-ghost); padding: 0 5px; }
+    .cal-chip.snoozed { opacity: 0.45; border-left-color: var(--amber); }
+    .cal-chip.clickable,
+    .cal-event.clickable { cursor: pointer; }
+    .cal-chip.clickable:hover,
+    .cal-event.clickable:hover { background: var(--bg-hi, var(--bg-3)); filter: brightness(1.12); }
+
+    @media (max-width: 640px) {
+      .cal-day { min-height: 64px; }
+      .cal-chip { font-size: 8px; }
+    }
+
+    /* ── Day timeline ── */
+    .day-wrap {
+      border: 1px solid var(--border);
+      background: var(--bg-2);
+      overflow: hidden;
+    }
+    .day-nav {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 14px;
+      border-bottom: 1px solid var(--border);
+      background: var(--bg-3);
+    }
+    .day-date {
+      font-size: 12px;
+      letter-spacing: 0.14em;
+      color: var(--text-hi);
+      min-width: clamp(110px, 35vw, 180px);
+      text-align: center;
+    }
+    .day-nav .btn-ghost { margin-left: auto; }
+    .day-zoom { display: flex; align-items: center; gap: 4px; }
+    .day-zoom .btn-refresh { padding: 2px 8px; }
+    .day-zoom-level {
+      font-size: 10px;
+      letter-spacing: 0.06em;
+      color: var(--text-ghost);
+      min-width: 22px;
+      text-align: center;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .day-scroll {
+      --dh: 40px;
+      max-height: 60vh;
+      overflow-y: auto;
+    }
+    .day-hour {
+      display: grid;
+      grid-template-columns: 64px 1fr;
+      min-height: var(--dh);
+      border-bottom: 1px solid var(--border);
+    }
+    .day-scroll > .day-hour:last-child { border-bottom: none; }
+    .day-hour.now { background: var(--accent-dim); }
+
+    .day-hour-label {
+      padding: 8px 10px;
+      font-size: 10px;
+      letter-spacing: 0.08em;
+      color: var(--text-ghost);
+      border-right: 1px solid var(--border);
+      text-align: right;
+    }
+    .day-hour.now .day-hour-label { color: var(--accent); }
+
+    .day-hour-slot {
+      display: flex;
+      flex-wrap: wrap;
+      align-content: flex-start;
+      gap: 4px;
+      padding: 6px 8px;
+    }
+
+    /* ── Detail (zoomed) mode: minute-positioned timeline ── */
+    /* Hour label becomes a quarter-hour ruler spanning the tall row. */
+    .day-scroll.detail .day-hour-label {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      padding: 0 10px;
+      text-align: right;
+    }
+    .day-scroll.detail .day-hour-label .qt { font-size: 9px; opacity: 0.45; }
+    .day-scroll.detail .day-hour-label .qt-end { height: 0; }
+    /* Slot is a positioning context with quarter-hour guide lines. */
+    .day-scroll.detail .day-hour-slot {
+      position: relative;
+      display: block;
+      padding: 0;
+    }
+    .day-scroll.detail .day-hour-slot::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      background: repeating-linear-gradient(
+        to bottom,
+        var(--border) 0,
+        var(--border) 1px,
+        transparent 1px,
+        transparent calc(var(--dh) / 4)
+      );
+      opacity: 0.5;
+    }
+    /* Each fire chip floats at its exact minute via inline top:%. */
+    .day-scroll.detail .day-chip {
+      position: absolute;
+      left: 8px;
+      max-width: calc(100% - 16px);
+      transform: translateY(-50%);
+      z-index: 1;
+    }
+    .day-scroll.detail .day-chip:hover { z-index: 2; }
+    .day-chip {
+      display: inline-flex;
+      align-items: baseline;
+      gap: 6px;
+      font-size: 10px;
+      padding: 2px 7px;
+      background: var(--bg-3);
+      border-left: 2px solid var(--accent);
+      color: var(--text);
+      max-width: 100%;
+    }
+    .day-chip-time {
+      font-variant-numeric: tabular-nums;
+      color: var(--text-hi);
+      letter-spacing: 0.02em;
+    }
+    .day-chip-label {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .day-chip.clickable { cursor: pointer; }
+    .day-chip.clickable:hover { filter: brightness(1.12); }
+    .day-chip.snoozed { opacity: 0.45; border-left-color: var(--amber); }
+    .day-chip-flag {
+      font-size: 9px;
+      color: var(--red);
+      margin-left: auto;
+      flex-shrink: 0;
+    }
+
+    @media (max-width: 640px) {
+      .day-hour { grid-template-columns: 52px 1fr; }
+      .day-chip { font-size: 9px; }
+    }
+
+    /* ── Enhanced log viewer ── */
+    /* Search bar — sticky so it stays visible while scrolling long logs. */
+    .log-search {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      border-bottom: 1px solid var(--border);
+      background: var(--bg-3);
+      position: sticky;
+      top: 0;
+      z-index: 1;
+    }
+    .log-search-input {
+      flex: 1;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      color: var(--text);
+      font-family: var(--mono);
+      font-size: 12px;
+      padding: 5px 9px;
+      outline: none;
+      min-width: 0;
+      transition: border-color 0.12s;
+    }
+    .log-search-input:focus { border-color: var(--accent); }
+    .log-search-input::placeholder { color: var(--text-ghost); }
+    /* Search clear button — type=search gives a native clear affordance but
+       we keep our styled button for visual consistency. */
+    input[type="search"]::-webkit-search-cancel-button { display: none; }
+    .log-match-count {
+      font-size: 10px;
+      letter-spacing: 0.06em;
+      color: var(--text-ghost);
+      white-space: nowrap;
+      margin-left: auto;
+    }
+    /* Numbered lines */
+    .log-lines { padding: 6px 0; }
+    .log-line {
+      display: flex;
+      font-family: var(--mono);
+      font-size: 12px;
+      line-height: 1.7;
+    }
+    .log-line:hover { background: var(--bg-3); }
+    .log-ln {
+      min-width: 44px;
+      padding: 0 8px 0 12px;
+      text-align: right;
+      color: var(--text-ghost);
+      user-select: none;
+      flex-shrink: 0;
+      border-right: 1px solid var(--border);
+      font-variant-numeric: tabular-nums;
+    }
+    .log-lc {
+      padding: 0 12px;
+      color: var(--text-mid);
+      flex: 1;
+      min-width: 0;
+      white-space: pre-wrap;
+      word-break: break-all;
+    }
+    /* Keyword highlight — amber on dark amber-dim, amber border, no border-radius
+       keeps the terminal aesthetic. */
+    mark.log-hl {
+      background: var(--amber-dim);
+      color: var(--amber);
+      border: 1px solid var(--amber);
+      padding: 0 1px;
+      border-radius: 0;
+    }
+    mark.log-hl:focus-visible { outline: 1px solid var(--accent); }
+
+    /* ── Reduced motion ── */
+    /* Honor the user's OS/browser "reduce motion" preference: settle the
+       decorative, continuous animations (glow pulse, refresh/loader spin) and
+       hover transitions near-instantly. Gated behind the user's own opt-in, so
+       default motion is unchanged for everyone else. */
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+      }
+    }
+
+    /* ── Keyboard focus ── */
+    /* Give every interactive control a clear, consistent focus ring for
+       keyboard users. :focus-visible only fires for keyboard/programmatic
+       focus, so mouse users see no change. Mirrors the accent ring already
+       used by .row-check. */
+    .btn:focus-visible,
+    .machine-badge:focus-visible,
+    .btn-refresh:focus-visible,
+    .btn-stop:focus-visible,
+    .tab-btn:focus-visible,
+    .act-btn:focus-visible,
+    .view-btn:focus-visible,
+    .preset-btn:focus-visible,
+    .modal-x:focus-visible,
+    .toggle input:focus-visible + .toggle-track {
+      outline: 1px solid var(--accent);
+      outline-offset: 1px;
+    }
+
+    /* ── Scrollbar ── */
+    /* Firefox / standard properties mirror the WebKit dark, thin scrollbar
+       below. They inherit, so this root declaration also styles the nested
+       scroll containers (logs, modal, day timeline) to match the WebKit rules,
+       which apply globally. Reuses the theme tokens so colors stay in sync. */
+    html { scrollbar-width: thin; scrollbar-color: var(--border-hi) var(--bg); }
+    ::-webkit-scrollbar       { width: 5px; }
+    ::-webkit-scrollbar-track { background: var(--bg); }
+    ::-webkit-scrollbar-thumb { background: var(--border-hi); }
+    ::-webkit-scrollbar-thumb:hover { background: var(--text-dim); }
+
+    /* ── Schedule heatmap ── */
+    .hm-filter { display: flex; gap: 6px; }
+    .hm-filter-btn {
+      font-family: var(--mono);
+      font-size: 9px; letter-spacing: 0.16em; text-transform: uppercase;
+      padding: 5px 11px;
+      background: var(--bg-2);
+      border: 1px solid var(--border);
+      color: var(--text-dim);
+      cursor: pointer;
+    }
+    .hm-filter-btn:hover { color: var(--accent); border-color: var(--border-hi); }
+    .hm-filter-btn.active { color: var(--bg); background: var(--accent); border-color: var(--accent); }
+    .hm-filter-btn:focus-visible { outline: 1px solid var(--accent); outline-offset: 2px; }
+
+    .hm-wrap {
+      border: 1px solid var(--border);
+      background: var(--bg-2);
+      overflow-x: auto;
+      padding: 6px;
+    }
+    table.heatmap {
+      border-collapse: separate;
+      border-spacing: 2px;
+      width: 100%;
+      min-width: 720px;
+      table-layout: fixed;
+    }
+    @media (max-width: 640px) {
+      table.heatmap { min-width: 480px; }
+      .hm-daylabel { width: 40px; }
+      .hm-cell { height: 16px; font-size: 8px; }
+    }
+    table.heatmap th, table.heatmap td { padding: 0; }
+    .hm-corner, .hm-hcol {
+      font-size: 8px; letter-spacing: 0.04em;
+      color: var(--text-ghost);
+      font-weight: 400;
+      text-align: center;
+      padding: 4px 0;
+    }
+    .hm-corner { text-align: right; padding-right: 8px; }
+    .hm-hcol.now { color: var(--accent); }
+    .hm-daylabel {
+      font-size: 9px; letter-spacing: 0.1em;
+      color: var(--text-dim);
+      font-weight: 400;
+      text-align: right;
+      padding-right: 8px;
+      white-space: nowrap;
+      width: 62px;
+    }
+    .hm-row.today .hm-daylabel { color: var(--accent); }
+    .hm-cell {
+      height: 22px;
+      border: 1px solid var(--border);
+      text-align: center;
+      vertical-align: middle;
+      font-size: 9px;
+      color: var(--text-hi);
+    }
+    .hm-cell.lvl-0 { background: var(--bg-3); }
+    .hm-cell.lvl-1 { background: #103a22; }
+    .hm-cell.lvl-2 { background: #1c6b3a; }
+    .hm-cell.lvl-3 { background: #2fa058; }
+    .hm-cell.lvl-4 { background: var(--accent); color: var(--bg); }
+    .hm-cell.now  { outline: 1px solid var(--text-mid); outline-offset: -1px; }
+    .hm-cell.peak { outline: 2px solid var(--amber); outline-offset: -1px; }
+    .hm-n { font-family: var(--mono); }
+    .hm-rowtot {
+      font-size: 9px;
+      color: var(--text-mid);
+      text-align: center;
+      background: var(--bg-3);
+      padding: 0 2px;
+    }
+    .hm-rowtot.grand { color: var(--text-hi); }
+    table.heatmap tfoot .hm-rowtot { border-top: 1px solid var(--border-hi); }
+
+    .hm-legend {
+      display: flex; align-items: center; gap: 6px; flex-wrap: wrap;
+      margin-top: 12px;
+      font-size: 9px; letter-spacing: 0.12em;
+      color: var(--text-dim);
+    }
+    .hm-legend-swatch {
+      display: inline-block; width: 16px; height: 14px;
+      border: 1px solid var(--border);
+    }
+    .hm-legend-note {
+      margin-left: 10px; letter-spacing: 0.06em;
+      color: var(--text-ghost); text-transform: none;
+    }
+</style>
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -1280,6 +2991,5 @@ export { initSync, __wbg_init as default };
 
 await __wbg_init();
 </script>
-  <link rel="stylesheet" href="./styles-675748a635454b93.css" integrity="sha384-vDCNMAhjYr4IZa7zeoEEnfby+Nm60OM2AyZSJ9vmV0psILRf1keve43Dtbd5Umfz"/>
 <body></body>
 </html>

--- a/src/build/ui.rs
+++ b/src/build/ui.rs
@@ -82,11 +82,13 @@ fn run_trunk(ui_dir: &Path) -> bool {
 /// Strategy: monkey-patch `fetch` before the wasm-bindgen init call so that
 /// any request for a `.wasm` URL returns our base64-encoded bytes instead.
 /// This avoids touching wasm-bindgen internals while keeping a single file.
+/// The compiled CSS is inlined into a `<style>` block the same way, so the
+/// served bundle makes zero external asset requests.
 fn inline_into_html(dist: &Path, output: &Path) {
     let html_src = std::fs::read_to_string(dist.join("index.html"))
         .expect("dist/index.html missing after trunk build");
 
-    let (js_path, wasm_path) = find_dist_assets(dist);
+    let (js_path, wasm_path, css_path) = find_dist_assets(dist);
 
     let js = js_path
         .as_ref()
@@ -101,6 +103,11 @@ fn inline_into_html(dist: &Path, output: &Path) {
         })
         .unwrap_or_default();
 
+    let css = css_path
+        .as_ref()
+        .map(|path| std::fs::read_to_string(path).expect("failed to read .css dist asset"))
+        .unwrap_or_default();
+
     let wasm_file = wasm_path
         .as_ref()
         .and_then(|path| path.file_name())
@@ -108,6 +115,12 @@ fn inline_into_html(dist: &Path, output: &Path) {
         .unwrap_or_default();
 
     let js_file = js_path
+        .as_ref()
+        .and_then(|path| path.file_name())
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    let css_file = css_path
         .as_ref()
         .and_then(|path| path.file_name())
         .map(|n| n.to_string_lossy().to_string())
@@ -130,7 +143,20 @@ await __wbg_init();
 </script>"#
     );
 
-    let final_html = assemble_html(&html_src, &inline_script, &js_file, &wasm_file);
+    let inline_style = if css.is_empty() {
+        String::new()
+    } else {
+        format!("<style>{css}</style>")
+    };
+
+    let final_html = assemble_html(
+        &html_src,
+        &inline_script,
+        &inline_style,
+        &js_file,
+        &wasm_file,
+        &css_file,
+    );
 
     if let Some(parent) = output.parent() {
         std::fs::create_dir_all(parent).expect("failed to create output dir");
@@ -138,10 +164,11 @@ await __wbg_init();
     std::fs::write(output, final_html).expect("failed to write inlined index.html");
 }
 
-/// Locate the `.js` and `.wasm` files in trunk's `dist/` directory.
-fn find_dist_assets(dist: &Path) -> (Option<PathBuf>, Option<PathBuf>) {
+/// Locate the `.js`, `.wasm`, and `.css` files in trunk's `dist/` directory.
+fn find_dist_assets(dist: &Path) -> (Option<PathBuf>, Option<PathBuf>, Option<PathBuf>) {
     let mut js_path = None;
     let mut wasm_path = None;
+    let mut css_path = None;
     for entry in std::fs::read_dir(dist).expect("dist dir missing").flatten() {
         let path = entry.path();
         let name = path.file_name().unwrap_or_default().to_string_lossy();
@@ -149,38 +176,61 @@ fn find_dist_assets(dist: &Path) -> (Option<PathBuf>, Option<PathBuf>) {
             js_path = Some(path);
         } else if name.ends_with(".wasm") {
             wasm_path = Some(path);
+        } else if name.ends_with(".css") {
+            css_path = Some(path);
         }
     }
-    (js_path, wasm_path)
+    (js_path, wasm_path, css_path)
 }
 
-/// Strip external asset references and inject the inline script.
-fn assemble_html(html: &str, inline_script: &str, js_file: &str, wasm_file: &str) -> String {
-    // Drop <link> preload/modulepreload lines referencing the generated assets
+/// Strip external asset references and inject the inline script and style.
+fn assemble_html(
+    html: &str,
+    inline_script: &str,
+    inline_style: &str,
+    js_file: &str,
+    wasm_file: &str,
+    css_file: &str,
+) -> String {
+    // Drop <link> preload/modulepreload/stylesheet lines referencing the
+    // generated assets — their bytes are inlined instead. A blank filename
+    // (asset not found in dist/) matches every line via `contains("")`, so
+    // guard against that rather than filtering the whole document away.
     let stripped: String = html
         .lines()
         .filter(|line| {
             let trimmed = line.trim();
-            !(trimmed.contains(js_file) || trimmed.contains(wasm_file))
+            let references = |name: &str| !name.is_empty() && trimmed.contains(name);
+            !(references(js_file) || references(wasm_file) || references(css_file))
         })
         .collect::<Vec<_>>()
         .join("\n");
+
+    // Inline the compiled CSS into <head> so no `<link rel="stylesheet">`
+    // ever points at an asset that isn't shipped with the single-file bundle.
+    let with_style = if inline_style.is_empty() {
+        stripped
+    } else if stripped.contains("</head>") {
+        stripped.replacen("</head>", &format!("{inline_style}\n</head>"), 1)
+    } else {
+        format!("{inline_style}\n{stripped}")
+    };
 
     // Replace the trunk-generated <script type="module">…</script> with our inline version.
     // Trunk emits exactly one such block; if the pattern changes between trunk versions
     // this falls back to appending before </body>.
     let marker = r#"<script type="module">"#;
-    if let Some(start) = stripped.find(marker) {
-        if let Some(rel_end) = stripped[start..].find("</script>") {
+    if let Some(start) = with_style.find(marker) {
+        if let Some(rel_end) = with_style[start..].find("</script>") {
             let end = start + rel_end + "</script>".len();
-            let mut out = stripped.clone();
+            let mut out = with_style.clone();
             out.replace_range(start..end, inline_script);
             return out;
         }
     }
 
     // Fallback: append before </body>
-    stripped.replace("</body>", &format!("{inline_script}\n</body>"))
+    with_style.replace("</body>", &format!("{inline_script}\n</body>"))
 }
 
 /// Encode `bytes` as standard base64.


### PR DESCRIPTION
## Summary
- `cargo install moadim` served a completely unstyled control panel — found via Playwright while validating the v0.27.0 release.
- Root cause: `src/build/ui.rs::inline_into_html` inlines trunk's compiled JS and WASM into a single self-contained `prebuilt.html`, but left the CSS as an external `<link rel="stylesheet" href="./styles-<hash>.css">`. Only `prebuilt.html` gets copied to the package root and shipped in the published crate, so that CSS file never ships. At runtime the server's catch-all route serves `index.html` for the missing CSS request, and strict MIME checking refuses to apply `text/html` as a stylesheet — the page renders with zero styling.
- Not a v0.27.0 regression: reproduces on the `v0.26.0` tag too. It was never caught because `src/build/ui.rs` only runs inside `build.rs` and isn't reachable by `cargo test`; the existing `prebuilt-ui.yml` CI job only checks *freshness* (does the committed `prebuilt.html` match a fresh trunk rebuild), not runtime asset serving.
- Fix: `find_dist_assets` now also locates the `.css` file in trunk's `dist/`, and `assemble_html` inlines its contents into a `<style>` block in `<head>` — the same inlining strategy already used for WASM — so the served bundle makes zero external asset requests.

## Test plan
- [x] `cargo test` — 994 passed, 0 failed.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] Rebuilt `prebuilt.html` locally (`cargo check` with `trunk` installed); confirmed no `rel="stylesheet"` link remains and the CSS is now inlined in a `<style>` block.
- [x] Ran the built binary and loaded the UI in a real browser via Playwright: fully styled dark-terminal theme renders correctly, no MIME/CSP errors for CSS.
- [x] Pre-push hook (full suite + 100% coverage gate) passed.