### PR TITLE
chore(lint): enable clippy::items_after_statements in the ui crate

### DIFF
--- a/.changeset/enable-clippy-items-after-statements-ui.md
+++ b/.changeset/enable-clippy-items-after-statements-ui.md
@@ -1,0 +1,11 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::items_after_statements` in the `ui` crate
+
+Adds `items_after_statements = "deny"` to `ui/Cargo.toml`'s `[lints.clippy]` table, matching the
+lint already denied workspace-root-side in `Cargo.toml` — the `ui` crate has its own `[lints]`
+table (no `workspace = true` inheritance) so it silently escaped this despite CI's `clippy` job
+running `--workspace`. The `ui` crate is already clean under this lint, so no code changes are
+needed; `deny` just locks that state in. No behavior change.

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -145,3 +145,11 @@ redundant_else = "deny"
 # this never applied to `ui/src` despite CI's `clippy` job running `--workspace`. The `ui` crate is
 # already clean, so `deny` locks that in.
 format_push_string = "deny"
+# Reject an item (`use`, `const`, etc.) declared after a statement in the same block — items are
+# scoped to the whole block from the start regardless of where they're written, so placing one
+# mid-block after other code misleads the reader into thinking order matters here. Hoisting it to
+# the top of the block states that up front. Mirrors the root crate's `items_after_statements =
+# "deny"` (see Cargo.toml) — the `ui` crate has its own `[lints.clippy]` table and doesn't inherit
+# root's extended deny-list, so this never applied to `ui/src` despite CI's `clippy` job running
+# `--workspace`. The `ui` crate is already clean, so `deny` locks that in.
+items_after_statements = "deny"


### PR DESCRIPTION
## Summary

The `ui` crate has its own `[lints.clippy]` table in `ui/Cargo.toml` with no `workspace = true` inheritance from the root `Cargo.toml`. This means lints denied root-side (`Cargo.toml`'s extended `[lints.clippy]` deny-list) silently never applied to `ui/src`, even though CI's `clippy` job runs `cargo clippy --workspace`. This is the same gap already closed for several other lints (`unreadable_literal`, `case_sensitive_file_extension_comparisons`, `format_push_string`, etc. — see recent merged/open PRs in this repo).

This PR closes the gap for one more: `clippy::items_after_statements`, which rejects an item (`use`, `const`, etc.) declared after a statement in the same block. Items are scoped to the whole block from the start regardless of where they're written, so placing one mid-block after other code misleads the reader into thinking order matters there; hoisting it to the top of the block states that up front.

`ui/src` is already clean under this lint (verified with `cargo clippy -p ui --all-targets -- -W clippy::items_after_statements`, zero warnings), so this is a pure lint-table addition — no source changes, no behavior change. `deny` just locks the current clean state in so it can't regress.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (280 tests)
- [x] `linecheck --max-lines 500 $(find src ui/src -name '*.rs')` passes
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main.rs'` passes (100% line coverage)
- [x] Added `.changeset/enable-clippy-items-after-statements-ui.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)