### PR TITLE
ci: lint and compile the ui (Yew/WASM) crate for wasm32 on PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,8 +11,19 @@ name: Lint
 # (build.rs falls back to it when trunk is absent), so no trunk step is needed
 # just to type-check and lint. The clippy job runs `--workspace` so the `ui`
 # member crate is linted too; `ui`'s deps (yew/gloo/web-sys) build fine on the
-# host target for clippy's purposes, so no wasm32 target install is required
-# here either.
+# host target for clippy's purposes.
+#
+# That host-target run alone is not enough, though (see #412): `ui` is a
+# Yew/WASM crate that only ever actually ships compiled for
+# `wasm32-unknown-unknown` (via `trunk build` in publish.yml), and clippy's
+# lint set — and even plain compilability — can differ between the host
+# target and wasm32 (cfg-gated code paths, wasm-bindgen/web-sys API surface,
+# etc.). Before this, nothing on a PR ever built or linted `ui` against the
+# target it's actually shipped to; a wasm32-only compile error or clippy
+# violation would sail through every PR green and only surface when cutting a
+# release. The `clippy-ui-wasm` job below closes that gap by installing the
+# wasm32 target and running clippy and a compile check against it directly,
+# scoped to the `ui` package.
 #
 # The pre-push hook's file-size gate (`linecheck --max-lines 500` over
 # `src/` and `ui/src/`) has no CI equivalent, so it's a no-op for any
@@ -114,6 +125,43 @@ jobs:
         # never enforced here, so a PR could lint-regress the dashboard and
         # still go fully green.
         run: cargo clippy --workspace --all-targets -- -D warnings
+
+  clippy-ui-wasm:
+    name: clippy (ui, wasm32)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Install Rust (with clippy, wasm32 target)
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+          components: clippy
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo registry and target/
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          # Own cache entry: this job's target/ holds wasm32 artifacts only,
+          # distinct from the host-target artifacts the `clippy` and `test`
+          # jobs cache under their own shared-keys.
+          shared-key: clippy-ui-wasm
+
+      - name: Run clippy (ui, wasm32-unknown-unknown)
+        # See #412: `ui`'s own `[lints.clippy] all = "deny"` (ui/Cargo.toml)
+        # is otherwise never enforced against the target it actually ships
+        # for. Scoped to `-p ui` (not `--workspace`) since the root `moadim`
+        # package doesn't build for wasm32 at all.
+        run: cargo clippy -p ui --target wasm32-unknown-unknown --all-targets -- -D warnings
+
+      - name: Build ui for wasm32-unknown-unknown
+        # Belt-and-suspenders compile check alongside the clippy run above:
+        # a plain `cargo build` catches the case where `--all-targets` clippy
+        # (which also covers tests/benches) diverges from what actually needs
+        # to compile for the shipped artifact.
+        run: cargo build -p ui --target wasm32-unknown-unknown
 
   linecheck:
     name: linecheck


### PR DESCRIPTION
## Problem

`lint.yml`'s `clippy` job runs `cargo clippy --workspace --all-targets -- -D warnings`, and `test.yml` runs `cargo test --workspace` — both of which do reach the `ui` member crate, but only compiled for the **host** target. `ui` is a Yew/WASM dashboard crate that only ever actually ships compiled for `wasm32-unknown-unknown` (via `trunk build` in `publish.yml`, at release time). clippy's lint set — and even plain compilability — can differ between the host target and wasm32 (cfg-gated code, wasm-bindgen/web-sys API surface, etc.), so a wasm32-only compile error or clippy violation in `ui/src` could sail through every PR green and only be caught when cutting a release.

`ui/Cargo.toml` has its own `[lints.clippy] all = "deny"`, but nothing on a PR ever enforced it against the target `ui` is actually shipped for.

## Fix

Adds a `clippy-ui-wasm` job to `lint.yml`:
- Installs the `wasm32-unknown-unknown` target alongside `clippy` via `dtolnay/rust-toolchain`.
- Runs `cargo clippy -p ui --target wasm32-unknown-unknown --all-targets -- -D warnings`.
- Runs `cargo build -p ui --target wasm32-unknown-unknown` as a belt-and-suspenders compile check.
- Reuses the existing `Swatinem/rust-cache` pattern from the `clippy`/`test` jobs, with its own `shared-key` so wasm32 `target/` artifacts don't collide with the host-target cache entries.

Updated the header comment block in `lint.yml` to explain why the existing `--workspace` host-target clippy run isn't sufficient on its own.

No changes to `ui`'s actual source — confirmed there are no pre-existing clippy violations once enforced against wasm32.

## Verification

Ran the exact new commands locally against the current `ui` source:
- `cargo clippy -p ui --target wasm32-unknown-unknown --all-targets -- -D warnings` → clean, exit 0.
- `cargo build -p ui --target wasm32-unknown-unknown` → clean, exit 0.

Then, to prove the check actually catches regressions, temporarily introduced (and reverted) two separate breaks in `ui/src/main.rs`:
- A trivial clippy violation (`explicit_iter_loop` + `needless_return`) → the clippy command above failed with the expected lint errors.
- A type-mismatch compile error → the build command above failed with `E0308`.

Also re-ran the full existing suite to confirm nothing else regressed:
- `cargo clippy --workspace --all-targets -- -D warnings` → clean.
- `cargo test --workspace` → all tests passing.
- `cargo fmt --check` → clean (confirms `rustfmt` already spans `ui` as a workspace member; no change needed there).

Closes #412