### PR TITLE
docs(contributing): document the pre-push hook's test-convention scan

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,15 +27,19 @@ cd daemon
 cargo build
 ```
 
-Run the checks the pre-push hook enforces before any push:
+Run the checks the pre-push hook enforces before any push. The hook's first
+gate isn't a single reusable command — it scans `src/` and `ui/src/` for
+inline `#[cfg(test)] mod foo { ... }` test blocks and rejects them in favor
+of `*_tests.rs` siblings (see [Tests](#tests) below) — everything after that
+is:
 
 ```sh
 cargo fmt --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
 cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'
-linecheck --max-lines 500 $(find src ui/src -name '*.rs')
 pnpm exec changeset status --since=origin/main
+linecheck --max-lines 500 $(find src ui/src -name '*.rs')
 ```
 
 Use `--workspace` for both clippy and test, matching the pre-push hook —


### PR DESCRIPTION
## Why

CONTRIBUTING.md's "Run the checks the pre-push hook enforces before any push" section lists six copy-pasteable commands (`fmt`, `clippy`, `test`, `llvm-cov`, `linecheck`, `changeset status`) but silently omits the hook's actual **first** gate: `.githooks/pre-push` scans `src/` and `ui/src/` for inline `#[cfg(test)] mod foo { ... }` test blocks and rejects them in favor of `*_tests.rs` siblings, before it ever runs `cargo fmt --check`.

That check isn't a single reusable CLI command (it's a custom shell scan), so it can't just be added as a seventh line in the code block — but its absence from the checklist means a contributor who runs exactly the six listed commands and sees them all pass can still hit a pre-push rejection with no corresponding line in the docs to explain why.

## What

- Adds a sentence before the command block calling out the scan explicitly and pointing at the existing (but separate) explanation in the "Tests" section below.
- Reorders the `changeset status` and `linecheck` lines to match the hook's actual execution order (changelog check runs before the line-count gate in `.githooks/pre-push`), matching the spirit of #334 which originally aligned this list with the real hook.

Docs-only change — no `src/`/`ui/` touched, so no changeset is needed (the `unreleased-entry` check is exempt for docs-only PRs).

## Checked locally
- `typos CONTRIBUTING.md` — clean
- Diffed against `.githooks/pre-push` step-by-step to confirm the new text and command order match

This pull request was opened by the "Daemon + Landing auto-improve & auto-merge lint/docs PRs" routine of moadim.