### PR TITLE
chore(lint): enable clippy::literal_string_with_formatting_args in the ui crate

### DIFF
--- a/.changeset/enable-clippy-literal-string-with-formatting-args-ui.md
+++ b/.changeset/enable-clippy-literal-string-with-formatting-args-ui.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::literal_string_with_formatting_args` in the `ui` crate
+
+Mirrors the root crate's `literal_string_with_formatting_args = "deny"` (root `Cargo.toml`) —
+the `ui` crate has its own `[lints.clippy]` table and doesn't inherit root's extended deny-list,
+so this never applied to `ui/src` despite CI's `clippy` job running `--workspace`. The `ui` crate
+was already clean, so this surfaced 0 violations. No behavior change.

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -336,3 +336,11 @@ many_single_char_names = "deny"
 # applied to `ui/src` despite CI's `clippy` job running `--workspace`. The `ui` crate is already
 # clean, so `deny` locks that in.
 redundant_clone = "deny"
+# Reject a string literal that looks like a `format!`-family placeholder (`"{name}"`) sitting
+# outside a formatting macro — usually a leftover `format!`/`println!` arg that got moved into a
+# plain string and silently stopped interpolating. Mirrors the root crate's
+# `literal_string_with_formatting_args = "deny"` (see Cargo.toml) — the `ui` crate has its own
+# `[lints.clippy]` table and doesn't inherit root's extended deny-list, so this never applied to
+# `ui/src` despite CI's `clippy` job running `--workspace`. The `ui` crate is already clean, so
+# `deny` locks that in.
+literal_string_with_formatting_args = "deny"


### PR DESCRIPTION
## Why

Root `Cargo.toml` denies `clippy::literal_string_with_formatting_args` workspace-wide (added in #1226), but the `ui` crate has its own `[lints.clippy]` table and does **not** inherit the workspace lints table via `workspace = true`. That means this lint — like several others before it (`redundant_clone`, `format_collect`, `similar_names`, `large_stack_arrays`, `unnested_or_patterns`, etc., see #1230, #1231, #1237, #1235, #1234) — silently never applied to `ui/src`, even though CI's `clippy` job runs with `--workspace` and looked like it should have caught it.

This lint specifically catches a string literal that looks like a `format!`-family placeholder (e.g. `"{name}"`) sitting outside a formatting macro — typically a leftover `format!`/`println!` argument that got moved into a plain string and silently stopped interpolating. It's a real correctness footgun worth having in both crates, not just the root one.

## What

Adds `literal_string_with_formatting_args = "deny"` to `ui/Cargo.toml`'s `[lints.clippy]` table, with a comment mirroring the existing convention used for every other lint in that file.

## Verification

- `cargo clippy -p ui --all-targets -- -D warnings` — 0 violations (the `ui` crate was already clean for this lint)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo test --workspace` — 1063 + 312 tests passing
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% line coverage maintained

No behavior change; this only locks in an already-clean state, same as the other lint-mirroring PRs in this series.