### PR TITLE
test(ui): cover routines::model::humanize_bytes with the CLI's edge cases

### DIFF
--- a/.changeset/ui-humanize-bytes-test-coverage.md
+++ b/.changeset/ui-humanize-bytes-test-coverage.md
@@ -1,0 +1,14 @@
+---
+"moadim": patch
+---
+
+test(ui): cover the UI's `humanize_bytes` byte-formatting helper
+
+`routines::model::humanize_bytes` (used by the cleanup toast) mirrors the CLI's own
+`humanize_bytes` (`src/cli/query.rs`, tested by `src/cli/cleanup_bytes_tests.rs`) byte-for-byte,
+but had zero unit tests of its own — the `ui` crate isn't held to the root package's 100%
+line-coverage floor, so this pure, deterministic function silently had no regression net despite
+its CLI twin being fully covered. Adds the same edge cases the CLI test already exercises (sub-KB,
+each unit boundary, MB-range rounding, and the u64::MAX TB cap) so a future edit that de-syncs the
+two implementations' output fails a test instead of only showing up as a visual mismatch between
+`moadim cleanup`'s CLI output and the UI's cleanup toast. No behavior change.

--- a/ui/src/routines/model_tests.rs
+++ b/ui/src/routines/model_tests.rs
@@ -14,3 +14,15 @@ fn routine_deserializes_without_prompt_field() {
     let routine: Routine = serde_json::from_str(json).unwrap();
     assert_eq!(routine.prompt, "");
 }
+
+/// Mirrors the CLI's own `humanize_bytes` test (`src/cli/cleanup_bytes_tests.rs`) so the two
+/// implementations stay provably identical: same unit boundaries, same rounding, same TB cap.
+#[test]
+fn humanize_bytes_formats_units() {
+    assert_eq!(humanize_bytes(0), "0 B");
+    assert_eq!(humanize_bytes(512), "512 B");
+    assert_eq!(humanize_bytes(1024), "1.0 KB");
+    assert_eq!(humanize_bytes(12_400_000), "11.8 MB");
+    // Caps at TB rather than indexing past the unit table, even for a value this large.
+    assert_eq!(humanize_bytes(u64::MAX), "16777216.0 TB");
+}


### PR DESCRIPTION
## Why

`routines::model::humanize_bytes` (`ui/src/routines/model.rs`) renders a byte count for the
cleanup toast, and its own doc comment says it "mirrors the CLI's `humanize_bytes` so the UI
cleanup toast and `moadim cleanup` report the freed size identically." The CLI twin
(`src/cli/query.rs`) is fully unit-tested (`src/cli/cleanup_bytes_tests.rs`), covered by the root
package's 100%-line-coverage gate — but the `ui` crate is explicitly *not* held to that floor
(see the pre-push hook's own comment: "the `ui` crate is a Yew/WASM UI that isn't held to that
floor"), so this pure, deterministic function had zero tests of its own. A future edit could
silently de-sync the two implementations' rounding/unit-boundary behavior and nothing would catch
it short of a human noticing the CLI and UI report different sizes for the same cleanup.

I surveyed the currently open PRs/issues first to avoid duplicating work — the same
"add host-testable coverage for an untested pure-logic file" shape is already in flight for
`ui/src/day_timeline.rs` in #1169, so I picked a different, non-overlapping gap.

## What

Adds `humanize_bytes_formats_units` to `ui/src/routines/model_tests.rs`, exercising the exact
edge cases the CLI's own test already covers: sub-1KB (bare integer), the KB boundary, an
MB-range value with decimal rounding, and the `u64::MAX` TB cap (verifying it stops at the last
unit table entry rather than indexing out of bounds). No production code changes — test-only.

## Test plan

- [x] `cargo test -p ui humanize_bytes` — new test passes
- [x] `cargo test --workspace` — 1041 (root) + 288 (ui, +1 new) passed
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% (root package scope, unchanged; test-only change under `ui/`)
- [x] `linecheck --max-lines 500 $(find src ui/src -name '*.rs')` — passed
- [x] Test-file convention check (no inline `#[cfg(test)]` blocks) — passed
- [x] `pnpm exec changeset status --since=origin/main` — passed (`.changeset/ui-humanize-bytes-test-coverage.md`, `patch`)
- [x] `cargo check` — confirms `prebuilt.html` is unaffected (test code is `#[cfg(test)]`-gated, never enters the trunk/wasm build)

---
This pull request was opened by the "Daemon + Landing auto-improve & auto-merge lint/docs PRs" routine of moadim.