### PR TITLE
chore(lint): enable clippy::large_stack_arrays workspace-wide

### DIFF
--- a/.changeset/enable-clippy-large-stack-arrays.md
+++ b/.changeset/enable-clippy-large-stack-arrays.md
@@ -1,0 +1,11 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::large_stack_arrays` workspace-wide
+
+Denies a local array literal over 512000 bytes — a value that size belongs on the heap
+(`Vec`/`Box`), not the stack. A daemon process runs long-lived worker threads with a fixed,
+comparatively small stack, so an oversized stack array is a latent stack-overflow risk that only
+surfaces under the right call depth, unlike a heap allocation which fails safely. The codebase was
+already clean, so this surfaced 0 violations. No behavior change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -282,3 +282,9 @@ redundant_clone = "deny"
 # `routines/command.rs::substitute`, both intentional `String::replace` placeholder tokens (not
 # formatting-macro arguments), which are now annotated with a scoped `#[allow]` explaining why.
 literal_string_with_formatting_args = "deny"
+# Reject a local array literal over 512000 bytes — a value that size belongs on the heap
+# (`Vec`/`Box`), not the stack. A daemon process runs long-lived worker threads with a fixed,
+# comparatively small stack, so an oversized stack array is a latent stack-overflow risk that only
+# surfaces under the right call depth, unlike a heap allocation which fails safely. The codebase is
+# already clean, so `deny` locks that in.
+large_stack_arrays = "deny"


### PR DESCRIPTION
## Why

`large_stack_arrays` isn't among the clippy lints this repo has been incrementally locking in (see the growing `[lints.clippy]` table in `Cargo.toml`). It denies a local array literal over 512000 bytes, which belongs on the heap (`Vec`/`Box`) rather than the stack.

A daemon process runs long-lived worker threads with a fixed, comparatively small stack. An oversized stack array is a latent stack-overflow risk that only surfaces under the right call depth — unlike a heap allocation, which fails safely (OOM/error) instead of corrupting the stack.

## What

- Adds `large_stack_arrays = "deny"` to `[lints.clippy]` in `Cargo.toml`, with the same rationale-comment style as the neighboring entries.
- The codebase was already clean: 0 violations surfaced, so no source changes beyond the lint table. No behavior change.
- Adds a changeset per the repo's Changesets convention.

## Test plan

Ran the full local pre-push suite (`.githooks/pre-push`) against this change:
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo clippy -p ui --target wasm32-unknown-unknown --all-targets -- -D warnings`
- [x] `cargo test --workspace` (307 passed)
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (100% lines)
- [x] `linecheck --max-lines 500` over `src/` + `ui/src/`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`

🤖 Generated with [Claude Code](https://claude.com/claude-code)