### PR TITLE
chore(lint): enable clippy::string_lit_as_bytes in the root crate

### DIFF
--- a/.changeset/enable-clippy-string-lit-as-bytes.md
+++ b/.changeset/enable-clippy-string-lit-as-bytes.md
@@ -1,0 +1,8 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::string_lit_as_bytes` in the root crate. Rewrites the two
+`"...".as_bytes()` comparisons in `src/routes/http_settings_routes_tests.rs` to byte-string
+literal slices (`&b"..."[..]`), stating "this is bytes" at the literal instead of via a runtime
+conversion call. No behavior change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -245,3 +245,8 @@ or_fun_call = "deny"
 # `_` isn't quietly discarding something meaningful. The codebase is already clean, so `deny` locks
 # that in.
 ignored_unit_patterns = "deny"
+# Reject `"literal".as_bytes()` in favour of a `b"literal"` byte-string literal — the byte string
+# is the same bytes without the runtime call, and states "this is bytes" at the point of
+# declaration instead of at a conversion tacked on afterward. The codebase is already clean, so
+# `deny` locks that in.
+string_lit_as_bytes = "deny"

--- a/src/routes/http_settings_routes_tests.rs
+++ b/src/routes/http_settings_routes_tests.rs
@@ -118,7 +118,7 @@ async fn user_prompt_empty_when_unset() {
     let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
         .await
         .unwrap();
-    assert_eq!(bytes, "".as_bytes());
+    assert_eq!(bytes, &b""[..]);
     let _ = std::fs::remove_dir_all(&dir);
     std::env::remove_var("MOADIM_HOME_OVERRIDE");
 }
@@ -177,7 +177,7 @@ async fn user_prompt_put_then_get_round_trips() {
     let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
         .await
         .unwrap();
-    assert_eq!(bytes, "always be terse".as_bytes());
+    assert_eq!(bytes, &b"always be terse"[..]);
     let _ = std::fs::remove_dir_all(&dir);
     std::env::remove_var("MOADIM_HOME_OVERRIDE");
 }


### PR DESCRIPTION
## Why

Continues the incremental clippy-parity effort (see #1200, #1195, #1165) of
enabling one additional lint at a time. `clippy::string_lit_as_bytes` catches
`"literal".as_bytes()`, preferring a byte-string literal instead — it's the
same bytes without the runtime call, and states "this is bytes" at the point
of declaration rather than via a conversion tacked on afterward.

## What

- Add `string_lit_as_bytes = "deny"` to the root crate's `[lints.clippy]` table.
- Fix the 2 violations this surfaced in `src/routes/http_settings_routes_tests.rs`,
  rewriting `"...".as_bytes()` to the equivalent `&b"..."[..]` slice (the bare
  `b"..."` array doesn't satisfy `Bytes: PartialEq`, so the slice form is needed).

No behavior change — test-only diff plus the lint declaration.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test -p moadim user_prompt` passes (the two touched tests)