### PR TITLE
test(http): cover the write-failure branch of PUT /config/user-prompt

### DIFF
--- a/.changeset/user-prompt-put-write-failure-coverage.md
+++ b/.changeset/user-prompt-put-write-failure-coverage.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Add a test for `PUT /config/user-prompt` returning 500 when the write itself fails (target path is a directory), closing the last untested error branch in that handler. No behavior change — test-only.

--- a/src/routes/http_settings_routes_tests.rs
+++ b/src/routes/http_settings_routes_tests.rs
@@ -205,3 +205,32 @@ async fn user_prompt_put_returns_500_on_write_failure() {
     let _ = std::fs::remove_file(&dir);
     std::env::remove_var("MOADIM_HOME_OVERRIDE");
 }
+
+#[tokio::test]
+async fn user_prompt_put_returns_500_when_target_path_is_a_directory() {
+    // `create_private_dir_all(parent)` succeeds here (the parent is a normal, writable
+    // directory); a directory in place of the prompt file itself makes the *second* fallible
+    // call, `std::fs::write(&path, ...)`, fail — the distinct `?` this test exercises versus
+    // `user_prompt_put_returns_500_on_write_failure` above, which only ever reaches the first.
+    let dir = std::env::temp_dir().join(format!(
+        "moadim-user-prompt-targetdir-{}",
+        uuid::Uuid::new_v4()
+    ));
+    std::env::set_var("MOADIM_HOME_OVERRIDE", &dir);
+    std::fs::create_dir_all(crate::paths::user_prompt_path()).unwrap();
+    let app = build_app(crate::routines::new_store());
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/api/v1/config/user-prompt")
+                .header(CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{"content":"x"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let _ = std::fs::remove_dir_all(&dir);
+    std::env::remove_var("MOADIM_HOME_OVERRIDE");
+}


### PR DESCRIPTION
## Why

`put_user_prompt` has two fallible steps:
1. `create_private_dir_all(parent)?`
2. `std::fs::write(&path, &body.content)?`

The existing `user_prompt_put_returns_500_on_write_failure` test only exercises the *first* — it places a regular file where the config directory should be, so `create_dir_all` fails before the write is ever attempted. That leaves the `std::fs::write` error branch (the actual write failure this handler's 500 response is documented to cover) completely untested.

## What

Adds `user_prompt_put_returns_500_when_target_path_is_a_directory`: lets the parent directory create succeed, but pre-creates the *target path itself* as a directory, so `std::fs::write` fails with `IsADirectory` instead. This mirrors the technique already used by `user_prompt_get_returns_500_on_non_not_found_read_error` for the GET handler's equivalent branch.

Test-only change, no behavior change. Verified locally: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test`, and `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` all pass, and the new test closes the last uncovered branch in `src/routes/http_settings_routes.rs` (confirmed via `cargo llvm-cov --html`).

Includes a changeset (`patch`, since this only adds test coverage).