### PR TITLE
chore(lint): enable clippy::case_sensitive_file_extension_comparisons in the ui crate

### DIFF
--- a/.changeset/enable-clippy-case-sensitive-file-extension-comparisons-ui.md
+++ b/.changeset/enable-clippy-case-sensitive-file-extension-comparisons-ui.md
@@ -1,0 +1,11 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::case_sensitive_file_extension_comparisons` in the `ui` crate
+
+Adds `case_sensitive_file_extension_comparisons = "deny"` to `ui/Cargo.toml`'s `[lints.clippy]`
+table, matching the lint already denied workspace-root-side in `Cargo.toml` — the `ui` crate has
+its own `[lints]` table (no `workspace = true` inheritance) so it silently escaped this despite
+CI's `clippy` job running `--workspace`. The `ui` crate is already clean under this lint, so no
+code changes are needed; `deny` just locks that state in. No behavior change.

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -107,3 +107,12 @@ uninlined_format_args = "deny"
 # `[lints]` table (no `workspace = true` inheritance) so it was silently exempt despite
 # `clippy --workspace` covering it in CI. The `ui` crate is already clean, so `deny` locks that in.
 unnecessary_debug_formatting = "deny"
+# Reject a case-sensitive `.ends_with(".ext")`/`.starts_with(...)` file-extension check in favour
+# of `Path::extension()` compared with `eq_ignore_ascii_case`. A literal `.md` check silently
+# mismatches an uppercase or mixed-case extension even though macOS's and Windows' default
+# filesystems treat the two names as the same file. Mirrors the root crate's
+# `case_sensitive_file_extension_comparisons = "deny"` (see Cargo.toml) — the `ui` crate has its
+# own `[lints.clippy]` table and doesn't inherit root's extended deny-list, so this never applied
+# to `ui/src` despite CI's `clippy` job running `--workspace`. The `ui` crate is already clean, so
+# `deny` locks that in.
+case_sensitive_file_extension_comparisons = "deny"


### PR DESCRIPTION
## Why

`ui/Cargo.toml` has its own `[lints.clippy]` table and does **not** inherit the workspace root's extended deny-list via `[lints] workspace = true`. That means every lint enabled root-side (`Cargo.toml`) silently never applies to `ui/src`, even though CI's `clippy` job runs `--workspace` — the per-crate table simply doesn't pick it up.

`case_sensitive_file_extension_comparisons` is one such gap: it rejects a literal `.ends_with(".ext")`/`.starts_with(...)` file-extension check in favor of `Path::extension()` compared with `eq_ignore_ascii_case`. A case-sensitive check silently mismatches an uppercase or mixed-case extension even though macOS's and Windows' default filesystems treat the two names as the same file — exactly the kind of cross-platform correctness bug this UI (a browser-facing Yew/WASM app, portable across dev machines) should guard against.

This mirrors the pattern already applied in #1085, #1102, and (open) #1092 for other root-side lints that were similarly missing from `ui/Cargo.toml`.

## What

- Adds `case_sensitive_file_extension_comparisons = "deny"` to `ui/Cargo.toml`'s `[lints.clippy]` table, with a doc comment matching this repo's established style for these entries.
- No code changes: `cargo clippy -p ui --all-targets -- -D warnings` confirms the crate is already clean under this lint, so `deny` just locks that state in.
- Adds a changeset (`patch`) per the `unreleased-entry` CI gate for `src/`/`ui/` changes.

## Test plan

- [x] `cargo clippy -p ui --all-targets -- -D warnings` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --workspace` — 999+280 passed
- [x] `linecheck --max-lines 500 $(find src ui/src -name '*.rs')` — clean