### PR TITLE
chore(lint): enable clippy::literal_string_with_formatting_args workspace-wide

### DIFF
--- a/.changeset/enable-clippy-literal-string-with-formatting-args.md
+++ b/.changeset/enable-clippy-literal-string-with-formatting-args.md
@@ -1,0 +1,12 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::literal_string_with_formatting_args` workspace-wide
+
+Denies a string literal that looks like a `format!`-family placeholder (`"{name}"`) sitting
+outside a formatting macro — usually a leftover `format!`/`println!` argument that got moved
+into a plain string and silently stopped interpolating. Surfaced 2 violations in
+`routines/command.rs::substitute`, both intentional `String::replace` placeholder tokens rather
+than formatting-macro arguments; annotated with a scoped `#[allow(reason = ...)]` explaining why.
+No behavior change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,3 +276,9 @@ unnested_or_patterns = "deny"
 # reads passed straight into a constructor that never touched the original again. Fixed by moving
 # the original instead. The codebase is otherwise already clean, so `deny` locks that in.
 redundant_clone = "deny"
+# Reject a string literal that looks like a `format!`-family placeholder (`"{name}"`) sitting
+# outside a formatting macro — usually a leftover `format!`/`println!` arg that got moved into a
+# plain string and silently stopped interpolating. Fixes the 2 violations this surfaced in
+# `routines/command.rs::substitute`, both intentional `String::replace` placeholder tokens (not
+# formatting-macro arguments), which are now annotated with a scoped `#[allow]` explaining why.
+literal_string_with_formatting_args = "deny"

--- a/src/routines/command.rs
+++ b/src/routines/command.rs
@@ -118,6 +118,10 @@ pub(crate) fn compose_prompt(routine: &Routine) -> String {
 ///
 /// `{prompt}` expands to a shell command substitution that reads `prompt.md` from the agent's
 /// cwd (the workbench), so the full prompt is passed as a single argument to the agent process.
+#[allow(
+    clippy::literal_string_with_formatting_args,
+    reason = "these are literal `String::replace` placeholder tokens, not `format!`-family arguments — there is no formatting macro here to move them into"
+)]
 pub(crate) fn substitute(template: &str, workbench: &str, prompt_file: &str) -> String {
     template
         .replace("{workbench}", workbench)


### PR DESCRIPTION
## What

Enables `clippy::literal_string_with_formatting_args` (deny) workspace-wide, continuing the incremental clippy-lint-enablement series already in progress on this repo.

## Why

The lint rejects a string literal that looks like a `format!`-family placeholder (`"{name}"`) sitting outside a formatting macro — usually a sign that a `format!`/`println!` argument got moved into a plain string and silently stopped interpolating.

Enabling it surfaced 2 violations, both in `routines/command.rs::substitute`:

```rust
template
    .replace("{workbench}", workbench)
    .replace("{prompt_file}", prompt_file)
```

These are intentional `String::replace` placeholder tokens, not formatting-macro arguments — there's no macro here to move them into. Rather than rewrite working, correct code, they're annotated with a scoped `#[allow(clippy::literal_string_with_formatting_args, reason = "...")]` on the function, matching this repo's existing convention (`allow_attributes_without_reason = "deny"`) of requiring a documented reason for every suppression.

No behavior change; `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings` (native + `wasm32-unknown-unknown`), `cargo test --workspace`, `cargo llvm-cov --fail-under-lines 100`, and `linecheck` all pass locally.

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.