### PR TITLE
chore(deps): bump clap and uuid to latest patch releases

### DIFF
--- a/.changeset/bump-clap-uuid-patch.md
+++ b/.changeset/bump-clap-uuid-patch.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Bump `clap` (4.6.1 → 4.6.2) and `uuid` (1.23.5 → 1.24.0) to their latest compatible patch releases. No behavior change.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -279,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2520,9 +2520,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.23.5"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",


### PR DESCRIPTION
## Why

Dependabot in this repo only tracks the JS/npm side (\`javascript\`/\`dependencies\` labels on the client workspace) — the Rust dependency graph has no automated bump PRs. \`cargo outdated\` currently shows two root-crate deps behind their latest compatible patch:

- \`clap\` 4.6.1 → 4.6.2
- \`uuid\` 1.23.5 → 1.24.0

Both are within the existing unpinned \`"4"\` / \`"1"\` semver ranges in \`Cargo.toml\`, so this is a \`Cargo.lock\`-only bump.

## What

- \`cargo update -p clap -p uuid\`
- Changeset noting the patch bump.

## Testing

- \`cargo test --workspace\`: 307 passed.
- \`cargo clippy --workspace --all-targets -- -D warnings\`: clean.
- \`cargo fmt --check\`: clean.