### PR TITLE
test(client): cover formatTtl's duration-formatting branches

### DIFF
--- a/.changeset/client-ttl-format-test.md
+++ b/.changeset/client-ttl-format-test.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Add a unit test for the client's `formatTtl` (workbench-retention duration formatter), the last pure-logic module in `client/src` without a matching `*.test.ts`. No behavior change — test-only.

--- a/client/src/pages/routines/ttl.test.ts
+++ b/client/src/pages/routines/ttl.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { formatTtl } from "./ttl";
+
+describe("formatTtl", () => {
+  it("renders null/undefined as the server default", () => {
+    expect(formatTtl(null)).toBe("default");
+    expect(formatTtl(undefined)).toBe("default");
+  });
+
+  it("renders zero as 0s rather than dividing into a unit", () => {
+    expect(formatTtl(0)).toBe("0s");
+  });
+
+  it("picks the largest whole unit that divides the value evenly", () => {
+    expect(formatTtl(172_800)).toBe("2d");
+    expect(formatTtl(7_200)).toBe("2h");
+    expect(formatTtl(120)).toBe("2m");
+  });
+
+  it("falls back to raw seconds when no larger unit divides evenly", () => {
+    expect(formatTtl(90)).toBe("90s");
+    expect(formatTtl(45)).toBe("45s");
+  });
+});


### PR DESCRIPTION
## Why

`client/src/pages/routines/ttl.ts` (`formatTtl` / `TTL_PRESETS`, used by `RoutineForm` and `RoutineRow` to render workbench-retention TTLs) was the only pure-logic module under `client/src` without a matching `*.test.ts` — every other `lib/*.ts` and `pages/*/*.ts` file (e.g. `bytes.ts`, `cronUtils.ts`, `runDisplay.ts`, `schedule.ts`, `savedViews.ts`, `filter.ts`, ...) has one. `formatTtl` has several branches (null/undefined default, exact-zero, day/hour/minute divisibility, seconds fallback) that weren't directly asserted anywhere.

## What

Add `ttl.test.ts` covering each branch of `formatTtl`:
- `null`/`undefined` → `"default"`
- `0` → `"0s"`
- values divisible by a day/hour/minute → largest matching unit
- values with no larger evenly-dividing unit → raw seconds

No behavior change — test-only.

## Test plan
- [x] `pnpm run test` (client) — 316 tests pass, including the 4 new ones
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean