### PR TITLE
feat(cli): ship shell completions via `moadim completions <shell>`

### DIFF
--- a/.changeset/cli-shell-completions.md
+++ b/.changeset/cli-shell-completions.md
@@ -1,0 +1,18 @@
+---
+"moadim": minor
+---
+
+### Added
+
+feat(cli): `moadim completions <shell>` prints a shell-completion script
+
+Prints a completion script for `bash`, `zsh`, `fish`, `powershell`, or
+`elvish` to stdout (e.g. `moadim completions zsh > _moadim`), covering the
+lifecycle subcommands (`restart`, `stop`, `status`, `cleanup`, `trigger`,
+`install`, `uninstall`, `machine`, `help`, `version`) and their `--json`/
+`--quiet` flags. A missing or unrecognized shell prints a usage error to
+stderr and exits non-zero, matching the rest of the CLI's error convention.
+
+Generated via `clap_complete` from a small `clap::Command` built only for
+this purpose — the CLI's existing hand-rolled argument parser is untouched
+by this change (#307).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,6 +1454,7 @@ dependencies = [
  "axum",
  "chrono",
  "clap",
+ "clap_complete",
  "croner",
  "dirs",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ anyhow = "1"
 axum = "0.8"
 chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 croner = "3"
 dirs = "6"
 env_logger = "0.11"

--- a/README.md
+++ b/README.md
@@ -353,6 +353,22 @@ stopped**. The supervisor restarts only on a *failure* exit (systemd `Restart=on
 To start the service again after a stop, use `moadim` (or your supervisor's `systemctl --user start`
 / `launchctl` controls).
 
+### Shell completions
+
+`moadim completions <shell>` prints a completion script for `bash`, `zsh`, `fish`, `powershell`, or
+`elvish` to stdout; redirect it to wherever your shell loads completions from:
+
+```sh
+# bash (adjust the path to wherever your bash-completion install looks)
+moadim completions bash > /etc/bash_completion.d/moadim
+
+# zsh (any directory on $fpath; start a new shell, or `compinit`, afterward)
+moadim completions zsh > "${fpath[1]}/_moadim"
+
+# fish
+moadim completions fish > ~/.config/fish/completions/moadim.fish
+```
+
 ### Data commands
 
 Beyond lifecycle, the CLI exposes the same routine actions the REST API and MCP tools

--- a/src/cli/completions.rs
+++ b/src/cli/completions.rs
@@ -1,0 +1,137 @@
+//! `moadim completions <shell>`: print a shell-completion script to stdout.
+//!
+//! [`crate::cli::parse`] hand-rolls its own argument parsing rather than using `clap` (see its
+//! module docs), so there is no single `clap::Command` to hand `clap_complete` for the whole CLI.
+//! [`build_cli`] below builds one anyway, purely as a completions source: it mirrors the
+//! verb/flag surface documented in [`super::help_text`], and generating from it is far less code
+//! (and far less likely to drift out of sync with reality) than hand-writing three shells' worth
+//! of completion scripts by hand, which is what issue #307 originally proposed.
+
+use std::io::Write;
+
+use clap::{Arg, ArgAction, Command as ClapCommand, ValueEnum as _};
+use clap_complete::Shell;
+
+/// Build the synthetic `clap::Command` tree used only to generate shell completions. It is never
+/// used to actually parse `std::env::args()` — [`super::parse`] still owns that.
+pub(super) fn build_cli() -> ClapCommand {
+    let json_flag = || Arg::new("json").long("json").action(ArgAction::SetTrue);
+    let quiet_flag = || {
+        Arg::new("quiet")
+            .short('q')
+            .long("quiet")
+            .action(ArgAction::SetTrue)
+    };
+    let interactive_flag = || {
+        Arg::new("interactive")
+            .short('i')
+            .long("interactive")
+            .action(ArgAction::SetTrue)
+    };
+
+    ClapCommand::new("moadim")
+        .about("routine scheduler with an MCP/REST API and a web control panel")
+        .arg(interactive_flag().long_help("run in the foreground, attached to the terminal"))
+        .arg(
+            Arg::new("foreground")
+                .short('f')
+                .long("foreground")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("background")
+                .short('b')
+                .long("background")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("detach")
+                .short('d')
+                .long("detach")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(Arg::new("daemon").long("daemon").action(ArgAction::SetTrue))
+        .subcommand(
+            ClapCommand::new("restart")
+                .arg(json_flag())
+                .arg(quiet_flag())
+                .arg(interactive_flag()),
+        )
+        .subcommand(ClapCommand::new("stop").arg(json_flag()).arg(quiet_flag()))
+        .subcommand(
+            ClapCommand::new("status")
+                .arg(json_flag())
+                .arg(Arg::new("wait").long("wait").num_args(0..=1)),
+        )
+        .subcommand(ClapCommand::new("cleanup").arg(json_flag()))
+        .subcommand(ClapCommand::new("trigger").alias("run").arg(Arg::new("id")))
+        .subcommand(ClapCommand::new("install"))
+        .subcommand(ClapCommand::new("uninstall"))
+        .subcommand(
+            ClapCommand::new("machine")
+                .subcommand(ClapCommand::new("show"))
+                .subcommand(ClapCommand::new("set").arg(Arg::new("name")))
+                .subcommand(ClapCommand::new("list")),
+        )
+        // `help` is not listed explicitly: `clap` auto-generates a `help` subcommand for any
+        // `Command` that has subcommands, so adding one here would collide with it.
+        .subcommand(ClapCommand::new("version"))
+        .subcommand(
+            ClapCommand::new("completions")
+                .about("print a shell-completion script")
+                .arg(
+                    Arg::new("shell")
+                        .value_parser(clap::value_parser!(Shell))
+                        .required(true),
+                ),
+        )
+        // Data-plane subcommands (`routines`, `agents`, `enable`, `disable`, `schedule`) are a
+        // separate clap parser already (`crate::commands::DataCli`); listing their bare names
+        // here (with no further flag detail) is enough for top-level tab-completion to find them.
+        .subcommand(ClapCommand::new("routines").visible_alias("routine"))
+        .subcommand(ClapCommand::new("schedule").visible_alias("sched"))
+        .subcommand(ClapCommand::new("enable").arg(Arg::new("routine")))
+        .subcommand(ClapCommand::new("disable").arg(Arg::new("routine")))
+        .subcommand(ClapCommand::new("agents"))
+}
+
+/// Write the completion script for `shell_name` to `out`.
+///
+/// Returns `Err(())` when `shell_name` doesn't name a shell `clap_complete` supports (bash,
+/// elvish, fish, powershell, zsh), leaving the caller to report the usage error.
+pub(super) fn write_completions(shell_name: &str, out: &mut impl Write) -> Result<(), ()> {
+    let shell = Shell::from_str(shell_name, false).map_err(|_ignored| ())?;
+    let mut cmd = build_cli();
+    clap_complete::generate(shell, &mut cmd, "moadim", out);
+    Ok(())
+}
+
+/// Print a `completions`-specific usage error to stderr, matching [`super::print_usage_error`]'s
+/// two-line shape.
+fn print_completions_usage_error(detail: &str) {
+    eprintln!("moadim: {detail}");
+    eprintln!("Run `moadim help` for usage.");
+}
+
+/// `moadim completions <shell>`: print `shell_name`'s completion script to stdout, or a usage
+/// error to stderr when `shell_name` is missing or unrecognized.
+///
+/// Returns the process exit code: `0` on success, [`super::EXIT_USAGE`] otherwise.
+pub fn completions(shell_name: Option<&str>) -> i32 {
+    let Some(name) = shell_name else {
+        print_completions_usage_error(
+            "completions requires a shell argument (bash, elvish, fish, powershell, zsh)",
+        );
+        return super::EXIT_USAGE;
+    };
+    let mut stdout = std::io::stdout();
+    write_completions(name, &mut stdout).map_or_else(
+        |()| {
+            print_completions_usage_error(&format!(
+                "unknown shell: {name} (expected bash, elvish, fish, powershell, or zsh)"
+            ));
+            super::EXIT_USAGE
+        },
+        |()| 0,
+    )
+}

--- a/src/cli/completions_tests.rs
+++ b/src/cli/completions_tests.rs
@@ -1,0 +1,101 @@
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and fixtures do not need doc comments"
+)]
+
+use super::*;
+
+/// Verbs the generated completion script must mention, mirroring the acceptance criteria in
+/// issue #307: every lifecycle subcommand plus the `--json`/`--quiet` flags shared across them.
+const EXPECTED_VERBS: &[&str] = &[
+    "restart",
+    "stop",
+    "status",
+    "cleanup",
+    "trigger",
+    "install",
+    "uninstall",
+    "machine",
+    "help",
+    "version",
+    "completions",
+];
+
+#[test]
+fn parse_recognizes_the_completions_command() {
+    assert_eq!(
+        parse(vec!["completions".to_string(), "zsh".to_string()]),
+        Command::Completions(Some("zsh".to_string()))
+    );
+}
+
+#[test]
+fn parse_without_a_shell_carries_no_shell() {
+    assert_eq!(
+        parse(vec!["completions".to_string()]),
+        Command::Completions(None)
+    );
+}
+
+#[test]
+fn bash_zsh_and_fish_each_emit_a_non_empty_script() {
+    for shell in ["bash", "zsh", "fish", "powershell", "elvish"] {
+        let mut out = Vec::new();
+        write_completions(shell, &mut out)
+            .unwrap_or_else(|()| panic!("{shell} should be a supported shell"));
+        assert!(
+            !out.is_empty(),
+            "{shell} completion script should not be empty"
+        );
+    }
+}
+
+#[test]
+fn generated_script_covers_every_lifecycle_verb() {
+    let mut out = Vec::new();
+    write_completions("zsh", &mut out).expect("zsh is supported");
+    let script = String::from_utf8(out).expect("clap_complete output is valid UTF-8");
+    for verb in EXPECTED_VERBS {
+        assert!(
+            script.contains(verb),
+            "zsh completion script is missing the `{verb}` subcommand \
+             (keep `build_cli` in sync with `Command`)"
+        );
+    }
+    for flag in ["json", "quiet"] {
+        assert!(
+            script.contains(flag),
+            "zsh completion script is missing the `--{flag}` flag"
+        );
+    }
+}
+
+#[test]
+fn unknown_shell_is_rejected() {
+    let mut out = Vec::new();
+    assert_eq!(write_completions("powersh", &mut out), Err(()));
+    assert!(out.is_empty());
+}
+
+#[test]
+fn completions_returns_success_for_a_supported_shell() {
+    assert_eq!(completions(Some("bash")), 0);
+}
+
+#[test]
+fn completions_returns_usage_error_for_an_unsupported_shell() {
+    assert_eq!(completions(Some("nope")), EXIT_USAGE);
+}
+
+#[test]
+fn completions_returns_usage_error_when_no_shell_given() {
+    assert_eq!(completions(None), EXIT_USAGE);
+}
+
+#[test]
+fn build_cli_has_a_completions_subcommand() {
+    let cli = build_cli();
+    assert!(cli
+        .get_subcommands()
+        .any(|sub| sub.get_name() == "completions"));
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -112,6 +112,10 @@ pub enum Command {
     Usage(String),
     /// Print the binary version.
     Version,
+    /// Print a shell-completion script for `shell` (bash/zsh/fish/powershell/elvish) to stdout,
+    /// or (when `shell` is missing or unrecognized) a usage error to stderr. See
+    /// [`crate::cli::completions`].
+    Completions(Option<String>),
     /// A data-plane subcommand (`routines`, `agents`) handled by the clap-based
     /// [`crate::commands`] dispatcher, which talks to the running server over HTTP. Carries the raw
     /// argv (including the subcommand keyword) for clap to parse.
@@ -161,6 +165,7 @@ pub fn parse(args: impl IntoIterator<Item = String>) -> Command {
         },
         Some("install") => Command::Install,
         Some("uninstall") => Command::Uninstall,
+        Some("completions") => Command::Completions(args.get(1).cloned()),
         Some("-h" | "--help" | "help") => Command::Help,
         Some("-V" | "--version" | "version") => Command::Version,
         Some("-i" | "--interactive" | "-f" | "--foreground") => Command::Foreground,
@@ -232,6 +237,8 @@ pub fn help_text() -> String {
          \x20   install                register moadim as an OS service (launchd / systemd user)\n\
          \x20   uninstall              remove the OS service registration and the managed crontab block\n\
          \x20   machine <show|set|list> show/set this machine's identity, or list machines referenced\n\
+         \x20   completions <shell>    print a completion script for bash/zsh/fish/powershell/elvish\n\
+         \x20                          (e.g. `moadim completions zsh > _moadim`)\n\
          \x20   help, -h, --help       show this help\n\
          \x20   version, -V, --version show the version\n\
          \n\
@@ -427,9 +434,19 @@ use cli_restart::start_detached_and_report;
 #[cfg(test)]
 use cli_restart::{restart_json, restart_rotation_line};
 
+#[path = "completions.rs"]
+mod cli_completions;
+pub use cli_completions::completions;
+#[cfg(test)]
+use cli_completions::{build_cli, write_completions};
+
 #[cfg(test)]
 #[path = "tests.rs"]
 mod cli_tests;
+
+#[cfg(test)]
+#[path = "completions_tests.rs"]
+mod cli_completions_tests;
 
 #[cfg(test)]
 #[path = "cleanup_bytes_tests.rs"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,7 @@ async fn main() -> anyhow::Result<()> {
         }
         cli::Command::Install => service::install(),
         cli::Command::Uninstall => uninstall(),
+        cli::Command::Completions(shell) => std::process::exit(cli::completions(shell.as_deref())),
         cli::Command::Data(args) => std::process::exit(commands::run(args)),
         cli::Command::Machine(args) => std::process::exit(machine::run(&args)),
         cli::Command::Foreground => {


### PR DESCRIPTION
## Summary

Adds a `moadim completions <shell>` subcommand that prints a shell-completion script to stdout for `bash`, `zsh`, `fish`, `powershell`, or `elvish` (e.g. `moadim completions zsh > _moadim`).

The CLI's main verb dispatch (`cli::parse` in `src/cli/mod.rs`) is hand-rolled string matching, not `clap`-based — but `clap` **is** already a dependency (it drives the `moadim routines`/`agents`/`enable`/`disable`/`schedule` data-plane subcommands in `src/commands.rs`). Rather than hand-writing three-plus shells' worth of completion scripts by hand, this adds `clap_complete` (the standard companion crate for `clap`, same maintainers) and builds a small `clap::Command` purely as a completions source — `clap_complete::generate` does the actual script generation. `cli::parse` itself is untouched.

- `moadim completions bash|zsh|fish|powershell|elvish` prints a valid script and exits `0`.
- A missing/unrecognized shell prints a two-line usage error to stderr and exits `EXIT_USAGE` (2), matching the CLI's existing error convention.
- Covers the lifecycle subcommands (`restart`, `stop`, `status`, `cleanup`, `trigger`, `install`, `uninstall`, `machine`, `help`, `version`) and the shared `--json`/`--quiet` flags, plus lists the data-plane subcommand names (`routines`, `schedule`, `enable`, `disable`, `agents`) for top-level tab-completion.
- A test (`generated_script_covers_every_lifecycle_verb`) asserts the generated script mentions every verb, guarding drift.
- README gets a new "Shell completions" section with the install snippet per shell.

## Scope note

Per the repo's known backlog of stuck/unmerged automated PRs (#903) and prior merge issues (#846): this change is **small and additive-only**. It touches nothing except:
- one new `src/cli/completions.rs` module (+ its `completions_tests.rs`)
- one new `Command::Completions` variant and one new `match` arm in `cli::parse` (`src/cli/mod.rs`)
- one new match arm in `main.rs`
- `Cargo.toml`/`Cargo.lock` (new `clap_complete` dependency)
- README + a changeset

No existing subcommand, flag, or shared dispatch logic was modified.

## Test plan

- [x] `cargo build`
- [x] `cargo test --workspace` (1009 + 280 tests pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean, matches this repo's strict lint set)
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --document-private-items` with `RUSTDOCFLAGS="-D warnings"` (no broken intra-doc links)
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — the new `src/cli/completions.rs` and updated `src/cli/mod.rs` are both 100% covered (verified against this repo's 100%-line-coverage gate)
- [x] `typos` / `linecheck --max-lines 500` clean

Closes #307