### PR TITLE
test(storage): cover write_runtime_state's atomic_write error branch

### DIFF
--- a/.changeset/routine-state-sidecar-write-failure-coverage.md
+++ b/.changeset/routine-state-sidecar-write-failure-coverage.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Add a test for `write_routine` returning an error when `state.local.toml`'s path is occupied by a directory, closing the last untested error branch in `write_runtime_state` (`routine_storage.rs`). No behavior change — test-only.

--- a/src/routine_storage_sidecar_state_tests.rs
+++ b/src/routine_storage_sidecar_state_tests.rs
@@ -167,6 +167,34 @@ fn load_routine_defaults_power_saving_false_for_legacy_sidecar() {
 }
 
 #[test]
+fn write_routine_errors_when_state_sidecar_path_is_occupied_by_a_directory() {
+    // `write_runtime_state`'s `atomic_write(&path, ...)` (routine_storage.rs) is the last
+    // fallible step in `write_routine`, but nothing exercised its own error branch — only
+    // `atomic_write`'s internal rename failure is covered directly (see
+    // `utils::atomic_tests::errors_and_cleans_up_when_rename_fails`), never `write_routine`
+    // observing and propagating that failure through its own `?`. Reuse the same
+    // directory-occupies-target-path technique: a pre-existing directory at
+    // `state.local.toml`'s path makes the rename inside `atomic_write` fail, so
+    // `write_runtime_state` (reached because `power_saving = true` skips the no-op early
+    // return) surfaces an `Err` instead of silently succeeding.
+    with_override_home(|_home| {
+        let title = "Rs Sidecar Occupied Routine";
+        let slug = slugify(title);
+        let mut routine = make_routine("rs-sidecar-occupied-id", title);
+        routine.power_saving = true;
+
+        let state_path = crate::paths::routine_state_path(&slug);
+        std::fs::create_dir_all(&state_path).unwrap();
+
+        let err = write_routine(&routine).unwrap_err();
+        assert!(
+            state_path.is_dir(),
+            "the occupying directory must be left untouched: {err}"
+        );
+    });
+}
+
+#[test]
 fn write_routine_clears_stale_sidecar_when_power_saving_cleared() {
     with_override_home(|_home| {
         let title = "Rs Clear Power Saving Routine";


### PR DESCRIPTION
## Why

`write_routine`'s final fallible step is `write_runtime_state`'s `atomic_write(&path, ...)?` in `routine_storage.rs`. Nothing exercised its error branch — `cargo llvm-cov` shows it as an uncovered region even though the file sits at 100% *line* coverage (the required floor only checks lines, not branches/regions).

Only `atomic_write`'s own internal rename failure is covered directly, via `utils::atomic_tests::errors_and_cleans_up_when_rename_fails`. No test exercised a *caller* observing and propagating that failure through its own `?` — the exact gap `#1144` closed for `PUT /config/user-prompt`'s write branch.

## What

Adds `write_routine_errors_when_state_sidecar_path_is_occupied_by_a_directory` to `src/routine_storage_sidecar_state_tests.rs`, reusing the same deterministic technique already established in this codebase: pre-create `state.local.toml`'s path as a directory so `atomic_write`'s `fs::rename` fails. `power_saving = true` is set on the routine so `write_runtime_state`'s no-op early return (nothing to persist) is skipped and the `atomic_write` call is actually reached.

Test-only, no behavior change. A `patch` changeset is included per this repo's convention for `src/` changes.

## Verified locally
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (1019 root + 284 ui passed)
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% lines (region misses 29 → 28)
- `linecheck --max-lines 500`
- test-file convention check (pre-push hook step 1)

This pull request was opened by the "Daemon + Landing auto-improve & auto-merge lint/docs PRs" routine of moadim.