### PR TITLE
fix(docs): add missing enable/disable entries to the man page

### DIFF
--- a/docs/moadim.1
+++ b/docs/moadim.1
@@ -89,6 +89,12 @@ Manage routines (alias:
 Trigger a routine by ID (invoked directly from the routine's crontab
 entry).
 .TP
+.BR "enable <routine> " [ \-\-json ]
+Turn a routine on (set enabled=true) by id or slug.
+.TP
+.BR "disable <routine> " [ \-\-json ]
+Turn a routine off (set enabled=false) by id or slug.
+.TP
 .B agents
 List available agent keys.
 .SH OPTIONS


### PR DESCRIPTION
## Why

`moadim enable <routine>` and `moadim disable <routine>` are real, working CLI data commands — they're listed in `DATA_COMMANDS` and `help_text()` in `src/cli/mod.rs`, and documented in the README's CLI section — but `docs/moadim.1` (the shipped Unix man page, referenced from the README as `docs/moadim.1`) never picked them up. Its `DATA COMMANDS` section only listed `routines`, `schedule`, and `agents`.

A user running `man moadim` (or `man ./docs/moadim.1`) would see no mention of `enable`/`disable` at all, even though `moadim --help` documents both.

## What

Added `.TP` entries for `enable <routine> [--json]` and `disable <routine> [--json]` to the `DATA COMMANDS` section of `docs/moadim.1`, mirroring the wording already used in `moadim --help` (`src/cli/mod.rs`) and the README's CLI section.

## Verification

- `man ./docs/moadim.1` renders the new entries correctly (checked locally).
- `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` all pass.
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` still passes (this change is docs-only, no `.rs` touched, so coverage is unaffected).
- No changeset needed — the change is confined to `docs/`, outside the `src/`/`ui/`/`client/` paths the changeset gate covers.