### PR TITLE
chore(deps): bump tokio to 1.52.4 and console_log to 1.1.0

### DIFF
--- a/.changeset/bump-tokio-console-log.md
+++ b/.changeset/bump-tokio-console-log.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Bump `tokio` (1.52.3 → 1.52.4) and `console_log` (1.0.0 → 1.1.0) to their latest compatible releases. No behavior change.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "console_log"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
+checksum = "86919cef3e37b9356ccf54d4421208c17ecfda01beae61393e7ffd72916c0ef1"
 dependencies = [
  "log",
  "web-sys",
@@ -2201,9 +2201,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "317fafbbe3f02fc663dad00ea6186197de963cd4190e86a26d8d0fae095539af"
 dependencies = [
  "bytes",
  "libc",


### PR DESCRIPTION
## Why

`cargo outdated --workspace` shows two Rust crates behind their latest compatible release, neither covered by any currently-open dependency PR (the open dependabot PRs in this repo are all JS/npm deps):

- `tokio` 1.52.3 → 1.52.4 (patch)
- `console_log` 1.0.0 → 1.1.0 (minor, used only by the `ui` crate)

## What changed

- `cargo update -p tokio -p console_log` — `Cargo.lock` only, no `Cargo.toml` changes (both are already declared as loose `"1"` version requirements).
- Added a changeset (`patch`).

No behavior change.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (312 passed)
- [x] `cargo fmt --check`