### PR TITLE
fix(service): install/uninstall error instead of panic when macOS home is unknown

### DIFF
--- a/.changeset/fix-macos-install-panics-unknown-home.md
+++ b/.changeset/fix-macos-install-panics-unknown-home.md
@@ -1,0 +1,13 @@
+---
+"moadim": patch
+---
+
+fix(service): `install`/`uninstall` return an error instead of panicking on macOS when `$HOME` is undeterminable
+
+The macOS launchd backend's `install()` and `uninstall()` both `.expect()`-ed the home directory
+lookup, crashing the whole process with a panic if the home directory couldn't be resolved (e.g.
+`$HOME` unset and no passwd entry, such as some minimal service/CI contexts). `plist_path_from_home`
+already turns that condition into a proper `anyhow::Error` — the callers just weren't using it. Now
+both functions propagate the error via `?`, matching the Linux systemd backend's `install()`/
+`uninstall()`, which already propagate their equivalent `unit_path()` lookup the same way. No
+behavior change on the happy path.

--- a/src/service/macos.rs
+++ b/src/service/macos.rs
@@ -148,9 +148,13 @@ fn report_installed(plist: &Path, log: &Path) {
 pub fn install() -> anyhow::Result<()> {
     let exe = moadim_exe().expect("current executable path is always available");
     let log = daemon_log();
-    let home =
-        crate::paths::home().expect("home directory must be known to install the launchd agent");
-    let plist = plist_path().expect("home directory must be known to install the launchd agent");
+    // Propagate an undeterminable home directory with `?` instead of `.expect()`-ing it into a
+    // panic. Mirrors the Linux backend's `install()`, which propagates `unit_path()` the same way.
+    let home = crate::paths::home();
+    let plist = plist_path_from_home(home.clone())?;
+    // The `?` above already returned if `home` were `None` (see `plist_path_from_home`), so this
+    // can never panic.
+    let home = home.expect("plist_path_from_home errors before this point when home is None");
     write_plist(&plist, &exe, &log, &home)?;
     reload_agent(&plist)?;
     report_installed(&plist, &log);
@@ -178,7 +182,7 @@ granting it here prevents background interruptions"
 
 /// Unload the `LaunchAgent` (if loaded) and delete its plist.
 pub fn uninstall() -> anyhow::Result<()> {
-    let plist = plist_path().expect("home directory must be known to uninstall the launchd agent");
+    let plist = plist_path()?;
     if plist.exists() {
         let plist_arg = plist.display().to_string();
         let _ = run(&launchctl_bin(), &["unload", "-w", &plist_arg]);


### PR DESCRIPTION
## Why

The macOS launchd backend's `install()` and `uninstall()` both `.expect()`-ed the home directory
lookup instead of propagating its error, so the whole `moadim` process panics if the home directory
can't be resolved (e.g. `$HOME` unset with no matching passwd entry — the kind of minimal/service
context `moadim install` can plausibly run in). The lower-level `plist_path_from_home` already turns
this into a proper `anyhow::Error` (and has a unit test proving it: `plist_path_errors_when_home_is_unknown`)
— the two public entry points just weren't using it.

This is also inconsistent within the same module: the sibling Linux systemd backend's `install()`/
`uninstall()` (`src/service/linux.rs`) already propagate the equivalent `unit_path()` lookup failure
via `?` instead of panicking.

## What changed

- `install()`: resolves `home` once, threads it through the already-tested `plist_path_from_home`,
  and propagates a `None` home as an `Err` via `?` instead of `.expect()`. The one remaining
  `.expect()` after that point is provably unreachable (the `?` above already returned), so it can't
  panic in practice.
- `uninstall()`: replaces `plist_path().expect(...)` with `plist_path()?`.

No behavior change on the happy path (home resolves normally in every real environment).

## Test plan

- [x] `cargo build`
- [x] `cargo test --workspace` (999 tests pass)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (100% line coverage; no coverage gap introduced — every new line is already exercised by the existing `install()`/`uninstall()` tests, and the `None`-home branch is reused from the already-unit-tested `plist_path_from_home`)
- [x] Added a changeset (`.changeset/fix-macos-install-panics-unknown-home.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)