### PR TITLE
chore(lint): enable clippy::string_lit_as_bytes in the ui crate

### DIFF
--- a/.changeset/enable-clippy-string-lit-as-bytes-in-ui.md
+++ b/.changeset/enable-clippy-string-lit-as-bytes-in-ui.md
@@ -1,0 +1,9 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::string_lit_as_bytes` in the `ui` crate. Mirrors the same lint
+already enabled workspace-root-side (#1202) — the `ui` crate has its own `[lints.clippy]` table
+with no `workspace = true` inheritance, so it was silently exempt despite `clippy --workspace`
+covering it in CI. The `ui` crate was already clean, so no source changes were needed. No
+behavior change.

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -273,3 +273,10 @@ cast_lossless = "deny"
 # `workspace = true` inheritance) so it was silently exempt despite `clippy --workspace` covering
 # it in CI. The `ui` crate is already clean, so `deny` locks that in.
 or_fun_call = "deny"
+# Reject `"literal".as_bytes()` in favour of a `b"literal"` byte-string literal — the byte string
+# is the same bytes without the runtime call, and states "this is bytes" at the point of
+# declaration instead of at a conversion tacked on afterward. Mirrors the same lint already
+# enabled workspace-root-side in Cargo.toml — the `ui` crate has its own `[lints.clippy]` table
+# (no `workspace = true` inheritance) so it was silently exempt despite `clippy --workspace`
+# covering it in CI. The `ui` crate is already clean, so `deny` locks that in.
+string_lit_as_bytes = "deny"


### PR DESCRIPTION
## Why

The `ui` crate has its own `[lints.clippy]` table (no `workspace = true` inheritance), so lints enabled in the workspace-root `Cargo.toml` never applied to `ui/src` even though CI's `clippy` job runs `--workspace`. This is the same gap the last ~20 `chore(lint): enable clippy::*` PRs have been closing one lint at a time (e.g. #1165 for `use_self`, #1138 for `needless_pass_by_value`).

`clippy::string_lit_as_bytes` was just enabled workspace-root-side in #1202. This PR mirrors it into `ui/Cargo.toml` so the two crates stay in lockstep.

## What changed

- `ui/Cargo.toml`: add `string_lit_as_bytes = "deny"` under `[lints.clippy]`, with a comment matching the existing convention in that file.
- `.changeset/enable-clippy-string-lit-as-bytes-in-ui.md`: changeset entry (patch bump on `moadim`).

No source changes were needed — `ui/src` has no `"...".as_bytes()` calls, so the crate was already clean; `deny` just locks that in for future code.

## Checks run locally

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean, no new violations
- `cargo test --workspace` — 299 passed, 0 failed

---

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.