### PR TITLE
chore(lint): enable clippy::manual_string_new in the ui crate

### DIFF
--- a/.changeset/enable-clippy-manual-string-new-ui.md
+++ b/.changeset/enable-clippy-manual-string-new-ui.md
@@ -1,0 +1,11 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::manual_string_new` in the `ui` crate
+
+Adds `manual_string_new = "deny"` to `ui/Cargo.toml`'s `[lints.clippy]` table, matching the
+lint already denied workspace-root-side in `Cargo.toml` — the `ui` crate has its own `[lints]`
+table (no `workspace = true` inheritance) so it silently escaped this despite CI's `clippy` job
+running `--workspace`. The `ui` crate is already clean under this lint, so no code changes are
+needed; `deny` just locks that state in. No behavior change.

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -153,3 +153,10 @@ format_push_string = "deny"
 # to `ui/src` despite CI's `clippy` job running `--workspace`. The `ui` crate is already clean,
 # so `deny` locks that in.
 cloned_instead_of_copied = "deny"
+# Prefer `String::new()` over `"".into()`/`"".to_string()`/`"".to_owned()` for constructing an
+# empty `String` — it says "empty string" directly instead of making the reader infer it from an
+# empty literal plus a conversion call. Mirrors the root crate's `manual_string_new = "deny"` (see
+# Cargo.toml) — the `ui` crate has its own `[lints.clippy]` table and doesn't inherit root's
+# extended deny-list, so this never applied to `ui/src` despite CI's `clippy` job running
+# `--workspace`. The `ui` crate is already clean, so `deny` locks that in.
+manual_string_new = "deny"


### PR DESCRIPTION
## Why

Following the established pattern of locking in one clippy lint at a time for the `ui` crate (see #1116, #1115, #1113, #1110, etc.): `manual_string_new` is already `deny`d workspace-root-side in `Cargo.toml`, but the `ui` crate has its own `[lints.clippy]` table with no `workspace = true` inheritance, so it silently escaped this lint despite CI's `clippy` job running `--workspace`.

## What

Adds `manual_string_new = "deny"` to `ui/Cargo.toml`. The crate is already clean under this lint — no code changes needed, this just locks the state in so a future violation fails CI.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo test -p ui` — 280 passed