### PR TITLE
chore(lint): enable clippy::format_collect workspace-wide

### DIFF
--- a/.changeset/enable-clippy-format-collect.md
+++ b/.changeset/enable-clippy-format-collect.md
@@ -1,0 +1,12 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::format_collect` workspace-wide
+
+Mirrors the existing `format_push_string = "deny"` lint (root `Cargo.toml`), which rejects
+`.push_str(&format!(...))` in favor of writing straight into the buffer with `write!`. This
+adds its sibling for the `.map(|x| format!(...)).collect::<String>()` shape, which has the same
+throwaway-allocation problem but wasn't yet covered. Surfaced one violation in
+`src/routines/service_trigger_tests.rs`, rewritten to fold a `writeln!` directly into the
+accumulator instead of collecting a `Vec` of one-off `format!` strings. No behavior change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,3 +250,9 @@ ignored_unit_patterns = "deny"
 # declaration instead of at a conversion tacked on afterward. The codebase is already clean, so
 # `deny` locks that in.
 string_lit_as_bytes = "deny"
+# Reject `.map(|x| format!(...)).collect::<String>()` in favour of folding a `write!`/`writeln!`
+# directly into a `String` buffer. Like `format_push_string` above, each `format!` call allocates a
+# throwaway `String` only to have `collect` immediately copy its contents into the result and drop
+# it — pure overhead a fold avoids by writing straight into the accumulator. The codebase is
+# already clean, so `deny` locks that in.
+format_collect = "deny"

--- a/src/routines/service_trigger_tests.rs
+++ b/src/routines/service_trigger_tests.rs
@@ -398,9 +398,11 @@ fn trigger_under_concurrency_cap(unique: &str, live_sessions: u32, cap_env: Opti
     let dir = std::env::temp_dir().join(format!("moadim-svc-cap-{}", uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&dir).unwrap();
     let stub = dir.join("tmux");
-    let sessions: String = (0..live_sessions)
-        .map(|i| format!("moadim-other-173000000{i}_1\n"))
-        .collect();
+    let sessions: String = (0..live_sessions).fold(String::new(), |mut acc, i| {
+        use std::fmt::Write as _;
+        let _ = writeln!(acc, "moadim-other-173000000{i}_1");
+        acc
+    });
     std::fs::write(&stub, format!("#!/bin/sh\nprintf '{sessions}'\nexit 0\n")).unwrap();
     #[cfg(unix)]
     std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).unwrap();


### PR DESCRIPTION
## Why

The root crate already `deny`s `clippy::format_push_string`, which rejects `.push_str(&format!(...))` because the `format!` call allocates a throwaway `String` only to have it immediately copied into the target buffer and dropped. `clippy::format_collect` is the sibling lint for the same overhead in the `.map(|x| format!(...)).collect::<String>()` shape, and wasn't enabled anywhere in the workspace yet.

## What

- Added `format_collect = "deny"` to `[lints.clippy]` in root `Cargo.toml`, documented in the same style as its neighbors.
- Fixed the single violation this surfaced, in `src/routines/service_trigger_tests.rs`: replaced `(0..live_sessions).map(|i| format!(...)).collect::<String>()` with a `fold` that `writeln!`s directly into the accumulator. No behavior change — same output string, verified by the passing test.
- `ui` crate checked separately and is already clean under this lint (has its own `[lints.clippy]` table that doesn't inherit root's).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p moadim --all-targets -- -D warnings` (clean, including the new lint)
- [x] `cargo test --bin moadim service_trigger` — all 13 tests pass, including the one exercising the rewritten code
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (no other regressions)

Includes a changeset (`.changeset/enable-clippy-format-collect.md`).

---
This pull request was opened by the "Daemon + Landing auto-improve & auto-merge lint/docs PRs" routine of moadim.