### PR TITLE
feat(ui): inline run-history sparkline column in the Routines table

### DIFF
--- a/.changeset/routines-run-history-sparkline.md
+++ b/.changeset/routines-run-history-sparkline.md
@@ -1,0 +1,15 @@
+---
+"moadim": minor
+---
+
+### Added
+
+feat(ui): inline run-history sparkline column in the Routines table
+
+Each row now shows a compact strip of ticks for its last ~10 runs (green =
+success, red = failed, pulsing amber = running, gray = unknown/no data),
+between LAST FIRE and AGENT — an at-a-glance pass/fail trend without opening
+the routine's HISTORY page, mirroring the "pipeline graph" pattern common to
+CI dashboards. Reuses the existing fleet-wide `GET /routines/runs` endpoint
+(already backing the Overview page's recent-runs panel), fetched once and
+grouped client-side by routine — no new API calls per row (#1103).

--- a/ui/src/routines/hooks.rs
+++ b/ui/src/routines/hooks.rs
@@ -3,6 +3,7 @@
 //! `page.rs`'s component body to the wiring that actually varies per-render.
 
 use std::cell::Cell;
+use std::collections::HashMap;
 use std::rc::Rc;
 
 use chrono::{DateTime, Local};
@@ -17,7 +18,8 @@ use crate::machines::api_current_machine;
 use crate::refresh::RefreshInterval;
 use crate::ToastKind;
 
-use super::model::{api_list, api_lock_status};
+use super::model::{api_all_runs, api_list, api_lock_status, FleetRunSummary};
+use super::sparkline::{group_recent_runs, RUN_HISTORY_FETCH_LIMIT};
 use super::state::{RAction, RModal, RState};
 
 /// Tick cadence for the live "now" handle (keeps DueSoon count fresh between fetches).
@@ -159,6 +161,35 @@ pub(crate) fn install_auto_refresh(
                 }
             });
         }
+        move || cancelled.set(true)
+    });
+}
+
+/// Loads the fleet-wide recent-run history backing the RUN HISTORY sparkline column,
+/// immediately on mount and then re-fetched on the same cadence as `interval` (an `Off`
+/// interval loads once and stops, matching `install_routines_loader`'s load-once behaviour).
+pub(crate) fn install_run_history_loader(
+    interval: RefreshInterval,
+    run_history: UseStateHandle<HashMap<String, Vec<FleetRunSummary>>>,
+) {
+    use_effect_with(interval, move |interval| {
+        let cancelled = Rc::new(Cell::new(false));
+        let period_ms = interval.as_millis();
+        let loop_cancelled = cancelled.clone();
+        spawn_local(async move {
+            loop {
+                if let Ok(runs) = api_all_runs(RUN_HISTORY_FETCH_LIMIT).await {
+                    if loop_cancelled.get() {
+                        break;
+                    }
+                    run_history.set(group_recent_runs(runs));
+                }
+                match period_ms {
+                    Some(ms) if !loop_cancelled.get() => TimeoutFuture::new(ms).await,
+                    _ => break,
+                }
+            }
+        });
         move || cancelled.set(true)
     });
 }

--- a/ui/src/routines/mod.rs
+++ b/ui/src/routines/mod.rs
@@ -16,7 +16,7 @@
 //! - `actions` — the list page's CRUD/API callbacks (unlock-all, create, cleanup,
 //!   trigger, toggle, save, confirm-delete).
 //! - `banner`, `filter_bar`, `calendar`, `table`, `row`, `form`, `bulk`, `logs`,
-//!   `flags_panel` — the list page's sub-components.
+//!   `flags_panel`, `sparkline` — the list page's sub-components.
 
 mod actions;
 mod banner;
@@ -34,6 +34,7 @@ mod logs;
 mod model;
 mod page;
 mod row;
+mod sparkline;
 mod state;
 mod table;
 

--- a/ui/src/routines/page.rs
+++ b/ui/src/routines/page.rs
@@ -1,6 +1,8 @@
 //! The routines list page: data loading, filter/sort/group wiring, bulk actions, and routing
 //! between the list, create, edit, logs, and flags sub-views.
 
+use std::collections::HashMap;
+
 use chrono::{Duration, Local};
 use yew::prelude::*;
 use yew_router::prelude::*;
@@ -25,9 +27,10 @@ use super::form::{clone_title, RoutineForm};
 use super::history::RoutineHistory;
 use super::hooks::{
     install_auto_refresh, install_current_machine_loader, install_lock_status_loader,
-    install_now_ticker, install_routines_loader, install_search_hotkey,
+    install_now_ticker, install_routines_loader, install_run_history_loader, install_search_hotkey,
 };
 use super::logs::RoutineLogs;
+use super::model::FleetRunSummary;
 use super::state::{
     sort_routines, RAction, RCol, RGroupBy, RModal, RPage, RState, RView, RoutineHistoryQuery,
 };
@@ -62,6 +65,12 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
 
     // Fetch lock status on mount and whenever routines reload.
     install_lock_status_loader(state.clone());
+
+    // Fleet-wide recent-run history backing the RUN HISTORY sparkline column, loaded on mount
+    // and re-fetched on the same cadence as the routine list.
+    let run_history: UseStateHandle<HashMap<String, Vec<FleetRunSummary>>> =
+        use_state(HashMap::new);
+    install_run_history_loader(*interval, run_history.clone());
 
     // Deep-link straight to a routine's HISTORY page when the URL carries a `?history=<id>`
     // query (e.g. `/routines?history=<id>`, as followed from the overview page's RECENT RUNS
@@ -340,6 +349,7 @@ pub fn routines_page(props: &RoutinesPageProps) -> Html {
                                             sort_col={sort_col}
                                             sort_dir={sort_dir}
                                             group_by={group_by}
+                                            run_history={(*run_history).clone()}
                                             on_sort={on_col_sort}
                                             on_edit={on_edit}
                                             on_clone={on_clone}

--- a/ui/src/routines/row.rs
+++ b/ui/src/routines/row.rs
@@ -9,7 +9,8 @@ use crate::schedule::{fmt_until, fmt_when, next_fires};
 
 use super::filter::{last_fire_at, routine_health, trigger_button_title};
 use super::form::format_ttl;
-use super::model::Routine;
+use super::model::{FleetRunSummary, Routine};
+use super::sparkline::RunHistorySparkline;
 use super::table::next_routine_run_cell;
 
 #[derive(Properties, PartialEq)]
@@ -17,6 +18,8 @@ pub struct RowProps {
     pub routine: Routine,
     /// Reference instant for the NEXT RUN countdown.
     pub now: chrono::DateTime<Local>,
+    /// This routine's recent runs, oldest to newest, backing the RUN HISTORY sparkline cell.
+    pub runs: Vec<FleetRunSummary>,
     /// Whether this row is currently selected.
     pub selected: bool,
     /// Fired when the selection checkbox is clicked.
@@ -186,6 +189,7 @@ pub fn routine_row(props: &RowProps) -> Html {
             </td>
             <td>{next_run}</td>
             <td>{last_fire}</td>
+            <td><RunHistorySparkline runs={props.runs.clone()} /></td>
             <td>
                 <span class="cell-handler" title={agent_title}>
                     <span class={agent_dot}></span>

--- a/ui/src/routines/sparkline.rs
+++ b/ui/src/routines/sparkline.rs
@@ -1,0 +1,76 @@
+//! Inline run-history sparkline for the Routines table: a compact strip of ticks giving an
+//! at-a-glance pass/fail trend per routine, mirroring the "pipeline graph" pattern common to CI
+//! dashboards (GitHub Actions' per-workflow run history, GitLab's pipeline mini-graph) without
+//! navigating to the routine's full HISTORY page.
+
+use std::collections::HashMap;
+
+use yew::prelude::*;
+
+use crate::reltime;
+
+use super::history::run_status_label;
+use super::model::{FleetRunSummary, RunStatus};
+
+/// Fleet-wide run count fetched to build every routine's sparkline. A global cap (not
+/// per-routine — the backing `GET /routines/runs` endpoint truncates the newest-first merged
+/// list to this many total), large enough that an active fleet's routines each keep a several-run
+/// trend without an unbounded payload.
+pub(crate) const RUN_HISTORY_FETCH_LIMIT: usize = 300;
+
+/// Max ticks rendered per routine, oldest to newest (left to right).
+const SPARKLINE_LEN: usize = 10;
+
+/// Buckets a fleet-wide, newest-first run list by routine, keeping each routine's most recent
+/// [`SPARKLINE_LEN`] runs in chronological (oldest-first) order for left-to-right rendering.
+pub(crate) fn group_recent_runs(
+    runs: Vec<FleetRunSummary>,
+) -> HashMap<String, Vec<FleetRunSummary>> {
+    let mut by_routine: HashMap<String, Vec<FleetRunSummary>> = HashMap::new();
+    for run in runs {
+        let bucket = by_routine.entry(run.routine_id.clone()).or_default();
+        if bucket.len() < SPARKLINE_LEN {
+            bucket.push(run);
+        }
+    }
+    for bucket in by_routine.values_mut() {
+        bucket.reverse();
+    }
+    by_routine
+}
+
+/// CSS class for one sparkline tick, colour-coded by run outcome (mirrors `run_status_class`'s
+/// palette, but as a small tick rather than a text badge).
+fn spark_tick_class(status: RunStatus) -> &'static str {
+    match status {
+        RunStatus::Running => "spark-tick running",
+        RunStatus::Success => "spark-tick success",
+        RunStatus::Failed => "spark-tick failed",
+        RunStatus::Unknown => "spark-tick unknown",
+    }
+}
+
+#[derive(Properties, PartialEq)]
+pub struct RunHistorySparklineProps {
+    /// This routine's recent runs, oldest to newest (as produced by [`group_recent_runs`]).
+    pub runs: Vec<FleetRunSummary>,
+}
+
+#[function_component(RunHistorySparkline)]
+pub fn run_history_sparkline(props: &RunHistorySparklineProps) -> Html {
+    if props.runs.is_empty() {
+        return html! { <span class="spark-empty muted">{"—"}</span> };
+    }
+    html! {
+        <div class="spark" role="img" aria-label={format!("Last {} runs", props.runs.len())}>
+            { for props.runs.iter().map(|run| {
+                let title = format!("{} · {}", run_status_label(run.status), reltime(run.started_at));
+                html! { <span class={spark_tick_class(run.status)} {title}></span> }
+            }) }
+        </div>
+    }
+}
+
+#[cfg(test)]
+#[path = "sparkline_tests.rs"]
+mod sparkline_tests;

--- a/ui/src/routines/sparkline_tests.rs
+++ b/ui/src/routines/sparkline_tests.rs
@@ -1,0 +1,80 @@
+//! Host-side unit tests for the pure run-history grouping/formatting helpers in [`super`]. No
+//! DOM/wasm dependency (mirrors the `history.rs` test conventions) — `RunHistorySparkline`'s
+//! `html!` output isn't covered here for the same reason no other component in this module is.
+
+use super::*;
+
+fn run(routine_id: &str, started_at: u64, status: RunStatus) -> FleetRunSummary {
+    FleetRunSummary {
+        routine_id: routine_id.to_string(),
+        routine_title: routine_id.to_string(),
+        workbench: format!("{routine_id}-{started_at}"),
+        started_at,
+        finished_at: Some(started_at + 1),
+        status,
+        exit_code: None,
+    }
+}
+
+#[test]
+fn group_recent_runs_empty_input_is_empty_map() {
+    assert!(group_recent_runs(Vec::new()).is_empty());
+}
+
+#[test]
+fn group_recent_runs_buckets_by_routine_id() {
+    let runs = vec![
+        run("a", 300, RunStatus::Success),
+        run("b", 200, RunStatus::Failed),
+        run("a", 100, RunStatus::Failed),
+    ];
+    let by_routine = group_recent_runs(runs);
+    assert_eq!(by_routine.len(), 2);
+    assert_eq!(by_routine["a"].len(), 2);
+    assert_eq!(by_routine["b"].len(), 1);
+}
+
+#[test]
+fn group_recent_runs_reverses_newest_first_input_to_oldest_first() {
+    // Fleet-wide list arrives newest-first; the sparkline renders oldest-to-newest left-to-right.
+    let runs = vec![
+        run("a", 300, RunStatus::Success),
+        run("a", 100, RunStatus::Failed),
+    ];
+    let by_routine = group_recent_runs(runs);
+    let a = &by_routine["a"];
+    assert_eq!(a[0].started_at, 100);
+    assert_eq!(a[1].started_at, 300);
+}
+
+#[test]
+fn group_recent_runs_caps_at_sparkline_len_per_routine() {
+    let runs: Vec<FleetRunSummary> = (0..SPARKLINE_LEN + 5)
+        .map(|i| run("a", i as u64, RunStatus::Success))
+        .collect();
+    let by_routine = group_recent_runs(runs);
+    assert_eq!(by_routine["a"].len(), SPARKLINE_LEN);
+}
+
+#[test]
+fn group_recent_runs_keeps_the_newest_runs_when_capping() {
+    // Input is newest-first; capping must keep the front (newest) slice, not the tail.
+    let runs: Vec<FleetRunSummary> = (0..SPARKLINE_LEN + 3)
+        .rev()
+        .map(|i| run("a", i as u64, RunStatus::Success))
+        .collect();
+    let by_routine = group_recent_runs(runs);
+    let a = &by_routine["a"];
+    assert_eq!(a.len(), SPARKLINE_LEN);
+    // Oldest-first after grouping, so the newest run (started_at == SPARKLINE_LEN + 2) is last.
+    assert_eq!(a.last().unwrap().started_at, (SPARKLINE_LEN + 2) as u64);
+    assert_eq!(a.first().unwrap().started_at, 3);
+}
+
+#[test]
+fn spark_tick_class_covers_every_variant() {
+    assert_eq!(spark_tick_class(RunStatus::Running), "spark-tick running");
+    assert_eq!(spark_tick_class(RunStatus::Success), "spark-tick success");
+    assert_eq!(spark_tick_class(RunStatus::Failed), "spark-tick failed");
+    assert_eq!(spark_tick_class(RunStatus::Unknown), "spark-tick unknown");
+}

--- a/ui/src/routines/table.rs
+++ b/ui/src/routines/table.rs
@@ -1,7 +1,7 @@
 //! Routine table: sortable/groupable header, empty states, and the NEXT RUN cell
 //! helper shared with the row component.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 
 use chrono::{Duration, Local};
 use yew::prelude::*;
@@ -9,7 +9,7 @@ use yew::prelude::*;
 use crate::schedule::{fmt_until, fmt_when, next_fire_after};
 
 use super::filter::{is_routine_snoozed, snooze_detail, DUE_SOON_WINDOW_SECS};
-use super::model::Routine;
+use super::model::{FleetRunSummary, Routine};
 use super::row::RoutineRow;
 use super::state::{group_routines, RCol, RDir, RGroupBy};
 
@@ -67,6 +67,9 @@ pub struct TableProps {
     pub sort_dir: RDir,
     /// Active group-by dimension; `None` renders a flat list.
     pub group_by: RGroupBy,
+    /// Each routine's recent runs (oldest to newest), keyed by routine id, backing the RUN
+    /// HISTORY sparkline column.
+    pub run_history: HashMap<String, Vec<FleetRunSummary>>,
     /// Fired when the user clicks a sortable column header.
     pub on_sort: Callback<RCol>,
     pub on_edit: Callback<String>,
@@ -150,6 +153,7 @@ pub fn routine_table(props: &TableProps) -> Html {
                         <th>{"SCHEDULE"}</th>
                         { sort_th("NEXT RUN", RCol::NextRun, props.sort_col, props.sort_dir, &props.on_sort) }
                         { sort_th("LAST FIRE", RCol::LastFire, props.sort_col, props.sort_dir, &props.on_sort) }
+                        <th>{"RUN HISTORY"}</th>
                         { sort_th("AGENT", RCol::Agent, props.sort_col, props.sort_dir, &props.on_sort) }
                         <th>{"REPOS"}</th>
                         <th>{"MACHINES"}</th>
@@ -169,17 +173,20 @@ pub fn routine_table(props: &TableProps) -> Html {
                             <>
                                 if grouped {
                                     <tr class="group-hd" key={format!("ghd-{label}")}>
-                                        <td colspan="12">
+                                        <td colspan="13">
                                             <span class="group-label">{label.clone()}</span>
                                             <span class="group-count">{format!("({count})")}</span>
                                         </td>
                                     </tr>
                                 }
-                                { for group.into_iter().map(|r| html! {
+                                { for group.into_iter().map(|r| {
+                                    let runs = props.run_history.get(&r.id).cloned().unwrap_or_default();
+                                    html! {
                                     <RoutineRow
                                         key={r.id.clone()}
                                         routine={r.clone()}
                                         now={props.now}
+                                        runs={runs}
                                         selected={props.selected.contains(&r.id)}
                                         on_select={props.on_select.clone()}
                                         on_edit={props.on_edit.clone()}
@@ -191,6 +198,7 @@ pub fn routine_table(props: &TableProps) -> Html {
                                         on_history={props.on_history.clone()}
                                         on_flags={props.on_flags.clone()}
                                     />
+                                    }
                                 }) }
                             </>
                         }

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -1083,6 +1083,27 @@
     .run-status.success { border-color: var(--accent); color: var(--accent); background: var(--accent-dim); }
     .run-status.failed  { border-color: var(--red);   color: var(--red);   background: var(--red-dim); }
     .run-status.unknown { border-color: var(--border-hi); color: var(--text-dim); }
+
+    /* ── Run history sparkline (Routines table RUN HISTORY column) ── */
+    .spark { display: flex; align-items: center; gap: 3px; }
+    .spark-empty { font-size: 12px; }
+    .spark-tick {
+      width: 6px;
+      height: 14px;
+      border-radius: 1px;
+      flex-shrink: 0;
+      background: var(--border-hi);
+    }
+    .spark-tick.success { background: var(--accent); }
+    .spark-tick.failed  { background: var(--red); }
+    .spark-tick.unknown { background: var(--border-hi); }
+    .spark-tick.running { background: var(--amber); animation: spark-pulse 1.2s ease-in-out infinite; }
+
+    @keyframes spark-pulse {
+      0%,100% { opacity: 1; }
+      50%     { opacity: 0.35; }
+    }
+
     .flag-badge {
       display: inline-block;
       min-width: 14px;


### PR DESCRIPTION
Closes #1103.

## Summary
- Adds a **RUN HISTORY** column to the Routines table: a compact strip of ticks for each routine's last ~10 runs (green = success, red = failed, pulsing amber = running, gray = unknown), positioned between LAST FIRE and AGENT.
- At-a-glance pass/fail trend without opening the routine's HISTORY page — mirrors the "pipeline graph" pattern used by CI dashboards (GitHub Actions' per-workflow run history, GitLab's pipeline mini-graph).
- No new backend/API calls: reuses the existing fleet-wide `GET /routines/runs` endpoint (already backing the Overview page's "recent runs" panel) via a new `install_run_history_loader` hook, fetched once for the whole table and grouped client-side by `routine_id` in `sparkline.rs`'s `group_recent_runs` — avoids one HTTP request per row.
- Refreshes on the same cadence as the routine list's existing auto-refresh interval.

## Scope
`ui/` only — frontend Yew component, hook, and CSS changes; no backend/daemon/API/data-model changes. Also includes the required `.changeset/*.md` entry (per `CONTRIBUTING.md`, mandatory for any PR touching `ui/**`).

## Testing
- `cargo build -p ui --target wasm32-unknown-unknown` — succeeds
- `cargo test -p ui` — 280 passed (6 new tests covering `group_recent_runs` and the tick-class mapping)
- `cargo clippy -p ui --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `typos` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)