### PR TITLE
chore(lint): enable clippy::mem_forget in the root crate

### DIFF
--- a/.changeset/enable-clippy-mem-forget.md
+++ b/.changeset/enable-clippy-mem-forget.md
@@ -1,0 +1,12 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::mem_forget` in the root crate
+
+Adds `mem_forget = "deny"` to `Cargo.toml`'s `[lints.clippy]` table. In a long-running daemon,
+a `std::mem::forget`'d value's `Drop` impl never runs — for file handles, locks, and other RAII
+guards that's an indefinitely leaked descriptor/lock rather than a one-off leak in a short-lived
+program. The single existing use (a test that manually closes a file descriptor and must stop
+`File::drop` from closing it again) gets a documented `#[allow(clippy::mem_forget, reason = ...)]`
+so the intent stays explicit. No behavior change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,3 +214,11 @@ unreadable_literal = "deny"
 # filesystems treat the two names as the same file, so the check's pass/fail result can disagree
 # with what's actually on disk. The codebase is already clean, so `deny` locks that in.
 case_sensitive_file_extension_comparisons = "deny"
+# Reject `std::mem::forget` in favour of `drop` or letting the value go out of scope. In a
+# long-running daemon, a forgotten value's `Drop` impl never runs — for file handles, locks, and
+# other RAII guards that means leaked descriptors/locks that accumulate over the process's
+# lifetime instead of a single one-off leak in a short-lived program. The one legitimate use in
+# this codebase (a test that manually closes a fd and must stop `File::drop` from closing it
+# again) is exempted with a documented `#[allow]`. The rest of the codebase is already clean, so
+# `deny` locks that in.
+mem_forget = "deny"

--- a/src/utils/claude_json_tests.rs
+++ b/src/utils/claude_json_tests.rs
@@ -224,6 +224,12 @@ fn lock_exclusive_and_unlock_error_on_a_closed_fd() {
     assert!(lock_exclusive(&file).is_err());
     assert!(unlock(&file).is_err());
 
+    #[allow(
+        clippy::mem_forget,
+        reason = "the fd was already manually closed above; letting `file`'s Drop run would close \
+                  it a second time (or, worse, a reused fd from an unrelated file), so forgetting \
+                  it is deliberate here, not a leak"
+    )]
     std::mem::forget(file);
     fs::remove_dir_all(&dir).unwrap();
 }


### PR DESCRIPTION
## Why

`std::mem::forget` skips a value's `Drop` impl entirely. In a short-lived CLI that's a
one-off leak; in `moadim`'s long-running daemon process it means any forgotten file
handle, lock, or other RAII guard stays leaked for the lifetime of the process instead
of ever being released. Nothing in `[lints.clippy]` currently catches a stray
`mem::forget` from creeping into a non-test code path.

## What

- Adds `mem_forget = "deny"` to `Cargo.toml`'s `[lints.clippy]` table, alongside the
  other resource/safety-motivated lints already denied there (`unwrap_used`,
  `needless_pass_by_ref_mut`, etc.).
- The one existing use, in `src/utils/claude_json_tests.rs`, is a test that manually
  closes a file descriptor via `libc::close` and then must stop `File::drop` from
  closing it a second time (or a reused fd from an unrelated file) — that's a
  deliberate forget, not a leak, so it gets a documented
  `#[allow(clippy::mem_forget, reason = "...")]` per this repo's
  `allow_attributes_without_reason` convention.
- Adds a changeset (`patch`, no behavior change).

## Testing

Ran the full local pre-push suite:
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (999+280 passing)
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% line coverage
- `linecheck --max-lines 500`

All green. No source behavior changes — Cargo.toml lint config + one test-site `#[allow]`.