### PR TITLE
docs(readme): list the /machine, /machines, and /config/* REST endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,13 @@ GET    /routines/{id}/logs    # run output
 POST   /routines/cleanup      # reap expired workbenches now
 GET    /agents                # list registered agents
 GET    /routines.ics          # subscribe to fire times as a calendar feed
+GET    /machine                # this machine's resolved identity
+PUT    /machine                # rename this machine's identity
+GET    /machines               # known machine names (union of routines' machines[] targets)
+GET    /config/user-prompt     # persistent system prompt appended to every routine
+PUT    /config/user-prompt     # replace it
+GET    /config/max-concurrent-runs # global routine concurrency cap
+PUT    /config/max-concurrent-runs # set/clear the persisted override
 ```
 
 **MCP** — the same operations are exposed as tools: `list_routines`,


### PR DESCRIPTION
## Why

README's REST section (under \`/api/v1\`) documents the routine/agent endpoints but has drifted out of sync with \`src/routes/http_settings_routes.rs\`: four real, mounted endpoints are missing from the list —

- \`GET/PUT /machine\` — this machine's resolved identity
- \`GET /machines\` — known machine names
- \`GET/PUT /config/user-prompt\` — persistent system prompt
- \`GET/PUT /config/max-concurrent-runs\` — global concurrency cap, added in the very last commit before this branch (#1166, closing #1155)

The README even documents \`MOADIM_MAX_CONCURRENT_RUNS\`'s behavior in prose without ever mentioning its REST endpoint.

## What

Adds the four missing routes to the fenced REST block, matching the existing terse comment style.

Docs-only — no \`src/\`/\`ui/\`/\`client/\` change, so no changeset needed per the repo's changelog check.

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace\`
- [x] \`bash scripts/check-readme-blocks.sh\`