### PR TITLE
chore(lint): enable clippy::format_push_string in the ui crate

### DIFF
--- a/.changeset/enable-clippy-format-push-string-ui.md
+++ b/.changeset/enable-clippy-format-push-string-ui.md
@@ -1,0 +1,17 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::format_push_string` in the `ui` crate
+
+Adds `format_push_string = "deny"` to `ui/Cargo.toml`'s `[lints.clippy]` table, mirroring the
+root crate's `format_push_string = "deny"` (`Cargo.toml`). The `ui` crate has its own
+`[lints.clippy]` table with no `workspace = true` inheritance, so this lint (like several others
+before it) silently never applied to `ui/src` despite CI's `clippy` job running `--workspace`.
+
+`format_push_string` catches `.push_str(&format!(...))`, which allocates a throwaway `String`
+only to immediately copy its contents into the target and drop it — a real perf-adjacent gap, not
+just a style one. `write!`/`writeln!` write straight into the existing buffer instead.
+
+The `ui` crate is already clean under this lint, so no code changes are needed — `deny` just locks
+that state in. No behavior change.

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -130,3 +130,11 @@ trivially_copy_pass_by_ref = "deny"
 # applied to `ui/src` despite CI's `clippy` job running `--workspace`. The `ui` crate is already
 # clean, so `deny` locks that in.
 redundant_else = "deny"
+# Reject `.push_str(&format!(...))` in favour of `write!`/`writeln!` directly into the `String`.
+# The `format!` call allocates a throwaway `String` only to immediately copy its contents into the
+# target and drop it, so it's pure overhead that `write!` avoids by writing straight into the
+# existing buffer. Mirrors the root crate's `format_push_string = "deny"` (see Cargo.toml) — the
+# `ui` crate has its own `[lints.clippy]` table and doesn't inherit root's extended deny-list, so
+# this never applied to `ui/src` despite CI's `clippy` job running `--workspace`. The `ui` crate is
+# already clean, so `deny` locks that in.
+format_push_string = "deny"


### PR DESCRIPTION
## Why

`format_push_string` is denied workspace-root-side in `Cargo.toml`, but the `ui` (Yew/WASM) crate has its own `[lints.clippy]` table with only a handful of lints mirrored over — it does not inherit the root's extended deny-list via `[lints] workspace = true`. As a result this lint silently never applied to `ui/src`, even though CI's `clippy` job runs `--workspace`. This is the same gap already closed for several other lints in `ui/Cargo.toml` (`unused_self`, `wildcard_imports`, `map_unwrap_or`, `match_same_arms`, `unused_async`, `dbg_macro`, `todo`/`unimplemented`, `uninlined_format_args`, `unnecessary_debug_formatting`, `case_sensitive_file_extension_comparisons`, `trivially_copy_pass_by_ref`, `redundant_else`, and in-flight `needless_collect` (#1110) / `unreadable_literal` (#1092)).

`format_push_string` catches `.push_str(&format!(...))` — the `format!` call allocates a throwaway `String` only to immediately copy its contents into the target and drop it, so it's pure overhead that `write!`/`writeln!` avoids by writing straight into the existing buffer. A real perf-adjacent gap, not just a style one.

## What

- Add `format_push_string = "deny"` to `ui/Cargo.toml`'s `[lints.clippy]` table.
- Add a changeset (`.changeset/enable-clippy-format-push-string-ui.md`) — this repo requires one for any PR touching `src/` or `ui/`.

## Verification

The `ui` crate is already clean under this lint — no code changes were needed. Ran locally, matching CI/pre-push exactly:

- `cargo fmt --check` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — pass, zero new violations
- `cargo test --workspace` — 999 root + 280 ui tests, all passing
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — pass (root package, unaffected by this ui-only change)
- `linecheck --max-lines 500` — pass
- `./scripts/check-readme-blocks.sh` — pass

No behavior change.