### PR TITLE
test(middlewares): cover allowed_hosts when MOADIM_BIND_ADDR has no port

### DIFF
--- a/.changeset/test-allowed-hosts-no-port-bind-addr.md
+++ b/.changeset/test-allowed-hosts-no-port-bind-addr.md
@@ -1,0 +1,13 @@
+---
+"moadim": patch
+---
+
+test(middlewares): cover `allowed_hosts` when `MOADIM_BIND_ADDR` has no port
+
+`allowed_hosts()` splits the configured bind address on `:` to derive a port and add
+`localhost:<port>`/`[::1]:<port>` entries to the `Host`/`Origin` allowlist. The branch where
+`MOADIM_BIND_ADDR` has no port (e.g. an operator setting it to a bare `0.0.0.0`) was never
+exercised by a test — one of several gaps keeping the repo's 100%-line-coverage gate (`cargo
+llvm-cov --fail-under-lines 100`, run in the pre-push hook) below 100% on `main`. Adds a test
+asserting the port-suffixed entries are skipped in that case, bringing this file to 100%. No
+behavior change.

--- a/src/middlewares/host_validation_tests.rs
+++ b/src/middlewares/host_validation_tests.rs
@@ -218,3 +218,16 @@ fn allowed_hosts_extends_from_env_var() {
     assert!(hosts.iter().any(|host| host == "reverse-proxy.internal"));
     assert!(hosts.iter().any(|host| host == "other.host:8080"));
 }
+
+#[test]
+fn allowed_hosts_skips_port_suffixed_entries_when_bind_addr_has_no_port() {
+    // A bind address without a `:port` suffix (e.g. an operator setting `MOADIM_BIND_ADDR=0.0.0.0`
+    // and letting the port default elsewhere) means `bind.rsplit_once(':')` returns `None`, so the
+    // `localhost:<port>`/`[::1]:<port>` allowlist entries must not be added — only the bare `bind`
+    // value itself.
+    let _guard = EnvGuard::set("MOADIM_BIND_ADDR", "0.0.0.0");
+    let hosts = allowed_hosts();
+    assert!(hosts.iter().any(|host| host == "0.0.0.0"));
+    assert!(!hosts.iter().any(|host| host.starts_with("localhost:")));
+    assert!(!hosts.iter().any(|host| host.starts_with("[::1]:")));
+}


### PR DESCRIPTION
## Why

`allowed_hosts()` in `src/middlewares/host_validation.rs` splits the configured bind address on `:` to derive a port, adding `localhost:<port>`/`[::1]:<port>` entries to the `Host`/`Origin` allowlist:

```rust
let port = bind.rsplit_once(':').map(|(_, port)| port);
...
if let Some(port) = port {
    hosts.push(format!("localhost:{port}"));
    hosts.push(format!("[::1]:{port}"));
}
```

The branch where `bind` has no colon (e.g. an operator setting `MOADIM_BIND_ADDR=0.0.0.0` with the port supplied elsewhere) was never exercised by any test. Confirmed locally with `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main.rs'`: this file sat at 98.96% line coverage before this change, one of several files keeping the repo below the 100%-line-coverage gate the pre-push hook enforces.

## What

Adds `allowed_hosts_skips_port_suffixed_entries_when_bind_addr_has_no_port`, using the `EnvGuard` pattern already established in this test file, asserting that when `MOADIM_BIND_ADDR` has no port, the bare bind value is still added but no `localhost:`/`[::1]:` port-suffixed entries are. This brings `middlewares/host_validation.rs` to 100% line coverage (repo-wide total moves from 30 to 29 missed lines — other pre-existing, unrelated gaps remain and are out of scope for this PR).

No production code changes — test-only, plus a changeset.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 1010 passed (was 1009), 0 failed
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main.rs'` — `middlewares/host_validation.rs` now 100.00% (was 98.96%)

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.