### PR TITLE
fix(routines): cap agent.log to 32 MiB on the watchdog tick

### DIFF
--- a/.changeset/cap-agent-log-on-watchdog-tick.md
+++ b/.changeset/cap-agent-log-on-watchdog-tick.md
@@ -1,0 +1,18 @@
+---
+"moadim": patch
+---
+
+fix(routines): cap each workbench's `agent.log` to 32 MiB on the watchdog tick
+
+`tmux pipe-pane -o` streams a session's raw pane output — every ANSI redraw
+frame of a full-screen TUI agent included — into `agent.log` via an
+unbounded, append-only `cat >>`. The `svc_logs`/`svc_run_log` read path
+already bounds a single response to a 2 MiB tail (#280), but nothing bounded
+the file's on-disk growth between TTL sweeps: a long-running or chatty
+session could otherwise fill the disk before it was ever reaped (#268).
+
+Adds `routines::cleanup::log_cap`, which truncates an oversized `agent.log`
+in place to its last 32 MiB (prefixed with a marker noting how many bytes
+were dropped) on the existing 30s watchdog tick, alongside the hung-session
+kill check it already runs per workbench. Best-effort: an I/O failure for
+one workbench is logged and does not abort the sweep for the rest.

--- a/src/routines/cleanup/log_cap.rs
+++ b/src/routines/cleanup/log_cap.rs
@@ -1,0 +1,68 @@
+//! Bound each workbench's on-disk `agent.log` to a fixed size on the watchdog tick.
+//!
+//! `tmux pipe-pane -o` streams a session's raw pane output — including every ANSI redraw frame of
+//! a full-screen TUI agent — into `agent.log` via an unbounded, append-only `cat >>` (see
+//! `routines::command::build_routine_command`). The read side already bounds a single response to
+//! `MAX_LOG_TAIL_BYTES` (#280), but nothing bounded the file's on-disk growth between TTL sweeps: a
+//! long-running or chatty session could fill the disk before it was ever reaped (#268). This module
+//! closes that gap by truncating an oversized log in place on the `WATCHDOG_INTERVAL` tick.
+
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::Path;
+
+/// Ceiling for a single workbench's on-disk `agent.log`. Chosen well above the read-side
+/// `MAX_LOG_TAIL_BYTES` (2 MiB) tail cap so a normal run's most recent output is never itself the
+/// part discarded here — this only stops truly unbounded growth from a long-running or chatty
+/// session between TTL sweeps (#268).
+pub(crate) const MAX_AGENT_LOG_BYTES: u64 = 32 * 1024 * 1024;
+
+/// If `path` exceeds [`MAX_AGENT_LOG_BYTES`], truncate it in place to just its last
+/// `MAX_AGENT_LOG_BYTES` bytes, prefixed with a marker noting how many bytes were dropped —
+/// mirroring the "recent output matters most" tradeoff the read-side tail already makes. Returns
+/// whether truncation happened. A missing file or one already within budget is a no-op.
+pub(crate) fn cap_agent_log_if_oversized(path: &Path) -> std::io::Result<bool> {
+    cap_agent_log_to(path, MAX_AGENT_LOG_BYTES)
+}
+
+/// Shared implementation of [`cap_agent_log_if_oversized`] for an injected `max_bytes`, so tests
+/// can exercise the truncation branch against a small cap instead of writing a real
+/// [`MAX_AGENT_LOG_BYTES`]-sized fixture, mirroring `service_log_tail::read_log_tail_of_len`'s
+/// same seam.
+fn cap_agent_log_to(path: &Path, max_bytes: u64) -> std::io::Result<bool> {
+    let len = match std::fs::metadata(path) {
+        Ok(meta) => meta.len(),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(err) => return Err(err),
+    };
+    if len <= max_bytes {
+        return Ok(false);
+    }
+    let omitted = len - max_bytes;
+    let mut file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)?;
+    file.seek(SeekFrom::Start(omitted))?;
+    let mut tail = Vec::with_capacity(max_bytes as usize);
+    file.read_to_end(&mut tail)?;
+    file.set_len(0)?;
+    file.seek(SeekFrom::Start(0))?;
+    let marker =
+        format!("... [{omitted} bytes truncated; agent.log capped at {max_bytes} bytes] ...\n");
+    file.write_all(marker.as_bytes())?;
+    file.write_all(&tail)?;
+    Ok(true)
+}
+
+/// [`cap_agent_log_if_oversized`], but best-effort: a failure (permissions, a vanishing workbench)
+/// is logged and swallowed rather than propagated, matching this module's other watchdog-tick
+/// helpers — a single workbench's I/O error must not abort the sweep for every other workbench.
+pub(crate) fn cap_agent_log_or_warn(path: &Path) {
+    if let Err(err) = cap_agent_log_if_oversized(path) {
+        log::warn!("cleanup: failed to cap {}: {err}", path.display());
+    }
+}
+
+#[cfg(test)]
+#[path = "log_cap_tests.rs"]
+mod log_cap_tests;

--- a/src/routines/cleanup/log_cap_tests.rs
+++ b/src/routines/cleanup/log_cap_tests.rs
@@ -1,0 +1,72 @@
+use super::*;
+
+fn temp_log_path(label: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!(
+        "moadim-log-cap-{label}-{}.log",
+        uuid::Uuid::new_v4()
+    ))
+}
+
+#[test]
+fn cap_agent_log_is_noop_for_a_missing_file() {
+    let path = temp_log_path("missing");
+    let _ = std::fs::remove_file(&path);
+    assert!(!cap_agent_log_if_oversized(&path).unwrap());
+}
+
+#[test]
+fn cap_agent_log_is_noop_within_budget() {
+    let path = temp_log_path("within-budget");
+    std::fs::write(&path, "hello agent\n").unwrap();
+    assert!(!cap_agent_log_if_oversized(&path).unwrap());
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), "hello agent\n");
+    std::fs::remove_file(&path).unwrap();
+}
+
+#[test]
+fn cap_agent_log_to_truncates_an_oversized_file_to_its_tail() {
+    let path = temp_log_path("oversized");
+    std::fs::write(&path, "0123456789ABCDEFGHIJ").unwrap(); // 20 bytes
+    let capped = cap_agent_log_to(&path, 10).unwrap();
+    assert!(capped);
+
+    let contents = std::fs::read_to_string(&path).unwrap();
+    assert!(
+        contents.ends_with("ABCDEFGHIJ"),
+        "expected the last 10 bytes to survive, got {contents:?}"
+    );
+    assert!(
+        contents.starts_with("... [10 bytes truncated; agent.log capped at 10 bytes] ..."),
+        "expected a truncation marker, got {contents:?}"
+    );
+    std::fs::remove_file(&path).unwrap();
+}
+
+#[test]
+fn cap_agent_log_to_is_noop_exactly_at_the_cap() {
+    let path = temp_log_path("exact-cap");
+    std::fs::write(&path, "0123456789").unwrap(); // 10 bytes
+    assert!(!cap_agent_log_to(&path, 10).unwrap());
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), "0123456789");
+    std::fs::remove_file(&path).unwrap();
+}
+
+#[test]
+fn cap_agent_log_or_warn_does_not_panic_on_a_missing_file() {
+    let path = temp_log_path("warn-missing");
+    let _ = std::fs::remove_file(&path);
+    cap_agent_log_or_warn(&path);
+}
+
+/// `metadata()` on a path nested under a regular file (not a directory) fails with `NotADirectory`
+/// rather than `NotFound`, exercising [`cap_agent_log_to`]'s non-`NotFound`-error passthrough.
+#[test]
+fn cap_agent_log_propagates_a_non_not_found_metadata_error() {
+    let parent = temp_log_path("not-a-dir-parent");
+    std::fs::write(&parent, "not a directory").unwrap();
+    let path = parent.join("agent.log");
+
+    assert!(cap_agent_log_if_oversized(&path).is_err());
+    cap_agent_log_or_warn(&path); // must log and swallow the same error, not panic
+    std::fs::remove_file(&parent).unwrap();
+}

--- a/src/routines/cleanup/mod.rs
+++ b/src/routines/cleanup/mod.rs
@@ -28,6 +28,7 @@ use super::model::{RoutineStore, RunStatus};
 use super::run_history::{append_persisted_run, has_persisted_run, read_exit_code, PersistedRun};
 
 mod disk_cap;
+mod log_cap;
 mod runtime;
 mod session;
 mod snapshot;
@@ -167,6 +168,10 @@ fn kill_if_hung(
 /// cadence, so a sub-hour `max_runtime_secs` is enforced near its bound instead of waiting for the
 /// hourly [`reap_dir`] sweep. Returns the number of sessions killed. The injected `max_runtime_for`,
 /// `is_alive`, and `kill` keep the decision logic unit-testable without a clock or a live tmux.
+///
+/// Also caps each workbench's `agent.log` to [`log_cap::MAX_AGENT_LOG_BYTES`] on this same tick
+/// (#268): the raw `tmux pipe-pane` capture is unbounded and append-only, so a long or chatty run
+/// could otherwise grow its log without limit between TTL sweeps.
 fn watchdog_dir(
     dir: &Path,
     now: u64,
@@ -190,6 +195,7 @@ fn watchdog_dir(
         let Some((slug, ts)) = parse_workbench_name(&name) else {
             continue;
         };
+        log_cap::cap_agent_log_or_warn(&entry.path().join("agent.log"));
         let session = format!("moadim-{name}");
         kill_if_hung(
             &entry.path(),


### PR DESCRIPTION
## Why

`tmux pipe-pane -o` streams a session's raw pane output — every ANSI redraw
frame of a full-screen TUI agent included — into `agent.log` via an
unbounded, append-only `cat >>` (`build_routine_command` in
`src/routines/command.rs`).

The read side already bounds a single `svc_logs`/`svc_run_log` response to a
2 MiB tail (#280), but nothing bounded the file's **on-disk growth** between
TTL sweeps: a long-running or chatty session (raw TUI redraw spam included)
could fill the disk before the next reap, and finished-but-not-yet-reaped
workbenches accumulate oversized logs in the meantime (#268).

## What

- Adds `routines::cleanup::log_cap`, a small module that truncates an
  oversized `agent.log` in place to its last 32 MiB (well above the 2 MiB
  read-side tail cap, so a normal run's served tail is never itself the part
  discarded here), prefixed with a marker noting how many bytes were
  dropped.
- Wires it into the existing 30s watchdog tick (`watchdog_dir`), right
  alongside the hung-session kill check it already runs per workbench — no
  new background task, no change to the tmux launch command itself.
- Best-effort: an I/O failure for one workbench's log is logged and does not
  abort the sweep for the rest, matching this module's other watchdog-tick
  helpers (e.g. `prune_claude_json`).

Only the disk-growth half of #268 is addressed here; the read-side memory
bound was already fixed by #280/#281.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (293 new/existing tests incl. 6 new
      `log_cap` tests covering: missing file, within-budget no-op,
      exact-cap no-op, truncation content/marker, and the non-`NotFound`
      metadata-error path for both the fallible and best-effort entry
      points)
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'`
- [x] `linecheck --max-lines 500`