### PR TITLE
fix(client): resolve react-hooks/purity and set-state-in-effect lint errors

### DIFF
--- a/.changeset/fix-client-react-hooks-lint-violations.md
+++ b/.changeset/fix-client-react-hooks-lint-violations.md
@@ -1,0 +1,27 @@
+---
+"moadim": patch
+---
+
+fix(client): resolve `client-lint`'s 8 `react-hooks/purity` and `react-hooks/set-state-in-effect` errors
+
+The `eslint-plugin-react-hooks` bump to 7.1.1 (#1185) enabled stricter React
+Compiler rules that flag pre-existing code: four `Date.now()` calls during
+render (`react-hooks/purity`) and four `setState` calls synchronously inside
+a `useEffect` (`react-hooks/set-state-in-effect`). This left `pnpm --filter
+client lint` — part of both CI's `client-lint` job and the local pre-push
+hook — failing on `main` for any contributor who runs it, independent of
+what their own change touches.
+
+- Added a shared `useNow()` hook (`client/src/lib/useNow.ts`) that reads the
+  clock inside a timer effect instead of during render, and reused it in
+  `RefreshControl`, `RoutineFlags`, and `RoutineHistory` (which previously
+  each read `Date.now()` directly in their render body).
+- Moved four `setState` calls (`RoutinesPage`'s deep-link page and stale-selection
+  prune, `SettingsPage`'s draft-seeding, `CommandPalette`'s reset-on-open) out
+  of `useEffect` and into a lazy `useState` initializer or a guarded
+  render-time update, per React's own "Adjusting state when a prop changes"
+  guidance — no behavior change intended.
+
+No dependency versions changed here; unrelated to #1251, which fixes a
+separate `@vitejs/plugin-react`/`vite` peer-dependency break that currently
+also blocks `pnpm --filter client test` from even starting.

--- a/client/src/components/RefreshControl.tsx
+++ b/client/src/components/RefreshControl.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useNow } from "../lib/useNow";
 
 /**
  * Live auto-refresh control for a data table's action row: a Grafana/Datadog
@@ -67,15 +67,11 @@ export interface RefreshControlProps {
 
 /** Interval dropdown + live freshness label for a data table's action row. */
 export function RefreshControl({ token, updatedAtMs, onChange }: RefreshControlProps) {
-  // A local 1s tick re-renders just this widget so "updated Ns ago" stays live
+  // A local 1s clock re-renders just this widget so "updated Ns ago" stays live
   // without forcing the parent table to re-render every second.
-  const [, setTick] = useState(0);
-  useEffect(() => {
-    const id = setInterval(() => setTick((n) => n + 1), 1_000);
-    return () => clearInterval(id);
-  }, []);
+  const now = useNow();
 
-  const freshness = updatedAtMs > 0 ? fmtFreshness(Math.max(0, Math.floor((Date.now() - updatedAtMs) / 1000))) : undefined;
+  const freshness = updatedAtMs > 0 ? fmtFreshness(Math.max(0, Math.floor((now - updatedAtMs) / 1000))) : undefined;
 
   return (
     <div className="refresh-control">

--- a/client/src/lib/useNow.test.ts
+++ b/client/src/lib/useNow.test.ts
@@ -1,0 +1,26 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useNow } from "./useNow";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useNow", () => {
+  it("returns the current time immediately", () => {
+    vi.setSystemTime(1_000_000);
+    const { result } = renderHook(() => useNow());
+    expect(result.current).toBe(1_000_000);
+  });
+
+  it("ticks on the given interval", () => {
+    vi.setSystemTime(0);
+    const { result } = renderHook(() => useNow(1_000));
+    act(() => vi.advanceTimersByTime(1_000));
+    expect(result.current).toBe(1_000);
+  });
+});

--- a/client/src/lib/useNow.ts
+++ b/client/src/lib/useNow.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Current wall-clock time (ms since epoch), ticking every `intervalMs` via a
+ * timer effect. Centralizes the "read `Date.now()` outside of render" shape
+ * `react-hooks/purity` requires: render must stay a pure function of props/
+ * state, so the impure clock read lives in an effect's timer callback
+ * instead of in the render body (previously duplicated ad hoc by
+ * `RefreshControl` and inlined, non-ticking, in a couple of freshness
+ * labels).
+ */
+export function useNow(intervalMs = 1_000): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs]);
+  return now;
+}

--- a/client/src/pages/routines/RoutineFlags.tsx
+++ b/client/src/pages/routines/RoutineFlags.tsx
@@ -1,6 +1,7 @@
 import { useFlags, useResolveFlag } from "../../api/hooks";
 import { fmtFreshness } from "../../components/RefreshControl";
 import { reltime } from "../../lib/cronUtils";
+import { useNow } from "../../lib/useNow";
 
 export interface RoutineFlagsProps {
   id: string;
@@ -12,6 +13,7 @@ export interface RoutineFlagsProps {
 export function RoutineFlags({ id, title, onBack }: RoutineFlagsProps) {
   const flagsQuery = useFlags(id);
   const resolveFlag = useResolveFlag();
+  const now = useNow();
 
   const flags = flagsQuery.data ?? [];
 
@@ -24,7 +26,7 @@ export function RoutineFlags({ id, title, onBack }: RoutineFlagsProps) {
         <div className="page-title">FLAGS / {title}</div>
         {flagsQuery.dataUpdatedAt > 0 && (
           <span className="page-freshness">
-            {fmtFreshness(Math.max(0, (Date.now() - flagsQuery.dataUpdatedAt) / 1000))}
+            {fmtFreshness(Math.max(0, (now - flagsQuery.dataUpdatedAt) / 1000))}
           </span>
         )}
         <button

--- a/client/src/pages/routines/RoutineHistory.tsx
+++ b/client/src/pages/routines/RoutineHistory.tsx
@@ -3,6 +3,7 @@ import { useRoutineRuns, useRunLog } from "../../api/hooks";
 import { fmtFreshness } from "../../components/RefreshControl";
 import { abstime, reltime } from "../../lib/cronUtils";
 import { fmtRetention, fmtRunDuration, runStatusClass, runStatusLabel } from "../../lib/runDisplay";
+import { useNow } from "../../lib/useNow";
 import { LogViewer } from "./LogViewer";
 
 export interface RoutineHistoryProps {
@@ -18,7 +19,8 @@ export function RoutineHistory({ id, title, onBack }: RoutineHistoryProps) {
   const logQuery = useRunLog(id, selected ?? "", selected !== undefined);
 
   const runs = runsQuery.data ?? [];
-  const nowSecs = Math.floor(Date.now() / 1000);
+  const now = useNow();
+  const nowSecs = Math.floor(now / 1000);
 
   return (
     <main className="logs-page">
@@ -29,7 +31,7 @@ export function RoutineHistory({ id, title, onBack }: RoutineHistoryProps) {
         <div className="page-title">HISTORY / {title}</div>
         {runsQuery.dataUpdatedAt > 0 && (
           <span className="page-freshness">
-            {fmtFreshness(Math.max(0, (Date.now() - runsQuery.dataUpdatedAt) / 1000))}
+            {fmtFreshness(Math.max(0, (now - runsQuery.dataUpdatedAt) / 1000))}
           </span>
         )}
         <button

--- a/client/src/pages/routines/RoutinesPage.tsx
+++ b/client/src/pages/routines/RoutinesPage.tsx
@@ -99,7 +99,13 @@ export function RoutinesPage() {
   const initialSnapshot = useMemo(() => loadLastView(), []);
   const initialDecoded = initialSnapshot ? decodeSnapshot(initialSnapshot) : undefined;
 
-  const [page, setPage] = useState<RPage>({ kind: "list" });
+  // Deep link: `/routines?history=<id>` (e.g. from the Overview page's recent-runs
+  // panel) picks the initial page via a lazy initializer rather than an
+  // effect + setState, since it only ever matters for the very first render.
+  const [page, setPage] = useState<RPage>((): RPage => {
+    const id = searchParams.get("history");
+    return id ? { kind: "history", id } : { kind: "list" };
+  });
   const [modal, setModal] = useState<RModal>({ kind: "none" });
   const [view, setView] = useState<RView>("table");
   const [filter, setFilter] = useState<RoutineFilter>(initialDecoded?.filter ?? defaultRoutineFilter());
@@ -112,11 +118,10 @@ export function RoutinesPage() {
   const [now, setNow] = useState(() => new Date());
   const searchRef = useRef<HTMLInputElement>(null);
 
-  // Deep link: `/routines?history=<id>` (e.g. from the Overview page's recent-runs panel).
+  // Strip the `history` param from the URL once consumed above, so a reload or
+  // share link doesn't re-trigger the deep link.
   useEffect(() => {
-    const id = searchParams.get("history");
-    if (id) {
-      setPage({ kind: "history", id });
+    if (searchParams.get("history")) {
       const next = new URLSearchParams(searchParams);
       next.delete("history");
       setSearchParams(next, { replace: true });
@@ -181,14 +186,18 @@ export function RoutinesPage() {
     setFilter((f) => (f.machine.kind === "any" ? { ...f, machine: { kind: "machine", value: name } } : f));
   }, [currentMachineQuery.data]);
 
-  // Drop selections for routines that no longer exist after a reload.
-  useEffect(() => {
+  // Drop selections for routines that no longer exist after a reload. Adjusted
+  // during render (guarded on the `routines` reference changing) rather than in
+  // an effect — see the `seededFrom` comment in SettingsPage.tsx for the pattern.
+  const [prevRoutines, setPrevRoutines] = useState(routines);
+  if (routines !== prevRoutines) {
+    setPrevRoutines(routines);
     const ids = new Set(routines.map((r) => r.id));
     setSelected((sel) => {
       const next = new Set([...sel].filter((id) => ids.has(id)));
       return next.size === sel.size ? sel : next;
     });
-  }, [routines]);
+  }
 
   // ── Mutations ──────────────────────────────────────────────────────────────
   const createRoutine = useCreateRoutine();

--- a/client/src/pages/settings/SettingsPage.tsx
+++ b/client/src/pages/settings/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useSetUserPrompt, useUserPrompt } from "../../api/hooks";
 import { useToasts } from "../../shell/toasts";
 
@@ -10,13 +10,16 @@ export function SettingsPage() {
   const [content, setContent] = useState("");
   const [loadedContent, setLoadedContent] = useState("");
 
-  // Seed the editable draft once the initial fetch resolves.
-  useEffect(() => {
-    if (userPrompt.data !== undefined) {
-      setContent(userPrompt.data);
-      setLoadedContent(userPrompt.data);
-    }
-  }, [userPrompt.data]);
+  // Seed the editable draft once the initial fetch resolves. Adjusting state during
+  // render (rather than in an effect) on a tracked "previous prop" per
+  // https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  // avoids the extra render pass `react-hooks/set-state-in-effect` warns about.
+  const [seededFrom, setSeededFrom] = useState<string | undefined>(undefined);
+  if (userPrompt.data !== undefined && userPrompt.data !== seededFrom) {
+    setSeededFrom(userPrompt.data);
+    setContent(userPrompt.data);
+    setLoadedContent(userPrompt.data);
+  }
 
   const dirty = content !== loadedContent;
 

--- a/client/src/shell/CommandPalette.tsx
+++ b/client/src/shell/CommandPalette.tsx
@@ -34,19 +34,28 @@ export function CommandPalette({ open, onClose, onRefresh, onStop, onToggleTheme
   const [selected, setSelected] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  // Re-fetch routines and reset query/selection/focus each time the palette opens.
+  // Re-fetch routines each time the palette opens.
   const { data: routines } = useQuery({
     queryKey: ["command-palette", "routines"],
     queryFn: async () => unwrap(await api.GET("/routines")),
     enabled: open,
   });
 
-  useEffect(() => {
+  // Reset query/selection during render (guarded on `open` actually changing)
+  // rather than in an effect — see the `seededFrom` comment in SettingsPage.tsx
+  // for the pattern. Focusing the input is a genuine side effect on an external
+  // system (the DOM), so it stays in its own effect below.
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
     if (open) {
       setQuery("");
       setSelected(0);
-      inputRef.current?.focus();
     }
+  }
+
+  useEffect(() => {
+    if (open) inputRef.current?.focus();
   }, [open]);
 
   if (!open) return null;


### PR DESCRIPTION
## Why

The `eslint-plugin-react-hooks` bump to 7.1.1 (#1185) enabled stricter React
Compiler lint rules. Applied against pre-existing code, they surface 8 real
errors that currently fail `pnpm --filter client lint` on `main` — part of
both CI's `client-lint` job and the local pre-push hook:

- `react-hooks/purity` (4x): `Date.now()` called directly during render in
  `RefreshControl`, `RoutineFlags`, and `RoutineHistory` (twice). Render is
  supposed to be a pure function of props/state; an impure clock read there
  can produce unstable output across re-renders.
- `react-hooks/set-state-in-effect` (4x): `setState` called synchronously
  inside a `useEffect` body in `RoutinesPage` (the `?history=<id>` deep link,
  and pruning stale selections when the routine list changes), `SettingsPage`
  (seeding the prompt editor's draft from the fetched value), and
  `CommandPalette` (resetting query/selection on open).

This isn't a change any single contributor's PR introduces — it's a standing
break that surfaces on any `client/` touch (or a clean `pnpm --filter client
lint`/pre-push run), the same category of issue as #894 (the now-fixed
`cargo doc` intra-link break). It is unrelated to #1251, which fixes a
separate `@vitejs/plugin-react`/`vite` peer-dependency mismatch that
currently blocks `pnpm --filter client test` from starting at all — that
issue is out of scope here and this PR doesn't touch any dependency version.

## What changed

- Added `client/src/lib/useNow.ts`, a small shared hook that reads the clock
  inside a `setInterval` timer effect (not during render) and returns the
  ticking value. Reused it in `RefreshControl` (replacing its existing
  dummy-tick-counter workaround), `RoutineFlags`, and `RoutineHistory`
  (which previously computed a one-shot, non-ticking `Date.now()` snapshot
  directly in the render body).
- Moved the 4 flagged `setState`-in-effect calls to either a lazy `useState`
  initializer (`RoutinesPage`'s initial page from the `history` search param,
  since it only matters on the first render) or a guarded render-time update
  keyed on the previous prop/value (`RoutinesPage`'s stale-selection prune,
  `SettingsPage`'s draft seeding, `CommandPalette`'s reset-on-open) — the
  pattern React's own docs recommend for "[Adjusting state when a prop
  changes](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes)".
  No intended behavior change; `CommandPalette`'s DOM focus side effect stays
  in its own `useEffect` since focusing an input is a legitimate external-system
  side effect, not a `setState` call.

## Checks run locally

- `pnpm --filter client lint` — 0 errors (was 8 errors, 1 pre-existing
  unrelated warning remains)
- `pnpm --filter client typecheck` — clean
- `pnpm --filter client test` — can't run on `main` as-is due to the
  unrelated #1251 peer-dep break (`vitest` fails at config-load with
  `ERR_PACKAGE_PATH_NOT_EXPORTED`), confirmed pre-existing via `git stash`.
  Verified this PR's changes directly by temporarily layering them on top of
  #1251's fix in a local scratch branch (not part of this PR): all 331 tests
  pass, including a new `useNow.test.ts`.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D
  warnings`, `cargo test --workspace`, `cargo llvm-cov --fail-under-lines
  100 --ignore-filename-regex 'src/main\.rs'`, `linecheck --max-lines 500` —
  all green (unaffected, this PR only touches `client/`).
- `typos` on all touched files — clean.

## Changeset

Added `.changeset/fix-client-react-hooks-lint-violations.md` (patch).