### PR TITLE
chore(lint): enable clippy::needless_raw_string_hashes in the root crate

### DIFF
--- a/.changeset/enable-clippy-needless-raw-string-hashes.md
+++ b/.changeset/enable-clippy-needless-raw-string-hashes.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::needless_raw_string_hashes` in the root crate
+
+Adds `needless_raw_string_hashes = "deny"` to `Cargo.toml`'s `[lints.clippy]` table and drops the
+unneeded `#` delimiters from the one raw string literal that had them
+(`src/routines/command_system_prompt.rs`) — its body contains no unescaped `"`, so the hashes
+were pure noise. No behavior change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,3 +222,8 @@ case_sensitive_file_extension_comparisons = "deny"
 # again) is exempted with a documented `#[allow]`. The rest of the codebase is already clean, so
 # `deny` locks that in.
 mem_forget = "deny"
+# Reject a raw string literal (`r#"..."#`) whose `#` delimiters aren't needed because the string
+# body contains no unescaped `"` that would otherwise terminate it early. The extra hashes are
+# pure noise once nothing inside requires them. The codebase is already clean, so `deny` locks
+# that in.
+needless_raw_string_hashes = "deny"

--- a/src/routines/command_system_prompt.rs
+++ b/src/routines/command_system_prompt.rs
@@ -76,7 +76,7 @@ pub(crate) fn system_prompt_stmts(
             header, disclosure, title
         ),
         format!(
-            r#"[ -f {uq} ] && {{ printf '\n---\n\n'; cat {uq}; printf '\n'; }} >> {dest} || true"#,
+            r"[ -f {uq} ] && {{ printf '\n---\n\n'; cat {uq}; printf '\n'; }} >> {dest} || true",
             uq = uq
         ),
     ]


### PR DESCRIPTION
## Why

Following the established pattern of incrementally locking in clippy restriction/pedantic
lints one at a time (see the many prior `chore(lint): enable clippy::*` PRs), this enables
`clippy::needless_raw_string_hashes` for the root `moadim` crate.

Deliberately scoped to the root crate (not `ui/`) and avoids touching `ui/**`,
`src/build/ui.rs`, or `prebuilt.html` — those paths currently trip the `prebuilt-html-fresh`
CI job for every open PR that touches them (main's committed `prebuilt.html` is stale and the
trunk-produced rebuild isn't byte-reproducible across environments), so several sibling lint
PRs (#1113, #1119, #1120, #1125) are stuck on that unrelated check. This PR sidesteps it
entirely by not touching those files.

## What

- Adds `needless_raw_string_hashes = "deny"` to `Cargo.toml`'s `[lints.clippy]` table.
- Drops the unneeded `#` delimiters from the one raw string literal that had them, in
  `src/routines/command_system_prompt.rs` — its body contains no unescaped `"`, so the hashes
  were pure noise.
- No behavior change; `cargo test`, `cargo clippy --workspace --all-targets -D warnings`,
  `cargo fmt --check`, 100% line coverage (`cargo llvm-cov`), and `linecheck` all pass locally.

## Testing

Ran the full `.githooks/pre-push` hook locally (test-file convention, `cargo fmt --check`,
`cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`,
`cargo llvm-cov --fail-under-lines 100`, `linecheck --max-lines 500`, changeset check) — all
green.

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs
routine of moadim.