### PR TITLE
test(routines): cover cap_agent_log_to's open-error branch for a directory path

### DIFF
--- a/.changeset/cover-log-cap-open-error-branch.md
+++ b/.changeset/cover-log-cap-open-error-branch.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Add a test for `cap_agent_log_to` propagating the `OpenOptions::open` error when the target path is a directory, closing an untested error branch in the watchdog's `agent.log` size cap. No behavior change — test-only.

--- a/src/routines/cleanup/log_cap_tests.rs
+++ b/src/routines/cleanup/log_cap_tests.rs
@@ -70,3 +70,19 @@ fn cap_agent_log_propagates_a_non_not_found_metadata_error() {
     cap_agent_log_or_warn(&path); // must log and swallow the same error, not panic
     std::fs::remove_file(&parent).unwrap();
 }
+
+/// `path` can pass the initial `metadata()`/size check (a directory has a nonzero `len()` too) and
+/// still fail the subsequent `OpenOptions::new().read(true).write(true).open(path)` — a directory
+/// can be stat'd but not opened as a file (`IsADirectory`). Exercises that separate `open`
+/// propagation, distinct from the `metadata()` error branch covered above.
+#[test]
+fn cap_agent_log_propagates_an_open_error_for_a_directory() {
+    let path = temp_log_path("is-a-directory");
+    std::fs::create_dir(&path).unwrap();
+
+    // max_bytes = 0 guarantees a directory's nonzero `len()` is "oversized", so execution reaches
+    // the `.open(path)?` this test targets instead of returning early via the budget check.
+    assert!(cap_agent_log_to(&path, 0).is_err());
+    cap_agent_log_or_warn(&path); // must log and swallow the same error, not panic
+    std::fs::remove_dir(&path).unwrap();
+}


### PR DESCRIPTION
## Why

`cargo llvm-cov` region coverage (not gated by the pre-push hook's 100% *line*
floor, but a real gap) shows `log_cap.rs`'s `?` on
`OpenOptions::new().read(true).write(true).open(path)` as never taken down
its error path. `log_cap_tests.rs` already covers the earlier `metadata()`
non-`NotFound`-error branch (`cap_agent_log_propagates_a_non_not_found_metadata_error`),
but nothing exercised `open()` itself failing after a successful, oversized
`metadata()` check — a materially different code path in the same function.

## What

Adds `cap_agent_log_propagates_an_open_error_for_a_directory`: a directory
has a nonzero `len()` (so it clears the size-budget check) but can't be
opened as a file (`IsADirectory`), giving a deterministic, portable way to
hit that specific `?` without mocking the filesystem. Calling with
`max_bytes = 0` guarantees the directory's `len()` counts as oversized so
execution reaches the targeted `open()` call instead of returning early.

No behavior change — test-only. Includes a changeset per `CONTRIBUTING.md`
since this touches `src/`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 287 (ui) + 1042 (root, was 1041) passed
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% lines (unchanged), region misses 34 → 33
- [x] `linecheck --max-lines 500 $(find src ui/src -name '*.rs')`
- [x] `pnpm --filter client typecheck && pnpm --filter client lint && pnpm --filter client test`
- [x] `pnpm exec changeset status --since=origin/main` — passes

This pull request was opened by the "Daemon + Landing auto-improve & auto-merge lint/docs PRs" routine of moadim.