### PR TITLE
chore(lint): enable clippy::allow_attributes_without_reason in the ui crate

### DIFF
--- a/.changeset/enable-clippy-allow-attributes-without-reason-ui.md
+++ b/.changeset/enable-clippy-allow-attributes-without-reason-ui.md
@@ -1,0 +1,12 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::allow_attributes_without_reason` in the `ui` crate
+
+Adds `allow_attributes_without_reason = "deny"` to `ui/Cargo.toml`'s `[lints.clippy]` table,
+matching the lint already denied workspace-root-side in `Cargo.toml` — the `ui` crate has its
+own `[lints]` table (no `workspace = true` inheritance) so it silently escaped this despite
+CI's `clippy` job running `--workspace`. There are no `#[allow(...)]` attributes anywhere in
+`ui/src` today, so the `ui` crate is already clean under this lint; `deny` just locks that state
+in and keeps any future suppression documented with a reason. No behavior change.

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -175,3 +175,10 @@ cloned_instead_of_copied = "deny"
 # extended deny-list, so this never applied to `ui/src` despite CI's `clippy` job running
 # `--workspace`. The `ui` crate is already clean, so `deny` locks that in.
 manual_string_new = "deny"
+# Require every `#[allow(...)]` suppression to carry a `reason = "..."` so reviewers can tell
+# at a glance why the lint was silenced, and silenced lints stay documented as the code
+# evolves. Mirrors the root crate's `allow_attributes_without_reason = "deny"` (see Cargo.toml)
+# — the `ui` crate has its own `[lints.clippy]` table and doesn't inherit root's extended
+# deny-list, so this never applied to `ui/src` despite CI's `clippy` job running `--workspace`.
+# The `ui` crate is already clean, so `deny` locks that in.
+allow_attributes_without_reason = "deny"


### PR DESCRIPTION
## What

Adds `allow_attributes_without_reason = "deny"` to `ui/Cargo.toml`'s `[lints.clippy]` table.

## Why

The root crate already denies this lint (`Cargo.toml:98`), but the `ui` crate has its own `[lints.clippy]` table with no `workspace = true` inheritance, so the lint silently never applied to `ui/src` despite CI's `clippy` job running `--workspace`. This follows the same pattern as the ~20 already-merged "enable clippy::X in the ui crate" PRs, which have been mirroring the root crate's extended deny-list into `ui/` one lint at a time.

`grep -rn 'allow(' ui/src` returns zero matches — there are no `#[allow(...)]` attributes anywhere in the `ui` crate today, so this is a no-op lock-in of the current clean state, not a behavior change.

Includes a changeset (`patch`, no behavior change).

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.