### PR TITLE
fix(client): restore abstime hover tooltips lost in the Yew-to-React port

### DIFF
--- a/.changeset/client-abstime-tooltips.md
+++ b/.changeset/client-abstime-tooltips.md
@@ -1,0 +1,13 @@
+---
+"moadim": patch
+---
+
+Fix the React client (`client/`) silently dropping the absolute-timestamp hover tooltip that the
+original Yew UI (`ui/`) shows next to every relative "N ago" time. `ui/src/cron_utils.rs`'s
+`abstime` had no TypeScript port at all, so the "STARTED"/"UPDATED" cells in
+`RecentRunsTable.tsx`/`RoutineRow.tsx` rendered no `title`, `RoutineHistory.tsx`'s run-row title
+carried only the workbench name, and `RunHistorySparkline.tsx`'s per-tick tooltip omitted the
+absolute time — all despite each file being documented as a "direct port" of its Rust
+counterpart. Adds `abstime` to `client/src/lib/cronUtils.ts` (mirroring the Rust formatting and
+its zero/out-of-range fallbacks) and wires it into the four call sites so hovering a relative time
+in the React client shows the same wall-clock timestamp the Yew UI has always shown.

--- a/client/src/lib/cronUtils.test.ts
+++ b/client/src/lib/cronUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { describeCronLive, normalizeCron, reltime } from "./cronUtils";
+import { abstime, describeCronLive, normalizeCron, reltime } from "./cronUtils";
 
 describe("normalizeCron", () => {
   it("passes through empty/blank", () => {
@@ -62,5 +62,22 @@ describe("reltime", () => {
     expect(reltime(now - 5 * 60)).toBe("5m ago");
     expect(reltime(now - 3 * 3_600)).toBe("3h ago");
     expect(reltime(now - 2 * 86_400)).toBe("2d ago");
+  });
+});
+
+describe("abstime", () => {
+  it("returns a dash for 0", () => {
+    expect(abstime(0)).toBe("—");
+  });
+
+  it("formats a known instant in local time, zero-padded", () => {
+    // Built via the local `Date` constructor so the expected string matches regardless of the
+    // host's timezone, mirroring `abstime_formats_a_known_instant` in `ui/src/cron_utils_tests.rs`.
+    const d = new Date(2026, 5, 21, 12, 0, 30); // June (0-indexed) 21, 2026, 12:00:30
+    expect(abstime(Math.floor(d.getTime() / 1000))).toBe("Jun 21, 2026 12:00");
+  });
+
+  it("falls back to a dash for an out-of-range instant", () => {
+    expect(abstime(Number.MAX_SAFE_INTEGER)).toBe("—");
   });
 });

--- a/client/src/lib/cronUtils.ts
+++ b/client/src/lib/cronUtils.ts
@@ -33,3 +33,32 @@ export function reltime(ts: number): string {
   if (diff < 86_400) return `${Math.floor(diff / 3_600)}h ago`;
   return `${Math.floor(diff / 86_400)}d ago`;
 }
+
+const MONTHS_ABBR = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+] as const;
+
+/**
+ * Absolute local (browser timezone) rendering of a unix-seconds timestamp, e.g.
+ * "Jun 21, 2026 12:00". Meant as a tooltip companion to `reltime`'s relative "N ago" text, so
+ * hovering reveals wall-clock time. Matches `ui/src/cron_utils.rs`'s `abstime`.
+ */
+export function abstime(ts: number): string {
+  if (ts === 0) return "—";
+  const d = new Date(ts * 1000);
+  if (Number.isNaN(d.getTime())) return "—";
+  const day = String(d.getDate()).padStart(2, "0");
+  const hm = `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+  return `${MONTHS_ABBR[d.getMonth()]} ${day}, ${d.getFullYear()} ${hm}`;
+}

--- a/client/src/pages/overview/RecentRunsTable.tsx
+++ b/client/src/pages/overview/RecentRunsTable.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import type { FleetRunSummary } from "../../api/hooks";
-import { reltime } from "../../lib/cronUtils";
+import { abstime, reltime } from "../../lib/cronUtils";
 import { fmtRunDuration, runStatusClass, runStatusLabel } from "../../lib/runDisplay";
 
 /**
@@ -49,7 +49,9 @@ export function RecentRunsTable({ runs, loading }: { runs: FleetRunSummary[]; lo
                 <Link to={`/routines?history=${encodeURIComponent(run.routine_id)}`}>{run.routine_title}</Link>
               </td>
               <td>
-                <div className="cell-time">{reltime(run.started_at)}</div>
+                <div className="cell-time" title={abstime(run.started_at)}>
+                  {reltime(run.started_at)}
+                </div>
               </td>
               <td>
                 <span className="cell-meta">

--- a/client/src/pages/routines/RoutineHistory.tsx
+++ b/client/src/pages/routines/RoutineHistory.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useRoutineRuns, useRunLog } from "../../api/hooks";
 import { fmtFreshness } from "../../components/RefreshControl";
-import { reltime } from "../../lib/cronUtils";
+import { abstime, reltime } from "../../lib/cronUtils";
 import { fmtRetention, fmtRunDuration, runStatusClass, runStatusLabel } from "../../lib/runDisplay";
 import { LogViewer } from "./LogViewer";
 
@@ -77,7 +77,7 @@ export function RoutineHistory({ id, title, onBack }: RoutineHistoryProps) {
                 return (
                   <tr key={run.workbench} className={isSelected ? "row-selected" : ""}>
                     <td>
-                      <div className="cell-time" title={run.workbench}>
+                      <div className="cell-time" title={`${run.workbench} · ${abstime(run.started_at)}`}>
                         {reltime(run.started_at)}
                       </div>
                     </td>

--- a/client/src/pages/routines/RoutineRow.tsx
+++ b/client/src/pages/routines/RoutineRow.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { FleetRunSummary, RoutineResponse } from "../../api/hooks";
-import { reltime } from "../../lib/cronUtils";
+import { abstime, reltime } from "../../lib/cronUtils";
 import { fmtUntil, fmtWhen, nextFireAfter, nextFires } from "../../lib/schedule";
 import {
   DUE_SOON_WINDOW_MS,
@@ -178,7 +178,9 @@ export function RoutineRow({
         </label>
       </td>
       <td>
-        <div className="cell-time">{updated}</div>
+        <div className="cell-time" title={abstime(r.updated_at)}>
+          {updated}
+        </div>
       </td>
       <td>
         <div className="row-actions">

--- a/client/src/pages/routines/RunHistorySparkline.tsx
+++ b/client/src/pages/routines/RunHistorySparkline.tsx
@@ -1,5 +1,5 @@
 import type { FleetRunSummary } from "../../api/hooks";
-import { reltime } from "../../lib/cronUtils";
+import { abstime, reltime } from "../../lib/cronUtils";
 import { runStatusLabel } from "../../lib/runDisplay";
 
 const TICK_W = 6;
@@ -44,7 +44,7 @@ export function RunHistorySparkline({ runs }: RunHistorySparklineProps) {
           fill={FILL[run.status]}
           className={`spark-tick ${run.status}`}
         >
-          <title>{`${runStatusLabel(run.status)} · ${reltime(run.started_at)}`}</title>
+          <title>{`${runStatusLabel(run.status)} · ${reltime(run.started_at)} (${abstime(run.started_at)})`}</title>
         </rect>
       ))}
     </svg>


### PR DESCRIPTION
## Why

`client/` (the React dashboard) is being built out as a direct, file-by-file port of the original Yew/WASM UI (`ui/`) — most files carry an explicit "Direct port of `ui/src/...`" doc comment, and their behavior is expected to match.

`ui/src/cron_utils.rs`'s `abstime()` renders an absolute wall-clock timestamp (`"Jun 21, 2026 12:00"`) and is used everywhere the UI shows a relative "N ago"/"Nm ago" time, as the `title` attribute for a hover tooltip:

- `overview_recent_runs.rs` — STARTED cell
- `routines/row.rs` — UPDATED cell
- `routines/history.rs` — run-row title (`"{workbench} · {abstime}"`)
- `routines/sparkline.rs` — per-tick tooltip (`"{status} · {reltime} ({abstime})"`)

The TypeScript port never gained an `abstime` function at all, so the equivalent React components silently regressed:

- `RecentRunsTable.tsx` — STARTED cell has no tooltip
- `RoutineRow.tsx` — UPDATED cell has no tooltip
- `RoutineHistory.tsx` — run-row title carries only the workbench name, missing the absolute time
- `RunHistorySparkline.tsx` — per-tick tooltip is missing the `(abstime)` suffix

An operator hovering a relative time in the React client currently can't see the exact timestamp the Yew UI has always shown there.

## What

- Add `abstime()` to `client/src/lib/cronUtils.ts`, mirroring the Rust formatting (`"MMM DD, YYYY HH:MM"`) and its `0`/out-of-range fallbacks to `"—"`.
- Wire it into the four call sites above so their tooltips match the Rust UI again.
- Add unit tests for `abstime` mirroring `ui/src/cron_utils_tests.rs`'s cases (zero placeholder, a known instant, an out-of-range instant).

## Test plan

- [x] `pnpm --filter client typecheck` — passes
- [x] `pnpm --filter client lint` — passes
- [x] `pnpm --filter client test` — 320/320 passing (incl. 3 new `abstime` tests)
- [x] `cargo fmt --check` — clean (no Rust files touched)
- [x] Changeset added (`.changeset/client-abstime-tooltips.md`, patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)