### PR TITLE
chore(lint): enable clippy::explicit_iter_loop in the ui crate

### DIFF
--- a/.changeset/enable-clippy-explicit-iter-loop-ui.md
+++ b/.changeset/enable-clippy-explicit-iter-loop-ui.md
@@ -1,0 +1,13 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::explicit_iter_loop` in the `ui` crate
+
+Adds `explicit_iter_loop = "deny"` to `ui/Cargo.toml`'s `[lints.clippy]` table, matching the lint
+already denied workspace-root-side in `Cargo.toml` — the `ui` crate has its own `[lints]` table
+(no `workspace = true` inheritance) so it silently escaped this despite CI's `clippy` job running
+`--workspace`. Unlike most sibling `ui`-crate lint-enablement PRs, this one wasn't a no-op: it
+surfaced two real violations in `day_timeline.rs`, rewritten from `for it in props.items.iter()`
+and `for b in buckets.iter_mut()` to `for it in &props.items` and `for b in &mut buckets`. No
+behavior change.

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -182,3 +182,11 @@ manual_string_new = "deny"
 # deny-list, so this never applied to `ui/src` despite CI's `clippy` job running `--workspace`.
 # The `ui` crate is already clean, so `deny` locks that in.
 allow_attributes_without_reason = "deny"
+# Reject `for x in collection.iter()`/`.iter_mut()` in favour of `for x in &collection`/
+# `&mut collection` — the reference syntax is shorter and states "borrow and iterate" without
+# making the reader confirm `.iter()` isn't secretly `.into_iter()` (which would move). Mirrors
+# the root crate's `explicit_iter_loop = "deny"` (see Cargo.toml) — the `ui` crate has its own
+# `[lints.clippy]` table and doesn't inherit root's extended deny-list, so this never applied to
+# `ui/src` despite CI's `clippy` job running `--workspace`. Fixes the 2 violations this surfaced
+# in `day_timeline.rs`.
+explicit_iter_loop = "deny"

--- a/ui/src/day_timeline.rs
+++ b/ui/src/day_timeline.rs
@@ -145,7 +145,7 @@ pub fn day_timeline(props: &DayTimelineProps) -> Html {
     // Bucket every item's fire times into the hour rows.
     let mut buckets: Vec<Vec<BucketEntry>> = (0..24).map(|_| Vec::new()).collect();
     let mut total = 0usize;
-    for it in props.items.iter() {
+    for it in &props.items {
         for t in fire_times(&it.schedule, day) {
             buckets[t.hour() as usize].push(BucketEntry {
                 time: t,
@@ -157,7 +157,7 @@ pub fn day_timeline(props: &DayTimelineProps) -> Html {
             total += 1;
         }
     }
-    for b in buckets.iter_mut() {
+    for b in &mut buckets {
         b.sort_by_key(|e| e.time);
     }
 


### PR DESCRIPTION
## Why

The root crate denies `clippy::explicit_iter_loop` (`Cargo.toml`), but the `ui` crate has its own `[lints.clippy]` table with no `workspace = true` inheritance — so this lint silently never applied to `ui/src` despite CI's `clippy` job running `--workspace`. This is the same gap already fixed piecemeal by the sibling `chore(lint): enable clippy::X in the ui crate` PRs.

Unlike most of those, this one isn't a no-op switch-flip: it surfaced two real violations in `day_timeline.rs`.

## What

- Add `explicit_iter_loop = "deny"` to `ui/Cargo.toml`'s `[lints.clippy]` table.
- Fix the two violations it surfaced in `ui/src/day_timeline.rs`:
  - `for it in props.items.iter()` → `for it in &props.items`
  - `for b in buckets.iter_mut()` → `for b in &mut buckets`
- Add a changeset (patch bump, no behavior change).

Verified locally with `cargo clippy -p ui --all-targets -- -D warnings` (clean).

No behavior change.