### PR TITLE
test(routines): cover svc_set_power_saving's write_routine failure branch

### DIFF
--- a/.changeset/svc-set-power-saving-write-failure-coverage.md
+++ b/.changeset/svc-set-power-saving-write-failure-coverage.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Add a test for `svc_set_power_saving` returning 500/Internal when `write_routine` fails (read-only config dir), closing the last untested error branch in that handler. No behavior change — test-only.

--- a/src/routines/service_power_saving_tests.rs
+++ b/src/routines/service_power_saving_tests.rs
@@ -169,3 +169,43 @@ fn svc_set_power_saving_sets_and_clears_without_touching_enabled() {
     assert!(!updated.power_saving);
     assert!(updated.enabled);
 }
+
+/// Cover the `write_routine(...).map_err(|_| AppError::Internal)?` branch: every other test in
+/// this file only exercises the success path, so that `?`'s error arm never ran. A read-only
+/// config dir makes `create_private_dir_all` inside `write_routine` fail, mirroring the technique
+/// already used for `lock`/`unlock` in `handlers_tests.rs`.
+#[test]
+fn svc_set_power_saving_returns_internal_on_write_failure() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let _home = TempHome::set();
+    let store = new_store();
+    let routine = make_routine(
+        "power-saving-write-fail-id",
+        "Power Saving Write Fail Test ZZZ",
+        1,
+        1,
+    );
+    store
+        .lock()
+        .unwrap()
+        .insert("power-saving-write-fail-id".into(), routine);
+
+    let config_dir = crate::paths::config_dir();
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let mut perms = std::fs::metadata(&config_dir).unwrap().permissions();
+    perms.set_mode(0o555);
+    std::fs::set_permissions(&config_dir, perms).unwrap();
+
+    let result = svc_set_power_saving(&store, "power-saving-write-fail-id", true);
+
+    // Restore write permission so `TempHome::drop` can remove the temp tree.
+    let mut perms = std::fs::metadata(&config_dir).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&config_dir, perms).unwrap();
+
+    assert!(
+        matches!(result, Err(AppError::Internal)),
+        "expected Internal error when write_routine fails, got {result:?}"
+    );
+}


### PR DESCRIPTION
## Why

`svc_set_power_saving` has one fallible step:

```rust
write_routine(&routine).map_err(|_| AppError::Internal)?;
```

Every existing test in `service_power_saving_tests.rs` only exercises the
success path (missing routine, set/clear power-saving). Region-level
coverage (`cargo llvm-cov --html`) shows this `?`'s error arm has never run
anywhere in the suite — a `region red` marker on that line, even though the
*line* itself is covered (so the repo's line-coverage gate doesn't catch it).

## What

Add `svc_set_power_saving_returns_internal_on_write_failure`: makes the
config dir read-only so `write_routine`'s internal `create_private_dir_all`
call fails, then asserts the handler surfaces `AppError::Internal` rather
than panicking or silently succeeding. This mirrors the exact technique
already used for `/routines/lock` and `/routines/unlock` in
`handlers_tests.rs` (chmod the config dir, call the fallible function
directly, restore permissions for cleanup).

No behavior change — test-only.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (1035 passed, up from 1034)
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (100% lines; region misses for `routines/service_trigger.rs` dropped from 1 to 0)
- [x] `linecheck --max-lines 500 $(find src ui/src -name '*.rs')`
- [x] Added `.changeset/svc-set-power-saving-write-failure-coverage.md` (patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)