### PR TITLE
test(middlewares): cover empty x-request-id header in logger

### DIFF
--- a/.changeset/logger-empty-request-id-test.md
+++ b/.changeset/logger-empty-request-id-test.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+test(middlewares): cover the empty `x-request-id` header case in `logger`. The handler already falls back to a generated id when an inbound `x-request-id` is empty (`.filter(|header| !header.is_empty())`), but no test exercised that branch — a future edit removing the filter would silently start echoing back an empty correlation id. Test-only change, no behavior change.

--- a/src/middlewares/logger_tests.rs
+++ b/src/middlewares/logger_tests.rs
@@ -114,6 +114,35 @@ async fn logger_reuses_an_inbound_request_id() {
 }
 
 #[tokio::test]
+async fn logger_generates_an_id_when_inbound_request_id_is_empty() {
+    // An empty `x-request-id` (e.g. a proxy that sends the header with no
+    // value) must not be echoed back verbatim — it should be treated the same
+    // as a missing header and get a freshly generated id instead.
+    let app = Router::new()
+        .route("/", get(|| async { "ok" }))
+        .layer(middleware::from_fn(logger));
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/")
+                .header("x-request-id", "")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let id = resp
+        .headers()
+        .get("x-request-id")
+        .expect("x-request-id header set")
+        .to_str()
+        .unwrap();
+    assert_eq!(id.len(), 8, "generated id is an 8-hex-digit counter value");
+}
+
+#[tokio::test]
 async fn logger_gives_concurrent_requests_distinct_generated_ids() {
     let app = Router::new()
         .route("/", get(|| async { "ok" }))


### PR DESCRIPTION
## Why

`logger()` in `src/middlewares/logger.rs` builds a request's correlation id from the inbound `x-request-id` header via:

```rust
.get(REQUEST_ID_HEADER)
.and_then(|header| header.to_str().ok())
.filter(|header| !header.is_empty())
.map(str::to_string)
```

An empty header value (e.g. a proxy or curl invocation sending `x-request-id:` with nothing after it) is a real, reachable case — the `.filter(...)` call correctly falls back to a freshly generated id instead of echoing back an empty string. But `logger_tests.rs` only covered "no header" and "non-empty caller-supplied header"; the empty-header branch had no test.

Without coverage here, a future simplification that drops the `.filter(...)` call would start echoing back an empty correlation id — silently breaking the "pair inbound/outbound log lines" invariant this middleware exists for, and potentially causing concurrent requests to share the same (empty) id in the logs.

## What changed

- `src/middlewares/logger_tests.rs`: one new test, `logger_generates_an_id_when_inbound_request_id_is_empty`, asserting a request sent with an empty `x-request-id` header gets back a freshly generated 8-hex-digit id, not an echoed empty value.
- `.changeset/logger-empty-request-id-test.md`: patch changeset (test-only, no behavior change).

Test-only change — no production code touched.

## Test plan

- [x] `cargo test --workspace middlewares::logger` — 7/7 passing (new test included)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`