### PR TITLE
fix(ci): stop the automated release path from racing itself on test.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,20 @@ name: Publish to crates.io
 #     is where the gap was (see #260): publish ran without ever checking
 #     cargo test/fmt/clippy. Fixed by calling lint.yml/test.yml (already
 #     workflow_call-callable) and gating `publish` on them via `needs:`.
+#
+# The `lint`/`test` skip below keys off `inputs.tag`, not `github.event_name`:
+# a *nested* `workflow_call` (this workflow, called from auto-release.yml,
+# itself triggered by a `push` to main) inherits `github.event_name` from the
+# chain's originating event — it reads `push` here too, not `workflow_call` —
+# so `github.event_name == 'push'` was always true and never actually skipped
+# anything. That silently ran this workflow's own `test.yml` call alongside
+# release.yml's identical call *and* the plain push-triggered `test.yml`, all
+# three racing for the same `test-${{ github.ref }}` concurrency group with
+# `cancel-in-progress: true` — auto-release.yml's `publish`/`release` jobs
+# routinely lost that race and the crate silently failed to publish. `inputs`
+# is only populated on the `workflow_call` path (`required: true` there), so
+# `inputs.tag == ''` reliably means "not called with a tag" — i.e. the direct
+# tag-push escape hatch — regardless of what `github.event_name` reports.
 
 on:
   push:
@@ -34,12 +48,12 @@ jobs:
   # (see header comment above).
   lint:
     name: Lint tagged commit
-    if: github.event_name == 'push'
+    if: inputs.tag == ''
     uses: ./.github/workflows/lint.yml
 
   test:
     name: Test tagged commit
-    if: github.event_name == 'push'
+    if: inputs.tag == ''
     uses: ./.github/workflows/test.yml
 
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,20 @@ name: GitHub Release
 # Release notes are extracted from the matching version section in CHANGELOG.md
 # so the published notes stay in sync with the changelog. Runs independently of
 # publish.yml — neither blocks the other.
+#
+# The `lint`/`test` skip below keys off `inputs.tag`, not `github.event_name`:
+# a *nested* `workflow_call` (this workflow, called from auto-release.yml,
+# itself triggered by a `push` to main) inherits `github.event_name` from the
+# chain's originating event — it reads `push` here too, not `workflow_call` —
+# so `github.event_name == 'push'` was always true and never actually skipped
+# anything. That silently ran this workflow's own `test.yml` call alongside
+# publish.yml's identical call *and* the plain push-triggered `test.yml`, all
+# three racing for the same `test-${{ github.ref }}` concurrency group with
+# `cancel-in-progress: true` — auto-release.yml's `publish`/`release` jobs
+# routinely lost that race. `inputs` is only populated on the `workflow_call`
+# path (`required: true` there), so `inputs.tag == ''` reliably means "not
+# called with a tag" — i.e. the direct tag-push escape hatch — regardless of
+# what `github.event_name` reports.
 
 on:
   push:
@@ -36,12 +50,12 @@ jobs:
   # (see header comment above).
   lint:
     name: Lint tagged commit
-    if: github.event_name == 'push'
+    if: inputs.tag == ''
     uses: ./.github/workflows/lint.yml
 
   test:
     name: Test tagged commit
-    if: github.event_name == 'push'
+    if: inputs.tag == ''
     uses: ./.github/workflows/test.yml
 
   release:


### PR DESCRIPTION
## Summary
- Discovered while chasing down why `v1.0.0`'s `Auto Release` run (triggered by #1098) got its `publish` job's `Test tagged commit` chain cancelled: `publish.yml` and `release.yml` each gate their own redundant `lint`/`test` re-run on `github.event_name == 'push'`, intended to skip it on the automated `workflow_call` path from `auto-release.yml` (that commit is already verified before landing on `main`).
- A *nested* `workflow_call` inherits `github.event_name` from the chain's originating event — since `auto-release.yml` itself is triggered by a `push` to `main`, `github.event_name` reads `push` all the way down, so that guard has never actually skipped anything.
- Net effect: every version bump ran **three** concurrent `test.yml` calls (`publish`'s own, `release`'s own, and the plain push-triggered `Test` workflow) all sharing the same `test-<ref>` concurrency group with `cancel-in-progress: true`. `auto-release.yml`'s `publish`/`release` jobs routinely lost that race — reproduced live 3/3 times on `v1.0.0`'s `publish` job (https://github.com/moadim-io/daemon/actions/runs/29029132803).
- Fix: switch the guard to `inputs.tag == ''`, which is only unset on the direct `push: tags` escape hatch and reliably distinguishes it regardless of what `github.event_name` reports in a nested call.

## Test plan
- [x] `actionlint .github/workflows/publish.yml .github/workflows/release.yml` — clean
- [x] pre-push hook (full suite + 100% coverage + changeset check) passed on push
- Real verification happens on the next version bump's `Auto Release` run — this fix can't be unit tested, only observed not to race next time.