### PR TITLE
chore(lint): enable clippy::trivially_copy_pass_by_ref in the ui crate

### DIFF
--- a/.changeset/enable-clippy-trivially-copy-pass-by-ref-ui.md
+++ b/.changeset/enable-clippy-trivially-copy-pass-by-ref-ui.md
@@ -1,0 +1,11 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::trivially_copy_pass_by_ref` in the `ui` crate
+
+Adds `trivially_copy_pass_by_ref = "deny"` to `ui/Cargo.toml`'s `[lints.clippy]` table, matching
+the lint already denied workspace-root-side in `Cargo.toml` — the `ui` crate has its own `[lints]`
+table (no `workspace = true` inheritance) so it silently escaped this despite CI's `clippy` job
+running `--workspace`. The `ui` crate is already clean under this lint, so no code changes are
+needed; `deny` just locks that state in. No behavior change.

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -116,3 +116,10 @@ unnecessary_debug_formatting = "deny"
 # to `ui/src` despite CI's `clippy` job running `--workspace`. The `ui` crate is already clean, so
 # `deny` locks that in.
 case_sensitive_file_extension_comparisons = "deny"
+# Reject a by-value `&self`-sized `Copy` parameter (e.g. `bool`, `u32`, small enums) passed by
+# reference — the indirection costs a pointer dereference for no benefit over passing the value
+# directly. Mirrors the root crate's `trivially_copy_pass_by_ref = "deny"` (see Cargo.toml) — the
+# `ui` crate has its own `[lints.clippy]` table and doesn't inherit root's extended deny-list, so
+# this never applied to `ui/src` despite CI's `clippy` job running `--workspace`. The `ui` crate is
+# already clean, so `deny` locks that in.
+trivially_copy_pass_by_ref = "deny"


### PR DESCRIPTION
## Why

`trivially_copy_pass_by_ref` is denied workspace-root-side in `Cargo.toml`, but the `ui` (Yew/WASM)
crate has its own `[lints.clippy]` table with only `all = "deny"` — it does not inherit the root's
extended deny-list via `[lints] workspace = true`. As a result this lint silently never applied to
`ui/src`, even though CI's `clippy` job runs `--workspace`. This is the same gap already closed for
several other lints in `ui/Cargo.toml` (`unused_self`, `wildcard_imports`, `map_unwrap_or`,
`match_same_arms`, `unused_async`, `uninlined_format_args`, `unnecessary_debug_formatting`,
`case_sensitive_file_extension_comparisons`, etc.).

Passing a `Copy`-sized value (e.g. `bool`, `u32`, a small enum) by reference costs an unnecessary
pointer indirection with no benefit over passing it directly — a future violation added to `ui/src`
would currently pass CI unnoticed.

## What

- Add `trivially_copy_pass_by_ref = "deny"` to `ui/Cargo.toml`'s `[lints.clippy]` table.
- Add a changeset (`.changeset/enable-clippy-trivially-copy-pass-by-ref-ui.md`) — this repo requires
  one for any PR touching `src/` or `ui/`.

## Verification

The `ui` crate is already clean under this lint — no code changes were needed. Ran locally,
matching CI/the pre-push hook exactly:

- `cargo fmt --check` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — pass, zero new violations
- `cargo test --workspace` — all tests pass
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — pass (100% line
  coverage on the root package, unaffected by this ui-only change)
- `linecheck --max-lines 500 $(find src ui/src -name '*.rs')` — pass

No behavior change.

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.