### PR TITLE
chore(lint): enable clippy::string_lit_as_bytes in the ui crate

### DIFF
--- a/.changeset/enable-ui-string-lit-as-bytes.md
+++ b/.changeset/enable-ui-string-lit-as-bytes.md
@@ -1,0 +1,9 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::string_lit_as_bytes` in the `ui` crate. Mirrors the same lint already
+enabled root-side (#1202) — the `ui` crate has its own `[lints.clippy]` table and doesn't inherit
+root's extended deny-list, so this never applied to `ui/src` despite CI's `clippy` job running
+`--workspace`. The `ui` crate is already clean (0 violations), so `deny` locks that in. No behavior
+change.

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -273,3 +273,11 @@ cast_lossless = "deny"
 # `workspace = true` inheritance) so it was silently exempt despite `clippy --workspace` covering
 # it in CI. The `ui` crate is already clean, so `deny` locks that in.
 or_fun_call = "deny"
+# Reject `"literal".as_bytes()` in favour of a `b"literal"` byte-string literal — the byte string
+# is the same bytes without the runtime call, and states "this is bytes" at the point of
+# declaration instead of at a conversion tacked on afterward. Mirrors the root crate's
+# `string_lit_as_bytes = "deny"` (see Cargo.toml) — the `ui` crate has its own `[lints.clippy]`
+# table and doesn't inherit root's extended deny-list, so this never applied to `ui/src` despite
+# CI's `clippy` job running `--workspace`. The `ui` crate is already clean, so `deny` locks that
+# in.
+string_lit_as_bytes = "deny"


### PR DESCRIPTION
## Why

`.github/workflows/lint.yml` runs `cargo clippy --workspace --all-targets -- -D warnings`, and the local pre-push hook mirrors it exactly for the same reason: since this is a non-virtual workspace (root `Cargo.toml` declares both a `[package]` and a `[workspace]`), a bare `cargo clippy` only lints the root package — `--workspace` is required to also cover the `ui` (Yew/WASM) member crate.

The root crate's `[lints.clippy]` table just picked up `string_lit_as_bytes = "deny"` in #1202. But `ui/Cargo.toml` has its *own* `[lints.clippy]` table (Cargo doesn't offer `workspace = true` lint inheritance for a non-virtual workspace member here), so that root-side `deny` silently never applied to `ui/src` — despite CI's clippy job running `--workspace` and looking like it should cover everything. This is the same enforcement gap the repo has been closing one lint at a time (`use_self`, `needless_pass_by_value`, `ignored_unit_patterns`, etc. — see the extensive comments already in `ui/Cargo.toml` documenting each prior fix).

## What

Adds `string_lit_as_bytes = "deny"` to `ui/Cargo.toml`'s `[lints.clippy]` table, with a comment following the same documented pattern as the other mirrored lints in that file.

The `ui` crate is already clean — `cargo clippy -p ui --all-targets -- -D clippy::string_lit_as_bytes` reports 0 violations — so this is a pure enforcement-gap fix with no code changes and no behavior change.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 1054 (root) + 299 (ui) passed
- [x] `linecheck --max-lines 500 $(find src ui/src -name '*.rs')` — clean
- [x] Added `.changeset/enable-ui-string-lit-as-bytes.md` (patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)