### PR TITLE
fix(security): add missing 127.0.0.1:<port> to loopback Host allowlist

### DIFF
--- a/.changeset/fix-allowed-hosts-loopback-ip-port.md
+++ b/.changeset/fix-allowed-hosts-loopback-ip-port.md
@@ -1,0 +1,13 @@
+---
+"moadim": patch
+---
+
+fix(security): add missing `127.0.0.1:<port>` entry to the loopback `Host`/`Origin` allowlist
+
+`allowed_hosts()` added `localhost:<port>` and `[::1]:<port>` alongside the bare bind address
+when the daemon's bind address carries a port, but never added the equivalent
+`127.0.0.1:<port>` entry — even though the bare `127.0.0.1` (no port) was already allowed. A
+browser sending `Host: 127.0.0.1:<port>` (the common case for anyone loading the UI via the
+raw IPv4 loopback address instead of `localhost`) was silently rejected with 403 by the
+DNS-rebinding guard from issue #266, while the functionally identical `localhost:<port>` was
+let through.

--- a/src/middlewares/host_validation.rs
+++ b/src/middlewares/host_validation.rs
@@ -27,6 +27,7 @@ pub(crate) fn allowed_hosts() -> Vec<String> {
     ];
     if let Some(port) = port {
         hosts.push(format!("localhost:{port}"));
+        hosts.push(format!("127.0.0.1:{port}"));
         hosts.push(format!("[::1]:{port}"));
     }
     if let Ok(extra) = std::env::var(ALLOWED_HOSTS_ENV) {

--- a/src/middlewares/host_validation_tests.rs
+++ b/src/middlewares/host_validation_tests.rs
@@ -223,11 +223,26 @@ fn allowed_hosts_extends_from_env_var() {
 fn allowed_hosts_skips_port_suffixed_entries_when_bind_addr_has_no_port() {
     // A bind address without a `:port` suffix (e.g. an operator setting `MOADIM_BIND_ADDR=0.0.0.0`
     // and letting the port default elsewhere) means `bind.rsplit_once(':')` returns `None`, so the
-    // `localhost:<port>`/`[::1]:<port>` allowlist entries must not be added — only the bare `bind`
-    // value itself.
+    // `localhost:<port>`/`127.0.0.1:<port>`/`[::1]:<port>` allowlist entries must not be added —
+    // only the bare `bind` value itself.
     let _guard = EnvGuard::set("MOADIM_BIND_ADDR", "0.0.0.0");
     let hosts = allowed_hosts();
     assert!(hosts.iter().any(|host| host == "0.0.0.0"));
     assert!(!hosts.iter().any(|host| host.starts_with("localhost:")));
+    assert!(!hosts.iter().any(|host| host.starts_with("127.0.0.1:")));
     assert!(!hosts.iter().any(|host| host.starts_with("[::1]:")));
+}
+
+#[test]
+fn allowed_hosts_includes_port_suffixed_loopback_entries_when_bind_addr_has_port() {
+    // A `Host` header carries the port a browser actually connected to (e.g.
+    // `127.0.0.1:5784`), so every loopback spelling needs a `:<port>` counterpart alongside its
+    // bare form — `127.0.0.1:<port>` was previously missing here even though `localhost:<port>`
+    // and `[::1]:<port>` were both present, silently rejecting IPv4-loopback requests that
+    // included the port.
+    let _guard = EnvGuard::set("MOADIM_BIND_ADDR", "127.0.0.1:5784");
+    let hosts = allowed_hosts();
+    assert!(hosts.iter().any(|host| host == "localhost:5784"));
+    assert!(hosts.iter().any(|host| host == "127.0.0.1:5784"));
+    assert!(hosts.iter().any(|host| host == "[::1]:5784"));
 }


### PR DESCRIPTION
## Summary

`allowed_hosts()` (in `src/middlewares/host_validation.rs`) adds `localhost:<port>` and `[::1]:<port>` to the DNS-rebinding-guard allowlist (issue #266) whenever the daemon's bind address carries a port — but never added the equivalent `127.0.0.1:<port>` entry, even though the bare `127.0.0.1` (no port) was already in the list.

A browser hitting the UI via `http://127.0.0.1:<port>` instead of `http://localhost:<port>` sends `Host: 127.0.0.1:<port>`, which fell outside the allowlist and got rejected with `403 Forbidden` — while the functionally identical `localhost:<port>` request passed. No existing test exercised the port-suffixed loopback branch, so this went unnoticed.

## Changes

- `allowed_hosts()`: push `127.0.0.1:<port>` alongside the existing `localhost:<port>` / `[::1]:<port>` entries.
- Added `allowed_hosts_includes_port_suffixed_loopback_entries_when_bind_addr_has_port`, asserting all three port-suffixed loopback spellings are present.
- Extended `allowed_hosts_skips_port_suffixed_entries_when_bind_addr_has_no_port` to also assert `127.0.0.1:` is absent when there's no port, mirroring its existing `localhost:`/`[::1]:` assertions.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --bin moadim host_validation` (13 passed)
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (100% line coverage)