### PR TITLE
chore(lint): enable clippy::redundant_else in the ui crate

### DIFF
--- a/.changeset/enable-clippy-redundant-else-ui.md
+++ b/.changeset/enable-clippy-redundant-else-ui.md
@@ -1,0 +1,11 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::redundant_else` in the `ui` crate
+
+Adds `redundant_else = "deny"` to `ui/Cargo.toml`'s `[lints.clippy]` table, matching the lint
+already denied workspace-root-side in `Cargo.toml` — the `ui` crate has its own `[lints]` table
+(no `workspace = true` inheritance) so it silently escaped this despite CI's `clippy` job running
+`--workspace`. The `ui` crate is already clean under this lint, so no code changes are needed;
+`deny` just locks that state in. No behavior change.

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -123,3 +123,10 @@ case_sensitive_file_extension_comparisons = "deny"
 # this never applied to `ui/src` despite CI's `clippy` job running `--workspace`. The `ui` crate is
 # already clean, so `deny` locks that in.
 trivially_copy_pass_by_ref = "deny"
+# Reject an `else` branch after an `if` whose every path already diverges (return/break/continue/
+# panic) — the `else` adds a level of nesting for nothing, since control flow never falls through
+# to it. Mirrors the root crate's `redundant_else = "deny"` (see Cargo.toml) — the `ui` crate has
+# its own `[lints.clippy]` table and doesn't inherit root's extended deny-list, so this never
+# applied to `ui/src` despite CI's `clippy` job running `--workspace`. The `ui` crate is already
+# clean, so `deny` locks that in.
+redundant_else = "deny"


### PR DESCRIPTION
## Why

The `ui` crate has its own `[lints.clippy]` table (no `workspace = true` inheritance), so lints denied at the workspace root silently don't apply to `ui/src` even though CI's `clippy` job runs `--workspace`. This repo has been closing that gap one lint at a time (see the recently merged `trivially_copy_pass_by_ref` and `case_sensitive_file_extension_comparisons` PRs) — this continues the pattern for `clippy::redundant_else`.

`redundant_else` rejects an `else` branch after an `if` whose every path already diverges (return/break/continue/panic), since the `else` adds nesting for nothing once control flow can never fall through to it.

## What

Adds `redundant_else = "deny"` to `ui/Cargo.toml`, matching the root `Cargo.toml`. The `ui` crate is already clean under this lint (confirmed via `cargo clippy --all-targets -- -W clippy::redundant_else`, 0 warnings), so this is purely locking in the current state — no code changes, no behavior change.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --check` passes