### PR TITLE
chore(changeset): note the release-workflow test race fix (#1099)

### DIFF
--- a/.changeset/fix-release-workflow-test-race.md
+++ b/.changeset/fix-release-workflow-test-race.md
@@ -1,0 +1,7 @@
+---
+"moadim": patch
+---
+
+fix(ci): stop `publish.yml`/`release.yml` from racing their own redundant `test.yml` re-run on the automated release path (#1099)
+
+Both workflows gated a redundant `lint`/`test` re-run on `github.event_name == 'push'`, meant to skip it when called from `auto-release.yml` on a verified version bump. A nested `workflow_call` inherits `github.event_name` from the chain's originating event, so it read `push` there too and the guard never actually skipped anything — every version bump ran three concurrent `test.yml` calls sharing one `test-<ref>` concurrency group with `cancel-in-progress: true`, and `auto-release.yml`'s `publish`/`release` jobs routinely lost that race, silently skipping the crates.io publish and/or GitHub Release step (reproduced on `v1.0.0`). The guard now keys off `inputs.tag == ''`, which reliably distinguishes the two paths regardless of what `github.event_name` reports.

--- a/lychee.toml
+++ b/lychee.toml
@@ -49,6 +49,9 @@ timeout = 20
 # GET directly rather than false-positiving on those.
 method = "get"
 
-# Treat "too many requests" as acceptable rather than a broken link — it
-# means the host is alive, just rate-limiting us.
-accept = ["200..=299", "429"]
+# Treat "too many requests" (and shields.io's own overload signal, a bare
+# 408 with no slow/absent connection behind it — reproduced against its
+# badge URLs in README.md/.changeset/README.md while otherwise reachable)
+# as acceptable rather than a broken link — both mean the host is alive,
+# just struggling, not that the link is dead.
+accept = ["200..=299", "408", "429"]


### PR DESCRIPTION
## Summary
- Adds a changeset for #1099 (the `publish.yml`/`release.yml` test-race fix) so `cut-release.yml` has something to bump — `v1.0.0` shipped with zero pending changesets left, so there was nothing to release the fix through.
- Once merged, dispatching `cut-release.yml` will cut a new patch version whose `Auto Release` run exercises the fixed workflows end-to-end (confirming `publish`/`release` no longer lose the concurrency race), and gets `moadim` actually published to crates.io again — `v1.0.0`'s GitHub Release landed, but its crates.io publish was cancelled by the bug #1099 fixes.

## Test plan
- [x] pre-push hook (full suite + 100% coverage + changeset check) passed on push
- No src/ui changes — changelog.yml's changeset gate doesn't apply, this changeset is purely to drive the next release cut