### PR TITLE
chore(deps): bump tokio to 1.53.0

### DIFF
--- a/.changeset/bump-tokio-1-53.md
+++ b/.changeset/bump-tokio-1-53.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Bump `tokio` from 1.52.4 to 1.53.0 (permitted by the existing `"1"` version requirement; the lockfile was simply stale). No API or behavior changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2201,9 +2201,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.4"
+version = "1.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317fafbbe3f02fc663dad00ea6186197de963cd4190e86a26d8d0fae095539af"
+checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
 dependencies = [
  "bytes",
  "libc",


### PR DESCRIPTION
## Why

`cargo outdated` flags `tokio` as resolved to `1.52.4` in `Cargo.lock` while the latest compatible release under the existing `Cargo.toml` requirement (`tokio = { version = "1", features = ["full"] }`) is `1.53.0`. The lockfile was simply stale.

## Change

- `cargo update -p tokio` — bumps `Cargo.lock` only, no `Cargo.toml` change.
- Added a changeset (`patch`, no behavior change).

## Verification

- `cargo build --workspace` — clean
- `cargo test --workspace` — 340 passed