### PR TITLE
feat(cli): add `moadim logs <id>` as a top-level shortcut

### DIFF
--- a/.changeset/cli-logs-shortcut.md
+++ b/.changeset/cli-logs-shortcut.md
@@ -1,0 +1,12 @@
+---
+"moadim": patch
+---
+
+feat(cli): add `moadim logs <id>` as a top-level shortcut for `moadim routines logs <id>`
+
+The daemon has served a routine's newest run log over `GET /api/v1/routines/{id}/logs` since
+`svc_logs()` landed, reachable from the CLI only via `moadim routines logs <id>`. `trigger`
+already gets a bare top-level shortcut alongside its `routines trigger` form; `logs` did not
+(issue #332). `moadim logs <id>` now mirrors that duality: same route, same exit-code
+conventions (`0` on success including an empty not-yet-run log, non-zero on an unknown routine,
+`3` when no daemon is reachable), documented in `--help` and shell completions.

--- a/src/cli/completions.rs
+++ b/src/cli/completions.rs
@@ -65,6 +65,7 @@ pub(super) fn build_cli() -> ClapCommand {
         )
         .subcommand(ClapCommand::new("cleanup").arg(json_flag()))
         .subcommand(ClapCommand::new("trigger").alias("run").arg(Arg::new("id")))
+        .subcommand(ClapCommand::new("logs").arg(Arg::new("id")))
         .subcommand(ClapCommand::new("install"))
         .subcommand(ClapCommand::new("uninstall"))
         .subcommand(

--- a/src/cli/completions_tests.rs
+++ b/src/cli/completions_tests.rs
@@ -13,6 +13,7 @@ const EXPECTED_VERBS: &[&str] = &[
     "status",
     "cleanup",
     "trigger",
+    "logs",
     "install",
     "uninstall",
     "machine",

--- a/src/cli/json_tests.rs
+++ b/src/cli/json_tests.rs
@@ -360,3 +360,38 @@ fn trigger_reports_not_running_when_no_server() {
     let _addr = EnvGuard::set(BIND_ADDR_ENV, UNREACHABLE_ADDR);
     assert_eq!(trigger("some-id").unwrap(), EXIT_NOT_RUNNING);
 }
+
+#[test]
+fn logs_prints_the_response_body_when_server_responds() {
+    let server = FakeServer::start(200, "line one\nline two\n".to_string());
+    let _addr = EnvGuard::set(BIND_ADDR_ENV, &server.addr);
+    assert_eq!(logs("some-id").unwrap(), 0);
+}
+
+#[test]
+fn logs_succeeds_on_an_empty_body() {
+    // No run yet: `svc_logs` returns an empty string, which is a normal, successful outcome.
+    let server = FakeServer::start(200, String::new());
+    let _addr = EnvGuard::set(BIND_ADDR_ENV, &server.addr);
+    assert_eq!(logs("some-id").unwrap(), 0);
+}
+
+#[test]
+fn logs_reports_unknown_routine_on_404() {
+    let server = FakeServer::start(404, String::new());
+    let _addr = EnvGuard::set(BIND_ADDR_ENV, &server.addr);
+    assert!(logs("missing").is_err());
+}
+
+#[test]
+fn logs_errors_on_unexpected_status() {
+    let server = FakeServer::start(500, String::new());
+    let _addr = EnvGuard::set(BIND_ADDR_ENV, &server.addr);
+    assert!(logs("some-id").is_err());
+}
+
+#[test]
+fn logs_reports_not_running_when_no_server() {
+    let _addr = EnvGuard::set(BIND_ADDR_ENV, UNREACHABLE_ADDR);
+    assert_eq!(logs("some-id").unwrap(), EXIT_NOT_RUNNING);
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -103,6 +103,13 @@ pub enum Command {
         /// UUID of the routine to trigger.
         id: String,
     },
+    /// Print a routine's newest run log (`agent.log`) to stdout, by UUID. A top-level shorthand
+    /// for `moadim routines logs <id>`, mirroring the `trigger`/`routines trigger` duality
+    /// (issue #332).
+    Logs {
+        /// UUID of the routine whose log to print.
+        id: String,
+    },
     /// Register the daemon as an OS service (launchd on macOS, systemd user on Linux).
     Install,
     /// Remove the OS service registration created by [`Command::Install`].
@@ -165,6 +172,12 @@ pub fn parse(args: impl IntoIterator<Item = String>) -> Command {
         // behavior). `run` is kept as a hidden back-compat alias of the original subcommand name.
         Some("trigger" | "run") => match args.get(1) {
             Some(id) => Command::Trigger { id: id.clone() },
+            None => Command::Help,
+        },
+        // `logs <id>` mirrors `trigger <id>`: without an id there is nothing to print, so fall
+        // back to help rather than silently no-op.
+        Some("logs") => match args.get(1) {
+            Some(id) => Command::Logs { id: id.clone() },
             None => Command::Help,
         },
         Some("install") => Command::Install,
@@ -238,6 +251,7 @@ pub fn help_text() -> String {
          \x20                          reachable or SECS elapse, default 30, instead of checking once)\n\
          \x20   cleanup [--json]       reap finished, expired routine workbenches now\n\
          \x20   trigger <id>           trigger a routine to run now, outside its schedule\n\
+         \x20   logs <id>              print a routine's newest run log (agent.log) to stdout\n\
          \x20   install                register moadim as an OS service (launchd / systemd user)\n\
          \x20   uninstall              remove the OS service registration and the managed crontab block\n\
          \x20   machine <show|set|list> show/set this machine's identity, or list machines referenced\n\
@@ -423,7 +437,7 @@ fn stop_json(running: bool, pid: Option<u32>) -> String {
 
 #[path = "query.rs"]
 mod cli_query;
-pub use cli_query::{cleanup, status, trigger};
+pub use cli_query::{cleanup, logs, status, trigger};
 #[cfg(test)]
 use cli_query::{
     cleanup_json, fetch_health, humanize_bytes, parse_health, status_json, HealthInfo,

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -3,8 +3,9 @@
 //! lifecycle (start/stop/restart), which remain in `cli/mod.rs`.
 
 use super::{
-    bind_addr, http_request, http_request_with_body, is_running, liveness_exit_code,
-    parse_freed_bytes, parse_removed_count, read_pid_file, wait_until, Duration,
+    bind_addr, http_request, http_request_json, http_request_with_body, is_running,
+    liveness_exit_code, parse_freed_bytes, parse_removed_count, read_pid_file, wait_until,
+    Duration,
 };
 
 /// Ask a running server to reap finished, expired routine run workbenches now, and print the count.
@@ -81,6 +82,32 @@ pub fn trigger(id: &str) -> anyhow::Result<i32> {
             anyhow::bail!("no routine with id {id}");
         }
         Ok(status) => {
+            anyhow::bail!("unexpected response from server: HTTP {status}");
+        }
+        Err(_) => {
+            println!("moadim is not running");
+            Ok(liveness_exit_code(false))
+        }
+    }
+}
+
+/// Print a routine's newest run log (`agent.log`) to stdout via `GET /api/v1/routines/{id}/logs`
+/// — the same route `moadim routines logs <id>` already drives, exposed here as a shorter
+/// top-level alias (issue #332). An empty log (no run yet) prints nothing and exits `0`, matching
+/// `svc_logs` returning an empty string. Uses the generous data-op timeout (like other data-plane
+/// commands) rather than the liveness-probe one, since reading a large log is real work.
+pub fn logs(id: &str) -> anyhow::Result<i32> {
+    match http_request_json("GET", &format!("/api/v1/routines/{id}/logs"), None) {
+        Ok((200, body)) => {
+            if !body.is_empty() {
+                println!("{body}");
+            }
+            Ok(liveness_exit_code(true))
+        }
+        Ok((404, _)) => {
+            anyhow::bail!("no routine with id {id}");
+        }
+        Ok((status, _)) => {
             anyhow::bail!("unexpected response from server: HTTP {status}");
         }
         Err(_) => {

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -217,6 +217,22 @@ fn trigger_without_an_id_falls_back_to_help() {
 }
 
 #[test]
+fn logs_command_carries_the_routine_id() {
+    assert_eq!(
+        parse(argv(&["logs", "abc-123"])),
+        Command::Logs {
+            id: "abc-123".to_string()
+        }
+    );
+}
+
+#[test]
+fn logs_without_an_id_falls_back_to_help() {
+    // Nothing to print without an id, so it shows usage rather than silently no-op'ing.
+    assert_eq!(parse(argv(&["logs"])), Command::Help);
+}
+
+#[test]
 fn restart_rotation_line_shows_old_and_new_pid() {
     assert_eq!(
         restart_rotation_line(Some(123), 456),

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,7 @@ async fn main() -> anyhow::Result<()> {
         cli::Command::Cleanup { json } => std::process::exit(cli::cleanup(json)?),
         cli::Command::Stop { json, quiet } => std::process::exit(cli::stop(json, quiet)?),
         cli::Command::Trigger { id } => std::process::exit(cli::trigger(&id)?),
+        cli::Command::Logs { id } => std::process::exit(cli::logs(&id)?),
         cli::Command::Background => cli::run_background(),
         cli::Command::Restart {
             json,


### PR DESCRIPTION
## Why

`moadim` already serves a routine's newest run log over `GET /api/v1/routines/{id}/logs`, reachable from the CLI via `moadim routines logs <id>`, but there's no bare top-level form — even though `trigger` gets exactly that duality (`moadim trigger <id>` alongside `routines trigger <id>`). Issue #332 asked for a top-level `moadim logs <routine>` specifically so an operator can check what a run did without leaving the terminal or hand-crafting an HTTP call. This closes that gap by adding the shortcut, reusing the server-side plumbing that already exists.

## What

- `Command::Logs { id }`, parsed the same way as `trigger`/`run` (no id falls back to help rather than silently no-op'ing).
- `cli::logs(id)` in `cli/query.rs`, mirroring `trigger()`'s shape: `GET /api/v1/routines/{id}/logs` via the existing `http_request_json` seam (respects `MOADIM_BIND_ADDR`), prints the body on `200` (silently succeeds on an empty not-yet-run log), reports "no routine with id" on `404`, and exits `EXIT_NOT_RUNNING` (`3`) when no daemon is reachable — the same conventions `status`/`cleanup`/`trigger` already use.
- Documented in `--help` and the generated shell-completion script.

## Checks

- `cargo fmt --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test` (1063 tests, incl. new `logs_*` parse/query tests) ✅
- `cargo llvm-cov --ignore-filename-regex 'src/main\.rs'` — every line touched by this PR (`cli/mod.rs`, `cli/query.rs`, `cli/completions.rs`) is 100% covered locally

## Out of scope

Streaming/`--follow`, pagination, and ANSI normalization stay out of scope, same as the parent issue notes (tracked separately under #279/#278/#268).

Closes #332.

---
This pull request was opened by the *Daemon + Landing auto-improve & auto-merge lint/docs PRs* routine of moadim.