### PR TITLE
chore(lint): enable clippy::cloned_instead_of_copied in the ui crate

### DIFF
--- a/.changeset/enable-clippy-cloned-instead-of-copied-ui.md
+++ b/.changeset/enable-clippy-cloned-instead-of-copied-ui.md
@@ -1,0 +1,11 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::cloned_instead_of_copied` in the `ui` crate
+
+Adds `cloned_instead_of_copied = "deny"` to `ui/Cargo.toml`'s `[lints.clippy]` table, matching the
+lint already denied workspace-root-side in `Cargo.toml` — the `ui` crate has its own `[lints]`
+table (no `workspace = true` inheritance) so it silently escaped this despite CI's `clippy` job
+running `--workspace`. The `ui` crate is already clean under this lint, so no code changes are
+needed; `deny` just locks that state in. No behavior change.

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -145,3 +145,11 @@ redundant_else = "deny"
 # this never applied to `ui/src` despite CI's `clippy` job running `--workspace`. The `ui` crate is
 # already clean, so `deny` locks that in.
 format_push_string = "deny"
+# Reject `.cloned()` on an iterator of `&Copy` items (e.g. `&i32`, `&bool`) in favour of
+# `.copied()` — cloning a `Copy` type is a needlessly indirect way to say "copy this value";
+# `.copied()` states the intent directly and optimizes identically. Mirrors the root crate's
+# `cloned_instead_of_copied = "deny"` (see Cargo.toml) — the `ui` crate has its own
+# `[lints.clippy]` table and doesn't inherit root's extended deny-list, so this never applied
+# to `ui/src` despite CI's `clippy` job running `--workspace`. The `ui` crate is already clean,
+# so `deny` locks that in.
+cloned_instead_of_copied = "deny"


### PR DESCRIPTION
## Summary

The `ui` crate has its own `[lints.clippy]` table in `ui/Cargo.toml` with no `workspace = true`
inheritance from the root `Cargo.toml`. This means lints denied root-side (`Cargo.toml`'s
extended `[lints.clippy]` deny-list) silently never applied to `ui/src`, even though CI's
`clippy` job runs `cargo clippy --workspace`. This is the same gap already closed for several
other lints (`unreadable_literal`, `case_sensitive_file_extension_comparisons`,
`format_push_string`, etc. — see recent merged/open PRs in this repo).

This PR closes the gap for one more: `clippy::cloned_instead_of_copied`, which rejects `.cloned()`
on an iterator of `&Copy` items (e.g. `&i32`, `&bool`) in favour of `.copied()` — cloning a `Copy`
type is a needlessly indirect way to say "copy this value"; `.copied()` states the intent directly
and optimizes identically.

Checked open PRs first to avoid duplicating a lint another in-flight PR already claims (#1115
`items_after_statements`, #1113 `single_match_else`, #1110 `needless_collect`) — this lint isn't
claimed by any of them.

`ui/src` is already clean under this lint (verified with
`cargo clippy -p ui --all-targets -- -W clippy::cloned_instead_of_copied`, zero warnings), so this
is a pure lint-table addition — no source changes, no behavior change. `deny` just locks the
current clean state in so it can't regress.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p ui --all-targets -- -D warnings` passes
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --workspace` passes (999 + 280 tests)
- [x] Added `.changeset/enable-clippy-cloned-instead-of-copied-ui.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)