### PR TITLE
chore(lint): enable clippy::panic workspace-wide

### DIFF
--- a/.changeset/enable-clippy-panic.md
+++ b/.changeset/enable-clippy-panic.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Enable `clippy::panic` workspace-wide to forbid `panic!()` in production code, matching the existing `unwrap_used`/`expect_used` hardening against unhandled panics in the long-running daemon process. Test code stays exempt via `allow-panic-in-tests` in `clippy.toml`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -307,3 +307,8 @@ large_stack_arrays = "deny"
 # same "silent leak on the way out" risk `mem_forget` above already guards against. The codebase
 # is already clean outside `main`, so `deny` locks that in.
 exit = "deny"
+# Forbid `panic!()` in production code: same rationale as `unwrap_used`/`expect_used`
+# above — an unhandled panic kills this long-running daemon process outright instead of
+# returning a structured error. The codebase is already clean, so `deny` locks that in.
+# Test code is exempt via `allow-panic-in-tests` in clippy.toml, same as the other two.
+panic = "deny"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,2 @@
 allow-unwrap-in-tests = true
+allow-panic-in-tests = true


### PR DESCRIPTION
## Why

`unwrap_used`, `expect_used`, and (in-flight, #1254) `unreachable` are already denied workspace-wide because an unhandled panic kills this long-running daemon process outright, dropping the in-flight request and skipping any graceful cleanup. `panic!()` itself was the one hole left in that hardening — it's exactly as fatal but wasn't covered.

## What

- Add `panic = "deny"` to `[lints.clippy]` in `Cargo.toml`.
- Add `allow-panic-in-tests = true` to `clippy.toml`, mirroring `allow-unwrap-in-tests`/`allow-expect-in-tests` already there, so test assertions can still use `panic!()` in `*_tests.rs` files.

No production code used `panic!()` already, so this is a pure lint-enablement change with no behavior change — `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`, `cargo test --workspace`, and `cargo llvm-cov --fail-under-lines 100` all pass locally unchanged.