### PR TITLE
chore(lint): enable clippy::or_fun_call in the root crate

### DIFF
--- a/.changeset/enable-clippy-or-fun-call.md
+++ b/.changeset/enable-clippy-or-fun-call.md
@@ -1,0 +1,15 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable clippy::or_fun_call in the root crate
+
+Adds `or_fun_call = "deny"` to the root crate's `[lints.clippy]` table. It rejects a function
+call passed directly as the fallback argument to `unwrap_or`/`ok_or`/`and`/`or`-style methods
+(e.g. `opt.unwrap_or(expensive())`) in favour of the lazy `_else` form
+(`opt.unwrap_or_else(expensive)`) — the eager form always evaluates the fallback, even on the
+common path where the value is already present, doing needless work (or a needless allocation)
+on every call.
+
+The codebase is already clean under it (zero violations), so `deny` locks that in. No behavior
+change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,3 +233,10 @@ needless_raw_string_hashes = "deny"
 # ever changes size; `i64::from(x)` is the same widening but fails to compile the moment it would
 # no longer be lossless. The codebase is already clean, so `deny` locks that in.
 cast_lossless = "deny"
+# Reject a function call passed directly as the fallback argument to `unwrap_or`/`ok_or`/
+# `and`/`or` and friends (e.g. `opt.unwrap_or(expensive())`) in favour of the lazy `_else`
+# form (`opt.unwrap_or_else(expensive)`). The eager form always evaluates the fallback, even
+# on the common path where the value is already present — silent, needless work (or a needless
+# allocation) on every call. The lazy form only runs it when actually needed. The codebase is
+# already clean, so `deny` locks that in.
+or_fun_call = "deny"


### PR DESCRIPTION
## Why

`clippy::or_fun_call` is a `nursery`/`perf`-adjacent lint not yet enabled in the root crate's `[lints.clippy]` table (part of the same incremental hardening as the many other `deny`-locked restriction/pedantic lints already there, e.g. `cast_lossless`, `needless_collect`, `redundant_else`). It flags a function call passed directly as the fallback argument to `unwrap_or`/`ok_or`/`and`/`or`-style methods (e.g. `opt.unwrap_or(expensive())`), which always evaluates the fallback eagerly — even on the common path where the value is already present — doing needless work (or a needless allocation) on every call. The lazy `_else` form (`opt.unwrap_or_else(expensive)`) only runs it when actually needed.

I surveyed the repo for a small, high-value, non-duplicate improvement (checked all currently-open PRs and issues first) and landed on this: the root crate is already clean under this lint (zero violations), so enabling it is a pure lock-in with no behavior change, matching this repo's established pattern of incrementally `deny`-ing clean restriction lints.

## What

- Add `or_fun_call = "deny"` to `Cargo.toml`'s `[lints.clippy]` table, with a doc comment matching the style of the neighboring entries.
- No code changes needed — 0 violations surfaced.
- Add a changeset (patch).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --workspace` — 287 passed
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% line coverage maintained

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim. I picked this change after surveying open issues/PRs for something concrete, small, and not already in flight — most other candidates I investigated (agent-config I/O error classification, PID liveness reconciliation, restart `-i`, MCP log tools, ANSI log stripping, retention countdown, region/branch-coverage gaps requiring flaky fault injection) turned out to already be implemented or genuinely impractical to test deterministically, so I landed on this zero-risk lint lock-in instead.