### PR TITLE
test(ui,client): cover healthBadge/healthBadgeClass for every RoutineHealth variant

### DIFF
--- a/.changeset/health-badge-class-test-coverage.md
+++ b/.changeset/health-badge-class-test-coverage.md
@@ -1,0 +1,15 @@
+---
+"moadim": patch
+---
+
+test(ui,client): cover `healthBadge`/`healthBadgeClass` (and their Rust `RoutineHealth` counterparts) for every variant
+
+`RoutineHealth::badge()`/`badge_class()` in `ui/src/routines/filter.rs` and their 1:1 TypeScript
+port `healthBadge`/`healthBadgeClass` in `client/src/pages/routines/filter.ts` were the only
+exported health-rendering functions with no test on either side — `priority()`/`healthPriority`
+already had one, but the badge label and CSS class returned for each of the 7 `RoutineHealth`
+variants were unverified. A typo or copy-paste duplicate (e.g. two variants sharing a CSS class,
+or a mismatched label) would have shipped silently to the ROUTINES table's health badge. Both
+sides now assert the exact rendered string per variant and that labels/classes stay unique across
+variants, mirroring the existing `health_priority_order_dormant_most_urgent`/`healthPriority`
+tests. No behavior change.

--- a/client/src/pages/routines/filter.test.ts
+++ b/client/src/pages/routines/filter.test.ts
@@ -9,6 +9,8 @@ import {
   distinctRepositories,
   distinctTags,
   filterRoutines,
+  healthBadge,
+  healthBadgeClass,
   healthPriority,
   isFilterActive,
   isRoutineSnoozed,
@@ -24,6 +26,7 @@ import {
   triggerButtonTitle,
   type NamedFacet,
   type RoutineFilter,
+  type RoutineHealth,
 } from "./filter";
 
 function routine(
@@ -667,5 +670,30 @@ describe("filter", () => {
     expect(healthPriority("disabled")).toBeLessThan(healthPriority("power-saving"));
     expect(healthPriority("power-saving")).toBeLessThan(healthPriority("snoozed"));
     expect(healthPriority("snoozed")).toBeLessThan(healthPriority("healthy"));
+  });
+
+  // `healthBadge`/`healthBadgeClass` were the only exported `filter.ts` functions with no test
+  // (mirrors ui/src/routines/filter_health_tests.rs's `health_badge_and_badge_class_cover_all_variants`,
+  // added alongside this test) — assert the exact rendered strings for every variant, and that
+  // both stay unique, so a copy-paste badge/class collision is caught here instead of silently in
+  // the UI.
+  it("health badge and badge class cover all variants", () => {
+    const cases: Array<[RoutineHealth, string, string]> = [
+      ["dormant", "DORMANT", "health-badge dormant"],
+      ["dead-schedule", "DEAD SCHEDULE", "health-badge dead"],
+      ["agent-missing", "AGENT MISSING", "health-badge agent-missing"],
+      ["disabled", "DISABLED", "health-badge disabled"],
+      ["power-saving", "POWER SAVING", "health-badge power-saving"],
+      ["snoozed", "SNOOZED", "health-badge snoozed"],
+      ["healthy", "HEALTHY", "health-badge healthy"],
+    ];
+    for (const [health, badge, badgeClass] of cases) {
+      expect(healthBadge(health)).toBe(badge);
+      expect(healthBadgeClass(health)).toBe(badgeClass);
+    }
+    const badges = cases.map(([health]) => healthBadge(health));
+    const classes = cases.map(([health]) => healthBadgeClass(health));
+    expect(new Set(badges).size).toBe(badges.length);
+    expect(new Set(classes).size).toBe(classes.length);
   });
 });

--- a/ui/src/routines/filter_health_tests.rs
+++ b/ui/src/routines/filter_health_tests.rs
@@ -344,3 +344,42 @@ fn health_priority_order_dormant_most_urgent() {
     assert!(RoutineHealth::PowerSaving.priority() < RoutineHealth::Snoozed.priority());
     assert!(RoutineHealth::Snoozed.priority() < RoutineHealth::Healthy.priority());
 }
+
+/// `badge()`/`badge_class()` were the only `RoutineHealth` methods without a test (`priority()`
+/// is covered above) — assert the exact rendered strings for every variant, and that both stay
+/// unique across variants, so a copy-paste badge/class collision (two variants rendering the same
+/// label or CSS class) is caught here instead of silently in the UI.
+#[test]
+fn health_badge_and_badge_class_cover_all_variants() {
+    let cases = [
+        (RoutineHealth::Dormant, "DORMANT", "health-badge dormant"),
+        (
+            RoutineHealth::DeadSchedule,
+            "DEAD SCHEDULE",
+            "health-badge dead",
+        ),
+        (
+            RoutineHealth::AgentMissing,
+            "AGENT MISSING",
+            "health-badge agent-missing",
+        ),
+        (RoutineHealth::Disabled, "DISABLED", "health-badge disabled"),
+        (
+            RoutineHealth::PowerSaving,
+            "POWER SAVING",
+            "health-badge power-saving",
+        ),
+        (RoutineHealth::Snoozed, "SNOOZED", "health-badge snoozed"),
+        (RoutineHealth::Healthy, "HEALTHY", "health-badge healthy"),
+    ];
+    for (health, badge, badge_class) in cases {
+        assert_eq!(health.badge(), badge);
+        assert_eq!(health.badge_class(), badge_class);
+    }
+    let badges: Vec<&str> = cases.iter().map(|(h, _, _)| h.badge()).collect();
+    let classes: Vec<&str> = cases.iter().map(|(h, _, _)| h.badge_class()).collect();
+    let unique_badges: std::collections::HashSet<&&str> = badges.iter().collect();
+    let unique_classes: std::collections::HashSet<&&str> = classes.iter().collect();
+    assert_eq!(unique_badges.len(), badges.len(), "duplicate badge label");
+    assert_eq!(unique_classes.len(), classes.len(), "duplicate badge class");
+}


### PR DESCRIPTION
## Why

`RoutineHealth::badge()`/`badge_class()` in `ui/src/routines/filter.rs` and their 1:1 TypeScript
port `healthBadge`/`healthBadgeClass` in `client/src/pages/routines/filter.ts` were the only
exported health-rendering functions with no test on either side of this deliberately-mirrored
codebase. `priority()`/`healthPriority` already had `health_priority_order_dormant_most_urgent`/
`"health priority order dormant most urgent"` tests, but the label and CSS class returned for
each of the 7 `RoutineHealth` variants (`Dormant`, `DeadSchedule`, `AgentMissing`, `Disabled`,
`PowerSaving`, `Snoozed`, `Healthy`) were unverified on both sides.

Concretely, a typo or copy-paste duplicate — e.g. two variants accidentally sharing the same
`health-badge` CSS class, or a mismatched label — would ship silently to the ROUTINES table's
health badge (rendered in `ui/src/routines.rs` and `client/src/pages/routines/RoutineRow.tsx`),
since nothing exercised these functions.

## What

Added one exhaustive test on each side asserting the exact rendered string per variant, plus a
uniqueness check across both the badge labels and the CSS classes:

- `ui/src/routines/filter_health_tests.rs`: `health_badge_and_badge_class_cover_all_variants`
- `client/src/pages/routines/filter.test.ts`: `"health badge and badge class cover all variants"`

No production code changed — test-only, mirroring the existing `healthPriority`/`priority()`
coverage pattern this file already uses.

## Testing

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
  `cargo clippy -p ui --target wasm32-unknown-unknown --all-targets -- -D warnings`,
  `cargo test --workspace` — all pass (314 passed in the `ui` crate, up from 313)
- `pnpm --filter client typecheck && pnpm --filter client lint && pnpm --filter client test` —
  all pass (323 passed, up from 322)