### PR TITLE
chore(lint): enable clippy::redundant_clone in the ui crate

### DIFF
--- a/.changeset/enable-clippy-redundant-clone-ui.md
+++ b/.changeset/enable-clippy-redundant-clone-ui.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::redundant_clone` in the `ui` crate
+
+Mirrors the root crate's `redundant_clone = "deny"` (root `Cargo.toml`) — the `ui` crate has
+its own `[lints.clippy]` table and doesn't inherit root's extended deny-list, so this never
+applied to `ui/src` despite CI's `clippy` job running `--workspace`. The `ui` crate was already
+clean, so this surfaced 0 violations. No behavior change.

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -303,3 +303,10 @@ string_lit_as_bytes = "deny"
 # table and doesn't inherit root's extended deny-list, so this never applied to `ui/src` despite
 # CI's `clippy` job running `--workspace`.
 ignored_unit_patterns = "deny"
+# Reject a `.clone()` whose result is never mutated and whose source is never used again after
+# the clone — the clone is pure overhead, since the original could have been moved or borrowed
+# instead. Mirrors the root crate's `redundant_clone = "deny"` (see Cargo.toml) — the `ui` crate
+# has its own `[lints.clippy]` table and doesn't inherit root's extended deny-list, so this never
+# applied to `ui/src` despite CI's `clippy` job running `--workspace`. The `ui` crate is already
+# clean, so `deny` locks that in.
+redundant_clone = "deny"


### PR DESCRIPTION
## Why

The root crate denies `clippy::redundant_clone`, but `ui/Cargo.toml` has its own `[lints.clippy]` table (no `workspace = true` inheritance), so the lint never actually applied to `ui/src` despite CI's `clippy` job running `--workspace`. Same gap as the already-open #1209 (`missing_docs`), just for a different lint — this repo has been closing these one at a time (`unused_self`, `wildcard_imports`, `unwrap_used`, `map_unwrap_or`, `match_same_arms`, …).

## What

- Adds `redundant_clone = "deny"` to `ui/Cargo.toml`, mirroring the root crate's existing entry.
- No source changes — the `ui` crate was already clean (0 violations).
- `.changeset/enable-clippy-redundant-clone-ui.md` added (patch).

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p ui --target wasm32-unknown-unknown --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

---
This pull request was opened by the "Daemon + Landing auto-improve & auto-merge lint/docs PRs" routine of moadim.