### PR TITLE
fix(cli): don't panic when writing a loopback HTTP request fails

### DIFF
--- a/.changeset/fix-cli-http-write-panic.md
+++ b/.changeset/fix-cli-http-write-panic.md
@@ -1,0 +1,12 @@
+---
+"moadim": patch
+---
+
+fix(cli): don't panic when writing a loopback HTTP request fails
+
+`http_request_core` (`src/cli/system.rs`) used `.expect(...)` on `TcpStream::write_all`, even
+though the very next line already tolerates a failed read on the same socket (a server that
+closes the connection mid-request, e.g. while `moadim restart` is killing the old process).
+Every caller (`status`, `stop`, `trigger`, `cleanup`, ...) already matches on this function's
+`io::Result` to degrade gracefully to "moadim is not running" — the write failure just needs
+to flow through the same `?` instead of panicking the CLI.

--- a/src/cli/system.rs
+++ b/src/cli/system.rs
@@ -270,9 +270,13 @@ fn http_request_core(
          Content-Length: {}\r\nConnection: close\r\n\r\n{payload}",
         payload.len()
     );
-    stream
-        .write_all(req.as_bytes())
-        .expect("write HTTP request to local server");
+    // Unlike the read below, a failed write here means the request never went out at all, so
+    // there is no partial response to salvage — propagate the error via `?` like the connect
+    // above, instead of panicking. The server can legitimately close the connection between
+    // `connect_timeout` succeeding and this write running (e.g. mid-`restart`, while the old
+    // server is being killed), and every caller already matches on this function's `Result` to
+    // degrade gracefully ("moadim is not running") rather than crash with a panic trace.
+    stream.write_all(req.as_bytes())?;
     let mut resp = String::new();
     // A failed read after a clean shutdown can still yield the status line we already received.
     let _ = stream.read_to_string(&mut resp);


### PR DESCRIPTION
## Why

`http_request_core` in `src/cli/system.rs` is the shared client every CLI subcommand (`status`, `stop`, `trigger`, `cleanup`, ...) uses to talk to the running daemon over loopback TCP. It returns `std::io::Result<(u16, String)>`, and every caller matches on that `Result` to degrade gracefully to a friendly "moadim is not running" message on failure.

`TcpStream::write_all` in that function was instead guarded with `.expect("write HTTP request to local server")`, which panics the whole CLI process on a write error — inconsistent with the very next line in the same function, which already tolerates a failed *read* on the same socket ("A failed read after a clean shutdown can still yield the status line we already received").

A write failure here is not an unreachable invariant violation: the server is a separate, independently-lifecycled process, and the connection can legitimately close between `connect_timeout` succeeding and this write running — for example while `moadim restart` is killing the old server, or if the server hits its own shutdown timing during a concurrent CLI invocation. Hitting that window today crashes the CLI with a raw panic trace instead of the intended graceful degradation.

## What changed

- `stream.write_all(req.as_bytes())?;` instead of `.expect(...)`, propagating the error through the function's existing `io::Result` return type, exactly like the `connect_timeout` call a few lines above already does.

## Testing

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (1013 + 284 passed)
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (passes; the changed line is already exercised by the existing success-path tests for `http_request`/`http_request_json`)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`

Added a changeset (`patch`) per `CONTRIBUTING.md`.