### PR TITLE
fix(machine): serialize machine.local.toml writes to close a lost-update race

### DIFF
--- a/.changeset/machine-toml-rmw-race.md
+++ b/.changeset/machine-toml-rmw-race.md
@@ -1,0 +1,14 @@
+---
+"moadim": patch
+---
+
+fix(machine): serialize `machine.local.toml` writes to close a lost-update race
+
+`set_machine` and `set_max_concurrent_runs_override` each read the whole `machine.local.toml`,
+mutate one field, and write the whole struct back, with no synchronization between the two. `PUT
+/machine` and `PUT /config/max-concurrent-runs` can be handled concurrently on the multi-thread
+Tokio runtime, so two overlapping read-modify-write round trips could interleave and the later
+write would silently drop whichever field the other request had just persisted (the same hazard
+class as the crontab read-modify-write race fixed in issue #365). Both functions now serialize
+through a single `Mutex`, mirroring the existing `crontab_sync_lock` pattern, so a concurrent
+machine-name rename and concurrency-cap update can no longer clobber each other.

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -13,6 +13,8 @@
 //! The file and env override exist because hostnames are not always meaningful or stable; the file
 //! is `*.local.*` (gitignored) so a name set on one host never travels in the shared repo.
 
+use std::sync::{Mutex, OnceLock};
+
 use serde::{Deserialize, Serialize};
 
 use crate::paths::machine_config_path;
@@ -140,6 +142,20 @@ fn read_machine_file() -> Option<String> {
     read_machine_toml().name
 }
 
+/// Process-wide lock serializing the `machine.local.toml` read-modify-write sequence.
+///
+/// [`set_machine`] and [`set_max_concurrent_runs_override`] each read the whole file, mutate one
+/// field, and write the whole struct back — an unsynchronized `PUT /machine` and
+/// `PUT /config/max-concurrent-runs` (`src/routes/http_settings_routes.rs`) can run concurrently on
+/// the multi-thread runtime, so two overlapping round trips can interleave and the later write wins
+/// outright, silently dropping whichever field the other request had just persisted. Same hazard
+/// class as the crontab read-modify-write race (issue #365, see `crontab_sync_lock` in
+/// `src/sync/routines.rs`), fixed the same way: hold this lock across the whole read-then-write span.
+fn machine_toml_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
 /// Write `toml` to `machine.local.toml`, creating the config dir if needed.
 fn write_machine_toml(toml: &MachineToml) -> std::io::Result<()> {
     let path = machine_config_path();
@@ -163,6 +179,7 @@ pub fn set_machine(name: &str) -> std::io::Result<()> {
             "machine name must not be empty",
         ));
     }
+    let _guard = machine_toml_lock().lock_recover();
     let mut toml = read_machine_toml();
     toml.name = Some(name.to_string());
     write_machine_toml(&toml)
@@ -179,6 +196,7 @@ pub fn max_concurrent_runs_override() -> Option<usize> {
 /// `machine.local.toml`. `None` clears the override. Preserves any other field already persisted
 /// in the file (e.g. the machine name).
 pub fn set_max_concurrent_runs_override(value: Option<usize>) -> std::io::Result<()> {
+    let _guard = machine_toml_lock().lock_recover();
     let mut toml = read_machine_toml();
     toml.max_concurrent_runs = value;
     write_machine_toml(&toml)

--- a/src/machine/mod_tests.rs
+++ b/src/machine/mod_tests.rs
@@ -405,6 +405,48 @@ fn set_max_concurrent_runs_override_preserves_existing_machine_name() {
 }
 
 #[test]
+fn concurrent_set_machine_and_set_cap_override_do_not_clobber_each_other() {
+    // Regression test for the machine.local.toml read-modify-write race: two threads racing
+    // `set_machine` and `set_max_concurrent_runs_override` each read the whole file, mutate one
+    // field, and write the whole struct back. Without `machine_toml_lock()` serializing that
+    // span, both threads can read the same (empty) snapshot before either writes, and whichever
+    // write lands second silently drops the other thread's field. A `Barrier` forces both
+    // threads to start their read-modify-write span at (as close to) the same instant, so an
+    // unsynchronized version of this test flakes/fails; with the lock in place, both fields
+    // always survive regardless of which thread wins the race.
+    let home = temp_home("concurrent-rmw");
+    // Set once on the parent thread before either child spawns; both children only read it
+    // (via `machine_config_path()`), so there is no concurrent env-var mutation to race on.
+    let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", home.to_str().unwrap());
+
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let b1 = std::sync::Arc::clone(&barrier);
+    let t1 = std::thread::spawn(move || {
+        b1.wait();
+        set_machine("racer-box").expect("set_machine");
+    });
+    let b2 = std::sync::Arc::clone(&barrier);
+    let t2 = std::thread::spawn(move || {
+        b2.wait();
+        set_max_concurrent_runs_override(Some(9)).expect("set_max_concurrent_runs_override");
+    });
+    t1.join().unwrap();
+    t2.join().unwrap();
+
+    assert_eq!(
+        read_machine_file(),
+        Some("racer-box".to_string()),
+        "concurrent cap-override write must not drop the machine name"
+    );
+    assert_eq!(
+        max_concurrent_runs_override(),
+        Some(9),
+        "concurrent machine-name write must not drop the cap override"
+    );
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+#[test]
 fn set_max_concurrent_runs_override_returns_err_on_write_failure() {
     let home = temp_home("cap-write-fail");
     let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", home.to_str().unwrap());


### PR DESCRIPTION
## Root cause

`set_machine` and `set_max_concurrent_runs_override` (`src/machine/mod.rs`) each read the whole
`machine.local.toml`, mutate one field of the parsed struct, and write the whole struct back via
`atomic_write` — with no synchronization between the two functions:

```rust
pub fn set_machine(name: &str) -> std::io::Result<()> {
    ...
    let mut toml = read_machine_toml();   // READ
    toml.name = Some(name.to_string());
    write_machine_toml(&toml)             // WRITE (whole file)
}

pub fn set_max_concurrent_runs_override(value: Option<usize>) -> std::io::Result<()> {
    let mut toml = read_machine_toml();   // READ
    toml.max_concurrent_runs = value;
    write_machine_toml(&toml)             // WRITE (whole file)
}
```

`atomic_write` only guarantees no *torn* writes (write-temp + rename) — it does nothing to prevent
one writer's read from happening before another writer's write lands. Both setters are reachable
concurrently over HTTP: `PUT /machine` → `put_machine` and `PUT /config/max-concurrent-runs` →
`put_max_concurrent_runs` (`src/routes/http_settings_routes.rs`). The Axum server runs on the
multi-thread Tokio runtime with a global concurrency limit of 64, so nothing serializes these two
routes. If a settings UI fires both requests close together (e.g. renaming the machine and setting
a concurrency cap in the same session), one request's read-modify-write can interleave with the
other's, and whichever `write_machine_toml` call lands second silently clobbers the field the
other request had just persisted — no merge, no error.

This is the exact same hazard class already identified and fixed for the crontab
read-modify-write sequence (issue #365, `crontab_sync_lock` in `src/sync/routines.rs`), just never
applied to `machine.local.toml`.

## Fix

Add `machine_toml_lock()`, a process-wide `Mutex<()>` mirroring `crontab_sync_lock`, and hold it
across the full read-then-write span in both `set_machine` and `set_max_concurrent_runs_override`.

## Testing

Added `concurrent_set_machine_and_set_cap_override_do_not_clobber_each_other`
(`src/machine/mod_tests.rs`): two threads race `set_machine` and
`set_max_concurrent_runs_override` via a `Barrier` that forces both read-modify-write spans to
start at (as close to) the same instant, then asserts both fields survive in the final file.

Verified the test actually exercises the bug: with the lock temporarily removed the test failed
40/40 runs; with the fix in place it passed 40/40 runs.

Local checks, all green:
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p ui --target wasm32-unknown-unknown -- -D warnings`
- `cargo test --workspace` (1064 + 312 tests)
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main.rs'` (100% lines; the
  touched file, `machine/mod.rs`, is 100% line *and* region covered)
- `linecheck --max-lines 500` over `src` + `ui/src`

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo llvm-cov --fail-under-lines 100` passes
- [x] `cargo fmt --check` / `cargo clippy` (workspace + `ui` wasm32) pass
- [x] Regression test independently verified to fail without the fix, pass with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)