### PR TITLE
chore(lint): enable clippy::similar_names workspace-wide

### DIFF
--- a/.changeset/enable-clippy-similar-names.md
+++ b/.changeset/enable-clippy-similar-names.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::similar_names` workspace-wide
+
+Rejects a binding whose name is a near-miss of another binding already in scope. Surfaced four
+violations: `rmcp::model::ContentBlock::Text(txt) => txt.text.clone()`, repeated across the MCP
+route tests, shadowed an existing local also named `text`. Renamed the match binding to `block`
+in each spot. No behavior change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,3 +256,9 @@ string_lit_as_bytes = "deny"
 # it — pure overhead a fold avoids by writing straight into the accumulator. The codebase is
 # already clean, so `deny` locks that in.
 format_collect = "deny"
+# Reject a binding whose name is a near-miss of another binding already in scope (e.g. `txt` next to
+# `text`) — a reader (or a future edit) can mix the two up since they differ by only a couple of
+# characters. Fixed the four violations this surfaced: a `ContentBlock::Text(txt) => txt.text.clone()`
+# match arm repeated across the MCP route tests, shadowing an existing local also named `text`;
+# renamed the binding to `block`. No behavior change.
+similar_names = "deny"

--- a/src/routes/health/mcp_tests.rs
+++ b/src/routes/health/mcp_tests.rs
@@ -27,7 +27,7 @@ fn health_content_contains_status() {
     let result = handler.health().unwrap();
     let text = &result.content[0];
     let json_str = match &text {
-        rmcp::model::ContentBlock::Text(txt) => txt.text.clone(),
+        rmcp::model::ContentBlock::Text(block) => block.text.clone(),
         _ => panic!("expected text content"),
     };
     let val: serde_json::Value = serde_json::from_str(&json_str).unwrap();

--- a/src/routes/mcp_lock_tests.rs
+++ b/src/routes/mcp_lock_tests.rs
@@ -78,7 +78,7 @@ fn unlock_routines_all_removes_both_sentinels() {
         .unwrap();
     assert!(!result.is_error.unwrap_or(false));
     let text = match &result.content[0] {
-        rmcp::model::ContentBlock::Text(txt) => txt.text.clone(),
+        rmcp::model::ContentBlock::Text(block) => block.text.clone(),
         _ => panic!("expected text content"),
     };
     let val: serde_json::Value = serde_json::from_str(&text).unwrap();
@@ -97,7 +97,7 @@ fn unlock_routines_shared_removes_only_shared() {
         .unwrap();
     assert!(!result.is_error.unwrap_or(false));
     let text = match &result.content[0] {
-        rmcp::model::ContentBlock::Text(txt) => txt.text.clone(),
+        rmcp::model::ContentBlock::Text(block) => block.text.clone(),
         _ => panic!("expected text content"),
     };
     let val: serde_json::Value = serde_json::from_str(&text).unwrap();
@@ -116,7 +116,7 @@ fn unlock_routines_local_removes_only_local() {
         .unwrap();
     assert!(!result.is_error.unwrap_or(false));
     let text = match &result.content[0] {
-        rmcp::model::ContentBlock::Text(txt) => txt.text.clone(),
+        rmcp::model::ContentBlock::Text(block) => block.text.clone(),
         _ => panic!("expected text content"),
     };
     let val: serde_json::Value = serde_json::from_str(&text).unwrap();
@@ -337,7 +337,7 @@ fn unlock_routines_returns_error_when_set_lock_fails() {
 /// Extract and parse the JSON text out of a tool result's first content item.
 fn result_json(result: &CallToolResult) -> serde_json::Value {
     let text = match &result.content[0] {
-        rmcp::model::ContentBlock::Text(txt) => txt.text.clone(),
+        rmcp::model::ContentBlock::Text(block) => block.text.clone(),
         _ => panic!("expected text content"),
     };
     serde_json::from_str(&text).unwrap()

--- a/src/routes/mcp_parity_tests.rs
+++ b/src/routes/mcp_parity_tests.rs
@@ -74,7 +74,7 @@ fn list_agents_tool_returns_array() {
     let result = handler.list_agents().unwrap();
     assert!(!result.is_error.unwrap_or(false));
     let text = match &result.content[0] {
-        rmcp::model::ContentBlock::Text(txt) => txt.text.clone(),
+        rmcp::model::ContentBlock::Text(block) => block.text.clone(),
         _ => panic!("expected text content"),
     };
     let val: serde_json::Value = serde_json::from_str(&text).unwrap();
@@ -96,7 +96,7 @@ fn routine_logs_tool_returns_logs_for_existing_routine() {
         .create_routine(Parameters(make_create_routine_req()))
         .unwrap();
     let text = match &created.content[0] {
-        rmcp::model::ContentBlock::Text(txt) => txt.text.clone(),
+        rmcp::model::ContentBlock::Text(block) => block.text.clone(),
         _ => panic!("expected text content"),
     };
     let id = serde_json::from_str::<serde_json::Value>(&text).unwrap()["id"]
@@ -108,7 +108,7 @@ fn routine_logs_tool_returns_logs_for_existing_routine() {
         .unwrap();
     assert!(!result.is_error.unwrap_or(false));
     let text = match &result.content[0] {
-        rmcp::model::ContentBlock::Text(txt) => txt.text.clone(),
+        rmcp::model::ContentBlock::Text(block) => block.text.clone(),
         _ => panic!("expected text content"),
     };
     let val: serde_json::Value = serde_json::from_str(&text).unwrap();
@@ -135,7 +135,7 @@ fn get_lock_status_returns_unlocked_by_default() {
     let result = handler.get_lock_status().unwrap();
     assert!(!result.is_error.unwrap_or(false));
     let text = match &result.content[0] {
-        rmcp::model::ContentBlock::Text(txt) => txt.text.clone(),
+        rmcp::model::ContentBlock::Text(block) => block.text.clone(),
         _ => panic!("expected text content"),
     };
     let val: serde_json::Value = serde_json::from_str(&text).unwrap();
@@ -155,7 +155,7 @@ fn lock_routines_shared_creates_sentinel_and_returns_status() {
         .unwrap();
     assert!(!result.is_error.unwrap_or(false));
     let text = match &result.content[0] {
-        rmcp::model::ContentBlock::Text(txt) => txt.text.clone(),
+        rmcp::model::ContentBlock::Text(block) => block.text.clone(),
         _ => panic!("expected text content"),
     };
     let val: serde_json::Value = serde_json::from_str(&text).unwrap();
@@ -176,7 +176,7 @@ fn lock_routines_local_creates_sentinel_and_returns_status() {
         .unwrap();
     assert!(!result.is_error.unwrap_or(false));
     let text = match &result.content[0] {
-        rmcp::model::ContentBlock::Text(txt) => txt.text.clone(),
+        rmcp::model::ContentBlock::Text(block) => block.text.clone(),
         _ => panic!("expected text content"),
     };
     let val: serde_json::Value = serde_json::from_str(&text).unwrap();

--- a/src/routes/mcp_prompt_preview_tests.rs
+++ b/src/routes/mcp_prompt_preview_tests.rs
@@ -88,7 +88,7 @@ fn preview_routine_prompt_success_contains_prompt() {
         .unwrap();
     assert!(!create_result.is_error.unwrap_or(false));
     let text = match &create_result.content[0] {
-        rmcp::model::ContentBlock::Text(txt) => txt.text.clone(),
+        rmcp::model::ContentBlock::Text(block) => block.text.clone(),
         _ => panic!("expected text content"),
     };
     let id = serde_json::from_str::<serde_json::Value>(&text).unwrap()["id"]
@@ -101,7 +101,7 @@ fn preview_routine_prompt_success_contains_prompt() {
         .unwrap();
     assert!(!result.is_error.unwrap_or(false));
     let text = match &result.content[0] {
-        rmcp::model::ContentBlock::Text(txt) => txt.text.clone(),
+        rmcp::model::ContentBlock::Text(block) => block.text.clone(),
         _ => panic!("expected text content"),
     };
     let preview: serde_json::Value = serde_json::from_str(&text).unwrap();

--- a/src/routes/mcp_routine_lifecycle_tests.rs
+++ b/src/routes/mcp_routine_lifecycle_tests.rs
@@ -39,7 +39,7 @@ fn snooze_routine_tool_both_modes_set_is_error() {
         .create_routine(Parameters(make_create_routine_req()))
         .unwrap();
     let text = match &result.content[0] {
-        rmcp::model::ContentBlock::Text(txt) => txt.text.clone(),
+        rmcp::model::ContentBlock::Text(block) => block.text.clone(),
         _ => panic!("expected text content"),
     };
     let id = serde_json::from_str::<serde_json::Value>(&text).unwrap()["id"]
@@ -73,7 +73,7 @@ fn snooze_routine_tool_sets_and_clears_snooze() {
         .create_routine(Parameters(make_create_routine_req()))
         .unwrap();
     let text = match &result.content[0] {
-        rmcp::model::ContentBlock::Text(txt) => txt.text.clone(),
+        rmcp::model::ContentBlock::Text(block) => block.text.clone(),
         _ => panic!("expected text content"),
     };
     let id = serde_json::from_str::<serde_json::Value>(&text).unwrap()["id"]
@@ -126,7 +126,7 @@ fn trigger_routine_tool_returns_error_when_disabled() {
         }))
         .unwrap();
     let text = match &result.content[0] {
-        rmcp::model::ContentBlock::Text(txt) => txt.text.clone(),
+        rmcp::model::ContentBlock::Text(block) => block.text.clone(),
         _ => panic!("expected text content"),
     };
     let id = serde_json::from_str::<serde_json::Value>(&text).unwrap()["id"]
@@ -167,7 +167,7 @@ fn set_power_saving_tool_blocks_trigger_without_touching_enabled() {
         .create_routine(Parameters(make_create_routine_req()))
         .unwrap();
     let text = match &result.content[0] {
-        rmcp::model::ContentBlock::Text(txt) => txt.text.clone(),
+        rmcp::model::ContentBlock::Text(block) => block.text.clone(),
         _ => panic!("expected text content"),
     };
     let id = serde_json::from_str::<serde_json::Value>(&text).unwrap()["id"]
@@ -218,7 +218,7 @@ fn list_routine_runs_tool_returns_empty_list_for_existing_routine() {
         .create_routine(Parameters(make_create_routine_req()))
         .unwrap();
     let text = match &created.content[0] {
-        rmcp::model::ContentBlock::Text(txt) => txt.text.clone(),
+        rmcp::model::ContentBlock::Text(block) => block.text.clone(),
         _ => panic!("expected text content"),
     };
     let id = serde_json::from_str::<serde_json::Value>(&text).unwrap()["id"]
@@ -230,7 +230,7 @@ fn list_routine_runs_tool_returns_empty_list_for_existing_routine() {
         .unwrap();
     assert!(!result.is_error.unwrap_or(false));
     let text = match &result.content[0] {
-        rmcp::model::ContentBlock::Text(txt) => txt.text.clone(),
+        rmcp::model::ContentBlock::Text(block) => block.text.clone(),
         _ => panic!("expected text content"),
     };
     let val: serde_json::Value = serde_json::from_str(&text).unwrap();

--- a/src/routes/mcp_tests.rs
+++ b/src/routes/mcp_tests.rs
@@ -132,7 +132,7 @@ fn create_get_update_trigger_delete_routine_success() {
         .unwrap();
     assert!(!result.is_error.unwrap_or(false));
     let text = match &result.content[0] {
-        rmcp::model::ContentBlock::Text(txt) => txt.text.clone(),
+        rmcp::model::ContentBlock::Text(block) => block.text.clone(),
         _ => panic!("expected text content"),
     };
     let id = serde_json::from_str::<serde_json::Value>(&text).unwrap()["id"]
@@ -186,7 +186,7 @@ fn cleanup_workbenches_tool_returns_removed_count() {
     let result = handler.cleanup_workbenches().unwrap();
     assert!(!result.is_error.unwrap_or(false));
     let json_str = match &result.content[0] {
-        rmcp::model::ContentBlock::Text(txt) => txt.text.clone(),
+        rmcp::model::ContentBlock::Text(block) => block.text.clone(),
         _ => panic!("expected text content"),
     };
     let val: serde_json::Value = serde_json::from_str(&json_str).unwrap();

--- a/src/routes/restart/mcp_tests.rs
+++ b/src/routes/restart/mcp_tests.rs
@@ -51,7 +51,7 @@ fn restart_tool_spawns_helper_and_acknowledges() {
     let result = handler.restart().unwrap();
     assert!(!result.is_error.unwrap_or(false));
     let text = match &result.content[0] {
-        rmcp::model::ContentBlock::Text(txt) => txt.text.clone(),
+        rmcp::model::ContentBlock::Text(block) => block.text.clone(),
         _ => panic!("expected text content"),
     };
     let val: serde_json::Value = serde_json::from_str(&text).unwrap();

--- a/src/routes/shutdown/mcp_tests.rs
+++ b/src/routes/shutdown/mcp_tests.rs
@@ -20,7 +20,7 @@ fn shutdown_tool_acknowledges() {
     let result = handler.shutdown().unwrap();
     assert!(!result.is_error.unwrap_or(false));
     let text = match &result.content[0] {
-        rmcp::model::ContentBlock::Text(txt) => txt.text.clone(),
+        rmcp::model::ContentBlock::Text(block) => block.text.clone(),
         _ => panic!("expected text content"),
     };
     let val: serde_json::Value = serde_json::from_str(&text).unwrap();


### PR DESCRIPTION
## Why

`clippy::similar_names` rejects a binding whose name is a near-miss of another binding already in scope (e.g. `txt` next to `text`) — differing by only a couple of characters, the two are easy to mix up on read or on a future edit. Sibling addition to the growing list of `deny`d pedantic lints already in `Cargo.toml`.

## What

Surfaced four violations, all the same shape: `rmcp::model::ContentBlock::Text(txt) => txt.text.clone()` in the MCP route tests, where the `txt` match binding shadowed an existing local also named `text`. Renamed the binding to `block` everywhere this exact pattern appears (23 spots across 8 test files) for consistency, not just the four the lint flagged.

No behavior change — test-only rename plus one new `deny` lint entry.