### PR TITLE
chore(lint): enable clippy::exit workspace-wide

### DIFF
--- a/.changeset/enable-clippy-exit.md
+++ b/.changeset/enable-clippy-exit.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable clippy::exit workspace-wide, forbidding `std::process::exit`/`std::process::abort` outside `fn main`. Prevents a `Drop`-skipping process termination (leaked lock guards, file handles, in-flight routine cleanup) from a long-running daemon code path other than the CLI's top-level dispatch. Codebase was already clean; no fixes needed.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -299,3 +299,11 @@ literal_string_with_formatting_args = "deny"
 # surfaces under the right call depth, unlike a heap allocation which fails safely. The codebase is
 # already clean, so `deny` locks that in.
 large_stack_arrays = "deny"
+# Reject `std::process::exit`/`std::process::abort` outside of `fn main` (the lint already
+# exempts `main` itself, where `src/main.rs`'s CLI dispatch legitimately calls `process::exit`
+# to set the process's exit code). Calling either from anywhere else terminates the process
+# immediately, skipping unwinding — so any `Drop` impl further up the call stack (an in-flight
+# routine's cleanup, a lock guard, a file handle) never runs. In a long-running daemon that's the
+# same "silent leak on the way out" risk `mem_forget` above already guards against. The codebase
+# is already clean outside `main`, so `deny` locks that in.
+exit = "deny"


### PR DESCRIPTION
## Why

`std::process::exit`/`std::process::abort` terminate the process immediately, skipping unwinding — so any `Drop` impl further up the call stack never runs. In a long-running daemon that means leaked lock guards, unclosed file handles, or a routine's in-flight cleanup silently skipped, the same risk `mem_forget` (already denied in this workspace) guards against for a single value.

`clippy::exit` already exempts `fn main` itself, where `src/main.rs`'s CLI dispatch legitimately calls `process::exit` to set the process's exit code — so this only closes off the rest of the codebase.

## What

- Add `exit = "deny"` to `[lints.clippy]` in `Cargo.toml`, following this repo's existing pattern of incrementally locking in already-clean restriction lints (see `mem_forget`, `unwrap_used` above it).
- No code changes: `cargo clippy --workspace --all-targets -- -D clippy::exit` reports zero violations outside `main`.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo build` — clean

A changeset is included (`.changeset/enable-clippy-exit.md`).