### PR TITLE
fix(hooks): correct out-of-order step numbering in pre-push

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -83,15 +83,7 @@ echo "Running coverage (100% line coverage required, excluding main.rs)..."
 # runs above, via the workspace-wide `cargo test`.
 cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'
 
-# ── 6. Changelog ────────────────────────────────────────────────────────────────
-# Mirror the CI `Changelog` workflow (.github/workflows/changelog.yml) locally so
-# pushes that would fail the `changeset status` check are caught before they hit
-# CI. If the commits being pushed touch `src/` or `ui/`, a new `.changeset/*.md`
-# file must be present in the same range. Set SKIP_CHANGELOG=1 to bypass (the
-# local equivalent of the `skip-changelog` PR label) for deliberately
-# undocumented src/ui changes.
-
-# ── 7. Line-count gate ────────────────────────────────────────────────────────
+# ── 6. Line-count gate ────────────────────────────────────────────────────────
 # Requires: cargo install linecheck
 if ! command -v linecheck >/dev/null 2>&1; then
   echo ""
@@ -105,7 +97,7 @@ echo "Checking .rs files do not exceed 500 lines..."
 linecheck --max-lines 500 $(find src ui/src -name '*.rs')
 echo "Line-count check passed."
 
-# ── 8. Client (React) checks ────────────────────────────────────────────────────
+# ── 7. Client (React) checks ────────────────────────────────────────────────────
 # `client/` isn't a Cargo workspace member, so none of the cargo-based gates
 # above ever touch it. Mirror them here the same way this hook already mirrors
 # CI for `src/`/`ui/` — matching the CI jobs added in `.github/workflows/lint.yml`
@@ -122,6 +114,13 @@ pnpm --filter client lint
 pnpm --filter client test
 echo "Client checks passed."
 
+# ── 8. Changelog ────────────────────────────────────────────────────────────────
+# Mirror the CI `Changelog` workflow (.github/workflows/changelog.yml) locally so
+# pushes that would fail the `changeset status` check are caught before they hit
+# CI. If the commits being pushed touch `src/` or `ui/`, a new `.changeset/*.md`
+# file must be present in the same range. Set SKIP_CHANGELOG=1 to bypass (the
+# local equivalent of the `skip-changelog` PR label) for deliberately
+# undocumented src/ui changes.
 if [ "${SKIP_CHANGELOG:-0}" != "1" ]; then
   echo "Checking for a changeset covering src/, ui/, or client/ changes..."
   # Range being pushed: everything on HEAD not yet on the upstream main branch,


### PR DESCRIPTION
## Why

`.githooks/pre-push`'s `── 6. Changelog ──` comment block describes the
changeset check (mirroring the CI `unreleased-entry`/`Changelog` workflow),
but no code follows it — the actual changeset-check code lives ~40 lines
later, after the line-count gate and client (React) checks, with no
comment marking it at all.

`CONTRIBUTING.md`'s documented run order already lists the changeset check
**last** (matching what the script actually executes end to end); only the
inline numbered comments had drifted out of sync with the code, presumably
after a past edit reordered steps without renumbering the comments. Anyone
reading the hook top-to-bottom to understand (or reorder) its gates would
be misled into thinking the changeset check runs right after coverage.

## What

- Renumbered steps 6-8 (line-count gate, client checks, changelog) to
  match the order the script actually runs them in.
- Moved the changelog step's explanatory comment to sit directly above its
  own code, instead of ~40 lines above the block it doesn't describe.
- No behavioral change: same checks, same order, same exit codes.

## Verification

Ran the hook end-to-end locally (`sh .githooks/pre-push`) after the fix:
test-convention scan, `cargo fmt --check`, `cargo clippy --workspace
--all-targets -- -D warnings`, `cargo test --workspace` (1035 + 287
passed), `cargo llvm-cov --fail-under-lines 100` (100% line coverage),
`linecheck --max-lines 500`, `pnpm --filter client typecheck`/`lint`/`test`
(312 passed), and the changeset check — all passed in the corrected order.

Comment-only change to a shell script; doesn't touch `src/`, `ui/`, or
`client/`, so no changeset is needed per the hook's own gate.