### PR TITLE
feat(routines): show local human-readable time alongside raw timestamps

### DIFF
--- a/.changeset/log-timestamps-local-text.md
+++ b/.changeset/log-timestamps-local-text.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+feat(routines): show local human-readable time alongside raw timestamps
+
+Run-history API responses (`RunSummary`/`FleetRunSummary`), the daemon's structured JSON log,
+and the UI's relative-time displays now also expose an absolute, human-readable local-time form
+next to the existing raw Unix timestamp / relative "N ago" text, so timestamps are readable
+without doing epoch math.

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -1235,6 +1235,7 @@
           "routine_title",
           "workbench",
           "started_at",
+          "started_at_local",
           "status"
         ],
         "properties": {
@@ -1255,6 +1256,13 @@
             "description": "Unix seconds the run finished (`exit_code` file's mtime), `None` while running or unknown.",
             "minimum": 0
           },
+          "finished_at_local": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "`finished_at` as a human-readable local timestamp, when finished."
+          },
           "routine_id": {
             "type": "string",
             "description": "The routine this run belongs to."
@@ -1268,6 +1276,10 @@
             "format": "int64",
             "description": "Unix seconds the run was triggered.",
             "minimum": 0
+          },
+          "started_at_local": {
+            "type": "string",
+            "description": "`started_at` as a human-readable local (daemon machine's timezone) timestamp."
           },
           "status": {
             "$ref": "#/components/schemas/RunStatus",
@@ -1672,6 +1684,7 @@
         "required": [
           "workbench",
           "started_at",
+          "started_at_local",
           "status"
         ],
         "properties": {
@@ -1692,6 +1705,13 @@
             "description": "Unix seconds the run finished (`exit_code` file's mtime), `None` while running or unknown.",
             "minimum": 0
           },
+          "finished_at_local": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "`finished_at` as a human-readable local timestamp, when finished."
+          },
           "retention_expires_at": {
             "type": [
               "integer",
@@ -1706,6 +1726,10 @@
             "format": "int64",
             "description": "Unix seconds the run was triggered.",
             "minimum": 0
+          },
+          "started_at_local": {
+            "type": "string",
+            "description": "`started_at` as a human-readable local (daemon machine's timezone) timestamp."
           },
           "status": {
             "$ref": "#/components/schemas/RunStatus",

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -29,10 +29,13 @@ impl LogFormat {
     }
 }
 
-/// Render a log record as a single-line JSON object: `ts` (RFC 3339), `level`, `target`, `msg`.
+/// Render a log record as a single-line JSON object: `ts` (RFC 3339 UTC, machine-parseable),
+/// `ts_local` (human-readable, this machine's local timezone), `level`, `target`, `msg`.
 fn format_json_line(record: &log::Record<'_>) -> String {
+    let now = chrono::Utc::now();
     serde_json::json!({
-        "ts": chrono::Utc::now().to_rfc3339(),
+        "ts": now.to_rfc3339(),
+        "ts_local": crate::utils::time::format_local(now.timestamp() as u64),
         "level": record.level().to_string(),
         "target": record.target(),
         "msg": record.args().to_string(),

--- a/src/logging/tests.rs
+++ b/src/logging/tests.rs
@@ -34,6 +34,13 @@ fn json_line_round_trips_through_a_parser() {
         "ts should be an RFC 3339 timestamp, got {:?}",
         parsed["ts"]
     );
+    assert!(
+        parsed["ts_local"]
+            .as_str()
+            .is_some_and(|ts| ts.contains('-') && ts.contains(':')),
+        "ts_local should be a human-readable local timestamp, got {:?}",
+        parsed["ts_local"]
+    );
 }
 
 #[test]

--- a/src/routines/model.rs
+++ b/src/routines/model.rs
@@ -335,8 +335,12 @@ pub struct RunSummary {
     pub workbench: String,
     /// Unix seconds the run was triggered.
     pub started_at: u64,
+    /// `started_at` as a human-readable local (daemon machine's timezone) timestamp.
+    pub started_at_local: String,
     /// Unix seconds the run finished (`exit_code` file's mtime), `None` while running or unknown.
     pub finished_at: Option<u64>,
+    /// `finished_at` as a human-readable local timestamp, when finished.
+    pub finished_at_local: Option<String>,
     /// Success/failure/running/unknown, derived from the exit-code file and tmux session liveness.
     pub status: RunStatus,
     /// Process exit code, when recorded.
@@ -359,8 +363,12 @@ pub struct FleetRunSummary {
     pub workbench: String,
     /// Unix seconds the run was triggered.
     pub started_at: u64,
+    /// `started_at` as a human-readable local (daemon machine's timezone) timestamp.
+    pub started_at_local: String,
     /// Unix seconds the run finished (`exit_code` file's mtime), `None` while running or unknown.
     pub finished_at: Option<u64>,
+    /// `finished_at` as a human-readable local timestamp, when finished.
+    pub finished_at_local: Option<String>,
     /// Success/failure/running/unknown, derived from the exit-code file and tmux session liveness.
     pub status: RunStatus,
     /// Process exit code, when recorded.

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -294,9 +294,12 @@ use service_trigger::migrate_workbenches;
 #[cfg(test)]
 pub(crate) use service_trigger::sh_bin;
 pub use service_trigger::{
-    svc_cleanup, svc_list_all_runs, svc_list_runs, svc_logs, svc_set_power_saving, svc_snooze,
-    svc_trigger, svc_trigger_scheduled,
+    svc_cleanup, svc_logs, svc_set_power_saving, svc_snooze, svc_trigger, svc_trigger_scheduled,
 };
+
+#[path = "service_runs.rs"]
+mod service_runs;
+pub use service_runs::{svc_list_all_runs, svc_list_runs};
 
 #[path = "service_run_files.rs"]
 mod service_run_files;

--- a/src/routines/service_runs.rs
+++ b/src/routines/service_runs.rs
@@ -1,0 +1,158 @@
+//! Run-history listing: per-routine and fleet-wide, merging live workbenches with durable
+//! `runs.log` records. Split out of `service_trigger.rs` to keep that file under the line-count
+//! gate.
+
+use crate::error::AppError;
+use crate::paths::workbenches_dir;
+use crate::utils::lock::LockRecover;
+use crate::utils::time::format_local;
+
+use crate::routines::cleanup::{parse_workbench_name, run_session_alive};
+use crate::routines::command::slugify;
+use crate::routines::model::{FleetRunSummary, RoutineStore, RunStatus, RunSummary};
+use crate::routines::run_history::{read_exit_code, read_persisted_runs};
+
+/// List every run for routine `id`, newest first: live (not-yet-reaped) workbenches, whose status
+/// derives from the tmux session's liveness and the `exit_code` file the launch command writes on
+/// completion (see [`crate::routines::command::build_routine_command`]), merged with durable
+/// records from `runs.log` for runs whose workbench has since been TTL-reaped (see
+/// [`crate::routines::run_history`]) — so this list is the routine's *full* history, not just what
+/// current retention happens to keep.
+pub fn svc_list_runs(store: &RoutineStore, id: &str) -> Result<Vec<RunSummary>, AppError> {
+    let routine = store
+        .lock_recover()
+        .get(id)
+        .cloned()
+        .ok_or(AppError::NotFound)?;
+    let slug = slugify(&routine.title);
+    let mut runs = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(workbenches_dir()) {
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let Some((dir_slug, ts)) = parse_workbench_name(&name) else {
+                continue;
+            };
+            if dir_slug != slug {
+                continue;
+            }
+            runs.push(run_summary(&name, ts, Some(routine.effective_ttl_secs())));
+        }
+    }
+    for persisted in read_persisted_runs(id) {
+        runs.push(RunSummary {
+            workbench: persisted.workbench,
+            started_at: persisted.started_at,
+            started_at_local: format_local(persisted.started_at),
+            finished_at: Some(persisted.finished_at),
+            finished_at_local: Some(format_local(persisted.finished_at)),
+            status: persisted.status,
+            exit_code: persisted.exit_code,
+            // The workbench is already gone (that's why this run came from `runs.log` instead of
+            // a live directory scan), so there is nothing left to count down to.
+            retention_expires_at: None,
+        });
+    }
+    runs.sort_by_key(|run| std::cmp::Reverse(run.started_at));
+    Ok(runs)
+}
+
+/// Default cap on [`svc_list_all_runs`] results when the caller doesn't specify one.
+pub const DEFAULT_FLEET_RUNS_LIMIT: usize = 20;
+
+/// List the most recent runs across *every* routine, newest first, capped at `limit` (or
+/// [`DEFAULT_FLEET_RUNS_LIMIT`] when `None`). Backs the overview "recent runs" panel with a single
+/// workbench-directory scan, rather than one [`svc_list_runs`] call per routine. Merges in durable
+/// `runs.log` records for TTL-reaped runs (see [`crate::routines::run_history`]) alongside live
+/// workbenches.
+///
+/// A workbench whose slug matches no current routine (the routine was since deleted, or renamed
+/// without a workbench migration failure — see `migrate_workbenches`) is skipped: there is no
+/// routine to attribute it to.
+pub fn svc_list_all_runs(store: &RoutineStore, limit: Option<usize>) -> Vec<FleetRunSummary> {
+    let limit = limit.unwrap_or(DEFAULT_FLEET_RUNS_LIMIT);
+    let routines: Vec<(String, String)> = store
+        .lock_recover()
+        .values()
+        .map(|routine| (routine.id.clone(), routine.title.clone()))
+        .collect();
+    let by_slug: std::collections::HashMap<String, (String, String)> = routines
+        .iter()
+        .map(|(id, title)| (slugify(title), (id.clone(), title.clone())))
+        .collect();
+    let mut runs = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(workbenches_dir()) {
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let Some((dir_slug, ts)) = parse_workbench_name(&name) else {
+                continue;
+            };
+            let Some((routine_id, routine_title)) = by_slug.get(dir_slug).cloned() else {
+                continue;
+            };
+            let run = run_summary(&name, ts, None);
+            runs.push(FleetRunSummary {
+                routine_id,
+                routine_title,
+                workbench: run.workbench,
+                started_at: run.started_at,
+                started_at_local: run.started_at_local,
+                finished_at: run.finished_at,
+                finished_at_local: run.finished_at_local,
+                status: run.status,
+                exit_code: run.exit_code,
+            });
+        }
+    }
+    for (routine_id, routine_title) in &routines {
+        for persisted in read_persisted_runs(routine_id) {
+            runs.push(FleetRunSummary {
+                routine_id: routine_id.clone(),
+                routine_title: routine_title.clone(),
+                workbench: persisted.workbench,
+                started_at: persisted.started_at,
+                started_at_local: format_local(persisted.started_at),
+                finished_at: Some(persisted.finished_at),
+                finished_at_local: Some(format_local(persisted.finished_at)),
+                status: persisted.status,
+                exit_code: persisted.exit_code,
+            });
+        }
+    }
+    runs.sort_by_key(|run| std::cmp::Reverse(run.started_at));
+    runs.truncate(limit);
+    runs
+}
+
+/// Derive a single [`RunSummary`] for workbench `dir` (named `{slug}-{started_at}`).
+///
+/// `effective_ttl_secs` is the owning routine's `Routine::effective_ttl_secs`, used to compute
+/// `retention_expires_at`; pass `None` when the caller (e.g. the fleet-wide
+/// [`svc_list_all_runs`]) doesn't need that field.
+fn run_summary(dir: &str, started_at: u64, effective_ttl_secs: Option<u64>) -> RunSummary {
+    let path = workbenches_dir().join(dir);
+    let exit_code = read_exit_code(&path);
+    let finished_at = std::fs::metadata(path.join("exit_code"))
+        .and_then(|meta| meta.modified())
+        .ok()
+        .and_then(|mtime| mtime.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|elapsed| elapsed.as_secs());
+    let session = format!("moadim-{dir}");
+    let status = match exit_code {
+        Some(0) => RunStatus::Success,
+        Some(_) => RunStatus::Failed,
+        None if run_session_alive(&session) => RunStatus::Running,
+        None => RunStatus::Unknown,
+    };
+    let retention_expires_at =
+        finished_at.and_then(|finish| effective_ttl_secs.map(|ttl| finish + ttl));
+    RunSummary {
+        workbench: dir.to_string(),
+        started_at,
+        started_at_local: format_local(started_at),
+        finished_at,
+        finished_at_local: finished_at.map(format_local),
+        status,
+        exit_code,
+        retention_expires_at,
+    }
+}

--- a/src/routines/service_trigger.rs
+++ b/src/routines/service_trigger.rs
@@ -358,4 +358,3 @@ fn skip_log_fallback(slug: &str) -> Result<LogWithMeta, AppError> {
     }
     read_log_tail_with_meta(&skip_log_path).map_err(|_| AppError::Internal)
 }
-

--- a/src/routines/service_trigger.rs
+++ b/src/routines/service_trigger.rs
@@ -8,17 +8,14 @@ use crate::utils::time::now_secs;
 
 use crate::routines::agents::load_agent_command;
 use crate::routines::cleanup::{
-    cleanup_expired_workbenches, parse_workbench_name, run_session_alive, tmux_session_count,
+    cleanup_expired_workbenches, parse_workbench_name, tmux_session_count,
     tmux_session_prefix_alive,
 };
 use crate::routines::command::{
     build_routine_command, inline_prompt_overflow, slugify, tmux_session_prefix, TriggerSource,
     TMUX_SESSION_PREFIX,
 };
-use crate::routines::model::{
-    CleanupResponse, FleetRunSummary, Routine, RoutineStore, RunStatus, RunSummary,
-};
-use crate::routines::run_history::{read_exit_code, read_persisted_runs};
+use crate::routines::model::{CleanupResponse, Routine, RoutineStore};
 use crate::routines::{max_concurrent_runs, MAX_CONCURRENT_RUNS_ENV};
 
 use super::service_log_tail::{read_log_tail_with_meta, LogWithMeta};
@@ -362,139 +359,3 @@ fn skip_log_fallback(slug: &str) -> Result<LogWithMeta, AppError> {
     read_log_tail_with_meta(&skip_log_path).map_err(|_| AppError::Internal)
 }
 
-/// List every run for routine `id`, newest first: live (not-yet-reaped) workbenches, whose status
-/// derives from the tmux session's liveness and the `exit_code` file the launch command writes on
-/// completion (see [`crate::routines::command::build_routine_command`]), merged with durable
-/// records from `runs.log` for runs whose workbench has since been TTL-reaped (see
-/// [`crate::routines::run_history`]) — so this list is the routine's *full* history, not just what
-/// current retention happens to keep.
-pub fn svc_list_runs(store: &RoutineStore, id: &str) -> Result<Vec<RunSummary>, AppError> {
-    let routine = store
-        .lock_recover()
-        .get(id)
-        .cloned()
-        .ok_or(AppError::NotFound)?;
-    let slug = slugify(&routine.title);
-    let mut runs = Vec::new();
-    if let Ok(entries) = std::fs::read_dir(workbenches_dir()) {
-        for entry in entries.flatten() {
-            let name = entry.file_name().to_string_lossy().into_owned();
-            let Some((dir_slug, ts)) = parse_workbench_name(&name) else {
-                continue;
-            };
-            if dir_slug != slug {
-                continue;
-            }
-            runs.push(run_summary(&name, ts, Some(routine.effective_ttl_secs())));
-        }
-    }
-    for persisted in read_persisted_runs(id) {
-        runs.push(RunSummary {
-            workbench: persisted.workbench,
-            started_at: persisted.started_at,
-            finished_at: Some(persisted.finished_at),
-            status: persisted.status,
-            exit_code: persisted.exit_code,
-            // The workbench is already gone (that's why this run came from `runs.log` instead of
-            // a live directory scan), so there is nothing left to count down to.
-            retention_expires_at: None,
-        });
-    }
-    runs.sort_by_key(|run| std::cmp::Reverse(run.started_at));
-    Ok(runs)
-}
-
-/// Default cap on [`svc_list_all_runs`] results when the caller doesn't specify one.
-pub const DEFAULT_FLEET_RUNS_LIMIT: usize = 20;
-
-/// List the most recent runs across *every* routine, newest first, capped at `limit` (or
-/// [`DEFAULT_FLEET_RUNS_LIMIT`] when `None`). Backs the overview "recent runs" panel with a single
-/// workbench-directory scan, rather than one [`svc_list_runs`] call per routine. Merges in durable
-/// `runs.log` records for TTL-reaped runs (see [`crate::routines::run_history`]) alongside live
-/// workbenches.
-///
-/// A workbench whose slug matches no current routine (the routine was since deleted, or renamed
-/// without a workbench migration failure — see [`migrate_workbenches`]) is skipped: there is no
-/// routine to attribute it to.
-pub fn svc_list_all_runs(store: &RoutineStore, limit: Option<usize>) -> Vec<FleetRunSummary> {
-    let limit = limit.unwrap_or(DEFAULT_FLEET_RUNS_LIMIT);
-    let routines: Vec<(String, String)> = store
-        .lock_recover()
-        .values()
-        .map(|routine| (routine.id.clone(), routine.title.clone()))
-        .collect();
-    let by_slug: std::collections::HashMap<String, (String, String)> = routines
-        .iter()
-        .map(|(id, title)| (slugify(title), (id.clone(), title.clone())))
-        .collect();
-    let mut runs = Vec::new();
-    if let Ok(entries) = std::fs::read_dir(workbenches_dir()) {
-        for entry in entries.flatten() {
-            let name = entry.file_name().to_string_lossy().into_owned();
-            let Some((dir_slug, ts)) = parse_workbench_name(&name) else {
-                continue;
-            };
-            let Some((routine_id, routine_title)) = by_slug.get(dir_slug).cloned() else {
-                continue;
-            };
-            let run = run_summary(&name, ts, None);
-            runs.push(FleetRunSummary {
-                routine_id,
-                routine_title,
-                workbench: run.workbench,
-                started_at: run.started_at,
-                finished_at: run.finished_at,
-                status: run.status,
-                exit_code: run.exit_code,
-            });
-        }
-    }
-    for (routine_id, routine_title) in &routines {
-        for persisted in read_persisted_runs(routine_id) {
-            runs.push(FleetRunSummary {
-                routine_id: routine_id.clone(),
-                routine_title: routine_title.clone(),
-                workbench: persisted.workbench,
-                started_at: persisted.started_at,
-                finished_at: Some(persisted.finished_at),
-                status: persisted.status,
-                exit_code: persisted.exit_code,
-            });
-        }
-    }
-    runs.sort_by_key(|run| std::cmp::Reverse(run.started_at));
-    runs.truncate(limit);
-    runs
-}
-
-/// Derive a single [`RunSummary`] for workbench `dir` (named `{slug}-{started_at}`).
-///
-/// `effective_ttl_secs` is the owning routine's [`Routine::effective_ttl_secs`], used to compute
-/// `retention_expires_at`; pass `None` when the caller (e.g. the fleet-wide
-/// [`svc_list_all_runs`]) doesn't need that field.
-fn run_summary(dir: &str, started_at: u64, effective_ttl_secs: Option<u64>) -> RunSummary {
-    let path = workbenches_dir().join(dir);
-    let exit_code = read_exit_code(&path);
-    let finished_at = std::fs::metadata(path.join("exit_code"))
-        .and_then(|meta| meta.modified())
-        .ok()
-        .and_then(|mtime| mtime.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|elapsed| elapsed.as_secs());
-    let session = format!("moadim-{dir}");
-    let status = match exit_code {
-        Some(0) => RunStatus::Success,
-        Some(_) => RunStatus::Failed,
-        None if run_session_alive(&session) => RunStatus::Running,
-        None => RunStatus::Unknown,
-    };
-    let retention_expires_at =
-        finished_at.and_then(|finish| effective_ttl_secs.map(|ttl| finish + ttl));
-    RunSummary {
-        workbench: dir.to_string(),
-        started_at,
-        finished_at,
-        status,
-        exit_code,
-        retention_expires_at,
-    }
-}

--- a/src/utils/time.rs
+++ b/src/utils/time.rs
@@ -1,8 +1,20 @@
 use std::time::SystemTime;
 
+use chrono::{Local, TimeZone};
+
 /// Return current Unix time in whole seconds.
 pub fn now_secs() -> u64 {
     secs_since_epoch(SystemTime::now())
+}
+
+/// Format Unix seconds `ts` as a human-readable local (this machine's timezone) timestamp,
+/// e.g. `"2026-07-13 14:30:05 +0300"`. The offset is included since "local" is the *daemon
+/// process's* timezone, which a remote reader can't otherwise infer.
+pub(crate) fn format_local(ts: u64) -> String {
+    Local
+        .timestamp_opt(ts as i64, 0)
+        .single()
+        .map_or_else(|| "—".to_string(), |dt| dt.format("%Y-%m-%d %H:%M:%S %z").to_string())
 }
 
 /// Whole seconds between the Unix epoch and `moment`.

--- a/src/utils/time.rs
+++ b/src/utils/time.rs
@@ -11,10 +11,10 @@ pub fn now_secs() -> u64 {
 /// e.g. `"2026-07-13 14:30:05 +0300"`. The offset is included since "local" is the *daemon
 /// process's* timezone, which a remote reader can't otherwise infer.
 pub(crate) fn format_local(ts: u64) -> String {
-    Local
-        .timestamp_opt(ts as i64, 0)
-        .single()
-        .map_or_else(|| "—".to_string(), |dt| dt.format("%Y-%m-%d %H:%M:%S %z").to_string())
+    Local.timestamp_opt(ts as i64, 0).single().map_or_else(
+        || "—".to_string(),
+        |dt| dt.format("%Y-%m-%d %H:%M:%S %z").to_string(),
+    )
 }
 
 /// Whole seconds between the Unix epoch and `moment`.

--- a/src/utils/time_tests.rs
+++ b/src/utils/time_tests.rs
@@ -37,3 +37,18 @@ fn now_secs_is_non_decreasing() {
     let t2 = now_secs();
     assert!(t2 >= t1);
 }
+
+#[test]
+fn format_local_renders_a_known_instant() {
+    // 2020-01-01T00:00:00Z; local rendering varies by timezone but must include the date and
+    // a colon-separated time.
+    let text = format_local(1_577_836_800);
+    assert!(text.contains("2020") || text.contains("2019"), "got {text}");
+    assert!(text.contains(':'), "got {text}");
+}
+
+#[test]
+fn format_local_falls_back_to_dash_for_an_out_of_range_instant() {
+    // Far beyond chrono's supported date range (~year 262,143), so `timestamp_opt` returns `None`.
+    assert_eq!(format_local(i64::MAX as u64), "—");
+}

--- a/ui/src/cron_utils.rs
+++ b/ui/src/cron_utils.rs
@@ -3,6 +3,7 @@
 //! the line-count gate; re-exported from the crate root so existing
 //! `crate::parse_cron`-style paths keep working unchanged.
 
+use chrono::{Local, TimeZone};
 use croner::Cron;
 
 /// Parse a cron expression into a `Cron`, normalizing the 7-field
@@ -52,6 +53,18 @@ pub(crate) fn reltime(ts: u64) -> String {
     } else {
         format!("{}d ago", diff / 86_400)
     }
+}
+
+/// Absolute local (browser timezone) rendering of `ts`, e.g. `"Jun 21, 2026 12:00"`. Meant as a
+/// tooltip companion to [`reltime`]'s relative "N ago" text, so hovering reveals wall-clock time.
+pub(crate) fn abstime(ts: u64) -> String {
+    if ts == 0 {
+        return "—".into();
+    }
+    Local
+        .timestamp_opt(ts as i64, 0)
+        .single()
+        .map_or_else(|| "—".into(), |dt| dt.format("%b %d, %Y %H:%M").to_string())
 }
 
 #[cfg(test)]

--- a/ui/src/cron_utils_tests.rs
+++ b/ui/src/cron_utils_tests.rs
@@ -1,10 +1,13 @@
 //! Host-side unit tests for the pure cron helpers in [`super`]: `parse_cron`'s
-//! field-count normalization and `describe_cron_live`'s validity/description
-//! pairing. `reltime` is excluded — it calls `js_sys::Date::now()` and needs a
-//! wasm/DOM host, so it isn't host-testable (mirrors the `refresh.rs`/
-//! `schedule.rs` split between pure and DOM-touching logic).
+//! field-count normalization, `describe_cron_live`'s validity/description
+//! pairing, and `abstime`'s absolute-timestamp formatting. `reltime` is
+//! excluded — it calls `js_sys::Date::now()` and needs a wasm/DOM host, so
+//! it isn't host-testable (mirrors the `refresh.rs`/`schedule.rs` split
+//! between pure and DOM-touching logic). `abstime` takes its instant as a
+//! plain `u64` rather than reading the clock, so it stays host-testable.
 
 use super::*;
+use chrono::TimeZone;
 
 #[test]
 fn parse_cron_rejects_empty_and_blank() {
@@ -63,4 +66,22 @@ fn describe_cron_live_describes_valid_expression() {
     let (valid, description) = describe_cron_live("0 * * * *");
     assert!(valid);
     assert!(!description.is_empty());
+}
+
+#[test]
+fn abstime_zero_is_a_placeholder() {
+    assert_eq!(abstime(0), "—");
+}
+
+#[test]
+fn abstime_formats_a_known_instant() {
+    // Built in `Local` directly so the expected components match `abstime`'s output regardless
+    // of the host's timezone.
+    let dt = Local.with_ymd_and_hms(2026, 6, 21, 12, 0, 30).unwrap();
+    assert_eq!(abstime(dt.timestamp() as u64), "Jun 21, 2026 12:00");
+}
+
+#[test]
+fn abstime_falls_back_to_dash_for_an_out_of_range_instant() {
+    assert_eq!(abstime(i64::MAX as u64), "—");
 }

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -26,7 +26,7 @@ mod schedule_heatmap_grid;
 mod settings;
 mod shell_dialogs;
 use command_palette::CommandPalette;
-pub(crate) use cron_utils::{describe_cron_live, parse_cron, reltime};
+pub(crate) use cron_utils::{abstime, describe_cron_live, parse_cron, reltime};
 use header::Header;
 pub(crate) use health::{Health, Toast, ToastKind};
 use overview::OverviewPage;

--- a/ui/src/overview_recent_runs.rs
+++ b/ui/src/overview_recent_runs.rs
@@ -10,11 +10,11 @@
 use yew::prelude::*;
 use yew_router::prelude::*;
 
-use crate::{abstime, reltime};
 use crate::routines::{
     fmt_run_duration, run_status_class, run_status_label, FleetRunSummary, RoutineHistoryQuery,
 };
 use crate::Route;
+use crate::{abstime, reltime};
 
 #[derive(Properties, PartialEq)]
 pub(crate) struct RecentRunsTableProps {

--- a/ui/src/overview_recent_runs.rs
+++ b/ui/src/overview_recent_runs.rs
@@ -10,7 +10,7 @@
 use yew::prelude::*;
 use yew_router::prelude::*;
 
-use crate::reltime;
+use crate::{abstime, reltime};
 use crate::routines::{
     fmt_run_duration, run_status_class, run_status_label, FleetRunSummary, RoutineHistoryQuery,
 };
@@ -58,7 +58,7 @@ pub(crate) fn recent_runs_table(props: &RecentRunsTableProps) -> Html {
                                     query={Some(RoutineHistoryQuery { history: run.routine_id.clone() })}
                                 >{ &run.routine_title }</Link<Route, RoutineHistoryQuery>>
                             </td>
-                            <td><div class="cell-time">{reltime(run.started_at)}</div></td>
+                            <td><div class="cell-time" title={abstime(run.started_at)}>{reltime(run.started_at)}</div></td>
                             <td><span class="cell-meta">{ run.finished_at.map_or_else(|| "—".to_string(), |f| fmt_run_duration(run.started_at, f)) }</span></td>
                             <td><span class={run_status_class(run.status)}>{run_status_label(run.status)}</span></td>
                             <td>{ run.exit_code.map_or_else(|| "—".to_string(), |c| c.to_string()) }</td>

--- a/ui/src/routines/history.rs
+++ b/ui/src/routines/history.rs
@@ -155,6 +155,7 @@ pub fn routine_history(props: &HistoryProps) -> Html {
     let now_secs = (js_sys::Date::now() / 1000.0) as u64;
     let rows = runs.iter().map(|run| {
         let started = crate::reltime(run.started_at);
+        let started_title = format!("{} · {}", run.workbench, crate::abstime(run.started_at));
         let duration = run.finished_at.map(|f| fmt_run_duration(run.started_at, f));
         let exit_code = run
             .exit_code
@@ -177,7 +178,7 @@ pub fn routine_history(props: &HistoryProps) -> Html {
         };
         html! {
             <tr key={workbench.clone()} class={if is_selected { "row-selected" } else { "" }}>
-                <td><div class="cell-time" title={workbench.clone()}>{started}</div></td>
+                <td><div class="cell-time" title={started_title}>{started}</div></td>
                 <td><span class={run_status_class(run.status)}>{run_status_label(run.status)}</span></td>
                 <td>{duration.unwrap_or_else(|| "—".to_string())}</td>
                 <td>{exit_code}</td>

--- a/ui/src/routines/row.rs
+++ b/ui/src/routines/row.rs
@@ -4,7 +4,7 @@
 use chrono::Local;
 use yew::prelude::*;
 
-use crate::reltime;
+use crate::{abstime, reltime};
 use crate::schedule::{fmt_until, fmt_when, next_fires};
 
 use super::filter::{last_fire_at, routine_health, trigger_button_title};
@@ -239,7 +239,7 @@ pub fn routine_row(props: &RowProps) -> Html {
                     <div class="toggle-track"></div>
                 </label>
             </td>
-            <td><div class="cell-time">{updated}</div></td>
+            <td><div class="cell-time" title={abstime(r.updated_at)}>{updated}</div></td>
             <td>
                 <div class="row-actions">
                     <button class="act-btn run" title={trigger_button_title(r)} aria-label="Run now" onclick={on_trigger}>{"▶"}</button>

--- a/ui/src/routines/row.rs
+++ b/ui/src/routines/row.rs
@@ -4,8 +4,8 @@
 use chrono::Local;
 use yew::prelude::*;
 
-use crate::{abstime, reltime};
 use crate::schedule::{fmt_until, fmt_when, next_fires};
+use crate::{abstime, reltime};
 
 use super::filter::{last_fire_at, routine_health, trigger_button_title};
 use super::form::format_ttl;

--- a/ui/src/routines/sparkline.rs
+++ b/ui/src/routines/sparkline.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use yew::prelude::*;
 
-use crate::reltime;
+use crate::{abstime, reltime};
 
 use super::history::run_status_label;
 use super::model::{FleetRunSummary, RunStatus};
@@ -64,7 +64,12 @@ pub fn run_history_sparkline(props: &RunHistorySparklineProps) -> Html {
     html! {
         <div class="spark" role="img" aria-label={format!("Last {} runs", props.runs.len())}>
             { for props.runs.iter().map(|run| {
-                let title = format!("{} · {}", run_status_label(run.status), reltime(run.started_at));
+                let title = format!(
+                    "{} · {} ({})",
+                    run_status_label(run.status),
+                    reltime(run.started_at),
+                    abstime(run.started_at)
+                );
                 html! { <span class={spark_tick_class(run.status)} {title}></span> }
             }) }
         </div>


### PR DESCRIPTION
## Summary
- Run-history API responses (`RunSummary`/`FleetRunSummary`) now include `started_at_local`/`finished_at_local` next to the existing raw Unix `started_at`/`finished_at`
- The daemon's structured JSON log (`MOADIM_LOG_FORMAT=json`) now includes `ts_local` next to the existing RFC 3339 UTC `ts`
- The UI's relative "N ago" timestamp displays (routine row, run-history sparkline, history table, overview recent runs) now show an absolute local-time tooltip on hover
- All additions are additive — no existing field changed or removed
- Split `svc_list_runs`/`svc_list_all_runs` out of `service_trigger.rs` into a new `service_runs.rs` to stay under the repo's 500-line-per-file gate

Closes #1159

## Test plan
- [x] `cargo test -p moadim` — 1022 passed
- [x] `cargo clippy --workspace --all-targets` — clean
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% line coverage
- [x] `ui` crate: `cargo test` (287 passed) and `cargo clippy --all-targets` — clean
- [x] Pre-push hook (fmt, clippy, tests, coverage, line-count, changeset) passed on push