### PR TITLE
chore(release): version packages v1.0.1

### DIFF
--- a/.changeset/fix-release-workflow-test-race.md
+++ b/.changeset/fix-release-workflow-test-race.md
@@ -1,7 +1,0 @@
----
-"moadim": patch
----
-
-fix(ci): stop `publish.yml`/`release.yml` from racing their own redundant `test.yml` re-run on the automated release path (#1099)
-
-Both workflows gated a redundant `lint`/`test` re-run on `github.event_name == 'push'`, meant to skip it when called from `auto-release.yml` on a verified version bump. A nested `workflow_call` inherits `github.event_name` from the chain's originating event, so it read `push` there too and the guard never actually skipped anything — every version bump ran three concurrent `test.yml` calls sharing one `test-<ref>` concurrency group with `cancel-in-progress: true`, and `auto-release.yml`'s `publish`/`release` jobs routinely lost that race, silently skipping the crates.io publish and/or GitHub Release step (reproduced on `v1.0.0`). The guard now keys off `inputs.tag == ''`, which reliably distinguishes the two paths regardless of what `github.event_name` reports.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-07-09
+
+fix(ci): stop `publish.yml`/`release.yml` from racing their own redundant `test.yml` re-run on the automated release path (#1099)
+
+Both workflows gated a redundant `lint`/`test` re-run on `github.event_name == 'push'`, meant to skip it when called from `auto-release.yml` on a verified version bump. A nested `workflow_call` inherits `github.event_name` from the chain's originating event, so it read `push` there too and the guard never actually skipped anything — every version bump ran three concurrent `test.yml` calls sharing one `test-<ref>` concurrency group with `cancel-in-progress: true`, and `auto-release.yml`'s `publish`/`release` jobs routinely lost that race, silently skipping the crates.io publish and/or GitHub Release step (reproduced on `v1.0.0`). The guard now keys off `inputs.tag == ''`, which reliably distinguishes the two paths regardless of what `github.event_name` reports.
+
 ## [1.0.0] - 2026-07-09
 
 chore(lint): enable `clippy::map_unwrap_or`
@@ -3134,7 +3140,8 @@ Enable `clippy::match_same_arms` and merge the two duplicate-body arms it flagge
 - Ship the prebuilt UI in the published crate.
 - Rename the binary to `moadim` and add install docs.
 
-[Unreleased]: https://github.com/moadim-io/daemon/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/moadim-io/daemon/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/moadim-io/daemon/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/moadim-io/daemon/compare/v0.27.0...v1.0.0
 [0.27.0]: https://github.com/moadim-io/daemon/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/moadim-io/daemon/compare/v0.25.0...v0.26.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ opt-level = "z"
 
 [package]
 name = "moadim"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 # Floor set by the transitive proc-macro build dependency `darling 0.23`
 # (pulled in via `rmcp-macros` <- `rmcp`), which itself declares

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "servers": [
     {

--- a/docs/moadim.1
+++ b/docs/moadim.1
@@ -1,7 +1,7 @@
 .\" Man page for moadim.
 .\" Mirrors the built-in `moadim --help` output (src/cli.rs::print_help).
 .\" View with:  man ./docs/moadim.1   or install into share/man/man1/.
-.TH MOADIM 1 "2026-07-07" "moadim 1.0.0" "Moadim Manual"
+.TH MOADIM 1 "2026-07-07" "moadim 1.0.1" "Moadim Manual"
 .SH NAME
 moadim \- routine scheduler with an MCP/REST API and a web control panel
 .SH SYNOPSIS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moadim",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "scripts": {


### PR DESCRIPTION
## Summary
- Output of `cut-release.yml`'s `Version bump` job (run https://github.com/moadim-io/daemon/actions/runs/29033527790), which already passed its `Lint version bump`/`Test version bump` gates in that run.
- Opened as a PR by hand because the workflow's own `Land on main` (direct push) step is blocked by this repo's branch-protection ruleset requiring PRs on `main` — same issue noted on #1098. Not something fixable from a code PR; flagging again here.
- This is the release that exercises #1099's fix (`publish.yml`/`release.yml` no longer racing their own redundant `test.yml` re-run) and should get `moadim` actually published to crates.io again (`v1.0.0` didn't make it there — see #1098/#1099/#1100).

## Test plan
- [x] Already verified by `cut-release.yml`'s own `Lint version bump` / `Test version bump` jobs before this PR was opened