### PR TITLE
test(ui): cover day_timeline's fire_times cron logic

### DIFF
--- a/.changeset/day-timeline-fire-times-coverage.md
+++ b/.changeset/day-timeline-fire-times-coverage.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Add host-side unit tests for the day timeline's `fire_times` (`ui/src/day_timeline.rs`), covering multi-fire schedules, the midnight-boundary seed, adjacent-day filtering, unparseable schedules, and the `MAX_FIRES` cap. This logic previously had no test module, unlike every other pure-logic file in the `ui` crate. No behavior change.

--- a/ui/src/day_timeline.rs
+++ b/ui/src/day_timeline.rs
@@ -267,3 +267,7 @@ pub fn day_timeline(props: &DayTimelineProps) -> Html {
         </div>
     }
 }
+
+#[cfg(test)]
+#[path = "day_timeline_tests.rs"]
+mod day_timeline_tests;

--- a/ui/src/day_timeline_tests.rs
+++ b/ui/src/day_timeline_tests.rs
@@ -1,0 +1,51 @@
+//! Host-side unit tests for `fire_times`: the pure cron-to-fire-times logic
+//! behind the day timeline, including the midnight-boundary handling and
+//! adjacent-day filtering.
+
+use super::*;
+
+fn day() -> NaiveDate {
+    NaiveDate::from_ymd_opt(2026, 6, 22).expect("valid date")
+}
+
+#[test]
+fn multiple_fires_within_a_day_are_returned_in_order() {
+    let times = fire_times("0 9,12,18 * * *", day());
+    assert_eq!(
+        times,
+        vec![
+            NaiveTime::from_hms_opt(9, 0, 0).unwrap(),
+            NaiveTime::from_hms_opt(12, 0, 0).unwrap(),
+            NaiveTime::from_hms_opt(18, 0, 0).unwrap(),
+        ]
+    );
+}
+
+#[test]
+fn midnight_fire_is_attributed_to_the_target_day_not_dropped() {
+    // The midnight-minus-one-second seed (see `fire_times`) must still catch
+    // an occurrence at exactly 00:00:00 on `day`, not skip past it.
+    let times = fire_times("0 0 * * *", day());
+    assert_eq!(times, vec![NaiveTime::from_hms_opt(0, 0, 0).unwrap()]);
+}
+
+#[test]
+fn fires_on_adjacent_days_are_excluded() {
+    // Every 12 hours from a fixed anchor lands once just before midnight the
+    // previous day and once at noon on `day` — only the noon fire belongs.
+    let times = fire_times("0 12 * * *", day());
+    assert_eq!(times, vec![NaiveTime::from_hms_opt(12, 0, 0).unwrap()]);
+}
+
+#[test]
+fn unparseable_schedule_returns_empty() {
+    assert!(fire_times("not a cron", day()).is_empty());
+    assert!(fire_times("", day()).is_empty());
+}
+
+#[test]
+fn pathological_schedule_respects_the_max_fires_cap() {
+    // Every second, all day, would be 86400 fires without the cap.
+    let times = fire_times("* * * * * *", day());
+    assert_eq!(times.len(), MAX_FIRES);
+}


### PR DESCRIPTION
## Summary
- `fire_times` in `ui/src/day_timeline.rs` is the pure cron-to-fire-times logic behind the routines day timeline: it handles a midnight-boundary seed trick (stepping back one second so a fire at exactly `00:00:00` isn't dropped), filters out spillover from adjacent days, and caps iteration at `MAX_FIRES` for pathological schedules.
- Every other pure-logic file in `ui/src` (e.g. `schedule_heatmap.rs`, `cron_utils.rs`, `command_palette_match.rs`) has a companion `#[cfg(test)] #[path = "..."]` test module. `day_timeline.rs` had none — this subtle date logic could silently break in a refactor with nothing to catch it.
- Adds `ui/src/day_timeline_tests.rs` covering: multiple fires in a day (ordering), the midnight-exactly-at-boundary case, adjacent-day exclusion, unparseable schedules, and the `MAX_FIRES` cap.
- No production code behavior change — `day_timeline.rs` only gains the `mod` wiring at the bottom, matching the existing convention.

## Test plan
- [x] `cargo test -p ui day_timeline` — 5 new tests pass
- [x] `cargo clippy -p ui --all-targets --all-features` — clean
- [x] `cargo fmt --all -- --check` — clean