### PR TITLE
chore(lint): enable clippy::doc_markdown in the ui crate

### DIFF
--- a/.changeset/enable-clippy-doc-markdown-ui.md
+++ b/.changeset/enable-clippy-doc-markdown-ui.md
@@ -1,0 +1,13 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable clippy::doc_markdown in the ui crate
+
+Mirrors the root crate's `doc_markdown = "deny"` (see `Cargo.toml`). The `ui` crate has its
+own `[lints.clippy]` table and doesn't inherit root's extended deny-list, so this never
+applied to `ui/src` despite CI's `clippy` job running `--workspace`. Fixed the 6 violations
+this surfaced across `cron_utils.rs`, `routines/banner.rs`, `routines/filter.rs`,
+`routines/filter_bar.rs`, `routines/filter_tests.rs`, and `routines/hooks.rs` by wrapping
+the flagged identifiers (`is_valid`, `DueSoon`, `schedule_description`, `NodeRef`) in
+backticks. No behavior change.

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -236,3 +236,11 @@ needless_raw_string_hashes = "deny"
 # root's extended deny-list, so this never applied to `ui/src` despite CI's `clippy` job
 # running `--workspace`. Fixes the 1 violation this surfaced in `routines/state.rs`.
 manual_let_else = "deny"
+# Reject a `CamelCase`/`snake_case`-looking identifier in a doc comment that isn't wrapped in
+# backticks — without them, rustdoc renders it as plain prose and a reader can't tell it's a type,
+# field, or item name rather than an English word. Mirrors the root crate's `doc_markdown = "deny"`
+# (see Cargo.toml) — the `ui` crate has its own `[lints.clippy]` table and doesn't inherit root's
+# extended deny-list, so this never applied to `ui/src` despite CI's `clippy` job running
+# `--workspace`. Fixes the 6 violations this surfaced across `cron_utils.rs`, `routines/banner.rs`,
+# `routines/filter.rs`, `routines/filter_bar.rs`, `routines/filter_tests.rs`, and `routines/hooks.rs`.
+doc_markdown = "deny"

--- a/ui/src/cron_utils.rs
+++ b/ui/src/cron_utils.rs
@@ -26,7 +26,7 @@ pub(crate) fn parse_cron(expr: &str) -> Option<Cron> {
     normalized.parse::<Cron>().ok()
 }
 
-/// Returns (is_valid, human description) for a cron expression.
+/// Returns (`is_valid`, human description) for a cron expression.
 pub(crate) fn describe_cron_live(expr: &str) -> (bool, String) {
     if expr.trim().is_empty() {
         return (false, "— enter a cron expression —".into());

--- a/ui/src/routines/banner.rs
+++ b/ui/src/routines/banner.rs
@@ -58,7 +58,7 @@ pub fn global_lock_banner(props: &GlobalLockBannerProps) -> Html {
 #[derive(Properties, PartialEq)]
 pub struct StatsBarProps {
     pub routines: Vec<Routine>,
-    /// "Now" used to compute the DueSoon count.
+    /// "Now" used to compute the `DueSoon` count.
     pub now: DateTime<Local>,
     /// Currently active status facet — drives `aria-pressed`.
     pub active: RoutineStatusFacet,

--- a/ui/src/routines/filter.rs
+++ b/ui/src/routines/filter.rs
@@ -191,7 +191,7 @@ impl TagFacet {
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct RoutineFilter {
     /// Free-text needle matched across title, agent, prompt, repositories,
-    /// schedule, and schedule_description.
+    /// schedule, and `schedule_description`.
     pub query: String,
     pub status: RoutineStatusFacet,
     pub agent: AgentFacet,

--- a/ui/src/routines/filter_bar.rs
+++ b/ui/src/routines/filter_bar.rs
@@ -25,7 +25,7 @@ pub struct FilterSortBarProps {
     /// Count after filtering / total loaded — rendered as "Showing N of M".
     pub shown: usize,
     pub total: usize,
-    /// NodeRef forwarded from the page so the `/` shortcut can focus this input.
+    /// `NodeRef` forwarded from the page so the `/` shortcut can focus this input.
     pub search_ref: NodeRef,
     pub on_query: Callback<String>,
     pub on_status: Callback<RoutineStatusFacet>,

--- a/ui/src/routines/filter_tests.rs
+++ b/ui/src/routines/filter_tests.rs
@@ -51,7 +51,7 @@ fn now() -> DateTime<Local> {
     Local.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap()
 }
 
-/// DueSoon window matching `DUE_SOON_WINDOW_SECS`.
+/// `DueSoon` window matching `DUE_SOON_WINDOW_SECS`.
 fn window() -> Duration {
     Duration::seconds(DUE_SOON_WINDOW_SECS)
 }

--- a/ui/src/routines/hooks.rs
+++ b/ui/src/routines/hooks.rs
@@ -22,7 +22,7 @@ use super::model::{api_all_runs, api_list, api_lock_status, FleetRunSummary};
 use super::sparkline::{group_recent_runs, RUN_HISTORY_FETCH_LIMIT};
 use super::state::{RAction, RModal, RState};
 
-/// Tick cadence for the live "now" handle (keeps DueSoon count fresh between fetches).
+/// Tick cadence for the live "now" handle (keeps `DueSoon` count fresh between fetches).
 const NEXT_RUN_TICK_MS: u32 = 30_000;
 
 /// Installs the keydown listener behind two routines-page shortcuts: `/` focuses


### PR DESCRIPTION
## What

Enables `clippy::doc_markdown = "deny"` in `ui/Cargo.toml`, mirroring the lint already denied in the root crate's `Cargo.toml`. The `ui` crate has its own `[lints.clippy]` table and doesn't inherit root's extended deny-list, so this lint (and several others before it) never actually applied to `ui/src` despite CI's `clippy` job running `--workspace`.

## Why

Undocumented gap: root already treats a bare `CamelCase`/`snake_case` identifier in a doc comment as an error (it should be wrapped in backticks so rustdoc renders it as code, not prose), but `ui/src` was silently exempt. Closing gaps like this one is an ongoing pattern in this repo (see the many `chore(lint): enable clippy::X in the ui crate` PRs already merged/open).

## Changes

Fixed the 6 violations this surfaced — wrapping `is_valid`, `DueSoon` (×3), `schedule_description`, and `NodeRef` in backticks across `cron_utils.rs`, `routines/banner.rs`, `routines/filter.rs`, `routines/filter_bar.rs`, `routines/filter_tests.rs`, and `routines/hooks.rs`. No behavior change — doc comments only.

Verified locally: `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test --workspace` all pass.

## Note

This repo's "Quality for branches" ruleset currently blocks every PR from merging regardless of passing checks (see #846, filed by this same routine) — flagging that here so review isn't confused by a stuck `mergeStateStatus`.

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.