### PR TITLE
fix(routines): serialize default-routine tombstone writes to close a lost-update race

### DIFF
--- a/.changeset/default-tombstone-rmw-race.md
+++ b/.changeset/default-tombstone-rmw-race.md
@@ -1,0 +1,17 @@
+---
+"moadim": patch
+---
+
+fix(routines): serialize the default-routine tombstone file's writes to close a lost-update race
+
+`record_removed_default` and `clear_removed_default` each read the whole `removed_defaults.local.toml`
+tombstone file, mutate the slug set, and write it back in full, with no synchronization between the
+two. `DELETE /routines/{id}` and `POST /routines` (which call them from `svc_delete`/`svc_create`
+respectively) can be handled concurrently on the multi-thread Tokio runtime, so two overlapping
+read-modify-write round trips could interleave and the later write would silently drop whichever
+change the other request had just persisted — e.g. deleting two different built-in default routines
+back to back could lose one tombstone, resurrecting a routine the user explicitly removed on the
+next daemon startup (the same hazard class as the crontab read-modify-write race fixed in issue
+#365, and the `machine.local.toml` race fixed in #1240). Both functions now serialize through a
+single `Mutex`, mirroring the existing `crontab_sync_lock`/`machine_toml_lock` pattern, so concurrent
+tombstone writes can no longer clobber each other.

--- a/src/routines/defaults/lock_tests.rs
+++ b/src/routines/defaults/lock_tests.rs
@@ -1,0 +1,77 @@
+//! Regression test for the tombstone-file read-modify-write race fixed by
+//! [`super::removed_defaults_lock`]. Split out of `mod_tests.rs` to keep that file under the
+//! repo's 500-line-per-file cap.
+
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and fixtures do not need doc comments"
+)]
+
+use super::*;
+
+/// Run `body` with `HOME`/`XDG_CONFIG_HOME` redirected at a fresh temp home, restoring the
+/// previous values and removing the temp home afterward. Mirrors `mod_tests.rs`'s own
+/// `with_redirected_home` helper (duplicated here, like every other split-out `*_tests.rs`
+/// sibling in this crate, rather than shared across `#[path]` test modules).
+fn with_redirected_home(body: impl FnOnce(&std::path::Path)) {
+    let home = std::env::temp_dir().join(format!("moadim-defaults-lock-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&home).unwrap();
+    let previous_home = std::env::var_os("HOME");
+    let previous_xdg = std::env::var_os("XDG_CONFIG_HOME");
+    // SAFETY: tests in this crate run single-threaded per binary; we set and immediately restore
+    // the overrides around this call. The spawned threads inside `body` only read these env vars
+    // (via `crate::paths`), never mutate them, so there is no concurrent-mutation hazard.
+    unsafe {
+        std::env::set_var("HOME", &home);
+        std::env::set_var("XDG_CONFIG_HOME", home.join(".config"));
+    }
+    body(&home);
+    unsafe {
+        match previous_home {
+            Some(value) => std::env::set_var("HOME", value),
+            None => std::env::remove_var("HOME"),
+        }
+        match previous_xdg {
+            Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
+            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        }
+    }
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+#[test]
+fn concurrent_record_removed_default_calls_do_not_clobber_each_other() {
+    // Regression test for the tombstone-file read-modify-write race: two threads racing
+    // `record_removed_default` for two *different* slugs each read the whole file, mutate the
+    // slug set, and write it back in full. Without `removed_defaults_lock()` serializing that
+    // span, both threads can read the same (empty) snapshot before either writes, and whichever
+    // write lands second silently drops the other thread's slug. A `Barrier` forces both threads
+    // to start their read-modify-write span at (as close to) the same instant, so an
+    // unsynchronized version of this test flakes/fails; with the lock in place, both slugs always
+    // survive regardless of which thread wins the race.
+    with_redirected_home(|_home| {
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let b1 = std::sync::Arc::clone(&barrier);
+        let t1 = std::thread::spawn(move || {
+            b1.wait();
+            record_removed_default("racer-one");
+        });
+        let b2 = std::sync::Arc::clone(&barrier);
+        let t2 = std::thread::spawn(move || {
+            b2.wait();
+            record_removed_default("racer-two");
+        });
+        t1.join().unwrap();
+        t2.join().unwrap();
+
+        let slugs = read_removed_defaults();
+        assert!(
+            slugs.contains("racer-one"),
+            "concurrent tombstone for racer-two must not drop racer-one"
+        );
+        assert!(
+            slugs.contains("racer-two"),
+            "concurrent tombstone for racer-one must not drop racer-two"
+        );
+    });
+}

--- a/src/routines/defaults/mod.rs
+++ b/src/routines/defaults/mod.rs
@@ -20,6 +20,7 @@
 //! Adding a new default means a new file + one entry in [`DEFAULT_ROUTINES`].
 
 use std::collections::BTreeSet;
+use std::sync::{Mutex, OnceLock};
 
 use crate::utils::lock::LockRecover;
 use serde::{Deserialize, Serialize};
@@ -235,11 +236,29 @@ fn write_removed_defaults(slugs: &BTreeSet<String>) -> std::io::Result<()> {
     std::fs::write(path, toml)
 }
 
+/// Process-wide lock serializing the tombstone-file read-modify-write sequence.
+///
+/// [`record_removed_default`] and [`clear_removed_default`] each read the whole file, mutate the
+/// slug set, and write it back in full — `DELETE /routines/{id}` and `POST /routines` (which call
+/// them from `svc_delete`/`svc_create` respectively) can run concurrently on the multi-thread
+/// runtime, so two overlapping round trips can interleave and the later write wins outright,
+/// silently dropping whichever change the other request had just persisted (e.g. deleting two
+/// different default routines back to back could lose one tombstone, resurrecting a routine the
+/// user explicitly removed on the next startup). Same hazard class as the crontab read-modify-write
+/// race (issue #365, see `crontab_sync_lock` in `src/sync/routines.rs`) and the `machine.local.toml`
+/// race (`machine_toml_lock` in `src/machine/mod.rs`), fixed the same way: hold this lock across
+/// the whole read-then-write span.
+fn removed_defaults_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
 /// Record that the built-in default identified by `slug` was explicitly deleted, so
 /// [`ensure_default_routines`] does not re-create it on the next startup. Best-effort: a write
 /// failure is logged rather than propagated, matching [`ensure_default_routines`]'s own
 /// best-effort persistence.
 pub fn record_removed_default(slug: &str) {
+    let _guard = removed_defaults_lock().lock_recover();
     let mut slugs = read_removed_defaults();
     if slugs.insert(slug.to_string()) {
         if let Err(err) = write_removed_defaults(&slugs) {
@@ -251,6 +270,7 @@ pub fn record_removed_default(slug: &str) {
 /// Clear the tombstone for `slug`, if any, letting [`ensure_default_routines`] re-seed it on the
 /// next startup. Called when the user creates a routine whose title matches a tombstoned default.
 pub fn clear_removed_default(slug: &str) {
+    let _guard = removed_defaults_lock().lock_recover();
     let mut slugs = read_removed_defaults();
     if slugs.remove(slug) {
         if let Err(err) = write_removed_defaults(&slugs) {
@@ -262,3 +282,7 @@ pub fn clear_removed_default(slug: &str) {
 #[cfg(test)]
 #[path = "mod_tests.rs"]
 mod defaults_tests;
+
+#[cfg(test)]
+#[path = "lock_tests.rs"]
+mod defaults_lock_tests;


### PR DESCRIPTION
## Summary

`record_removed_default` and `clear_removed_default` (`src/routines/defaults/mod.rs`) each read the whole `removed_defaults.local.toml` tombstone file, mutate the slug set, and write it back in full — with no synchronization between the two calls.

`DELETE /routines/{id}` and `POST /routines` (which call `svc_delete`/`svc_create` respectively, in `src/routines/service.rs`) can be handled concurrently on the multi-thread Tokio runtime. Two overlapping read-modify-write round trips can interleave, and the later write wins outright, silently dropping whichever change the other request had just persisted. Concretely: deleting two different built-in default routines back to back (or racing a delete against a create) can lose one tombstone entry, so a routine the user explicitly deleted gets silently resurrected, enabled, on the next daemon startup.

This is the same hazard class already fixed twice elsewhere in this codebase for the identical read-whole-file/mutate-one-field/write-whole-file-back pattern:
- the crontab read-modify-write race (issue #365, `crontab_sync_lock` in `src/sync/routines.rs`)
- the `machine.local.toml` race (#1240, `machine_toml_lock` in `src/machine/mod.rs`)

...but it was never mirrored onto the tombstone file.

## Changes

- `src/routines/defaults/mod.rs`: add `removed_defaults_lock()`, a process-wide `Mutex<()>` mirroring `machine_toml_lock`, and hold it across the whole read-then-write span in both `record_removed_default` and `clear_removed_default`.
- `src/routines/defaults/lock_tests.rs` (new): a regression test that races two `record_removed_default` calls for two different slugs via a `Barrier`, and asserts both tombstones survive. Split into its own file (rather than added to the existing `mod_tests.rs`) to keep every file under the repo's 500-line cap (`linecheck`).
- `.changeset/default-tombstone-rmw-race.md`: changeset entry, following the pattern of the existing `machine-toml-rmw-race.md`.

## Verification

- Confirmed the race is real: with the lock temporarily removed, the new regression test failed 8/8 runs; restored, it passed 8/8 runs.
- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 1065 (root) + 312 (`ui`) passed
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% line coverage maintained (exit 0)
- `linecheck --max-lines 500` — passed
- Full `.githooks/pre-push` run (test-file convention, fmt, clippy, workspace tests, coverage, linecheck, client typecheck/lint/test) — all green
- `prebuilt.html` gets regenerated as a side effect of `cargo build`/`cargo check` locally (pre-existing staleness, already the subject of open PR #1233) — reverted before committing, not part of this diff

## Test plan

- [x] CI: fmt, clippy, test, coverage, docs, changelog checks