### PR TITLE
fix(routines): verify Claude trust-dialog pre-seed persisted before launch

### DIFF
--- a/.changeset/harden-claude-trust-preseed-verification.md
+++ b/.changeset/harden-claude-trust-preseed-verification.md
@@ -1,0 +1,14 @@
+---
+"moadim": patch
+---
+
+fix(routines): verify the Claude trust-dialog pre-seed actually persisted before launching
+
+The `claude` agent's `setup` step pre-seeds `~/.claude.json` so a headless routine run
+never blocks on Claude Code's "Do you trust this folder?" dialog. Live runs were found
+parked at that exact dialog for hours — reaped only by the ~1h watchdog, with an empty
+log — because the write had silently not taken effect for that workbench. The setup
+script now reads `~/.claude.json` back after writing and asserts the seeded entry is
+actually there; a failed assertion makes the script exit non-zero, which the launcher's
+existing `{setup}; } || { ...; exit 1; }` guard turns into an immediate, diagnosable
+"agent setup failed" abort instead of a silent multi-hour hang.

--- a/src/routines/agents/claude_code/setup.rs
+++ b/src/routines/agents/claude_code/setup.rs
@@ -11,6 +11,17 @@ pub const NAME: &str = "claude";
 /// on the workspace-trust dialog or a project MCP-server approval prompt. Both are keyed by exact
 /// path (not inherited from parent dirs), so they must be seeded for each fresh workbench.
 ///
+/// The write is verified by reading `~/.claude.json` back and asserting the seeded entry is
+/// actually there before declaring success: a run that hit this seen live sessions parked at the
+/// trust dialog for hours with `hasTrustDialogAccepted` missing from the file despite `setup`
+/// having (apparently) run — most plausibly a write silently lost to disk pressure, a permission
+/// hiccup on `~/.claude.json`, or `$WB` disagreeing with the path `claude` actually resolves for
+/// the workbench. Any of those now makes the assertion fail, which `build_routine_command`'s
+/// `{setup}; } || { ... exit 1; }` guard turns into a same-run `agent setup failed` abort instead
+/// of the agent launching anyway into an unattended dialog that only the ~1h watchdog reaps, with
+/// no diagnostic. This can't catch the CLI itself changing what it reads from the file — only that
+/// this process actually wrote what it meant to.
+///
 /// Reads project instructions from `AGENTS.md` — the same file Codex uses — so the moadim-managed
 /// system prompt and routine-origin disclosure are unified onto one instructions file across
 /// agents. Claude Code loads `AGENTS.md` as a memory/context file, so the disclosure is honored
@@ -28,5 +39,8 @@ instructions_file = "AGENTS.md"
 # temp file + os.replace (atomic rename). ~/.claude.json is shared with the live claude process,
 # so a plain open("w") truncate-then-write could interleave with a concurrent writer and leave a
 # spliced, unparseable file; the atomic replace guarantees readers always see one complete JSON.
-setup = '''python3 -c 'import json,os,sys,tempfile,fcntl; home=os.path.expanduser("~"); p=home+"/.claude.json"; lf=open(p+".lock","w"); fcntl.flock(lf,fcntl.LOCK_EX); d=json.load(open(p)) if os.path.exists(p) else {}; wb=sys.argv[1]; e=d.setdefault("projects",{}).setdefault(wb,{}); e.update({"hasTrustDialogAccepted":True,"hasCompletedProjectOnboarding":True}); e.setdefault("projectOnboardingSeenCount",1); g=lambda f: list(json.load(open(f)).get("mcpServers",{}).keys()) if os.path.exists(f) else []; e["disabledMcpjsonServers"]=sorted(set(e.get("disabledMcpjsonServers",[]))|set(g(home+"/.mcp.json"))|set(g(wb+"/.mcp.json"))); fd,tmp=tempfile.mkstemp(dir=home,prefix=".claude.json.",suffix=".tmp"); os.write(fd,json.dumps(d).encode()); os.close(fd); os.replace(tmp,p); fcntl.flock(lf,fcntl.LOCK_UN)' "$WB"'''
+# After unlocking, re-read the file from disk and assert the entry landed — a non-zero exit here
+# aborts the launch instead of leaving the agent to hang unattended at the dialog this was meant
+# to skip.
+setup = '''python3 -c 'import json,os,sys,tempfile,fcntl; home=os.path.expanduser("~"); p=home+"/.claude.json"; lf=open(p+".lock","w"); fcntl.flock(lf,fcntl.LOCK_EX); d=json.load(open(p)) if os.path.exists(p) else {}; wb=sys.argv[1]; e=d.setdefault("projects",{}).setdefault(wb,{}); e.update({"hasTrustDialogAccepted":True,"hasCompletedProjectOnboarding":True}); e.setdefault("projectOnboardingSeenCount",1); g=lambda f: list(json.load(open(f)).get("mcpServers",{}).keys()) if os.path.exists(f) else []; e["disabledMcpjsonServers"]=sorted(set(e.get("disabledMcpjsonServers",[]))|set(g(home+"/.mcp.json"))|set(g(wb+"/.mcp.json"))); fd,tmp=tempfile.mkstemp(dir=home,prefix=".claude.json.",suffix=".tmp"); os.write(fd,json.dumps(d).encode()); os.close(fd); os.replace(tmp,p); fcntl.flock(lf,fcntl.LOCK_UN); v=json.load(open(p)).get("projects",{}).get(wb,{}); assert v.get("hasTrustDialogAccepted") is True, "trust-dialog pre-seed did not persist to "+p+" for "+wb' "$WB"'''
 "#;

--- a/src/routines/flags.rs
+++ b/src/routines/flags.rs
@@ -78,10 +78,9 @@ fn is_safe_flag_filename(filename: &str) -> bool {
 fn parse_filename(filename: &str) -> Option<(u64, FlagScope)> {
     let (stem, scope) = if let Some(stem) = filename.strip_suffix(".local.md") {
         (stem, FlagScope::Local)
-    } else if let Some(stem) = filename.strip_suffix(".md") {
-        (stem, FlagScope::General)
     } else {
-        return None;
+        let stem = filename.strip_suffix(".md")?;
+        (stem, FlagScope::General)
     };
     let (_, ts) = stem.rsplit_once('-')?;
     let created_at = ts.parse().ok()?;


### PR DESCRIPTION
## Summary
- Live routine runs were found parked for hours at Claude Code's "Do you trust this folder?" dialog — reaped only by the ~1h watchdog, with an empty `agent.log` and no diagnostic.
- Root cause: the `claude` agent's `setup` step pre-seeds `~/.claude.json` (`hasTrustDialogAccepted`) to skip that dialog for headless tmux launches, but the write had silently not taken effect for the affected workbenches — the on-disk entry was simply missing.
- The setup script now reads `~/.claude.json` back after writing and asserts the seeded entry is actually present. A failed assertion makes the script exit non-zero, which `build_routine_command`'s existing `{setup}; } || { ...; exit 1; }` guard turns into an immediate, logged "agent setup failed" abort instead of a silent multi-hour hang.
- Note: this can't detect the CLI itself ignoring a correctly-written key (a future onboarding/schema change on Claude Code's side) — only that *this* process's write actually landed. That's the honest limit of what's fixable from this side.

## Test plan
- [x] `cargo build`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test --workspace` (994 + 274 passed)
- [x] `cargo llvm-cov --fail-under-lines 100` — no coverage regression (string/doc-only change)
- [x] `typos` spellcheck clean
- [x] pre-push hook (full suite + 100% coverage + changeset check) passed on push