### PR TITLE
docs(contributing): add the changeset check to the pre-push command list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
 cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'
 linecheck --max-lines 500 $(find src ui/src -name '*.rs')
+pnpm exec changeset status --since=origin/main
 ```
 
 Use `--workspace` for both clippy and test, matching the pre-push hook —
@@ -48,7 +49,12 @@ own test suite. `linecheck` keeps any single `.rs` file under `src/` or
 `ui/src/` from growing past 500 lines — a convention two independently green
 PRs can each respect yet still blow past together, since it isn't a required
 branch-protection check (see the `linecheck` job in
-[`lint.yml`](.github/workflows/lint.yml)).
+[`lint.yml`](.github/workflows/lint.yml)). The `changeset status` check only
+fails when a commit touches `src/` or `ui/` without an accompanying
+`.changeset/*.md` file, matching the CI `unreleased-entry` job (see
+[Workflow](#workflow) below) — run `pnpm install` once first so `pnpm exec`
+can find it, or set `SKIP_CHANGELOG=1` to bypass it locally the way the
+`skip-changelog` PR label does in CI.
 
 Enable the bundled git hooks once per clone:
 


### PR DESCRIPTION
## Why

\`.githooks/pre-push\` runs 7 checks before a push: test-file convention, \`cargo fmt --check\`, \`cargo clippy\`, \`cargo test --workspace\`, \`cargo llvm-cov\`, \`linecheck\`, and (step 6) a changeset check that mirrors CI's \`unreleased-entry\` job — failing if a commit touches \`src/\` or \`ui/\` without a \`.changeset/*.md\` file.

CONTRIBUTING.md's "Run the checks the pre-push hook enforces before any push" snippet only lists 5 of those (fmt/clippy/test/coverage/linecheck) and never mentions the changeset check at all. A contributor who runs exactly what the doc says, sees everything green, and pushes can still get a CI failure on the \`unreleased-entry\` job for a missing changeset — the doc gave them a false "you're clear to push" signal.

## What

Add \`pnpm exec changeset status --since=origin/main\` (the exact command CI runs, per \`.github/workflows/changelog.yml\`) to the reproducible command list, plus a short explanation of when it fires and how to bypass it locally (\`SKIP_CHANGELOG=1\`, mirroring the \`skip-changelog\` PR label).

Docs-only change, no code touched.