### PR TITLE
fix(logs): snap truncated tail reads to the next line start

### DIFF
--- a/.changeset/log-tail-line-aware-truncation.md
+++ b/.changeset/log-tail-line-aware-truncation.md
@@ -1,0 +1,9 @@
+---
+"moadim": patch
+---
+
+fix(logs): snap truncated tail reads to the next line start
+
+Prevents `--tail` reads that begin mid-line (because the read window doesn't align to
+a line boundary) from emitting a partial first line. The read now skips ahead to the
+next newline before returning output.

--- a/src/routines/service_log_tail.rs
+++ b/src/routines/service_log_tail.rs
@@ -51,11 +51,15 @@ pub(crate) fn read_log_tail_with_meta(path: &std::path::Path) -> std::io::Result
 /// Read `path`, returning only the last [`MAX_LOG_TAIL_BYTES`] when it's larger than that.
 ///
 /// The seek point is snapped forward to the next UTF-8 character boundary so a multi-byte
-/// character split by the byte-offset seek isn't silently mangled, and a truncated read is
-/// prefixed with a marker noting how many bytes were omitted rather than starting mid-line with
-/// no indication anything is missing. [`strip_ansi_noise`] runs over the returned content so
-/// terminal escape sequences and `\r`-redraw noise from the raw `tmux pipe-pane` capture (#278)
-/// don't clutter the served log.
+/// character split by the byte-offset seek isn't silently mangled, then snapped forward again to
+/// the start of the next line (#281). A byte-offset seek lands mid-line more often than not;
+/// without the second snap, the truncated window could start mid-ANSI-escape-sequence — `strip_ansi_noise`
+/// only recognizes escapes that begin with their leading `ESC` byte, so a fragment missing that
+/// byte leaks as literal garbage — or simply mid-line with no clean boundary for a caller to
+/// render. A truncated read is prefixed with a marker noting how many bytes were omitted rather
+/// than starting with no indication anything is missing. [`strip_ansi_noise`] runs over the
+/// returned content so terminal escape sequences and `\r`-redraw noise from the raw
+/// `tmux pipe-pane` capture (#278) don't clutter the served log.
 pub(crate) fn read_log_tail(path: &std::path::Path) -> std::io::Result<String> {
     let len = std::fs::metadata(path)?.len();
     read_log_tail_of_len(path, len)
@@ -75,11 +79,18 @@ fn read_log_tail_of_len(path: &std::path::Path, len: u64) -> std::io::Result<Str
     file.read_to_end(&mut buf)?;
     // A UTF-8 continuation byte is 10xxxxxx; skip up to 3 of them (the longest possible
     // multi-byte sequence) to land on the next real character's leading byte.
-    let start = buf
+    let utf8_start = buf
         .iter()
         .take(4)
         .position(|&byte| !(0x80..0xC0).contains(&byte))
         .unwrap_or(0);
+    // Snap forward again to the start of the next line so the window can't begin mid-line or
+    // mid-escape-sequence. Only when a newline actually exists in the retained window — an
+    // omitted single line longer than the whole cap has nowhere to snap to and is served as-is.
+    let start = buf[utf8_start..]
+        .iter()
+        .position(|&byte| byte == b'\n')
+        .map_or(utf8_start, |offset| utf8_start + offset + 1);
     let tail = String::from_utf8_lossy(&buf[start..]);
     Ok(format!(
         "... [{omitted} bytes omitted; showing the last {MAX_LOG_TAIL_BYTES} bytes] ...\n{}",

--- a/src/routines/service_logs_tests.rs
+++ b/src/routines/service_logs_tests.rs
@@ -226,6 +226,32 @@ fn read_log_tail_snaps_to_a_utf8_char_boundary() {
 }
 
 #[test]
+fn read_log_tail_snaps_to_the_next_line_start() {
+    let dir = std::env::temp_dir().join(format!("moadim-logtail-line-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("agent.log");
+    // The seek point lands 3 bytes into the word "PARTIAL" (all ASCII, so no UTF-8 boundary
+    // issue), which without a line-aware snap would leak "TIAL" as a mangled first line. The
+    // fix must also skip past the following '\n' so the kept tail starts on a clean line.
+    let mut content = "PAR".to_string();
+    content.push_str("TIAL\n");
+    content.push_str(&"a".repeat(MAX_LOG_TAIL_BYTES as usize - 5));
+    std::fs::write(&path, &content).unwrap();
+
+    let tail = read_log_tail(&path).unwrap();
+
+    assert_eq!(
+        tail,
+        format!(
+            "... [3 bytes omitted; showing the last {} bytes] ...\n{}",
+            MAX_LOG_TAIL_BYTES,
+            "a".repeat(MAX_LOG_TAIL_BYTES as usize - 5),
+        )
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn svc_logs_reads_through_the_size_cap() {
     let _home = TempHome::set();
     // End-to-end: svc_logs must go through read_log_tail, not a raw read_to_string, so an


### PR DESCRIPTION
## Summary
`read_log_tail_of_len` already snapped its byte-offset seek forward to a UTF-8 character boundary, but not to a line boundary. A truncated tail window could still start mid-line — including mid-ANSI-escape-sequence, since `strip_ansi_noise` only recognizes escapes that begin with their leading `ESC` byte, so a split escape fragment leaked as literal garbage instead of being stripped.

## Fix
After snapping to the UTF-8 boundary, also skip forward to just past the next `\n` in the retained window (when one exists) so the tail starts cleanly on a line boundary. When no newline exists in the window (the omitted single line is longer than the whole cap), the previous behavior is preserved as a fallback.

## Testing
- `cargo test --bin moadim service_logs_tests` — all 10 tests pass, including a new regression test (`read_log_tail_snaps_to_the_next_line_start`) that reproduces the mid-line leak and asserts the fix.
- `cargo clippy --bin moadim --all-targets` — clean.
- `cargo fmt --check` — clean.

Closes #281