### PR TITLE
feat(ui): add a RELIABILITY page ranking routines by success rate, streaks, and flakiness

### DIFF
--- a/.changeset/ui-reliability-page.md
+++ b/.changeset/ui-reliability-page.md
@@ -1,0 +1,13 @@
+---
+"moadim": minor
+---
+
+feat(ui): add a RELIABILITY page ranking routines by success rate, active failure streaks, and
+flakiness
+
+Adds a new `/reliability` tab to the dashboard that ranks every routine by its most recent 20
+finished runs (issue #1256): success rate, active pass/fail streak, and a flakiness signal
+(≥40% adjacent-run status flips) distinct from steadily-failing routines. Ranked worst-first — an
+active failure streak outranks a merely-low historical success rate. Reads the existing fleet-wide
+`GET /api/v1/routines/runs` endpoint (already used by the Routines table's sparkline column); no
+backend change.

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -24,6 +24,8 @@ mod overview_recent_runs;
 mod overview_stats;
 mod overview_upcoming;
 mod refresh;
+mod reliability;
+mod reliability_stats;
 mod routines;
 mod schedule;
 mod schedule_heatmap;
@@ -36,6 +38,7 @@ pub(crate) use cron_utils::{abstime, describe_cron_live, parse_cron, reltime};
 use header::Header;
 pub(crate) use health::{Health, Toast, ToastKind};
 use overview::OverviewPage;
+use reliability::ReliabilityPage;
 use routines::RoutinesPage;
 use schedule_heatmap::HeatmapPage;
 use settings::SettingsPage;
@@ -97,6 +100,9 @@ pub enum Route {
     /// The calendar heatmap page.
     #[at("/heatmap")]
     Heatmap,
+    /// The reliability ranking page.
+    #[at("/reliability")]
+    Reliability,
     /// The settings page.
     #[at("/settings")]
     Settings,
@@ -291,6 +297,7 @@ pub fn shell() -> Html {
             Route::Home => html! { <OverviewPage on_toast={on_toast.clone()} /> },
             Route::Routines => html! { <RoutinesPage on_toast={on_toast.clone()} /> },
             Route::Heatmap => html! { <HeatmapPage /> },
+            Route::Reliability => html! { <ReliabilityPage /> },
             Route::Settings => html! { <SettingsPage on_toast={on_toast.clone()} /> },
             Route::NotFound => html! { <Redirect<Route> to={Route::Home} /> },
         })
@@ -415,6 +422,9 @@ pub fn nav() -> Html {
             </Link<Route>>
             <Link<Route> classes={classes!(cls(&Route::Heatmap))} to={Route::Heatmap}>
                 { "HEATMAP" }
+            </Link<Route>>
+            <Link<Route> classes={classes!(cls(&Route::Reliability))} to={Route::Reliability}>
+                { "RELIABILITY" }
             </Link<Route>>
             <Link<Route> classes={classes!(cls(&Route::Settings))} to={Route::Settings}>
                 { "SETTINGS" }

--- a/ui/src/reliability.rs
+++ b/ui/src/reliability.rs
@@ -1,0 +1,209 @@
+//! The RELIABILITY page: ranks every routine by recent run outcomes so an operator can spot
+//! what's actively broken or flaky without opening each routine's HISTORY tab individually.
+//!
+//! Best practice (CI/CD reliability dashboards — GitHub Actions Insights, `CircleCI` Insights,
+//! Datadog Test Visibility): surface a success-rate ranking and flag flaky jobs (alternating
+//! pass/fail) as their own category, distinct from steadily-failing ones — the response to each
+//! differs (investigate vs. page on-call).
+//!
+//! The page reads the existing `GET /routines/runs` endpoint (already used by the Routines
+//! table's inline sparkline column) — no backend change. All ranking/flakiness math lives in
+//! pure, host-tested functions in `reliability_stats.rs`; this module is the thin data-fetching
+//! shell that renders the result.
+
+use gloo_timers::future::TimeoutFuture;
+use wasm_bindgen_futures::spawn_local;
+use yew::prelude::*;
+use yew_router::prelude::*;
+
+use crate::refresh::{load_interval, save_interval, RefreshControl, RefreshInterval};
+use crate::reliability_stats::{
+    compute_reliability, fleet_summary, rate_class, rate_label, streak_class, streak_label,
+    FleetReliability, RoutineReliability,
+};
+use crate::routines::{api_all_runs, RoutineHistoryQuery};
+use crate::Route;
+
+/// Fleet-wide runs fetched to build the reliability sample. Mirrors the Routines table's
+/// sparkline fetch cap (`GET /routines/runs` truncates its newest-first merged list to this
+/// many total, across every routine) — high enough that an active fleet's routines each keep a
+/// `SAMPLE_LEN`-sized window without an unbounded payload.
+const FETCH_LIMIT: usize = 300;
+
+/// Loaded state for the reliability page.
+#[derive(Clone, PartialEq, Default)]
+struct Data {
+    items: Vec<RoutineReliability>,
+    loading: bool,
+}
+
+#[function_component(ReliabilityPage)]
+pub fn reliability_page() -> Html {
+    let data = use_state(|| Data {
+        loading: true,
+        ..Data::default()
+    });
+    let interval = use_state(load_interval);
+    let updated_at = use_state(|| 0.0_f64);
+
+    let load = {
+        let data = data.clone();
+        let updated_at = updated_at.clone();
+        move || {
+            let data = data.clone();
+            let updated_at = updated_at.clone();
+            spawn_local(async move {
+                let runs = api_all_runs(FETCH_LIMIT).await.unwrap_or_default();
+                let items = compute_reliability(&runs);
+                updated_at.set(js_sys::Date::now());
+                data.set(Data {
+                    items,
+                    loading: false,
+                });
+            });
+        }
+    };
+
+    {
+        let load = load.clone();
+        use_effect_with((), move |()| load());
+    }
+
+    {
+        use std::cell::Cell;
+        use std::rc::Rc;
+        use_effect_with(*interval, move |interval| {
+            let cancelled = Rc::new(Cell::new(false));
+            if let Some(period_ms) = interval.as_millis() {
+                let cancelled = cancelled.clone();
+                spawn_local(async move {
+                    loop {
+                        TimeoutFuture::new(period_ms).await;
+                        if cancelled.get() {
+                            break;
+                        }
+                        load();
+                    }
+                });
+            }
+            move || cancelled.set(true)
+        });
+    }
+
+    let on_set_interval = {
+        let interval = interval.clone();
+        Callback::from(move |next: RefreshInterval| {
+            save_interval(next);
+            interval.set(next);
+        })
+    };
+
+    let summary = fleet_summary(&data.items);
+
+    html! {
+        <main>
+            <div class="section-hd">
+                <span class="section-label">{"RELIABILITY"}</span>
+                <div class="section-acts">
+                    <RefreshControl
+                        interval={*interval}
+                        updated_at_ms={*updated_at}
+                        on_change={on_set_interval}
+                    />
+                </div>
+            </div>
+            <SummaryTiles summary={summary} />
+            { render_table(&data.items, data.loading) }
+        </main>
+    }
+}
+
+#[derive(Properties, PartialEq)]
+struct SummaryTilesProps {
+    summary: FleetReliability,
+}
+
+/// The page's KPI tile row: fleet-wide success rate plus counts of routines currently failing
+/// or flaky, reusing the same `.stats`/`.stat-card` layout as the Overview page.
+#[function_component(SummaryTiles)]
+fn summary_tiles(props: &SummaryTilesProps) -> Html {
+    let s = &props.summary;
+    html! {
+        <div class="stats">
+            <div class="stat-card all">
+                <div class="stat-label">{"FLEET SUCCESS RATE"}</div>
+                <div class="stat-val">{rate_label(s.success_rate())}</div>
+            </div>
+            <div class="stat-card due">
+                <div class="stat-label">{"FAILING NOW"}</div>
+                <div class={classes!("stat-val", if s.failing_count > 0 { "c-red" } else { "c-accent" })}>
+                    {s.failing_count}
+                </div>
+            </div>
+            <div class="stat-card disabled">
+                <div class="stat-label">{"FLAKY"}</div>
+                <div class={classes!("stat-val", if s.flaky_count > 0 { "c-amber" } else { "c-accent" })}>
+                    {s.flaky_count}
+                </div>
+            </div>
+            <div class="stat-card system">
+                <div class="stat-label">{"SAMPLED RUNS"}</div>
+                <div class="stat-val">{s.sample_size}</div>
+            </div>
+        </div>
+    }
+}
+
+/// Renders the ranked reliability table (worst-first), or the loading/empty state.
+fn render_table(items: &[RoutineReliability], loading: bool) -> Html {
+    if loading {
+        return html! { <div class="table-wrap"><div class="empty"><div class="spinner"></div></div></div> };
+    }
+    if items.is_empty() {
+        return html! {
+            <div class="table-wrap">
+                <div class="empty">
+                    <div class="empty-icon">{"⧗"}</div>
+                    <div class="empty-msg">{"NO FINISHED RUNS YET"}</div>
+                </div>
+            </div>
+        };
+    }
+    html! {
+        <div class="table-wrap">
+            <table>
+                <thead>
+                    <tr>
+                        <th>{"ROUTINE"}</th>
+                        <th>{"STREAK"}</th>
+                        <th>{"SUCCESS RATE"}</th>
+                        <th>{"SAMPLE"}</th>
+                        <th>{"FLAKY"}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    { for items.iter().map(render_row) }
+                </tbody>
+            </table>
+        </div>
+    }
+}
+
+/// Renders one routine's reliability row.
+fn render_row(item: &RoutineReliability) -> Html {
+    let rate = item.success_rate();
+    html! {
+        <tr key={item.routine_id.clone()}>
+            <td>
+                <Link<Route, RoutineHistoryQuery>
+                    to={Route::Routines}
+                    query={Some(RoutineHistoryQuery { history: item.routine_id.clone() })}
+                >{ &item.routine_title }</Link<Route, RoutineHistoryQuery>>
+            </td>
+            <td><span class={streak_class(item.streak)}>{streak_label(item.streak)}</span></td>
+            <td><span class={rate_class(rate)}>{rate_label(rate)}</span></td>
+            <td><span class="cell-meta">{item.sample_size}</span></td>
+            <td>{ if item.is_flaky() { html! { <span class="run-status running">{"FLAKY"}</span> } } else { html! {} } }</td>
+        </tr>
+    }
+}

--- a/ui/src/reliability_stats.rs
+++ b/ui/src/reliability_stats.rs
@@ -1,0 +1,241 @@
+//! Pure reliability-metrics computation for the RELIABILITY page: per-routine success rate,
+//! active pass/fail streak, and flakiness (status-flip rate) over each routine's most recent
+//! finished runs. Split from `reliability.rs` (the page shell) so the math stays host-testable
+//! without a wasm/DOM dependency, mirroring `overview.rs`'s split from `overview_tests.rs`.
+//!
+//! Best practice (CI/CD reliability dashboards — GitHub Actions Insights, `CircleCI` Insights,
+//! Datadog Test Visibility): rank jobs by recent success rate and flag flaky ones (alternating
+//! pass/fail) separately from steadily-failing ones, since the two call for different responses
+//! — a flaky routine needs investigation, a steadily-failing one needs immediate attention.
+
+use std::cmp::Ordering;
+use std::collections::HashMap;
+
+use crate::routines::{FleetRunSummary, RunStatus};
+
+/// Most recent finished runs per routine considered for reliability metrics. Caps memory/render
+/// cost per routine the same way `sparkline.rs`'s `SPARKLINE_LEN` caps its tick strip, just with
+/// a longer window since flakiness needs more samples than an at-a-glance sparkline does.
+pub(crate) const SAMPLE_LEN: usize = 20;
+
+/// Minimum finished-run sample before flakiness is judged — a 2-run sample that flips once is
+/// noise, not a signal.
+const FLAKY_MIN_SAMPLE: usize = 5;
+
+/// A routine whose adjacent-run status flips make up at least this fraction of its sample's
+/// adjacent pairs is flagged flaky.
+const FLAKY_FLIP_RATIO: f64 = 0.4;
+
+/// A routine's most-recent-run streak: consecutive finished runs, newest first, sharing the same
+/// outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Streak {
+    /// `n` consecutive successes (n >= 1), most recent run first.
+    Success(usize),
+    /// `n` consecutive failures (n >= 1), most recent run first.
+    Failure(usize),
+    /// No finished run in the sample.
+    None,
+}
+
+/// Reliability metrics for one routine, derived from its most recent finished
+/// (`Success`/`Failed`) runs — `Running`/`Unknown` runs are excluded since they say nothing
+/// about reliability.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RoutineReliability {
+    pub routine_id: String,
+    pub routine_title: String,
+    /// Finished runs considered, out of up to `SAMPLE_LEN`.
+    pub sample_size: usize,
+    /// `Success` runs within the sample.
+    pub successes: usize,
+    pub streak: Streak,
+    /// Count of status flips (success→failure or vice versa) across adjacent runs in the
+    /// sample — high relative to `sample_size` indicates flakiness rather than a steady trend.
+    pub flips: usize,
+}
+
+impl RoutineReliability {
+    /// `successes / sample_size`, or `None` when the sample is empty.
+    pub(crate) fn success_rate(&self) -> Option<f64> {
+        if self.sample_size == 0 {
+            None
+        } else {
+            Some(self.successes as f64 / self.sample_size as f64)
+        }
+    }
+
+    /// `true` when this routine's flip rate crosses the flaky threshold.
+    pub(crate) fn is_flaky(&self) -> bool {
+        if self.sample_size < FLAKY_MIN_SAMPLE {
+            return false;
+        }
+        let pairs = self.sample_size - 1;
+        pairs > 0 && (self.flips as f64) / (pairs as f64) >= FLAKY_FLIP_RATIO
+    }
+}
+
+/// Fleet-wide reliability summary, aggregated across every routine's sample.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub(crate) struct FleetReliability {
+    pub sample_size: usize,
+    pub successes: usize,
+    /// Routines with an active (>= 1 run) failure streak.
+    pub failing_count: usize,
+    pub flaky_count: usize,
+}
+
+impl FleetReliability {
+    /// `successes / sample_size`, or `None` when nothing has been sampled yet.
+    pub(crate) fn success_rate(&self) -> Option<f64> {
+        if self.sample_size == 0 {
+            None
+        } else {
+            Some(self.successes as f64 / self.sample_size as f64)
+        }
+    }
+}
+
+/// Per-routine accumulator while bucketing the fleet-wide run list.
+struct RoutineAcc {
+    title: String,
+    /// Newest-first, capped at `SAMPLE_LEN`.
+    statuses: Vec<RunStatus>,
+}
+
+/// Buckets a fleet-wide, newest-first run list by routine, keeping only `Success`/`Failed` runs
+/// and capping each bucket at `SAMPLE_LEN`, newest-first.
+fn bucket_finished_runs(runs: &[FleetRunSummary]) -> HashMap<String, RoutineAcc> {
+    let mut by_routine: HashMap<String, RoutineAcc> = HashMap::new();
+    for run in runs {
+        if !matches!(run.status, RunStatus::Success | RunStatus::Failed) {
+            continue;
+        }
+        let acc = by_routine
+            .entry(run.routine_id.clone())
+            .or_insert_with(|| RoutineAcc {
+                title: run.routine_title.clone(),
+                statuses: Vec::new(),
+            });
+        if acc.statuses.len() < SAMPLE_LEN {
+            acc.statuses.push(run.status);
+        }
+    }
+    by_routine
+}
+
+/// The active streak at the head (newest-first) of a finished-run sample.
+fn compute_streak(statuses: &[RunStatus]) -> Streak {
+    let Some(&newest) = statuses.first() else {
+        return Streak::None;
+    };
+    let n = statuses.iter().take_while(|&&s| s == newest).count();
+    if newest == RunStatus::Success {
+        Streak::Success(n)
+    } else {
+        Streak::Failure(n)
+    }
+}
+
+/// Count of adjacent-pair status changes in a finished-run sample.
+fn count_flips(statuses: &[RunStatus]) -> usize {
+    statuses
+        .windows(2)
+        .filter(|pair| pair[0] != pair[1])
+        .count()
+}
+
+/// The length of an active failure streak, or 0 for a success streak or no sample.
+fn failure_streak_len(streak: Streak) -> usize {
+    match streak {
+        Streak::Failure(n) => n,
+        Streak::Success(_) | Streak::None => 0,
+    }
+}
+
+/// Computes every routine's reliability metrics from a fleet-wide run list, ranked
+/// worst-first: an active failure streak outranks everything else (longer streak first),
+/// then lowest success rate, then title for a stable tie-break. Routines with no finished
+/// run in the sample are omitted — there is nothing to rank.
+pub(crate) fn compute_reliability(runs: &[FleetRunSummary]) -> Vec<RoutineReliability> {
+    let mut items: Vec<RoutineReliability> = bucket_finished_runs(runs)
+        .into_iter()
+        .map(|(routine_id, acc)| RoutineReliability {
+            sample_size: acc.statuses.len(),
+            successes: acc
+                .statuses
+                .iter()
+                .filter(|&&s| s == RunStatus::Success)
+                .count(),
+            streak: compute_streak(&acc.statuses),
+            flips: count_flips(&acc.statuses),
+            routine_title: acc.title,
+            routine_id,
+        })
+        .collect();
+
+    items.sort_by(|a, b| {
+        failure_streak_len(b.streak)
+            .cmp(&failure_streak_len(a.streak))
+            .then_with(|| {
+                let a_rate = a.success_rate().unwrap_or(1.0);
+                let b_rate = b.success_rate().unwrap_or(1.0);
+                a_rate.partial_cmp(&b_rate).unwrap_or(Ordering::Equal)
+            })
+            .then_with(|| a.routine_title.cmp(&b.routine_title))
+    });
+    items
+}
+
+/// Aggregates per-routine metrics into a fleet-wide summary for the page's stat tiles.
+pub(crate) fn fleet_summary(items: &[RoutineReliability]) -> FleetReliability {
+    FleetReliability {
+        sample_size: items.iter().map(|r| r.sample_size).sum(),
+        successes: items.iter().map(|r| r.successes).sum(),
+        failing_count: items
+            .iter()
+            .filter(|r| failure_streak_len(r.streak) > 0)
+            .count(),
+        flaky_count: items.iter().filter(|r| r.is_flaky()).count(),
+    }
+}
+
+/// CSS class for a routine's streak badge (reuses the generic `run-status` pill classes).
+pub(crate) fn streak_class(streak: Streak) -> &'static str {
+    match streak {
+        Streak::Success(_) => "run-status success",
+        Streak::Failure(_) => "run-status failed",
+        Streak::None => "run-status unknown",
+    }
+}
+
+/// Display label for a routine's streak badge.
+pub(crate) fn streak_label(streak: Streak) -> String {
+    match streak {
+        Streak::Success(n) => format!("{n} OK"),
+        Streak::Failure(n) => format!("{n} FAILING"),
+        Streak::None => "—".to_string(),
+    }
+}
+
+/// CSS class for a success-rate badge (reuses the generic `run-status` pill classes).
+pub(crate) fn rate_class(rate: Option<f64>) -> &'static str {
+    match rate {
+        None => "run-status unknown",
+        Some(r) if r >= 0.9 => "run-status success",
+        Some(r) if r >= 0.7 => "run-status running",
+        Some(_) => "run-status failed",
+    }
+}
+
+/// Display label for a success-rate badge.
+pub(crate) fn rate_label(rate: Option<f64>) -> String {
+    match rate {
+        None => "—".to_string(),
+        Some(r) => format!("{:.0}%", r * 100.0),
+    }
+}
+
+#[cfg(test)]
+#[path = "reliability_stats_tests.rs"]
+mod reliability_stats_tests;

--- a/ui/src/reliability_stats_tests.rs
+++ b/ui/src/reliability_stats_tests.rs
@@ -1,0 +1,313 @@
+//! Host-side unit tests for the pure reliability-metrics math in [`super`]. No DOM/wasm
+//! dependency (mirrors the `sparkline_tests.rs` test conventions).
+
+use super::*;
+
+/// Builds a `FleetRunSummary` with just the fields the reliability math reads.
+/// `started_at` doubles as an ordering key: callers pass runs newest-first, exactly like the
+/// real `GET /routines/runs` response.
+fn run(routine_id: &str, title: &str, started_at: u64, status: RunStatus) -> FleetRunSummary {
+    FleetRunSummary {
+        routine_id: routine_id.to_string(),
+        routine_title: title.to_string(),
+        workbench: format!("{routine_id}-{started_at}"),
+        started_at,
+        finished_at: Some(started_at + 1),
+        status,
+        exit_code: None,
+    }
+}
+
+// ─── compute_reliability / bucketing ───────────────────────────────────────────
+
+#[test]
+fn compute_reliability_empty_input_is_empty() {
+    assert_eq!(compute_reliability(&[]), Vec::new());
+}
+
+#[test]
+fn compute_reliability_excludes_running_and_unknown_runs() {
+    let runs = vec![
+        run("a", "Alpha", 3, RunStatus::Running),
+        run("a", "Alpha", 2, RunStatus::Success),
+        run("a", "Alpha", 1, RunStatus::Unknown),
+    ];
+    let items = compute_reliability(&runs);
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].sample_size, 1);
+    assert_eq!(items[0].successes, 1);
+}
+
+#[test]
+fn compute_reliability_omits_routines_with_no_finished_run() {
+    let runs = vec![run("a", "Alpha", 1, RunStatus::Running)];
+    assert!(compute_reliability(&runs).is_empty());
+}
+
+#[test]
+fn compute_reliability_caps_sample_at_sample_len() {
+    let runs: Vec<FleetRunSummary> = (0..SAMPLE_LEN + 10)
+        .map(|i| run("a", "Alpha", i as u64, RunStatus::Success))
+        .collect();
+    let items = compute_reliability(&runs);
+    assert_eq!(items[0].sample_size, SAMPLE_LEN);
+}
+
+#[test]
+fn compute_reliability_keeps_newest_runs_when_capping() {
+    // 25 runs, oldest is a lone failure past the SAMPLE_LEN=20 cutoff; the capped sample should
+    // never see it, so the streak reads as a full-success run rather than being cut short.
+    let mut runs: Vec<FleetRunSummary> = (0..SAMPLE_LEN + 5)
+        .map(|i| {
+            run(
+                "a",
+                "Alpha",
+                (SAMPLE_LEN + 5 - i) as u64,
+                RunStatus::Success,
+            )
+        })
+        .collect();
+    runs.push(run("a", "Alpha", 0, RunStatus::Failed));
+    let items = compute_reliability(&runs);
+    assert_eq!(items[0].sample_size, SAMPLE_LEN);
+    assert_eq!(items[0].successes, SAMPLE_LEN);
+    assert_eq!(items[0].streak, Streak::Success(SAMPLE_LEN));
+}
+
+// ─── streak ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn streak_all_success() {
+    let runs = vec![
+        run("a", "Alpha", 3, RunStatus::Success),
+        run("a", "Alpha", 2, RunStatus::Success),
+        run("a", "Alpha", 1, RunStatus::Success),
+    ];
+    assert_eq!(compute_reliability(&runs)[0].streak, Streak::Success(3));
+}
+
+#[test]
+fn streak_stops_at_first_status_change_newest_first() {
+    // Newest-first input: 2 recent failures, then older successes — streak should read as
+    // Failure(2), not be thrown off by the older, unrelated successes.
+    let runs = vec![
+        run("a", "Alpha", 4, RunStatus::Failed),
+        run("a", "Alpha", 3, RunStatus::Failed),
+        run("a", "Alpha", 2, RunStatus::Success),
+        run("a", "Alpha", 1, RunStatus::Success),
+    ];
+    assert_eq!(compute_reliability(&runs)[0].streak, Streak::Failure(2));
+}
+
+#[test]
+fn streak_none_when_sample_empty() {
+    assert_eq!(compute_streak(&[]), Streak::None);
+}
+
+// ─── flips / flaky ──────────────────────────────────────────────────────────
+
+#[test]
+fn count_flips_counts_adjacent_status_changes() {
+    assert_eq!(
+        count_flips(&[
+            RunStatus::Success,
+            RunStatus::Failed,
+            RunStatus::Failed,
+            RunStatus::Success,
+        ]),
+        2
+    );
+}
+
+#[test]
+fn count_flips_zero_for_uniform_sample() {
+    assert_eq!(count_flips(&[RunStatus::Success, RunStatus::Success]), 0);
+}
+
+#[test]
+fn is_flaky_false_below_minimum_sample() {
+    // 4 runs alternating every time (3 flips out of 3 pairs = 100%) but under FLAKY_MIN_SAMPLE.
+    let runs = vec![
+        run("a", "Alpha", 4, RunStatus::Success),
+        run("a", "Alpha", 3, RunStatus::Failed),
+        run("a", "Alpha", 2, RunStatus::Success),
+        run("a", "Alpha", 1, RunStatus::Failed),
+    ];
+    assert!(!compute_reliability(&runs)[0].is_flaky());
+}
+
+#[test]
+fn is_flaky_true_at_or_above_ratio_with_enough_sample() {
+    // 6 runs alternating throughout: 5 flips / 5 pairs = 100% >= 40% ratio, sample_size 6 >= 5.
+    let runs = vec![
+        run("a", "Alpha", 6, RunStatus::Success),
+        run("a", "Alpha", 5, RunStatus::Failed),
+        run("a", "Alpha", 4, RunStatus::Success),
+        run("a", "Alpha", 3, RunStatus::Failed),
+        run("a", "Alpha", 2, RunStatus::Success),
+        run("a", "Alpha", 1, RunStatus::Failed),
+    ];
+    assert!(compute_reliability(&runs)[0].is_flaky());
+}
+
+#[test]
+fn is_flaky_false_for_steady_run_with_enough_sample() {
+    let runs: Vec<FleetRunSummary> = (0..6)
+        .map(|i| run("a", "Alpha", i as u64, RunStatus::Success))
+        .collect();
+    assert!(!compute_reliability(&runs)[0].is_flaky());
+}
+
+// ─── success_rate ───────────────────────────────────────────────────────────
+
+#[test]
+fn success_rate_none_when_sample_empty() {
+    let r = RoutineReliability {
+        routine_id: "a".into(),
+        routine_title: "Alpha".into(),
+        sample_size: 0,
+        successes: 0,
+        streak: Streak::None,
+        flips: 0,
+    };
+    assert_eq!(r.success_rate(), None);
+}
+
+#[test]
+fn success_rate_computed_from_successes_over_sample_size() {
+    let runs = vec![
+        run("a", "Alpha", 3, RunStatus::Success),
+        run("a", "Alpha", 2, RunStatus::Success),
+        run("a", "Alpha", 1, RunStatus::Failed),
+    ];
+    let rate = compute_reliability(&runs)[0].success_rate().unwrap();
+    assert!((rate - (2.0 / 3.0)).abs() < f64::EPSILON);
+}
+
+// ─── ranking order ──────────────────────────────────────────────────────────
+
+#[test]
+fn ranks_active_failure_streak_before_low_success_rate() {
+    // Beta has a lower overall success rate but no *active* failure streak (its worst run is
+    // buried in the middle); Alpha is currently failing right now. Alpha should rank first —
+    // an active incident outranks a merely-mediocre history.
+    let runs = vec![
+        run("alpha", "Alpha", 2, RunStatus::Failed),
+        run("alpha", "Alpha", 1, RunStatus::Success),
+        run("beta", "Beta", 4, RunStatus::Success),
+        run("beta", "Beta", 3, RunStatus::Failed),
+        run("beta", "Beta", 2, RunStatus::Failed),
+        run("beta", "Beta", 1, RunStatus::Success),
+    ];
+    let items = compute_reliability(&runs);
+    assert_eq!(items[0].routine_id, "alpha");
+    assert_eq!(items[1].routine_id, "beta");
+}
+
+#[test]
+fn ranks_longer_failure_streak_first() {
+    let runs = vec![
+        run("short", "Short", 1, RunStatus::Failed),
+        run("long", "Long", 2, RunStatus::Failed),
+        run("long", "Long", 1, RunStatus::Failed),
+    ];
+    let items = compute_reliability(&runs);
+    assert_eq!(items[0].routine_id, "long");
+    assert_eq!(items[1].routine_id, "short");
+}
+
+#[test]
+fn ranks_lower_success_rate_first_when_no_active_failure_streak() {
+    let runs = vec![
+        run("worse", "Worse", 4, RunStatus::Success),
+        run("worse", "Worse", 3, RunStatus::Failed),
+        run("worse", "Worse", 2, RunStatus::Success),
+        run("better", "Better", 2, RunStatus::Success),
+        run("better", "Better", 1, RunStatus::Success),
+    ];
+    let items = compute_reliability(&runs);
+    assert_eq!(items[0].routine_id, "worse");
+    assert_eq!(items[1].routine_id, "better");
+}
+
+#[test]
+fn ranks_ties_by_title() {
+    let runs = vec![
+        run("z", "Zeta", 1, RunStatus::Success),
+        run("a", "Alpha", 1, RunStatus::Success),
+    ];
+    let items = compute_reliability(&runs);
+    assert_eq!(items[0].routine_id, "a");
+    assert_eq!(items[1].routine_id, "z");
+}
+
+// ─── fleet_summary ──────────────────────────────────────────────────────────
+
+#[test]
+fn fleet_summary_of_empty_is_zeroed() {
+    assert_eq!(fleet_summary(&[]), FleetReliability::default());
+}
+
+#[test]
+fn fleet_summary_aggregates_across_routines() {
+    let runs = vec![
+        run("a", "Alpha", 2, RunStatus::Failed),
+        run("a", "Alpha", 1, RunStatus::Success),
+        run("b", "Beta", 1, RunStatus::Success),
+    ];
+    let items = compute_reliability(&runs);
+    let summary = fleet_summary(&items);
+    assert_eq!(summary.sample_size, 3);
+    assert_eq!(summary.successes, 2);
+    assert_eq!(summary.failing_count, 1);
+}
+
+#[test]
+fn fleet_reliability_success_rate_none_when_unsampled() {
+    assert_eq!(FleetReliability::default().success_rate(), None);
+}
+
+#[test]
+fn fleet_reliability_success_rate_computed() {
+    let summary = FleetReliability {
+        sample_size: 4,
+        successes: 3,
+        failing_count: 0,
+        flaky_count: 0,
+    };
+    assert!((summary.success_rate().unwrap() - 0.75).abs() < f64::EPSILON);
+}
+
+// ─── badge class/label helpers ──────────────────────────────────────────────
+
+#[test]
+fn streak_class_covers_every_variant() {
+    assert_eq!(streak_class(Streak::Success(1)), "run-status success");
+    assert_eq!(streak_class(Streak::Failure(1)), "run-status failed");
+    assert_eq!(streak_class(Streak::None), "run-status unknown");
+}
+
+#[test]
+fn streak_label_covers_every_variant() {
+    assert_eq!(streak_label(Streak::Success(3)), "3 OK");
+    assert_eq!(streak_label(Streak::Failure(2)), "2 FAILING");
+    assert_eq!(streak_label(Streak::None), "—");
+}
+
+#[test]
+fn rate_class_thresholds() {
+    assert_eq!(rate_class(None), "run-status unknown");
+    assert_eq!(rate_class(Some(1.0)), "run-status success");
+    assert_eq!(rate_class(Some(0.9)), "run-status success");
+    assert_eq!(rate_class(Some(0.89)), "run-status running");
+    assert_eq!(rate_class(Some(0.7)), "run-status running");
+    assert_eq!(rate_class(Some(0.69)), "run-status failed");
+    assert_eq!(rate_class(Some(0.0)), "run-status failed");
+}
+
+#[test]
+fn rate_label_formats_percentage_or_dash() {
+    assert_eq!(rate_label(None), "—");
+    assert_eq!(rate_label(Some(0.5)), "50%");
+    assert_eq!(rate_label(Some(1.0)), "100%");
+}


### PR DESCRIPTION
## Summary
- New `/reliability` dashboard tab ranking every routine by its most recent 20 finished runs: success rate, active pass/fail streak, and a flakiness signal (status flips distinct from steadily-failing).
- Worst-first ranking: an active failure streak (an ongoing incident) outranks a merely-low historical success rate.
- Reads the existing fleet-wide `GET /api/v1/routines/runs` endpoint (already used by the Routines table's sparkline column) — no backend/API/data-model change. Frontend-only, confined to `ui/`.
- Reuses existing CSS classes (`.stats`/`.stat-card`/`.table-wrap`/`.run-status` pills) — no new stylesheet. Routine names link through to the existing per-routine HISTORY view.

Closes #1256 — see the issue for the researched best-practice rationale (CI/CD flaky-job detection, cron dashboard success-rate ranking).

## Test plan
- [x] `cargo build -p ui --target wasm32-unknown-unknown` succeeds
- [x] `cargo clippy -p ui --all-targets -- -D warnings` clean
- [x] `cargo test -p ui` — 340 passed (27 new `reliability_stats` tests covering bucketing, streak, flip/flaky thresholds, ranking order, and badge helpers)
- [x] `linecheck --max-lines 500` passes (new files: 259/213/306 lines)
- [x] `cargo fmt --check` clean
- [x] `git diff --name-only origin/main...HEAD` touches only `ui/` and `.changeset/`