### PR TITLE
fix(ical): TZID-qualify DTSTART against an embedded VTIMEZONE

### DIFF
--- a/.changeset/ical-vtimezone-tzid-dtstart.md
+++ b/.changeset/ical-vtimezone-tzid-dtstart.md
@@ -1,0 +1,24 @@
+---
+"moadim": patch
+---
+
+fix(routines): TZID-qualify the `.ics` feed's `DTSTART` against an embedded `VTIMEZONE`
+
+`build_ical` (`GET /routines.ics`) emitted every `VEVENT` as a bare UTC instant with no embedded
+`VTIMEZONE`, per issue #387. The fire times themselves were correct (evaluated in the host's local
+zone, matching crontab semantics), but with no timezone identity in the feed, a subscribing
+calendar rendered each event in *its own* default zone rather than the host's — a routine scheduled
+`0 9 * * *` on a `UTC+3` host displayed at 06:00 to a subscriber whose calendar defaults to UTC.
+
+When the host's zone can be named (`iana_time_zone`/`local_timezone`), the feed now emits one
+`VTIMEZONE` component (a `STANDARD` sub-component pinned to the feed's current UTC offset) and
+qualifies each `DTSTART` as `DTSTART;TZID=<zone>:<local-wall-clock>`, so a subscriber sees the
+routine's actual configured local time regardless of their calendar's own default zone. `DTSTAMP`
+stays UTC as RFC 5545 requires. When the zone can't be named, the feed falls back to the original
+bare UTC-instant `DTSTART` with no `VTIMEZONE`, exactly as before.
+
+Scope: this does not model DST transition rules (a full `STANDARD`/`DAYLIGHT` pair with recurrence
+rules would need a timezone-database dependency the daemon doesn't have). A routine in a
+DST-observing zone may display shifted by the DST delta once the host crosses a transition after
+the feed was generated — tracked as a follow-up on issue #387, which also covers the full
+DST-aware acceptance criteria.

--- a/Architecture.md
+++ b/Architecture.md
@@ -198,8 +198,12 @@ interval from piling up concurrent agent sessions against the same target (dupli
 racing pushes); see `routines::service_trigger::spawn_routine_command`.
 
 `GET /routines.ics` returns an iCalendar (RFC 5545) feed of every enabled routine's upcoming fire
-times (next 30 days, capped per routine), evaluated in the host local timezone and emitted as UTC
-instants so external calendars can subscribe without an embedded `VTIMEZONE`. The optional
+times (next 30 days, capped per routine), evaluated in the host local timezone. When that zone can
+be named, each event's `DTSTART` is `TZID`-qualified with the local wall-clock time against an
+embedded `VTIMEZONE` (pinned to the feed's current UTC offset, no DST transition rules), so a
+subscriber whose calendar defaults to a different zone still sees the routine's actual configured
+local time instead of the same instant reinterpreted in their own zone; when the zone can't be
+named, the feed falls back to a bare UTC-instant `DTSTART` with no `VTIMEZONE`. The optional
 `?routine=<id>` query param scopes the feed to a single routine (named after it via `X-WR-CALNAME`);
 an unknown or disabled id yields a well-formed empty calendar. See `src/routines/ical.rs`.
 

--- a/src/routines/ical.rs
+++ b/src/routines/ical.rs
@@ -57,6 +57,49 @@ fn format_utc(dt: DateTime<Utc>) -> String {
     dt.format("%Y%m%dT%H%M%SZ").to_string()
 }
 
+/// Format a local wall-clock instant as an iCalendar local date-time (`YYYYMMDDTHHMMSS`, no
+/// trailing `Z`), for use with a `TZID`-qualified `DTSTART` (RFC 5545 §3.3.5).
+fn format_local(dt: DateTime<Local>) -> String {
+    dt.format("%Y%m%dT%H%M%S").to_string()
+}
+
+/// Format a UTC offset as an RFC 5545 §3.3.14 `utc-offset` (`+HHMM`, or `+HHMMSS` when the
+/// offset carries seconds — some pre-1900 zones do).
+fn format_utc_offset(offset: chrono::FixedOffset) -> String {
+    let total = offset.local_minus_utc();
+    let sign = if total < 0 { '-' } else { '+' };
+    let total = total.unsigned_abs();
+    let (hours, minutes, seconds) = (total / 3600, (total % 3600) / 60, total % 60);
+    if seconds == 0 {
+        format!("{sign}{hours:02}{minutes:02}")
+    } else {
+        format!("{sign}{hours:02}{minutes:02}{seconds:02}")
+    }
+}
+
+/// Build the `VTIMEZONE` component lines identifying the host's local zone.
+///
+/// Emits a single `STANDARD` sub-component pinned to the feed's current UTC offset rather than a
+/// full `STANDARD`/`DAYLIGHT` pair with DST transition rules — the daemon has no timezone-database
+/// dependency to derive those from. A routine whose zone observes DST may therefore display
+/// shifted by the DST delta in a subscriber's calendar once the host crosses a transition after the
+/// feed was generated. This still fixes the common complaint (issue #387): a subscriber whose
+/// calendar defaults to a *different* zone than the host now sees the routine's actual configured
+/// local time instead of the UTC instant reinterpreted in their own zone.
+fn vtimezone_lines(tzid: &str, offset: chrono::FixedOffset) -> Vec<String> {
+    let offset_str = format_utc_offset(offset);
+    vec![
+        "BEGIN:VTIMEZONE".to_string(),
+        format!("TZID:{}", escape_text(tzid)),
+        "BEGIN:STANDARD".to_string(),
+        "DTSTART:19700101T000000".to_string(),
+        format!("TZOFFSETFROM:{offset_str}"),
+        format!("TZOFFSETTO:{offset_str}"),
+        "END:STANDARD".to_string(),
+        "END:VTIMEZONE".to_string(),
+    ]
+}
+
 /// Maximum characters of a routine prompt shown in a `DESCRIPTION` before truncation.
 const DESCRIPTION_PROMPT_MAX: usize = 120;
 
@@ -112,8 +155,12 @@ fn fold_line(line: &str) -> String {
 ///
 /// Each enabled routine with a parseable schedule contributes one `VEVENT` per fire time in
 /// `(now, now + HORIZON_DAYS]`, capped at [`MAX_EVENTS_PER_ROUTINE`]. Fire times are evaluated in
-/// the host's local timezone (matching crontab semantics) and emitted as UTC instants so the feed
-/// needs no embedded `VTIMEZONE`. Disabled, power-saving, and unparseable-schedule (e.g. `@reboot`)
+/// the host's local timezone (matching crontab semantics). When that zone can be named (see
+/// [`super::model::local_timezone`]), each `DTSTART` is `TZID`-qualified with the local wall-clock
+/// time, backed by one `VTIMEZONE` component (issue #387) — so a subscriber whose calendar
+/// defaults to a different zone still sees the routine's actual configured local time. When the
+/// zone can't be resolved, the feed falls back to a bare UTC-instant `DTSTART` with no
+/// `VTIMEZONE`, exactly as before. Disabled, power-saving, and unparseable-schedule (e.g. `@reboot`)
 /// routines contribute nothing. A snoozed routine (`snoozed_until` in the future, or `skip_runs`
 /// above zero) has its would-be-skipped fires filtered out too, mirroring the skip that
 /// `svc_trigger_scheduled` actually performs at fire time, so the feed never advertises a run that
@@ -139,11 +186,31 @@ fn build_ical_named(routines: &[Routine], now: DateTime<Local>, cal_name: &str) 
 
 /// Core iCalendar builder parameterised by `max_events` so tests can exercise the truncation paths
 /// with a small cap without needing a schedule that fires exactly [`MAX_EVENTS_PER_ROUTINE`] times.
+///
+/// Resolves the host's `VTIMEZONE` info itself (see [`build_ical_core_with_tz`] for the
+/// test-only seam that overrides it).
 fn build_ical_core(
     routines: &[Routine],
     now: DateTime<Local>,
     cal_name: &str,
     max_events: usize,
+) -> String {
+    // `None` when the host zone can't be named, in which case every DTSTART falls back to the
+    // original bare UTC-instant form (see `vtimezone_lines`'s doc comment for the scope of what a
+    // `Some` here does and doesn't model).
+    let host_tz = super::model::local_timezone().map(|tzid| (tzid, *now.offset()));
+    build_ical_core_with_tz(routines, now, cal_name, max_events, host_tz.as_ref())
+}
+
+/// Like [`build_ical_core`] but with the host `VTIMEZONE` info (`(TZID, UTC offset)`) passed in
+/// explicitly, so tests can exercise both the `TZID`-qualified and UTC-fallback `DTSTART` forms
+/// deterministically instead of depending on the test machine's own resolvable timezone.
+fn build_ical_core_with_tz(
+    routines: &[Routine],
+    now: DateTime<Local>,
+    cal_name: &str,
+    max_events: usize,
+    host_tz: Option<&(String, chrono::FixedOffset)>,
 ) -> String {
     let dtstamp = format_utc(now.with_timezone(&Utc));
     let horizon = now + Duration::days(HORIZON_DAYS);
@@ -159,6 +226,15 @@ fn build_ical_core(
         format!("REFRESH-INTERVAL;VALUE=DURATION:{REFRESH_DURATION}"),
         format!("X-PUBLISHED-TTL:{REFRESH_DURATION}"),
     ];
+    if let Some((tzid, offset)) = &host_tz {
+        lines.extend(vtimezone_lines(tzid, *offset));
+    }
+    // `TZID` param-values never need quoting here: IANA zone names (e.g. `Asia/Jerusalem`) never
+    // contain the `:`/`;`/`,` characters RFC 5545 §3.2 would require escaping.
+    let dtstart_line = |local: DateTime<Local>, utc_stamp: &str| match &host_tz {
+        Some((tzid, _)) => format!("DTSTART;TZID={tzid}:{}", format_local(local)),
+        None => format!("DTSTART:{utc_stamp}"),
+    };
     let globally_locked = crate::global_lock::is_globally_locked();
     for routine in routines {
         if !routine.enabled || globally_locked || routine.power_saving {
@@ -194,7 +270,7 @@ fn build_ical_core(
             lines.push("BEGIN:VEVENT".to_string());
             lines.push(format!("UID:{}-{}@moadim", routine.id, stamp));
             lines.push(format!("DTSTAMP:{dtstamp}"));
-            lines.push(format!("DTSTART:{stamp}"));
+            lines.push(dtstart_line(fire, &stamp));
             lines.push(format!("DURATION:{EVENT_DURATION}"));
             // The feed is purely informational ("when will my loops fire?"), so a
             // fire must not consume the subscriber's free/busy time. RFC 5545
@@ -224,7 +300,7 @@ fn build_ical_core(
                 lines.push("BEGIN:VEVENT".to_string());
                 lines.push(format!("UID:{}-truncated@moadim", routine.id));
                 lines.push(format!("DTSTAMP:{dtstamp}"));
-                lines.push(format!("DTSTART:{stamp}"));
+                lines.push(dtstart_line(next, &stamp));
                 // Mirror the regular fire VEVENT's DURATION/TRANSP/BUSYSTATUS (see the comments
                 // on EVENT_DURATION and on the regular-fire VEVENT above): without a DURATION
                 // this marker is a zero-length instant, which most calendar UIs render as an
@@ -261,6 +337,31 @@ pub(crate) fn build_ical_with_cap(
     max_events: usize,
 ) -> String {
     build_ical_core(routines, now, DEFAULT_CAL_NAME, max_events)
+}
+
+/// Test-only entry point: build the iCalendar feed with an explicit per-routine event cap *and*
+/// an explicit host `VTIMEZONE` override (`(TZID, UTC offset)`, or `None` for the
+/// no-resolvable-zone fallback), so both the truncation-marker path and the choice between a
+/// `TZID`-qualified and a bare-UTC `DTSTART` can be tested deterministically instead of depending
+/// on whichever timezone the test machine itself resolves to.
+#[cfg(test)]
+#[allow(
+    clippy::needless_pass_by_value,
+    reason = "owned Option reads cleanest at test call sites; internally borrowed once"
+)]
+pub(crate) fn build_ical_with_tz(
+    routines: &[Routine],
+    now: DateTime<Local>,
+    max_events: usize,
+    host_tz: Option<(String, chrono::FixedOffset)>,
+) -> String {
+    build_ical_core_with_tz(
+        routines,
+        now,
+        DEFAULT_CAL_NAME,
+        max_events,
+        host_tz.as_ref(),
+    )
 }
 
 /// Build the iCalendar feed for every routine currently in `store`.

--- a/src/routines/ical_tests.rs
+++ b/src/routines/ical_tests.rs
@@ -85,7 +85,7 @@ fn enabled_daily_routine_yields_events_within_horizon() {
     assert!(ics.contains("DESCRIPTION:do the thing (agent: claude)\r\n"));
     assert!(ics.contains("UID:r1-"));
     assert!(ics.contains("@moadim\r\n"));
-    assert!(ics.contains("DTSTART:"));
+    assert!(ics.contains("DTSTART"));
     assert!(ics.contains("DTSTAMP:"));
     // Fire times are momentary triggers, not busy blocks: every event is
     // TRANSPARENT so subscribers aren't marked BUSY (one per VEVENT).
@@ -150,7 +150,9 @@ fn snoozed_routine_skips_fires_before_the_deadline() {
     let now = fixed_now();
     let deadline = now + Duration::minutes(3);
     routine.snoozed_until = Some(u64::try_from(deadline.timestamp()).unwrap());
-    let ics = build_ical_with_cap(&[routine], now, 5);
+    // Force the plain-UTC fallback so this test only exercises the snooze-filtering logic, not
+    // the TZID-formatting choice (covered separately below).
+    let ics = build_ical_with_tz(&[routine], now, 5, None);
     // The first two per-minute fires (00:01, 00:02) fall before the deadline and are
     // dropped; the feed starts at the deadline itself (00:03).
     assert!(ics.contains(&format!(
@@ -173,7 +175,9 @@ fn skip_runs_drops_the_next_n_fires() {
     let mut routine = routine_with("r1", "* * * * *", true);
     routine.skip_runs = Some(2);
     let now = fixed_now();
-    let ics = build_ical_with_cap(&[routine], now, 3);
+    // Force the plain-UTC fallback so this test only exercises the skip-count logic, not the
+    // TZID-formatting choice (covered separately below).
+    let ics = build_ical_with_tz(&[routine], now, 3, None);
     let first_kept = now + Duration::minutes(3);
     let first_dropped = now + Duration::minutes(1);
     assert!(ics.contains(&format!(
@@ -494,5 +498,93 @@ fn at_cap_with_more_fires_still_in_horizon_adds_truncation_marker() {
     assert!(
         ics.contains("-truncated@moadim"),
         "truncation marker expected"
+    );
+}
+
+// ── VTIMEZONE / TZID-qualified DTSTART (issue #387) ──────────────────────────
+
+#[test]
+fn known_host_zone_emits_vtimezone_and_tzid_dtstart() {
+    let offset = chrono::FixedOffset::east_opt(3 * 3600).unwrap(); // e.g. Asia/Jerusalem in winter
+    let now = fixed_now();
+    let ics = build_ical_with_tz(
+        &[routine_with("r1", "@daily", true)],
+        now,
+        MAX_EVENTS_PER_ROUTINE,
+        Some(("Asia/Jerusalem".to_string(), offset)),
+    );
+    assert!(ics.contains("BEGIN:VTIMEZONE\r\n"));
+    assert!(ics.contains("TZID:Asia/Jerusalem\r\n"));
+    assert!(ics.contains("BEGIN:STANDARD\r\n"));
+    assert!(ics.contains("TZOFFSETFROM:+0300\r\n"));
+    assert!(ics.contains("TZOFFSETTO:+0300\r\n"));
+    assert!(ics.contains("END:STANDARD\r\n"));
+    assert!(ics.contains("END:VTIMEZONE\r\n"));
+    // Every DTSTART references the VTIMEZONE's TZID with a local (non-`Z`-suffixed) wall-clock
+    // time instead of the bare UTC-instant form.
+    let events = count(&ics, "BEGIN:VEVENT");
+    assert!(events > 0);
+    assert_eq!(count(&ics, "DTSTART;TZID=Asia/Jerusalem:"), events);
+    // The only bare `DTSTART:` left is the `VTIMEZONE`'s own `STANDARD` sub-component
+    // (RFC 5545 requires it there, unrelated to any `VEVENT`'s `DTSTART`).
+    assert_eq!(count(&ics, "DTSTART:"), 1);
+    // DTSTAMP still stays UTC (RFC 5545 requires it), regardless of the host zone.
+    assert!(ics.contains("DTSTAMP:") && ics.contains('Z'));
+}
+
+#[test]
+fn unresolvable_host_zone_falls_back_to_bare_utc_dtstart() {
+    let now = fixed_now();
+    let ics = build_ical_with_tz(
+        &[routine_with("r1", "@daily", true)],
+        now,
+        MAX_EVENTS_PER_ROUTINE,
+        None,
+    );
+    assert!(!ics.contains("VTIMEZONE"));
+    assert!(!ics.contains("TZID"));
+    let events = count(&ics, "BEGIN:VEVENT");
+    assert!(events > 0);
+    assert_eq!(count(&ics, "DTSTART:"), events);
+}
+
+#[test]
+fn truncation_marker_also_uses_tzid_dtstart_when_host_zone_known() {
+    let offset = chrono::FixedOffset::west_opt(5 * 3600).unwrap(); // e.g. America/New_York in winter
+    let now = fixed_now();
+    let ics = build_ical_with_tz(
+        &[routine_with("r1", "* * * * *", true)],
+        now,
+        2,
+        Some(("America/New_York".to_string(), offset)),
+    );
+    assert!(ics.contains("-truncated@moadim"));
+    // 2 real events + 1 truncation marker, all TZID-qualified.
+    assert_eq!(count(&ics, "BEGIN:VEVENT"), 3);
+    assert_eq!(count(&ics, "DTSTART;TZID=America/New_York:"), 3);
+}
+
+#[test]
+fn utc_offset_formats_per_rfc5545() {
+    assert_eq!(
+        format_utc_offset(chrono::FixedOffset::east_opt(0).unwrap()),
+        "+0000"
+    );
+    assert_eq!(
+        format_utc_offset(chrono::FixedOffset::east_opt(3 * 3600).unwrap()),
+        "+0300"
+    );
+    assert_eq!(
+        format_utc_offset(chrono::FixedOffset::west_opt(5 * 3600).unwrap()),
+        "-0500"
+    );
+    assert_eq!(
+        format_utc_offset(chrono::FixedOffset::east_opt(5 * 3600 + 30 * 60).unwrap()),
+        "+0530"
+    );
+    // A non-zero seconds component (some pre-1900 zones) appends a third HH:MM:SS group.
+    assert_eq!(
+        format_utc_offset(chrono::FixedOffset::east_opt(3 * 3600 + 25).unwrap()),
+        "+030025"
     );
 }


### PR DESCRIPTION
## Problem

`build_ical` (`GET /routines.ics`) emits every `VEVENT` as a bare UTC instant and ships no `VTIMEZONE` block (issue #387). The fire times themselves are correct — evaluated in the host's local zone, matching crontab semantics — but with no timezone identity in the feed, a subscribing calendar renders each event in *its own* default zone instead of the host's. A routine scheduled `0 9 * * *` on a `UTC+3` host displays at 06:00 to a subscriber whose calendar defaults to UTC.

## What changed

- When the host's zone can be named (`local_timezone`, backed by `iana_time_zone`), the feed now emits one `VTIMEZONE` component and `TZID`-qualifies each `DTSTART` with the local wall-clock time (`DTSTART;TZID=<zone>:<local-time>`), so a subscriber sees the routine's actual configured local time regardless of their calendar's own default zone. `DTSTAMP` stays UTC as RFC 5545 requires.
- When the zone can't be resolved, the feed falls back to the original bare UTC-instant `DTSTART` with no `VTIMEZONE` — unchanged behavior, no dangling `TZID`.
- Both the regular per-fire `VEVENT`s and the schedule-truncation marker event use the same `DTSTART` form.
- Updated `Architecture.md`'s description of the feed and added a changeset.

## Scope (what this does NOT do)

The `VTIMEZONE` here is a single `STANDARD` sub-component pinned to the feed's current UTC offset — not a full `STANDARD`/`DAYLIGHT` pair with DST transition rules, since generating those correctly needs a timezone-database dependency (e.g. `chrono-tz` plus transition-rule derivation) the daemon doesn't currently have. A routine in a DST-observing zone may therefore display shifted by the DST delta once the host crosses a transition after the feed was generated. This still fixes the everyday complaint the issue opens with (wrong-hour display for any subscriber whose calendar defaults to a different zone than the host), for the common case. Full DST-transition modeling stays open on #387 as a follow-up.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test` (1074/1074, including 4 new tests: known-zone VTIMEZONE/TZID content, offset formatting across sign/seconds cases, unresolvable-zone fallback, and the truncation marker's DTSTART form)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`
- [x] `cargo llvm-cov` — `src/routines/ical.rs` itself is 100% line-covered (the residual ~99.6% total reflects pre-existing gaps in unrelated files, unchanged by this PR)