### PR TITLE
chore(lint): enable clippy::unnecessary_debug_formatting in the ui crate

### DIFF
--- a/.changeset/enable-clippy-unnecessary-debug-formatting-ui.md
+++ b/.changeset/enable-clippy-unnecessary-debug-formatting-ui.md
@@ -1,0 +1,11 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::unnecessary_debug_formatting` in the `ui` crate
+
+Adds `unnecessary_debug_formatting = "deny"` to `ui/Cargo.toml`'s `[lints.clippy]` table, matching
+the lint already denied workspace-root-side in `Cargo.toml` — the `ui` crate has its own `[lints]`
+table (no `workspace = true` inheritance) so it silently escaped this despite CI's `clippy` job
+running `--workspace`. The `ui` crate is already clean under this lint, so no code changes are
+needed; `deny` just locks that state in. No behavior change.

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -84,3 +84,10 @@ unused_async = "deny"
 # `workspace = true` inheritance) so it was silently exempt despite `clippy --workspace`
 # covering it in CI. The `ui` crate is already clean, so `deny` locks that in.
 uninlined_format_args = "deny"
+# Reject `{:?}` (Debug) formatting of a `Path`/`PathBuf` in user-facing output. Debug-formats
+# a path with surrounding quotes and escaped separators/backslashes, which reads oddly and
+# diverges from every other path already printed via `.display()`. Kept in lockstep with the
+# same lint already enabled workspace-root-side in Cargo.toml — the `ui` crate has its own
+# `[lints]` table (no `workspace = true` inheritance) so it was silently exempt despite
+# `clippy --workspace` covering it in CI. The `ui` crate is already clean, so `deny` locks that in.
+unnecessary_debug_formatting = "deny"


### PR DESCRIPTION
## Why

`unnecessary_debug_formatting` is denied workspace-root-side in `Cargo.toml`, but the `ui` (Yew/WASM) crate has its own `[lints.clippy]` table with only `all = "deny"` — it does not inherit the root's extended deny-list via `[lints] workspace = true`. As a result this lint silently never applied to `ui/src`, even though CI's `clippy` job runs `--workspace`. This is the same gap already closed for several other lints in `ui/Cargo.toml` (`unused_self`, `wildcard_imports`, `unwrap_used`, `redundant_closure_for_method_calls`, `needless_pass_by_ref_mut`, `map_unwrap_or`, `match_same_arms`, `unused_async`, `uninlined_format_args`).

The lint rejects `{:?}` (Debug) formatting of a `Path`/`PathBuf` in user-facing output (log lines, error messages, etc.). Debug-formats a path with surrounding quotes and escaped separators/backslashes, which reads oddly and diverges from every other path already printed via `.display()`. A future `ui/src` change that accidentally debug-formats a path would currently pass CI unnoticed.

## What

- Add `unnecessary_debug_formatting = "deny"` to `ui/Cargo.toml`'s `[lints.clippy]` table, with a comment mirroring the root's rationale.
- Add a changeset (`.changeset/enable-clippy-unnecessary-debug-formatting-ui.md`) — this repo requires one for any PR touching `src/` or `ui/`.

## Verification

The `ui` crate is already clean under this lint — no code changes were needed. Ran locally, matching CI/pre-push:

- `cargo fmt --check` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — pass, zero new violations
- `cargo test --workspace` — 274 (ui) + 998 (root) passed, 0 failed
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% lines (root package, unaffected by this ui-only change)

No behavior change.