### PR TITLE
feat(routines): default global concurrency cap to unlimited (0)

### DIFF
--- a/.changeset/routine-concurrency-cap-default-unlimited.md
+++ b/.changeset/routine-concurrency-cap-default-unlimited.md
@@ -1,0 +1,11 @@
+---
+"moadim": patch
+---
+
+feat(routines): `MOADIM_MAX_CONCURRENT_RUNS` now defaults to unlimited (`0`)
+
+The global routine concurrency cap (#335) previously defaulted to `4` and rejected `0` as an
+"off" value, always falling back to the default instead. That was inconsistent with
+`MOADIM_MAX_WORKBENCH_DISK_BYTES`'s "0 means unbounded" convention elsewhere in the daemon.
+`0` (or unset) now means no cap is enforced; set `MOADIM_MAX_CONCURRENT_RUNS` to a positive
+number to opt into bounding how many routine agent sessions may run at once.

--- a/Architecture.md
+++ b/Architecture.md
@@ -324,9 +324,10 @@ fires its `ShutdownSignal`, whichever comes first.
   sessions (CPU/RAM exhaustion, provider API rate-limit bursts). `spawn_routine_command` counts live
   sessions sharing the `moadim-` prefix (`cleanup::tmux_session_count` — derived from actual tmux
   session liveness, not an in-memory counter that could drift after a crash) and, at or over
-  `MOADIM_MAX_CONCURRENT_RUNS` (default `4`), skips the fire with a logged reason instead of
-  launching it or queueing it — the simpler, lower-risk policy, matching the overlap guard's own
-  skip-with-warning shape rather than adding new queueing infrastructure.
+  `MOADIM_MAX_CONCURRENT_RUNS` (default `0`, meaning unbounded — same convention as
+  `MOADIM_MAX_WORKBENCH_DISK_BYTES`), skips the fire with a logged reason instead of launching it or
+  queueing it — the simpler, lower-risk policy, matching the overlap guard's own skip-with-warning
+  shape rather than adding new queueing infrastructure.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -190,11 +190,12 @@ nothing on its own bounds how many *different* routines run at once — the OS
 crontab naturally aligns fires from separate routines onto the same minute
 boundary (e.g. `*/5 * * * *`), so a shared tick can otherwise launch an
 unbounded thundering herd of agent sessions. Set `MOADIM_MAX_CONCURRENT_RUNS`
-to cap how many routine agent sessions may be alive at once (default `4`);
-once reached, a new fire is skipped — logging the reason — rather than
-launched, and is picked up again on its next scheduled tick. The count is
-derived from actual live tmux sessions, not an in-memory counter, so it stays
-correct across a daemon crash/restart.
+to cap how many routine agent sessions may be alive at once. Unset or `0`
+(the default) means unlimited; once the cap is reached, a new fire is
+skipped — logging the reason — rather than launched, and is picked up again
+on its next scheduled tick. The count is derived from actual live tmux
+sessions, not an in-memory counter, so it stays correct across a daemon
+crash/restart.
 
 **REST** — under the `/api/v1` prefix:
 

--- a/src/routines/concurrency_cap.rs
+++ b/src/routines/concurrency_cap.rs
@@ -13,22 +13,20 @@
 //! session name begins with) before launching, and skips the fire — logging a warning — rather than
 //! queueing it, the same non-fatal skip shape the overlap guard above already uses.
 
-/// Env var naming the global concurrency cap. Unset, empty, unparsable, or `0` falls back to
-/// [`DEFAULT_MAX_CONCURRENT_RUNS`] — unlike `MOADIM_MAX_WORKBENCH_DISK_BYTES`'s "0 means unbounded"
-/// convention, an unbounded fan-out is exactly the bug this cap exists to prevent, so there is no
-/// "off" setting here.
+/// Env var naming the global concurrency cap. Unset or unparsable falls back to
+/// [`DEFAULT_MAX_CONCURRENT_RUNS`]. `0` (unset or explicit) means unbounded — the same convention
+/// `MOADIM_MAX_WORKBENCH_DISK_BYTES` uses.
 pub(crate) const MAX_CONCURRENT_RUNS_ENV: &str = "MOADIM_MAX_CONCURRENT_RUNS";
 
-/// Sane default cap applied when [`MAX_CONCURRENT_RUNS_ENV`] is unset/unparsable/zero.
-const DEFAULT_MAX_CONCURRENT_RUNS: usize = 4;
+/// Default cap applied when [`MAX_CONCURRENT_RUNS_ENV`] is unset/unparsable: `0`, i.e. no limit.
+const DEFAULT_MAX_CONCURRENT_RUNS: usize = 0;
 
 /// The configured global concurrency cap: how many routine agent sessions may be alive at once
-/// before a new fire is skipped instead of launched.
+/// before a new fire is skipped instead of launched. `0` means unbounded.
 pub(crate) fn max_concurrent_runs() -> usize {
     std::env::var(MAX_CONCURRENT_RUNS_ENV)
         .ok()
         .and_then(|value| value.parse::<usize>().ok())
-        .filter(|&cap| cap > 0)
         .unwrap_or(DEFAULT_MAX_CONCURRENT_RUNS)
 }
 

--- a/src/routines/concurrency_cap_tests.rs
+++ b/src/routines/concurrency_cap_tests.rs
@@ -50,14 +50,14 @@ fn max_concurrent_runs_falls_back_to_default_on_garbage() {
 }
 
 #[test]
-fn max_concurrent_runs_falls_back_to_default_on_zero() {
-    // Unlike the disk-cap env var, `0` is not "unbounded" here — an unbounded fan-out is exactly
-    // the bug this cap prevents, so `0` is rejected like any other unparsable value.
+fn max_concurrent_runs_parses_zero_as_unlimited() {
+    // `0` is a valid, meaningful value here (unbounded) — same convention as the disk-cap env
+    // var — not rejected like an unparsable value.
     let prev = std::env::var_os(MAX_CONCURRENT_RUNS_ENV);
     // SAFETY: tests in this crate run single-threaded (RUST_TEST_THREADS=1); restored below.
     unsafe {
         std::env::set_var(MAX_CONCURRENT_RUNS_ENV, "0");
     }
-    assert_eq!(max_concurrent_runs(), DEFAULT_MAX_CONCURRENT_RUNS);
+    assert_eq!(max_concurrent_runs(), 0);
     restore(prev);
 }

--- a/src/routines/service_trigger.rs
+++ b/src/routines/service_trigger.rs
@@ -237,10 +237,10 @@ fn spawn_routine_command(routine: &Routine, source: TriggerSource) {
             // uses, just matched against every routine's shared `moadim-` prefix instead of one
             // routine's own. Skips (rather than queues) this fire when at/over the cap: the
             // simpler, lower-risk policy, and consistent with the overlap guard's own
-            // skip-with-warning shape above.
+            // skip-with-warning shape above. A cap of `0` (the default) means unlimited, so the check is skipped entirely.
             let live = tmux_session_count(TMUX_SESSION_PREFIX);
             let cap = max_concurrent_runs();
-            if live >= cap {
+            if cap > 0 && live >= cap {
                 let reason = format!(
                     "{live} routine session(s) already running, at or over the global \
                      concurrency cap of {cap} (set {MAX_CONCURRENT_RUNS_ENV} to raise it); this \

--- a/src/routines/service_trigger_tests.rs
+++ b/src/routines/service_trigger_tests.rs
@@ -380,53 +380,55 @@ fn svc_delete_syncs_crontab_on_success() {
     });
 }
 
-#[test]
-fn svc_trigger_skips_spawn_when_the_global_concurrency_cap_is_reached() {
-    // The global cap (#335) must trip even when the live sessions belong to *other* routines —
-    // unlike the per-routine overlap guard, it counts every `moadim-`-prefixed session regardless
-    // of slug. The stub reports one live session under an unrelated slug ("other"), so this
-    // routine's own overlap guard sees no match, but the cap (set to 1 below) is already at its
-    // limit and the fire must still be skipped.
+/// Drive `svc_trigger` with a stub `tmux` reporting `live_sessions` other-routine sessions and
+/// `cap_env` as `MOADIM_MAX_CONCURRENT_RUNS`, returning whether the fire was skipped (i.e. whether
+/// a `skip.log` was written for it) — shared by the two cap scenario tests below.
+fn trigger_under_concurrency_cap(unique: &str, live_sessions: u32, cap_env: Option<&str>) -> bool {
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt as _;
 
     let _home = TempHome::set();
 
-    let agent_name = "svc-trigger-cap-agent-zzz";
+    let agent_name = format!("svc-trigger-cap-agent-{unique}");
     std::fs::create_dir_all(crate::paths::agents_dir()).unwrap();
-    let cfg = crate::paths::agent_toml_path(agent_name);
+    let cfg = crate::paths::agent_toml_path(&agent_name);
     std::fs::write(&cfg, "command = \"true\"\nargs = []\n").unwrap();
 
-    let title = "Svc Trigger Concurrency Cap ZZZ";
+    let title = format!("Svc Trigger Concurrency Cap {unique}");
     let dir = std::env::temp_dir().join(format!("moadim-svc-cap-{}", uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&dir).unwrap();
     let stub = dir.join("tmux");
-    std::fs::write(
-        &stub,
-        "#!/bin/sh\nprintf 'moadim-other-1730000000_1\\n'\nexit 0\n",
-    )
-    .unwrap();
+    let sessions: String = (0..live_sessions)
+        .map(|i| format!("moadim-other-173000000{i}_1\n"))
+        .collect();
+    std::fs::write(&stub, format!("#!/bin/sh\nprintf '{sessions}'\nexit 0\n")).unwrap();
     #[cfg(unix)]
     std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).unwrap();
 
+    let id = format!("trig-cap-{unique}");
     let store = new_store();
-    let mut routine = make_routine("trig-cap-id", title, 1, 1);
-    routine.agent = agent_name.into();
+    let mut routine = make_routine(&id, &title, 1, 1);
+    routine.agent = agent_name;
     crate::routine_storage::write_routine(&routine).unwrap();
-    store.lock().unwrap().insert("trig-cap-id".into(), routine);
+    store.lock().unwrap().insert(id.clone(), routine);
 
     let prev_tmux = std::env::var_os("MOADIM_TMUX_BIN");
     let prev_cap = std::env::var_os("MOADIM_MAX_CONCURRENT_RUNS");
     // SAFETY: tests in this crate run single-threaded (RUST_TEST_THREADS=1).
     unsafe {
         std::env::set_var("MOADIM_TMUX_BIN", &stub);
-        std::env::set_var("MOADIM_MAX_CONCURRENT_RUNS", "1");
+        match cap_env {
+            Some(value) => std::env::set_var("MOADIM_MAX_CONCURRENT_RUNS", value),
+            None => std::env::remove_var("MOADIM_MAX_CONCURRENT_RUNS"),
+        }
     }
 
-    let triggered = svc_trigger(&store, "trig-cap-id").unwrap();
-    // The trigger still records its own timestamp and returns Ok — the same non-fatal shape as the
-    // overlap guard's skip in `service_overlap_guard_tests.rs` — it's the *launch* that is skipped.
+    let triggered = svc_trigger(&store, &id).unwrap();
+    // The trigger still records its own timestamp and returns Ok regardless of whether the
+    // launch itself was skipped — the same non-fatal shape as the overlap guard's skip in
+    // `service_overlap_guard_tests.rs`.
     assert!(triggered.last_manual_trigger_at.is_some());
+    let skipped = crate::paths::routine_skip_log_path(&crate::routines::slugify(&title)).exists();
 
     // SAFETY: single-threaded harness; restore the saved overrides.
     unsafe {
@@ -440,4 +442,20 @@ fn svc_trigger_skips_spawn_when_the_global_concurrency_cap_is_reached() {
         }
     }
     let _ = std::fs::remove_dir_all(&dir);
+    skipped
+}
+
+#[test]
+fn svc_trigger_skips_spawn_when_the_global_concurrency_cap_is_reached() {
+    // The global cap (#335) must trip even when the live sessions belong to *other* routines —
+    // unlike the per-routine overlap guard, it counts every `moadim-`-prefixed session regardless
+    // of slug. One live (unrelated) session already meets a cap of 1, so the fire must be skipped.
+    assert!(trigger_under_concurrency_cap("zzz", 1, Some("1")));
+}
+
+#[test]
+fn svc_trigger_does_not_cap_when_max_concurrent_runs_is_unset_or_zero() {
+    // `0`/unset now means unbounded (#335 policy flip) — a live session count that would have
+    // tripped the old hardcoded default-of-4 cap must not be skipped when the cap is unset.
+    assert!(!trigger_under_concurrency_cap("unlimited", 4, None));
 }


### PR DESCRIPTION
## Summary
- `MOADIM_MAX_CONCURRENT_RUNS` previously rejected `0` and always fell back to a hardcoded default of `4`, inconsistent with `MOADIM_MAX_WORKBENCH_DISK_BYTES`'s "0 means unbounded" convention used elsewhere in the daemon.
- `0` (or unset) now means no cap is enforced; set a positive number to opt into bounding how many routine agent sessions may run concurrently.
- Updated `README.md`/`Architecture.md` docs and added a changeset.

## Test plan
- [x] `cargo test` (full suite, 1020 passed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo llvm-cov --fail-under-lines 100` (pre-push gate, passed)
- [x] `linecheck --max-lines 500` (pre-push gate, passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)