### PR TITLE
docs(readme): use the full /api/v1 prefix for /shutdown and /health

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,8 +369,8 @@ moadim stop --json     # same, as a machine-readable JSON object
 | `moadim -i`        | interactive   | Runs in the foreground; logs to the terminal; Ctrl-C stops it. |
 | `moadim restart`   | background    | Stops the running server (if any) and spawns a fresh detached instance, so you get a clean process without a separate stop/start. Prints the PID rotation as `restarted: pid <old> -> <new>` (old reads `none` when nothing was running) so scripts/logs can confirm the process actually changed. Add `--quiet`/`-q` to print only that rotation line, suppressing the preamble and the reach/manage hint block. Add `--json` for `{"old":N\|null,"new":M,"address":"127.0.0.1:5784"}`. |
 | `moadim restart -i`, `--interactive` | interactive | Stops the running server (if any), same as `moadim restart`, but brings the fresh instance up in the foreground instead of backgrounding it — mirrors `moadim -i`. |
-| `moadim stop`      | —             | Sends `POST /shutdown` to the running server for a graceful stop. Add `--json` for `{"running":bool,"pid":N\|null,"address":"127.0.0.1:5784"}` (the `pid` is read before the shutdown request, since a graceful stop clears the pid file). Exits `0` when a running server was asked to shut down, `3` when none was reachable. **Only stops the daemon process** — a routine agent already running in its own detached tmux session is independent of the daemon and keeps running (and can keep acting on your behalf) until it finishes on its own or a later `moadim` start's watchdog/cleanup sweep reaps it. |
-| `moadim status`    | —             | Prints whether a server is reachable on `127.0.0.1:5784`. Add `--json` for `{"running":bool,"pid":N\|null,"address":"127.0.0.1:5784","uptime_secs":N\|null,"version":S\|null}` — `uptime_secs`/`version` come from the server's `GET /health`, so a single call returns liveness **and** age/version (both `null` when no server answers). Add `--wait[=SECS]` to poll `GET /health` every 200ms until it answers or `SECS` elapse (default 30) instead of checking once, so a launch script can block on startup rather than sleeping blindly. Exits `0` when running, `3` when not (including a `--wait` timeout). |
+| `moadim stop`      | —             | Sends `POST /api/v1/shutdown` to the running server for a graceful stop. Add `--json` for `{"running":bool,"pid":N\|null,"address":"127.0.0.1:5784"}` (the `pid` is read before the shutdown request, since a graceful stop clears the pid file). Exits `0` when a running server was asked to shut down, `3` when none was reachable. **Only stops the daemon process** — a routine agent already running in its own detached tmux session is independent of the daemon and keeps running (and can keep acting on your behalf) until it finishes on its own or a later `moadim` start's watchdog/cleanup sweep reaps it. |
+| `moadim status`    | —             | Prints whether a server is reachable on `127.0.0.1:5784`. Add `--json` for `{"running":bool,"pid":N\|null,"address":"127.0.0.1:5784","uptime_secs":N\|null,"version":S\|null}` — `uptime_secs`/`version` come from the server's `GET /api/v1/health`, so a single call returns liveness **and** age/version (both `null` when no server answers). Add `--wait[=SECS]` to poll `GET /api/v1/health` every 200ms until it answers or `SECS` elapse (default 30) instead of checking once, so a launch script can block on startup rather than sleeping blindly. Exits `0` when running, `3` when not (including a `--wait` timeout). |
 | `moadim cleanup`   | —             | Sends `POST /api/v1/routines/cleanup` to the running server and prints how many finished, expired routine workbenches were reaped and the disk space freed, e.g. `cleanup removed 3 workbenches (freed 12.4 MB)` (the on-demand version of the periodic sweep). Add `--json` for `{"running":bool,"removed":N,"freed_bytes":N,"address":"127.0.0.1:5784"}` (matching `status`/`stop --json`'s shape). Exits `0` when running, `3` when not. |
 | `moadim trigger <id>` | —          | Sends `POST /api/v1/routines/{id}/trigger` to the running server, launching the routine immediately outside its schedule (the terminal equivalent of the REST/MCP on-demand trigger). Prints `triggered routine <id>` on success. Exits `0` when triggered, `3` when no server is reachable, and `1` with `no routine with id <id>` on a `404`. (`moadim run <id>` is kept as a hidden back-compat alias.) |
 
@@ -383,7 +383,7 @@ with a message on stderr.
 systemd user unit on Linux, a launchd agent on macOS), `moadim stop` makes the daemon **stay
 stopped**. The supervisor restarts only on a *failure* exit (systemd `Restart=on-failure`, launchd
 `KeepAlive = { SuccessfulExit = false }`), so a clean shutdown — `moadim stop`, the UI STOP button,
-`POST /shutdown`, all of which exit `0` — is not resurrected, while a crash is still auto-restarted.
+`POST /api/v1/shutdown`, all of which exit `0` — is not resurrected, while a crash is still auto-restarted.
 To start the service again after a stop, use `moadim` (or your supervisor's `systemctl --user start`
 / `launchctl` controls).
 
@@ -449,7 +449,7 @@ on stdout. Paired with the exit codes above, a caller gets the full contract wit
 
 | Command            | `--json` shape | Exit codes |
 |--------------------|----------------|------------|
-| `moadim status --json`  | `{"running":bool,"pid":N\|null,"address":"127.0.0.1:5784","uptime_secs":N\|null,"version":S\|null}` — `pid` is `null` when no pid file is present; `uptime_secs`/`version` are folded in from the server's `GET /health` and are `null` when no server answers | `0` running, `3` not |
+| `moadim status --json`  | `{"running":bool,"pid":N\|null,"address":"127.0.0.1:5784","uptime_secs":N\|null,"version":S\|null}` — `pid` is `null` when no pid file is present; `uptime_secs`/`version` are folded in from the server's `GET /api/v1/health` and are `null` when no server answers | `0` running, `3` not |
 | `moadim cleanup --json` | `{"running":bool,"removed":N,"freed_bytes":N,"address":"127.0.0.1:5784"}` — `removed`/`freed_bytes` are `0` when no server is running; `address` is the bound endpoint (matching `status`/`stop --json`) | `0` running, `3` not |
 | `moadim stop --json`    | `{"running":bool,"pid":N\|null,"address":"127.0.0.1:5784"}` — `running` is `true` when a running server was asked to shut down; `pid` is the stopped server's PID (read before shutdown) or `null` when none was reachable | `0` running, `3` not |
 
@@ -478,7 +478,7 @@ echo "moadim: reaped ${removed} workbench(es)"
 
 Because the default mode is detached, you stop the server **from the client**:
 press the **STOP** button in the UI header, run `moadim stop`, or send
-`POST /shutdown`. (During development, `cargo run -- --interactive` keeps it in
+`POST /api/v1/shutdown`. (During development, `cargo run -- --interactive` keeps it in
 the foreground.)
 
 Starts on `http://127.0.0.1:5784`. On startup the server loads all routines,


### PR DESCRIPTION
## Summary

`README.md`'s `## Running` section documents `moadim stop` / `moadim status` as sending `POST /shutdown` and polling `GET /health` — bare, unprefixed paths. But every route is actually mounted under the `/api/v1` prefix (`src/routes/http.rs:211-212`, nested at `.nest("/api/v1", api)`), and the *sibling* rows in the exact same table (`moadim cleanup`, `moadim trigger`) already correctly spell out `POST /api/v1/routines/cleanup` and `POST /api/v1/routines/{id}/trigger`. Only the `stop`/`status` rows — plus a couple of prose mentions elsewhere in the same section — dropped the prefix, which is an internally inconsistent, copy-pasteable-looking mistake: literally running `curl -X POST http://127.0.0.1:5784/shutdown` doesn't hit the shutdown handler at all, it falls through to the SPA `.fallback(get(index))` and returns a `200` with `index.html`, silently doing nothing.

This fixes every bare `/shutdown` / `/health` mention in that section (the command table, the service-install note, the `--json` shapes table, and the closing "how to stop it" paragraph) to the real `/api/v1/...` path, matching the convention already used two rows down in the very same table.

Not a duplicate of #345 (that issue is about the `--json` payload *shapes* matching code, which I verified they already do) or #271 (already-fixed `MAX_RUNTIME_SECS` drift). This is README-only — no `src/`, `ui/`, or `client/` changes, so no changeset is required per the pre-push hook's changed-path check.

## Why this matters

The `README` is the primary reference for scripting against the daemon's REST surface (see the `## Scripting` section right above the fixed table). A reader following the documented path literally gets a silent no-op instead of a graceful shutdown, with no error to signal the mistake.

## Test plan

- [x] `sh .githooks/pre-push` run end-to-end (fmt, clippy `--workspace --all-targets -D warnings`, `cargo test --workspace` — 1064 + 312 passed, `cargo llvm-cov --fail-under-lines 100` — 100% lines, linecheck, client typecheck/lint/test) — all green, exit 0.
- [x] Confirmed the actual route mounts via `src/routes/http.rs` (`.route("/health", ...)`, `.route("/shutdown", ...)` on the router nested at `/api/v1`).
- [x] `git diff` scoped to `README.md` only; no incidental changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)