### PR TITLE
chore(lint): enable clippy::ignored_unit_patterns in the root crate

### DIFF
--- a/.changeset/enable-ignored-unit-patterns.md
+++ b/.changeset/enable-ignored-unit-patterns.md
@@ -1,0 +1,8 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::ignored_unit_patterns` in the root crate. Rewrites the four
+`tokio::select!` arms in `src/routes/http_listener.rs` that matched a `()`-typed future with `_`
+to match `()` explicitly instead, so the pattern states its type rather than leaving the reader to
+confirm `_` isn't silently discarding something meaningful. No behavior change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,3 +240,8 @@ cast_lossless = "deny"
 # allocation) on every call. The lazy form only runs it when actually needed. The codebase is
 # already clean, so `deny` locks that in.
 or_fun_call = "deny"
+# Reject `_` as a `match`/`tokio::select!` arm pattern when the matched value's type is `()` —
+# spelling out `()` states the value's type explicitly instead of leaving the reader to check that
+# `_` isn't quietly discarding something meaningful. The codebase is already clean, so `deny` locks
+# that in.
+ignored_unit_patterns = "deny"

--- a/src/routes/http_listener.rs
+++ b/src/routes/http_listener.rs
@@ -72,12 +72,12 @@ pub(super) async fn serve_with_grace(
     // Phase 1: serve normally until it returns on its own or a shutdown is requested.
     tokio::select! {
         res = &mut serve => return res,
-        _ = shutdown_started => {}
+        () = shutdown_started => {}
     }
     // Phase 2: shutdown requested — give open connections a bounded window to drain, then force exit.
     tokio::select! {
         res = &mut serve => res,
-        _ = tokio::time::sleep(grace) => {
+        () = tokio::time::sleep(grace) => {
             log::warn!(
                 "graceful shutdown exceeded {grace:?}; forcing exit with connections still open"
             );
@@ -170,8 +170,8 @@ pub async fn run_with_listener_until(
     // the `/shutdown` route fires `signal` (the UI "STOP" button / `moadim stop`).
     let combined = async move {
         tokio::select! {
-            _ = shutdown => {}
-            _ = signal.notified() => {}
+            () = shutdown => {}
+            () = signal.notified() => {}
         }
         started.notify_one();
     };


### PR DESCRIPTION
## Why

The root crate (`Cargo.toml`) already turns on a long list of pedantic clippy lints one at a time,
each with a `deny` and a documented rationale — `use_self`, `cast_lossless`, `or_fun_call`, and so
on. `clippy::ignored_unit_patterns` was not yet one of them, and the codebase had four live sites
that trip it: the `tokio::select!` arms in `src/routes/http_listener.rs` matched a `()`-typed
future with `_`, which reads the same as "discard whatever this produces" even though the future's
output type is a known, trivial `()`. Spelling the pattern out as `()` states that explicitly
instead of leaving a reader to double-check that `_` isn't quietly discarding something meaningful.

## What changed

- Enabled `clippy::ignored_unit_patterns = "deny"` in `Cargo.toml`'s `[lints.clippy]`, with the
  same style of inline justification comment as its neighboring lints.
- Rewrote the 4 flagged `tokio::select!` arms in `src/routes/http_listener.rs` from `_ = fut => {}`
  to `() = fut => {}`. Purely a pattern-spelling change — no behavior change.

This is a root-crate-only lint addition, not a mirror of an already-enabled `ui`-crate lint, so it
doesn't add to the existing root→ui clippy-mirroring PR backlog.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean, zero warnings
- `cargo test --workspace` — 1054 + 299 passed, 0 failed
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% line
  coverage (unchanged region-coverage gaps are pre-existing and identical before/after this change)
- `RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items --no-deps` — clean
- `linecheck --max-lines 500 $(find src ui/src -name '*.rs')` — clean
- `cargo deny check` — advisories/bans/licenses/sources all ok (pre-existing duplicate transitive
  crate warnings only, unrelated to this change)

Added a patch changeset (`.changeset/enable-ignored-unit-patterns.md`) since this touches `src/`.

---
This pull request was opened by the "Daemon + Landing auto-improve & auto-merge lint/docs PRs" routine of moadim.
cc @tupe12334