### PR TITLE
docs(man): sync moadim.1 with restart flags, logs command, and /api/v1 path

### DIFF
--- a/docs/moadim.1
+++ b/docs/moadim.1
@@ -1,7 +1,7 @@
 .\" Man page for moadim.
 .\" Mirrors the built-in `moadim --help` output (src/cli.rs::print_help).
 .\" View with:  man ./docs/moadim.1   or install into share/man/man1/.
-.TH MOADIM 1 "2026-07-17" "moadim 1.3.1" "Moadim Manual"
+.TH MOADIM 1 "2026-07-18" "moadim 1.3.1" "Moadim Manual"
 .SH NAME
 moadim \- routine scheduler with an MCP/REST API and a web control panel
 .SH SYNOPSIS
@@ -33,8 +33,18 @@ Run in the foreground, attached to the terminal (Ctrl-C to stop).
 Start the server detached in the background (the explicit default).
 .SH COMMANDS
 .TP
-.B restart
-Stop a running server (if any) and start a fresh background one.
+.BR "restart " [ \-\-json "] [" \-q "] [" \-i ]
+Stop a running server (if any) and start a fresh one.
+.B \-q
+/
+.B \-\-quiet
+prints only the
+.B "restarted: pid <old> -> <new>"
+rotation line, suppressing the preamble and the reach/manage hint block.
+.B \-i
+/
+.B \-\-interactive
+brings the fresh instance up in the foreground instead of detached.
 .TP
 .BR "stop " [ \-\-json "] [" \-q ]
 Stop a running background server.
@@ -51,7 +61,7 @@ start reaps it.
 Show whether a server is running.
 .B \-\-wait
 polls
-.B GET /health
+.B GET /api/v1/health
 until the server answers or
 .I SECS
 elapses (default 30) instead of checking once, so scripts can block on
@@ -62,6 +72,11 @@ Reap finished, expired routine workbenches now.
 .TP
 .B "trigger <id>"
 Trigger a routine to run now, outside its schedule.
+.TP
+.B "logs <id>"
+Print a routine's newest run log
+.RI ( agent.log )
+to stdout.
 .TP
 .B install
 Register moadim as an OS service (launchd / systemd user).
@@ -111,13 +126,15 @@ List available agent keys.
 .TP
 .B \-\-json
 Pass to
-.BR stop ", " status ", or " cleanup
+.BR restart ", " stop ", " status ", or " cleanup
 for a single-line, machine-readable object on stdout.
 .TP
 .BR \-q ", " \-\-quiet
 Pass to
 .B stop
-to suppress its human-readable status line.
+to suppress its human-readable status line, or to
+.B restart
+to print only the rotation line.
 .TP
 .BR "\-\-wait" [ = SECS ]
 Pass to


### PR DESCRIPTION
## Why

`docs/moadim.1` documents itself as mirroring `moadim --help` (see its header comment), but had drifted:

- **`restart`** gained `--json`/`-q`/`-i` flags (see the CLI's `print_help` in `src/cli/mod.rs`), but the man page still showed it as a bare, flag-less command with no mention of what `--json`/`-q`/`-i` do.
- **`moadim logs <id>`** (added in #1236, `feat(cli): add moadim logs <id> as a top-level shortcut for routines logs`) was missing from `COMMANDS` entirely.
- The `status --wait` entry still said `GET /health`. Every route is actually mounted under `/api/v1` — README.md's "Running" table had the identical drift and was fixed in #1244 (`docs(readme): use the full /api/v1 prefix for /shutdown and /health`), but the man page was missed in that pass.
- `OPTIONS`' `--json` and `-q`/`--quiet` entries only listed `stop`/`status`/`cleanup`, omitting `restart` even though `restart` accepts both.

## What

Docs-only fix to `docs/moadim.1`:
- Documents `restart`'s `--json`/`-q`/`-i` flags and behavior (mirroring the existing `stop`/`status` entries' style).
- Adds the missing `logs <id>` entry.
- Fixes `GET /health` → `GET /api/v1/health`.
- Adds `restart` to the `--json`/`-q` OPTIONS entries.
- Bumps the `.TH` date to the day of the edit.

No source or behavior change, so no `.changeset/*.md` entry — matching the precedent of the other recent docs-only commits (`9b6d554`, `cbbdf15`), which also skipped changesets.

## Verification

- `mandoc -T lint docs/moadim.1` — clean, no warnings.
- Rendered `man ./docs/moadim.1` locally and read through every changed section.
- `typos docs/moadim.1` — clean.
- `lychee --config lychee.toml docs/moadim.1` — no broken links.
- Diffed against the actual `cargo run -- --help` output to confirm every documented flag/command now matches.