### PR TITLE
fix(routines): surface why a skipped trigger never spawned (#1145)

### DIFF
--- a/.changeset/surface-skipped-trigger-reason.md
+++ b/.changeset/surface-skipped-trigger-reason.md
@@ -1,0 +1,9 @@
+---
+"moadim": patch
+---
+
+Fix a manual `trigger_routine` that gets skipped (agent load failure, an oversized inline
+prompt, the overlap guard, or the global concurrency cap) surfacing no reason anywhere a caller
+could see (#1145). `spawn_routine_command`'s skip branches now also append the reason to a new
+per-routine `skip.log`, and `svc_logs` (the `routine_logs` backend) falls back to it when no
+workbench was spawned, instead of coming back indistinguishable from "never triggered".

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -150,6 +150,19 @@ pub fn routine_manual_log_path(id: &str) -> PathBuf {
     routine_dir(id).join("manual.log")
 }
 
+/// Returns the path to `{routines_dir}/{id}/skip.log`, the gitignored append-only log recording
+/// why a trigger did not spawn a workbench (agent load failure, an oversized inline prompt, the
+/// per-routine overlap guard, or the global concurrency cap — see
+/// `crate::routines::service_trigger::spawn_routine_command`).
+///
+/// Without this, a skipped trigger left no trace anywhere a caller could read back: `routine_logs`
+/// looks up the newest *workbench's* `agent.log`, and a skipped trigger never creates a workbench
+/// (#1145). The `.log` suffix matches the `*.log` pattern in the routine's `.gitignore`.
+#[must_use]
+pub fn routine_skip_log_path(id: &str) -> PathBuf {
+    routine_dir(id).join("skip.log")
+}
+
 /// Returns the path to `{routines_dir}/{id}/runs.log`, the gitignored append-only NDJSON log of
 /// every finished run's outcome, keyed by the routine's stable UUID (unlike its workbenches, which
 /// are keyed by slug and reaped after their TTL).

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -16,8 +16,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::paths::{
     routine_compiled_prompt_path, routine_dir, routine_gitignore_path, routine_manual_log_path,
-    routine_prompts_dir, routine_pure_prompt_path, routine_script_path, routine_state_path,
-    routine_toml_path,
+    routine_prompts_dir, routine_pure_prompt_path, routine_script_path, routine_skip_log_path,
+    routine_state_path, routine_toml_path,
 };
 use crate::routines::{compose_prompt, slugify, Repository, Routine, RoutineStore};
 use crate::utils::atomic::atomic_write;
@@ -286,6 +286,28 @@ pub fn append_manual_trigger_log(slug: &str, ts: u64) {
             "append_manual_trigger_log: failed to write {}: {err}",
             path.display()
         );
+    }
+}
+
+/// Append a `{ts}\t{reason}` entry to a routine's `skip.log`, recording why a trigger did not
+/// spawn a workbench.
+///
+/// Called by `spawn_routine_command` from every branch that returns without launching (agent load
+/// failure, an oversized inline prompt, the overlap guard, or the global concurrency cap), so
+/// `routine_logs` has something to show instead of coming back empty when the newest — or only —
+/// signal for a skipped trigger previously lived solely in the daemon's own process log (#1145).
+/// Best-effort, like [`append_manual_trigger_log`]: a log-write failure is warned but never
+/// surfaced, so a disk hiccup can't turn a skip into a harder failure.
+pub fn append_skip_log(slug: &str, ts: u64, reason: &str) {
+    let path = routine_skip_log_path(slug);
+    let line = format!("{ts}\t{reason}\n");
+    if let Err(err) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .and_then(|mut file| std::io::Write::write_all(&mut file, line.as_bytes()))
+    {
+        log::warn!("append_skip_log: failed to write {}: {err}", path.display());
     }
 }
 

--- a/src/routine_storage_snooze_tests.rs
+++ b/src/routine_storage_snooze_tests.rs
@@ -350,3 +350,46 @@ fn append_manual_trigger_log_warns_on_write_failure() {
     }
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+#[test]
+fn append_skip_log_creates_and_appends() {
+    // Each call appends one `{ts}\t{reason}` line; the log grows across calls (#1145).
+    with_override_home(|_home| {
+        let title = "Rs Skip Log Append Routine";
+        let slug = slugify(title);
+        write_routine(&make_routine("rs-skip-log-id", title)).unwrap();
+
+        append_skip_log(&slug, 100, "overlap guard");
+        append_skip_log(&slug, 200, "concurrency cap");
+
+        let log_path = crate::paths::routine_skip_log_path(&slug);
+        let text = std::fs::read_to_string(&log_path).unwrap();
+        assert_eq!(text, "100\toverlap guard\n200\tconcurrency cap\n");
+    });
+}
+
+#[test]
+fn append_skip_log_warns_on_write_failure() {
+    // Pointing the log path at a directory (so open fails) exercises the warn branch and
+    // does not panic, mirroring `append_manual_trigger_log_warns_on_write_failure`.
+    let dir = scratch_dir("skip-log-fail");
+    std::fs::create_dir_all(&dir).unwrap();
+    let slug_dir = dir.join("rs-skip-log-fail-routine");
+    std::fs::create_dir_all(&slug_dir).unwrap();
+    let blocker = slug_dir.join("skip.log");
+    std::fs::create_dir_all(&blocker).unwrap();
+
+    let previous = std::env::var_os("MOADIM_HOME_OVERRIDE");
+    unsafe {
+        std::env::set_var("MOADIM_HOME_OVERRIDE", &dir);
+    }
+    // Should not panic; just logs a warning.
+    append_skip_log("rs-skip-log-fail-routine", 42, "agent load failure");
+    unsafe {
+        match previous {
+            Some(value) => std::env::set_var("MOADIM_HOME_OVERRIDE", value),
+            None => std::env::remove_var("MOADIM_HOME_OVERRIDE"),
+        }
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/src/routines/service_overlap_guard_tests.rs
+++ b/src/routines/service_overlap_guard_tests.rs
@@ -103,6 +103,20 @@ fn svc_trigger_skips_spawn_when_a_previous_run_is_still_alive() {
     let triggered = svc_trigger(&store, "trig-overlap-id").unwrap();
     assert!(triggered.last_manual_trigger_at.is_some());
 
+    // The overlap guard never spawns a workbench, so without a `skip.log` fallback
+    // `routine_logs` would come back empty — indistinguishable from a routine that
+    // was simply never triggered (#1145). Assert the skip reason lands in both the
+    // durable log and what `svc_logs` (the `routine_logs` backend) actually returns.
+    let skip_log = std::fs::read_to_string(crate::paths::routine_skip_log_path(&slug)).unwrap();
+    assert!(skip_log.contains("overlap guard"), "skip.log: {skip_log}");
+
+    let logs = svc_logs(&store, "trig-overlap-id").unwrap();
+    assert!(
+        logs.content.contains("overlap guard"),
+        "logs: {}",
+        logs.content
+    );
+
     // SAFETY: single-threaded harness; restore the saved override.
     unsafe {
         match previous {

--- a/src/routines/service_trigger.rs
+++ b/src/routines/service_trigger.rs
@@ -2,7 +2,7 @@
 
 use crate::error::AppError;
 use crate::paths::workbenches_dir;
-use crate::routine_storage::{append_manual_trigger_log, write_routine};
+use crate::routine_storage::{append_manual_trigger_log, append_skip_log, write_routine};
 use crate::utils::lock::LockRecover;
 use crate::utils::time::now_secs;
 
@@ -201,14 +201,15 @@ fn spawn_routine_command(routine: &Routine, source: TriggerSource) {
             // surfaces anywhere, so catch it here instead and skip the launch with a visible
             // warning, the same non-fatal shape as the agent-load-failure arm below.
             if let Some(len) = inline_prompt_overflow(routine, &agent) {
-                log::warn!(
-                    "trigger: composed prompt for routine {:?} is {len} bytes, over the \
-                     inline-argument limit for agent {:?}; skipping launch (would fail silently \
-                     inside tmux otherwise) — switch the agent's args to {{prompt_file}} or \
-                     shorten the routine's prompt/open flags",
-                    routine.id,
+                let reason = format!(
+                    "composed prompt is {len} bytes, over the inline-argument limit for agent \
+                     {:?}; skipping launch (would fail silently inside tmux otherwise) — switch \
+                     the agent's args to {{prompt_file}} or shorten the routine's prompt/open \
+                     flags",
                     routine.agent,
                 );
+                log::warn!("trigger: routine {:?} skipped — {reason}", routine.id);
+                append_skip_log(&slugify(&routine.title), now_secs(), &reason);
                 return;
             }
             // Overlap guard (#514): a routine has no built-in mutual exclusion between fires, so a
@@ -218,12 +219,12 @@ fn spawn_routine_command(routine: &Routine, source: TriggerSource) {
             // any of them is still alive, skip this fire instead of launching a second one.
             let session_prefix = tmux_session_prefix(&slugify(&routine.title));
             if tmux_session_prefix_alive(&session_prefix) {
-                log::warn!(
-                    "trigger: routine {:?} skipped — a previous run (tmux session prefix {:?}) is \
-                     still active (overlap guard)",
-                    routine.id,
-                    session_prefix,
+                let reason = format!(
+                    "a previous run (tmux session prefix {session_prefix:?}) is still active \
+                     (overlap guard)"
                 );
+                log::warn!("trigger: routine {:?} skipped — {reason}", routine.id);
+                append_skip_log(&slugify(&routine.title), now_secs(), &reason);
                 return;
             }
             // Global concurrency cap (#335): the overlap guard above only stops one routine from
@@ -240,12 +241,13 @@ fn spawn_routine_command(routine: &Routine, source: TriggerSource) {
             let live = tmux_session_count(TMUX_SESSION_PREFIX);
             let cap = max_concurrent_runs();
             if live >= cap {
-                log::warn!(
-                    "trigger: routine {:?} skipped — {live} routine session(s) already running, \
-                     at or over the global concurrency cap of {cap} (set {MAX_CONCURRENT_RUNS_ENV} \
-                     to raise it); this fire will be retried on its next scheduled tick",
-                    routine.id,
+                let reason = format!(
+                    "{live} routine session(s) already running, at or over the global \
+                     concurrency cap of {cap} (set {MAX_CONCURRENT_RUNS_ENV} to raise it); this \
+                     fire will be retried on its next scheduled tick"
                 );
+                log::warn!("trigger: routine {:?} skipped — {reason}", routine.id);
+                append_skip_log(&slugify(&routine.title), now_secs(), &reason);
                 return;
             }
             let cmd = build_routine_command(routine, &agent, source);
@@ -258,12 +260,11 @@ fn spawn_routine_command(routine: &Routine, source: TriggerSource) {
             // linger as a zombie for the daemon's lifetime (the trigger stays non-blocking).
             crate::utils::process::spawn_and_reap(command, "routine command");
         }
-        Err(err) => log::warn!(
-            "trigger: cannot load agent {:?} ({}) for routine {:?}",
-            routine.agent,
-            err,
-            routine.id
-        ),
+        Err(err) => {
+            let reason = format!("cannot load agent {:?} ({err})", routine.agent);
+            log::warn!("trigger: routine {:?} skipped — {reason}", routine.id);
+            append_skip_log(&slugify(&routine.title), now_secs(), &reason);
+        }
     }
 }
 
@@ -338,13 +339,27 @@ pub fn svc_logs(store: &RoutineStore, id: &str) -> Result<LogWithMeta, AppError>
         }
     }
     let Some((_, dir)) = newest else {
-        return Ok(LogWithMeta::empty());
+        return skip_log_fallback(&slug);
     };
     let log_path = workbenches_dir().join(dir).join("agent.log");
     if !log_path.exists() {
-        return Ok(LogWithMeta::empty());
+        return skip_log_fallback(&slug);
     }
     read_log_tail_with_meta(&log_path).map_err(|_| AppError::Internal)
+}
+
+/// Fall back to a routine's `skip.log` (see [`append_skip_log`]) when [`svc_logs`] finds no
+/// workbench: a trigger that got skipped before spawning (agent load failure, an oversized inline
+/// prompt, the overlap guard, or the concurrency cap) never creates a workbench, so without this
+/// `routine_logs` would come back looking identical to a routine that was simply never triggered
+/// (#1145). Returns an empty tail when `skip.log` doesn't exist either — a routine really can just
+/// have no history yet.
+fn skip_log_fallback(slug: &str) -> Result<LogWithMeta, AppError> {
+    let skip_log_path = crate::paths::routine_skip_log_path(slug);
+    if !skip_log_path.exists() {
+        return Ok(LogWithMeta::empty());
+    }
+    read_log_tail_with_meta(&skip_log_path).map_err(|_| AppError::Internal)
 }
 
 /// List every run for routine `id`, newest first: live (not-yet-reaped) workbenches, whose status


### PR DESCRIPTION
## Why

Fixes #1145. A manual `trigger_routine` that gets skipped before spawning a
workbench — the per-routine overlap guard, the global concurrency cap, an
oversized inline `{prompt}` argument, or a failure to load the routine's
agent config — only ever logged a `log::warn!` to the daemon's own process
log. `routine_logs` reads the newest *workbench's* `agent.log`, and a
skipped trigger never creates a workbench, so the API came back completely
empty: indistinguishable from a routine that was simply never triggered at
all. The reporter's repro (4 other routines already running) matches the
concurrency cap's default of 4 exactly.

This addresses request #3 from the issue ("emit a log line when a trigger
is accepted but deferred/dropped, so `routine_logs` isn't empty"). Requests
#1/#2 (a queued/pending run state, exposing queue depth) are separately
scoped, larger asks and are intentionally left out of this small, focused
fix.

## What

- New per-routine `skip.log` (gitignored via the existing `*.log` pattern),
  written by a new `append_skip_log(slug, ts, reason)` alongside the
  existing `manual.log`/`scheduled.log` helpers.
- Every skip branch in `spawn_routine_command` (agent-load failure, inline
  prompt overflow, overlap guard, concurrency cap) now appends its reason
  there in addition to the existing `log::warn!`.
- `svc_logs` (the `routine_logs` backend) falls back to `skip.log`'s tail
  when no workbench was found, instead of returning an empty log.

## Test plan

- [x] `cargo test --all` — 1013 + 284 passed, 0 failed (2 new unit tests for
      `append_skip_log`, plus assertions added to the existing overlap-guard
      integration test covering the full `svc_trigger` → `skip.log` →
      `svc_logs` path)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% line coverage maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)