### PR TITLE
docs: prune stale TODO.md entry referencing removed cron jobs feature

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,5 +3,3 @@
 > _Today's TODO, tomorrow's changelog. Ship one, dream up two._
 
 This is a list of todos for consumption, in a pr remove the todo you have implemented and add any new ones you think of.
-
-- Extend the day-detail popover to the Cron Jobs calendar (`ui/src/cron_jobs.rs`), mirroring the routines one added for this TODO


### PR DESCRIPTION
## Why

`TODO.md` currently reads:

> Extend the day-detail popover to the Cron Jobs calendar (`ui/src/cron_jobs.rs`), mirroring the routines one added for this TODO

But the cron jobs feature — including `ui/src/cron_jobs.rs` — was removed entirely in c7ad088 (`feat!: remove cron jobs, focus on AI-agent routines`, #842), which is an ancestor of the commit (f20a618, today) that wrote this TODO line. There is no "Cron Jobs calendar" left to extend and no `ui/src/cron_jobs.rs` file to edit.

Per `TODO.md`'s own convention ("in a pr remove the todo you have implemented and add any new ones you think of"), a stale/impossible entry should be pruned rather than left to mislead the next contributor (human or automated routine) into chasing a nonexistent file for a deliberately-removed feature.

This mirrors the repo's existing precedent for pruning stale `TODO.md` entries as small, standalone docs changes (#1095, #1058) — no CHANGELOG/changeset entry, since neither touches `src/`, `ui/`, or `client/`.

## What

- Removes the single stale TODO line from `TODO.md`.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Confirmed `ui/src/cron_jobs.rs` does not exist (`find . -iname '*cron_job*'` returns nothing) and that its removal (c7ad088) is an ancestor of the commit that introduced this TODO line (`git merge-base --is-ancestor`)
- Change is doc-only (`TODO.md`), no behavior change — `cargo test`/coverage/client checks are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)