### PR TITLE
fix(cli): rotate daemon.log on a daily tick, not just at spawn

### DIFF
--- a/.changeset/rotate-daemon-log-on-daily-tick.md
+++ b/.changeset/rotate-daemon-log-on-daily-tick.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+fix(cli): rotate daemon.log on a daily tick, not just at spawn
+
+`rotate_daemon_log_if_oversized` only rotated at detached-spawn time or on size, so a
+long-lived daemon that stayed under the size cap and never restarted never rotated its log.
+Renamed to `rotate_daemon_log_if_due` and added a 24h age-based trigger alongside the size
+check, re-evaluated hourly via a new periodic task in `run_with_listener_until`.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -426,6 +426,7 @@ use cli_system::{
 };
 #[cfg(test)]
 pub(crate) use cli_system::{parse_body, parse_status_code, DAEMON_LOG_MAX_BYTES};
+pub(crate) use cli_system::{rotate_daemon_log_if_due, LOG_ROTATION_CHECK_INTERVAL};
 
 #[path = "restart.rs"]
 mod cli_restart;

--- a/src/cli/system.rs
+++ b/src/cli/system.rs
@@ -2,7 +2,7 @@
 
 use std::io::{Read as _, Write as _};
 use std::net::SocketAddr;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 /// How long to wait when probing or signalling a running server over HTTP.
 const PROBE_TIMEOUT: Duration = Duration::from_millis(750);
@@ -12,14 +12,40 @@ const PROBE_TIMEOUT: Duration = Duration::from_millis(750);
 /// without a cap it grows unbounded until it fills the disk (#316).
 pub(crate) const DAEMON_LOG_MAX_BYTES: u64 = 10 * 1024 * 1024;
 
-/// Rotate `log_path` to a sibling `.1` file (overwriting any previous one) if it has grown past
-/// [`DAEMON_LOG_MAX_BYTES`]. Best-effort: a failed rotation (permissions, race) falls through to
-/// the caller's own `append(true)` open rather than blocking the spawn.
-fn rotate_daemon_log_if_oversized(log_path: &std::path::Path) {
+/// How long a `daemon.log` segment may age before it is rotated regardless of size. The size cap
+/// above only trims the file at the next detached spawn; a daemon that runs for weeks without a
+/// restart and stays under [`DAEMON_LOG_MAX_BYTES`] would otherwise never rotate at all (#1157).
+pub(crate) const DAEMON_LOG_MAX_AGE: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// How often the running daemon re-checks whether `daemon.log` is due for rotation. Cheap (a
+/// single `stat`), so an interval well under [`DAEMON_LOG_MAX_AGE`] keeps the daily trigger from
+/// drifting far past its target without needing a dedicated timer thread (#1157).
+pub(crate) const LOG_ROTATION_CHECK_INTERVAL: Duration = Duration::from_secs(60 * 60);
+
+/// Whether a `daemon.log` of `size` bytes, created `age` ago, is due for rotation. Split out from
+/// [`rotate_daemon_log_if_due`] so the trigger logic is testable with injected size/age values
+/// instead of needing to fake a real file's birth time.
+fn log_rotation_is_due(size: u64, age: Duration) -> bool {
+    size > DAEMON_LOG_MAX_BYTES || age > DAEMON_LOG_MAX_AGE
+}
+
+/// Rotate `log_path` to a sibling `.1` file (overwriting any previous one) if it is due per
+/// [`log_rotation_is_due`] — oversized, or older than [`DAEMON_LOG_MAX_AGE`] since creation.
+/// Called both at detached-spawn time and, by the running server's periodic tick, on
+/// [`LOG_ROTATION_CHECK_INTERVAL`] — so a long-lived daemon rotates without needing a restart.
+/// Best-effort: a failed rotation (permissions, race) or a filesystem that can't report a birth
+/// time (age treated as zero, so only the size check applies) falls through to the caller rather
+/// than blocking.
+pub(crate) fn rotate_daemon_log_if_due(log_path: &std::path::Path) {
     let Ok(metadata) = std::fs::metadata(log_path) else {
         return;
     };
-    if metadata.len() <= DAEMON_LOG_MAX_BYTES {
+    let age = metadata
+        .created()
+        .ok()
+        .and_then(|created| SystemTime::now().duration_since(created).ok())
+        .unwrap_or_default();
+    if !log_rotation_is_due(metadata.len(), age) {
         return;
     }
     let rotated_path = log_path.with_extension("log.1");
@@ -351,7 +377,7 @@ fn spawn_detached_with(configure: impl FnOnce(&mut std::process::Command)) -> an
     crate::utils::fs_perms::create_private_dir_all(
         log_path.parent().expect("daemon log path has a parent dir"),
     )?;
-    rotate_daemon_log_if_oversized(&log_path);
+    rotate_daemon_log_if_due(&log_path);
     let out = std::fs::OpenOptions::new()
         .create(true)
         .append(true)

--- a/src/cli/system_tests.rs
+++ b/src/cli/system_tests.rs
@@ -6,21 +6,21 @@
 use super::*;
 
 #[test]
-fn rotate_daemon_log_if_oversized_is_a_no_op_when_file_is_missing() {
+fn rotate_daemon_log_if_due_is_a_no_op_when_file_is_missing() {
     let path = std::env::temp_dir().join(format!("moadim-log-missing-{}", uuid::Uuid::new_v4()));
     // No file at `path`: must not panic or create anything.
-    rotate_daemon_log_if_oversized(&path);
+    rotate_daemon_log_if_due(&path);
     assert!(!path.exists());
 }
 
 #[test]
-fn rotate_daemon_log_if_oversized_leaves_small_files_in_place() {
+fn rotate_daemon_log_if_due_leaves_small_files_in_place() {
     let base = std::env::temp_dir().join(format!("moadim-log-small-{}", uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&base).unwrap();
     let path = base.join("daemon.log");
     std::fs::write(&path, b"a few bytes").unwrap();
 
-    rotate_daemon_log_if_oversized(&path);
+    rotate_daemon_log_if_due(&path);
 
     assert!(path.exists(), "file under the cap must not be rotated");
     let mut rotated = path.as_os_str().to_os_string();
@@ -30,13 +30,13 @@ fn rotate_daemon_log_if_oversized_leaves_small_files_in_place() {
 }
 
 #[test]
-fn rotate_daemon_log_if_oversized_rolls_the_file_past_the_cap() {
+fn rotate_daemon_log_if_due_rolls_the_file_past_the_cap() {
     let base = std::env::temp_dir().join(format!("moadim-log-big-{}", uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&base).unwrap();
     let path = base.join("daemon.log");
     std::fs::write(&path, vec![b'x'; (DAEMON_LOG_MAX_BYTES + 1) as usize]).unwrap();
 
-    rotate_daemon_log_if_oversized(&path);
+    rotate_daemon_log_if_due(&path);
 
     assert!(
         !path.exists(),
@@ -52,7 +52,7 @@ fn rotate_daemon_log_if_oversized_rolls_the_file_past_the_cap() {
 }
 
 #[test]
-fn rotate_daemon_log_if_oversized_replaces_a_previous_1_file() {
+fn rotate_daemon_log_if_due_replaces_a_previous_1_file() {
     let base = std::env::temp_dir().join(format!("moadim-log-replace-{}", uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&base).unwrap();
     let path = base.join("daemon.log");
@@ -62,7 +62,7 @@ fn rotate_daemon_log_if_oversized_replaces_a_previous_1_file() {
     let rotated = std::path::PathBuf::from(rotated);
     std::fs::write(&rotated, b"stale rotated content").unwrap();
 
-    rotate_daemon_log_if_oversized(&path);
+    rotate_daemon_log_if_due(&path);
 
     assert!(rotated.exists());
     assert_eq!(
@@ -71,4 +71,36 @@ fn rotate_daemon_log_if_oversized_replaces_a_previous_1_file() {
         "rotation must replace a stale .1 file with the freshly-rolled one"
     );
     let _ = std::fs::remove_dir_all(&base);
+}
+
+// `log_rotation_is_due` is the pure trigger predicate `rotate_daemon_log_if_due` reads a real
+// file's size/age into; it is tested directly here with injected values since a real file's birth
+// time can't be back-dated portably to exercise the "stale" branch end-to-end (#1157).
+
+#[test]
+fn log_rotation_is_due_is_false_for_a_small_fresh_log() {
+    assert!(!log_rotation_is_due(1024, Duration::from_secs(60)));
+}
+
+#[test]
+fn log_rotation_is_due_is_true_when_oversized_but_fresh() {
+    assert!(log_rotation_is_due(
+        DAEMON_LOG_MAX_BYTES + 1,
+        Duration::from_secs(0)
+    ));
+}
+
+#[test]
+fn log_rotation_is_due_is_true_when_small_but_stale() {
+    // The whole point of #1157: a long-lived daemon whose log never crosses the size cap must
+    // still rotate once it's been more than a day since the current segment was created.
+    assert!(log_rotation_is_due(
+        1024,
+        DAEMON_LOG_MAX_AGE + Duration::from_secs(1)
+    ));
+}
+
+#[test]
+fn log_rotation_is_due_is_false_right_at_the_age_boundary() {
+    assert!(!log_rotation_is_due(1024, DAEMON_LOG_MAX_AGE));
 }

--- a/src/routes/http_listener.rs
+++ b/src/routes/http_listener.rs
@@ -147,6 +147,19 @@ pub async fn run_with_listener_until(
             .await;
         }
     });
+    // Periodically rotate `daemon.log` if it has grown past its size cap or aged past its daily
+    // floor. The spawn-time check in `cli::system` only fires when the daemon restarts, so a
+    // long-lived process needs this tick to ever roll its own log over (#1157).
+    let log_rotation_task = tokio::spawn(async move {
+        let mut tick = tokio::time::interval(crate::cli::LOG_ROTATION_CHECK_INTERVAL);
+        loop {
+            tick.tick().await;
+            let _ = tokio::task::spawn_blocking(|| {
+                crate::cli::rotate_daemon_log_if_due(&crate::paths::daemon_log_file());
+            })
+            .await;
+        }
+    });
     let app = build_app_with_shutdown(routines, signal.clone());
     crate::utils::startup_print::print(&addr);
     // Fires the instant a shutdown is requested, so the grace watchdog below can start its clock
@@ -169,5 +182,6 @@ pub async fn run_with_listener_until(
     cleanup_task.abort();
     watchdog_task.abort();
     version_task.abort();
+    log_rotation_task.abort();
     Ok(())
 }


### PR DESCRIPTION
## Summary

`rotate_daemon_log_if_oversized` (`src/cli/system.rs`) only rotated `daemon.log`:
- **at detached-spawn time** — a long-uptime daemon that never restarts never rotates
- **on size** (`DAEMON_LOG_MAX_BYTES`, 10MB) — never time

A long-lived daemon that stays under the size cap and never restarts would never rotate its log at all.

This PR:
- Renames `rotate_daemon_log_if_oversized` to `rotate_daemon_log_if_due` and adds a `DAEMON_LOG_MAX_AGE` (24h) time-based trigger alongside the existing size check, computed from the log file's creation time.
- Splits the pure trigger predicate into `log_rotation_is_due(size, age)` so it's unit-testable with injected values (a real file's birth time can't portably be back-dated in a test).
- Reuses the daemon's existing periodic-tick infrastructure in `run_with_listener_until` (`src/routes/http_listener.rs`) — which already runs a `cleanup_task`, `watchdog_task`, and `version_task` via `tokio::spawn` + `tokio::time::interval` — adding a fourth `log_rotation_task` on a new `LOG_ROTATION_CHECK_INTERVAL` (hourly) that re-checks rotation while the server is alive, not just at process spawn.
- The size-based check at spawn time is preserved as-is (now goes through the same combined function).
- No multi-generation retention added (out of scope per the issue) — still a single `daemon.log` -> `daemon.log.1` rotation.

## Test plan
- [x] `cargo build`
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (1027 + 287 passed, including 4 new `log_rotation_is_due` unit tests covering fresh/oversized/stale/boundary cases, plus the renamed existing `rotate_daemon_log_if_due` tests)
- [x] `linecheck --max-lines 500 $(find src ui/src -name '*.rs')`
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (100% line coverage maintained)

Closes #1157