### PR TITLE
test(client): cover StatsBar's KPI tile counts and status-facet toggle

### DIFF
--- a/.changeset/stats-bar-kpi-tiles-coverage.md
+++ b/.changeset/stats-bar-kpi-tiles-coverage.md
@@ -1,0 +1,11 @@
+---
+"moadim": patch
+---
+
+test(client): cover `StatsBar`'s KPI tile counts and status-facet toggle
+
+`client/src/pages/routines/StatsBar.tsx` — the KPI tile row above the routines table — had 0%
+test coverage despite deriving eight non-trivial counts (total/enabled/disabled, due-soon,
+snoozed, dormant, flagged, unregistered-agent) from the loaded routine list. Adds a test file
+covering the derived counts, the `has-dormant`/`has-flags` conditional classes, the toggle-on/
+toggle-off click behavior, and `aria-pressed` state. No production code changes.

--- a/client/src/pages/routines/StatsBar.test.tsx
+++ b/client/src/pages/routines/StatsBar.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { RoutineResponse } from "../../api/hooks";
+import type { RoutineStatusFacet } from "./filter";
+import { StatsBar } from "./StatsBar";
+
+const NOW = new Date("2026-07-17T12:00:00Z");
+
+function routine(id: string, enabled: boolean, overrides: Partial<RoutineResponse> = {}): RoutineResponse {
+  return {
+    id,
+    title: id,
+    agent: "claude",
+    model: null,
+    // Fires every minute, so an enabled routine using this schedule is always "due soon".
+    schedule: "* * * * *",
+    prompt: "",
+    repositories: [],
+    machines: ["box-1"],
+    enabled,
+    source: "",
+    created_at: 0,
+    updated_at: 0,
+    last_manual_trigger_at: null,
+    last_scheduled_trigger_at: null,
+    snoozed_until: null,
+    skip_runs: null,
+    power_saving: false,
+    ttl_secs: null,
+    tags: [],
+    agent_registered: true,
+    agent_command_available: true,
+    is_running: false,
+    file_path: "",
+    schedule_description: null,
+    goal: null,
+    flag_count: 0,
+    ...overrides,
+  };
+}
+
+function renderBar(routines: RoutineResponse[], active: RoutineStatusFacet = "all") {
+  const onStatus = vi.fn();
+  render(<StatsBar routines={routines} now={NOW} active={active} onStatus={onStatus} />);
+  return onStatus;
+}
+
+function tileValue(label: string): string {
+  return screen.getByText(label).nextElementSibling?.textContent ?? "";
+}
+
+describe("StatsBar", () => {
+  it("counts total/enabled/disabled", () => {
+    renderBar([routine("a", true), routine("b", true), routine("c", false)]);
+    expect(tileValue("TOTAL")).toBe("3");
+    expect(tileValue("ENABLED")).toBe("2");
+    expect(tileValue("DISABLED")).toBe("1");
+  });
+
+  it("counts due-soon, snoozed, dormant, flagged, and unregistered-agent routines", () => {
+    const futureSnooze = Math.floor(NOW.getTime() / 1000) + 3600;
+    renderBar([
+      // Every-minute schedule, so every enabled+unsnoozed routine below also counts as "due soon".
+      routine("due", true),
+      routine("snoozed", true, { snoozed_until: futureSnooze }),
+      routine("dormant", true, { machines: [] }),
+      routine("flagged", true, { flag_count: 2 }),
+      routine("unreg", true, { agent_registered: false }),
+      // Disabled routines never count toward the enabled-only tiles above.
+      routine("disabled-dormant", false, { machines: [] }),
+    ]);
+    expect(tileValue("DUE SOON")).toBe("4");
+    expect(tileValue("SNOOZED")).toBe("1");
+    expect(tileValue("DORMANT")).toBe("1");
+    expect(tileValue("FLAGS")).toBe("2");
+    expect(tileValue("UNREGISTERED AGENT")).toBe("1");
+  });
+
+  it("applies a has-* class only when its tile's count is non-zero", () => {
+    renderBar([routine("a", true, { machines: [] })]);
+    expect(screen.getByText("DORMANT").closest("button")).toHaveClass("has-dormant");
+    expect(screen.getByText("FLAGS").closest("button")).not.toHaveClass("has-flags");
+  });
+
+  it("clicking an inactive tile selects its facet", () => {
+    const onStatus = renderBar([routine("a", true)]);
+    fireEvent.click(screen.getByText("ENABLED").closest("button")!);
+    expect(onStatus).toHaveBeenCalledWith("enabled");
+  });
+
+  it("clicking the active tile again clears back to all", () => {
+    const onStatus = renderBar([routine("a", true)], "enabled");
+    fireEvent.click(screen.getByText("ENABLED").closest("button")!);
+    expect(onStatus).toHaveBeenCalledWith("all");
+  });
+
+  it("marks the active tile with aria-pressed", () => {
+    renderBar([routine("a", true)], "enabled");
+    expect(screen.getByText("ENABLED").closest("button")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByText("TOTAL").closest("button")).toHaveAttribute("aria-pressed", "false");
+  });
+});


### PR DESCRIPTION
## Why

`client/src/pages/routines/StatsBar.tsx` — the KPI tile row above the routines table
(TOTAL/ENABLED/DISABLED/DORMANT/DUE SOON/SNOOZED/FLAGS/UNREGISTERED AGENT) — had **0%**
test coverage (`pnpm run test:coverage`), despite deriving eight non-trivial counts from
the loaded routine list (enabled-only filtering, snooze-timestamp math, dormant/machine
detection, flag-count summing across all routines regardless of enabled state) and driving
click-to-toggle status-facet selection.

Checked for duplication: no open PR touches `StatsBar.tsx` or its test file.

## What changed

- Adds `client/src/pages/routines/StatsBar.test.tsx`: covers the eight derived counts,
  the conditional `has-dormant`/`has-flags` classes, the toggle-on/toggle-off click
  behavior (clicking the active tile clears back to `"all"`), and `aria-pressed` state.
- No production code changes — `StatsBar.tsx` itself is untouched.
- Adds a changeset (`client/` changes require one per this repo's Changelog check).

## Test plan

- [x] `pnpm run test` — 22 files, 328/328 passing (6 new)
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.