### PR TITLE
chore(lint): enable clippy::or_fun_call in the ui crate

### DIFF
--- a/.changeset/enable-clippy-or-fun-call-ui.md
+++ b/.changeset/enable-clippy-or-fun-call-ui.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable clippy::or_fun_call in the ui crate
+
+Mirrors the root crate's `or_fun_call = "deny"` (see `Cargo.toml`). The `ui` crate has its own
+`[lints.clippy]` table and doesn't inherit root's extended deny-list, so this never applied to
+`ui/src` despite CI's `clippy` job running `--workspace`. The `ui` crate is already clean under
+it (zero violations), so `deny` locks that in. No behavior change.

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -257,3 +257,11 @@ doc_markdown = "deny"
 # `clippy --workspace` covering it in CI. Fixes the 1 violation this surfaced in
 # `routines/calendar.rs`.
 cast_lossless = "deny"
+# Reject a function call passed directly as the fallback argument to `unwrap_or`/`ok_or`/`and`/`or`
+# and friends (e.g. `opt.unwrap_or(expensive())`) in favour of the lazy `_else` form
+# (`opt.unwrap_or_else(expensive)`). The eager form always evaluates the fallback, even on the
+# common path where the value is already present. Mirrors the same lint already enabled
+# workspace-root-side in Cargo.toml — the `ui` crate has its own `[lints.clippy]` table (no
+# `workspace = true` inheritance) so it was silently exempt despite `clippy --workspace` covering
+# it in CI. The `ui` crate is already clean, so `deny` locks that in.
+or_fun_call = "deny"


### PR DESCRIPTION
## Summary

Adds `or_fun_call = "deny"` to the `ui` crate's `[lints.clippy]` table, mirroring the same lint already enabled workspace-root-side in `Cargo.toml`. The `ui` crate has its own `[lints.clippy]` table (no `workspace = true` inheritance), so this lint never applied to `ui/src` despite CI's `clippy` job running `--workspace`.

`or_fun_call` rejects a function call passed directly as the fallback argument to `unwrap_or`/`ok_or`/`and`/`or`-style methods (e.g. `opt.unwrap_or(expensive())`) in favor of the lazy `_else` form (`opt.unwrap_or_else(expensive)`) — the eager form always evaluates the fallback even on the common path where the value is already present.

The `ui` crate is already clean under this lint (zero violations surfaced), so this is a pure lockstep/config change — no behavior change, no source edits beyond `ui/Cargo.toml`.

This follows the same pattern as the already-merged/open root-crate → ui-crate lint lockstep PRs (e.g. #1165 `use_self`, #1140 `derive_partial_eq_without_eq`, #1138 `needless_pass_by_value`), for a lint not covered by any of those.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (0 new violations)
- [x] `cargo test --workspace` — 1054 + 299 tests pass
- [x] Added `.changeset/enable-clippy-or-fun-call-ui.md` (patch, `moadim` package)

🤖 Generated with [Claude Code](https://claude.com/claude-code)