### PR TITLE
fix(routines): serialize create_flag against a collision-check-then-write race

### DIFF
--- a/.changeset/flags-create-rmw-race.md
+++ b/.changeset/flags-create-rmw-race.md
@@ -1,0 +1,16 @@
+---
+"moadim": patch
+---
+
+fix(routines): serialize flag-creation's collision-check-then-write span to close a lost-update race
+
+`create_flag` reads the routine's `flags/` directory to find a free `{type}-{timestamp}.md`
+filename, then writes to it, with no synchronization between the check and the write. The HTTP and
+MCP flag-creation handlers can be invoked concurrently on the multi-thread Tokio runtime, so two
+overlapping calls for the same routine and flag type could both observe the same candidate filename
+as free before either writes, and whichever write lands second would silently clobber the first —
+directly contradicting `create_flag`'s own doc comment that "a flag never silently overwrites
+another" (the same hazard class as the crontab, `machine.local.toml`, and default-tombstone
+read-modify-write races fixed in issues #365, #1240, and #1243). `create_flag` now serializes
+through a single `Mutex`, mirroring the existing `crontab_sync_lock`/`machine_toml_lock` pattern, so
+concurrent flag creation can no longer clobber another in-flight flag.

--- a/src/routines/flags.rs
+++ b/src/routines/flags.rs
@@ -10,11 +10,14 @@
 //! There is no status field: an "open" flag is simply a file that exists. Resolving a flag means
 //! deleting it ([`resolve_flag`]).
 
+use std::sync::{Mutex, OnceLock};
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::paths::routine_flags_dir;
 use crate::utils::atomic::atomic_write;
+use crate::utils::lock::LockRecover;
 use crate::utils::time::now_secs;
 
 use super::command::slugify;
@@ -87,6 +90,19 @@ fn parse_filename(filename: &str) -> Option<(u64, FlagScope)> {
     Some((created_at, scope))
 }
 
+/// Process-wide lock serializing the collision-check-then-write span in [`create_flag`].
+///
+/// The free-filename loop reads (`dir.join(&candidate).exists()`) and the subsequent
+/// `atomic_write` are not otherwise synchronized, so two concurrent calls for the same routine
+/// (reachable via the HTTP and MCP flag-creation handlers, both async on the multi-thread Tokio
+/// runtime) can both observe the same candidate as free before either writes, and the second
+/// write silently clobbers the first — the same read-modify-write hazard fixed the same way for
+/// `machine.local.toml` (see `machine_toml_lock` in `src/machine/mod.rs`).
+fn flags_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
 /// Create a new flag under the routine identified by `slug`, returning the persisted record.
 ///
 /// `flag_type` and `description` are trimmed; callers are expected to have already rejected blank
@@ -103,6 +119,8 @@ pub fn create_flag(
     let description = description.trim();
     let dir = routine_flags_dir(slug);
     crate::utils::fs_perms::create_private_dir_all(&dir)?;
+
+    let _guard = flags_lock().lock_recover();
 
     let type_slug = slugify(flag_type);
     let mut created_at = now_secs();

--- a/src/routines/flags_tests.rs
+++ b/src/routines/flags_tests.rs
@@ -97,6 +97,41 @@ fn create_flag_bumps_timestamp_on_collision() {
 }
 
 #[test]
+fn concurrent_create_flag_calls_do_not_clobber_each_other() {
+    // Regression test for the flags/ collision-check-then-write race: two threads racing
+    // `create_flag` for the same routine and type each read the directory for a free filename,
+    // then write. Without `flags_lock()` serializing that span, both threads can observe the
+    // same candidate filename as free before either writes, and whichever write lands second
+    // silently clobbers the first. A `Barrier` forces both threads to start their
+    // check-then-write span at (as close to) the same instant, so an unsynchronized version of
+    // this test flakes/fails; with the lock in place, both flags always survive.
+    let _home = TempHome::set();
+
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let b1 = std::sync::Arc::clone(&barrier);
+    let t1 = std::thread::spawn(move || {
+        b1.wait();
+        create_flag("r1", "bug", "first", FlagScope::General).unwrap()
+    });
+    let b2 = std::sync::Arc::clone(&barrier);
+    let t2 = std::thread::spawn(move || {
+        b2.wait();
+        create_flag("r1", "bug", "second", FlagScope::General).unwrap()
+    });
+    let flag1 = t1.join().unwrap();
+    let flag2 = t2.join().unwrap();
+
+    assert_ne!(
+        flag1.filename, flag2.filename,
+        "concurrent create_flag calls must not resolve to the same filename"
+    );
+    let created = list_flags("r1");
+    assert_eq!(created.len(), 2, "both flags must survive on disk");
+    assert!(created.iter().any(|flag| flag.description == "first"));
+    assert!(created.iter().any(|flag| flag.description == "second"));
+}
+
+#[test]
 fn create_flag_propagates_write_failure() {
     use std::os::unix::fs::PermissionsExt as _;
 


### PR DESCRIPTION
## Problem

`create_flag`'s free-filename loop reads the routine's `flags/` directory (`dir.join(&candidate).exists()`) and then writes to it (`atomic_write`), with no synchronization between the check and the write.

The HTTP and MCP flag-creation handlers can invoke `create_flag` concurrently on the multi-thread Tokio runtime. Two overlapping calls for the same routine and flag type can both observe the same candidate filename as free before either writes — the second `atomic_write` then silently clobbers the first, dropping whichever flag lost the race entirely.

This directly contradicts the function's own doc comment: "a flag never silently overwrites another." It's the same read-modify-write hazard class already fixed for `crontab.local` (#365), `machine.local.toml` (#1240), and the default-routine tombstone file (#1243).

## Fix

Serialize the whole collision-check-then-write span through a single process-wide `Mutex`, mirroring the existing `machine_toml_lock`/`crontab_sync_lock` pattern (`lock_recover()` from `src/utils/lock.rs`).

Added a `Barrier`-based regression test (`concurrent_create_flag_calls_do_not_clobber_each_other`) that races two `create_flag` calls for the same routine/type and asserts both flags survive on disk with distinct filenames.

## Testing
- `cargo test --workspace` — 1378 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main.rs'` — `routines/flags.rs` at 100%