### PR TITLE
chore(deps): bump transitive cc 1.2.66 -> 1.2.67

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,9 +228,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "shlex",


### PR DESCRIPTION
## What

Routine transitive-dependency freshness: `cargo update -p cc` picks up the
latest compatible patch of the `cc` build-dependency (Cargo.lock only — no
`Cargo.toml`, `src/`, or `ui/` changes).

## Why

Kept `Cargo.lock` current with the latest compatible patch release available
on crates.io (verified via `cargo update --dry-run`), consistent with this
repo's existing pattern of periodic transitive-dependency bumps (e.g. #1114,
#1111). Verified locally: `cargo fmt --check`, `cargo clippy --workspace
--all-targets -- -D warnings`, and `cargo test --workspace` all pass on this
branch. No changeset needed — the change touches neither `src/` nor `ui/`.

I checked the currently open PRs and didn't find one already proposing this
same bump, so this isn't a duplicate.

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.