### PR TITLE
chore(deps): bump rmcp/rmcp-macros to 2.2.0

### DIFF
--- a/.changeset/bump-rmcp-2-2-0.md
+++ b/.changeset/bump-rmcp-2-2-0.md
@@ -1,0 +1,13 @@
+---
+"moadim": patch
+---
+
+chore(deps): bump `rmcp`/`rmcp-macros` to 2.2.0
+
+Both stay within the `rmcp = "2.0.0"` (caret) requirement already declared in `Cargo.toml`, so
+this is a `Cargo.lock`-only refresh — no manifest or code changes. The 2.1.0 -> 2.2.0 release
+notes list only fixes (cancel-safe transport receive, refresh-token preservation, redirect
+header-leak guard, unparsable-message handling, protocol version negotiation) and one addition
+(rejecting auth servers lacking S256 PKCE support); no breaking changes. `cargo build`,
+`cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` all pass
+unchanged after the bump.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1781,9 +1781,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rmcp"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433"
+checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
 dependencies = [
  "async-trait",
  "base64",
@@ -1812,9 +1812,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee70afb7956da9f30d5348a2539b5eb90d9038f834463657ab717076ac3b1ad"
+checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",


### PR DESCRIPTION
## Why

`rmcp`/`rmcp-macros` are pinned `"2.0.0"` (caret) in `Cargo.toml`, but `Cargo.lock` was still resolving to `2.1.0` even though `2.2.0` is out and compatible. This refreshes the lockfile to pick it up — no manifest change needed.

## Changelog check

Compared the [rmcp-v2.1.0 -> rmcp-v2.2.0](https://github.com/modelcontextprotocol/rust-sdk/releases) and rmcp-macros equivalent release notes before bumping:

- **rmcp 2.2.0**: fixes only — cancel-safe transport `receive`, refresh-token preservation on refresh responses that omit it, a redirect header-leak guard, unparsable-message handling, and protocol-version negotiation in the handler — plus one addition (reject auth servers lacking S256 PKCE support). No breaking changes.
- **rmcp-macros 2.2.0**: no changes beyond the version bump itself (the `[breaking]` model-type-alignment change landed back in 2.0 -> 2.1, which this repo is already past).

## What changed

`Cargo.lock` only — `rmcp` and `rmcp-macros` 2.1.0 -> 2.2.0.

## Verification

- `cargo build --workspace`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (999 root + 280 `ui` tests, all passing)

All green, no code changes needed.

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.