### PR TITLE
docs(architecture): fix stale src/build/ module listing

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -81,8 +81,9 @@ src/
 │
 └── build/               build-script modules (compiled by build.rs, not the binary)
     ├── mod.rs
-    ├── openapi.rs       writes apis/openapi.json
-    └── ui.rs            runs trunk, inlines WASM → prebuilt.html / $OUT_DIR/index.html
+    ├── routine_schema.rs  writes schemas/routine.schema.json + routine.example.toml
+    ├── ui.rs              runs trunk, inlines WASM → prebuilt.html / $OUT_DIR/index.html
+    └── client.rs          builds the React client/ app → prebuilt-client.html / $OUT_DIR/client.html
 
 ui/                      Yew workspace member (separate Cargo.toml)
 ```
@@ -273,8 +274,9 @@ Implements `IntoResponse` → `{"error": "<message>"}` JSON body with matching s
 
 | Step | Output |
 |---|---|
-| `openapi::generate` | `apis/openapi.json` — hand-authored OpenAPI 3.0 spec |
+| `routine_schema::generate` | `schemas/routine.schema.json` + `schemas/routine.example.toml` |
 | `ui::build` | `$OUT_DIR/index.html` — Yew UI inlined as single file |
+| `client::build` | `$OUT_DIR/client.html` — React `client/` app, copied as-is (already self-contained via `vite-plugin-singlefile`) |
 
 ### UI inlining strategy
 


### PR DESCRIPTION
## Why

\`Architecture.md\`'s source-layout tree and its "Build-time code generation" table both still describe \`src/build/\` as containing \`openapi.rs\` and \`ui.rs\` only. That's stale:

- \`openapi.rs\` was removed from \`src/build/\` back in d8bc52f — OpenAPI generation moved to runtime via utoipa decorators (see \`src/openapi.rs\`), not build-time codegen.
- \`routine_schema.rs\` (writes \`schemas/routine.schema.json\` + \`schemas/routine.example.toml\`) and \`client.rs\` (builds the React \`client/\` app into \`$OUT_DIR/client.html\`) were added since but never documented.

A contributor reading the doc today would look for a nonexistent \`openapi.rs\` and miss that the schema/client build steps exist at all.

## What

Docs-only change to \`Architecture.md\`:
- Source-layout tree now lists \`routine_schema.rs\`, \`ui.rs\`, \`client.rs\` (matches \`ls src/build/\`).
- Build-time codegen table now lists the three actual steps run by \`src/build/mod.rs::run\`.

No code change, no behavior change, doesn't touch \`src/\`/\`ui/\`/\`client/\` so no changeset needed.

## Test plan

- [x] Diffed the new listing against \`ls src/build/\` and \`src/build/mod.rs::run\`
- [x] \`cargo test --workspace\` — sanity check nothing else touched