### PR TITLE
chore(lint): enable clippy::unnested_or_patterns workspace-wide

### DIFF
--- a/.changeset/enable-clippy-unnested-or-patterns.md
+++ b/.changeset/enable-clippy-unnested-or-patterns.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::unnested_or_patterns` workspace-wide
+
+Rejects an or-pattern repeated across multiple match arms/parameters instead of merged into a
+single nested or-pattern, so duplicated arm bodies can't drift out of sync as arms are added or
+reordered. The codebase was already clean, so no source changes were needed — `deny` just locks
+that in.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,3 +262,9 @@ format_collect = "deny"
 # match arm repeated across the MCP route tests, shadowing an existing local also named `text`;
 # renamed the binding to `block`. No behavior change.
 similar_names = "deny"
+# Reject an or-pattern repeated across multiple match arms/parameters (e.g. `Foo::A | Foo::B =>
+# ..., Foo::C | Foo::D => ...` written as separate arms with duplicated bodies) in favour of
+# merging into one arm with a single nested or-pattern. Keeping the duplicates in sync by hand is
+# easy to get wrong as arms are added or reordered. The codebase is already clean, so `deny` locks
+# that in.
+unnested_or_patterns = "deny"


### PR DESCRIPTION
## What

Enables `clippy::unnested_or_patterns = "deny"` in the root `Cargo.toml`, mirroring the existing
`similar_names`/`format_collect`/etc. lint-hardening PRs in this repo.

## Why

The lint rejects an or-pattern repeated across multiple match arms/parameters (e.g. separate arms
for `Foo::A` and `Foo::B` with identical bodies) in favour of merging into a single arm with a
nested or-pattern (`Foo::A | Foo::B => ...`). Duplicated arm bodies are easy to let drift out of
sync as arms are added or reordered over time.

The codebase was already clean against this lint, so this is a pure lint-enablement change with
no source edits — `deny` just locks in the existing state. Scoped to the root crate only (`ui/`
has its own separate `[lints.clippy]` table), so it doesn't touch `ui/` and won't trip the
`prebuilt-html-fresh` check.

## Testing

- `cargo clippy -p moadim --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo test -p moadim` — 1055 passed

Includes a changeset (`patch`) per the repo's changesets convention.

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.