### PR TITLE
docs(cli): add completions command and mode aliases to the man page

### DIFF
--- a/docs/moadim.1
+++ b/docs/moadim.1
@@ -26,10 +26,10 @@ Once running, manage it from the web client (the STOP button) or with
 .B (default)
 Start the server in the background and exit.
 .TP
-.BR \-i ", " \-\-interactive
+.BR \-i ", " \-\-interactive ", " \-f ", " \-\-foreground
 Run in the foreground, attached to the terminal (Ctrl-C to stop).
 .TP
-.BR \-b ", " \-\-background
+.BR \-b ", " \-\-background ", " \-d ", " \-\-detach ", " \-\-daemon
 Start the server detached in the background (the explicit default).
 .SH COMMANDS
 .TP
@@ -72,6 +72,12 @@ Remove the OS service registration and the managed crontab block.
 .B machine <show|set|list>
 Show or set this machine's identity, or list the machines referenced by
 routines.
+.TP
+.B "completions <shell>"
+Print a completion script for
+.BR bash ", " zsh ", " fish ", " powershell ", or " elvish
+(e.g.
+.BR "moadim completions zsh > _moadim" ).
 .TP
 .BR "help" ", " \-h ", " \-\-help
 Show usage help.


### PR DESCRIPTION
## Summary
- `docs/moadim.1` documents itself as mirroring `moadim --help` (src/cli.rs::print_help), but had drifted from it.
- The `completions <shell>` data command was missing from the man page's COMMANDS section entirely.
- The `-f`/`--foreground` and `-d`/`--detach`/`--daemon` aliases (for `-i`/`--interactive` and `-b`/`--background` respectively) were never mirrored into the MODES section.

Both are real, currently-supported CLI entry points (see `src/cli/mod.rs`, the `Some("completions")` and `"-f" | "--foreground"` / `"-d" | "--detach" | "--daemon"` match arms), so `man moadim` was omitting/under-documenting them. Same class of fix as #1174 (missing `enable`/`disable` entries), same file.

## Test plan
- [x] `man ./docs/moadim.1` renders correctly (checked output)
- [x] `mandoc -Tlint docs/moadim.1` — no warnings
- [x] `typos` — clean
- [x] `cargo fmt --check` — clean (no Rust files touched)
- [x] No changeset needed: change is docs-only (`docs/moadim.1`), doesn't touch `src/`, `ui/`, or `client/`, matching the pre-push hook's changeset-gate scope and the precedent set by #1174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)