### PR TITLE
test: cover the parent-directory error branches the coverage gate flags

### DIFF
--- a/.changeset/cover-parent-dir-error-branches.md
+++ b/.changeset/cover-parent-dir-error-branches.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+test: cover the "path has no parent directory" error branches that `cargo llvm-cov`'s 100% line floor was failing on. Five call sites (`write_pid_file`, `ensure_readme`, `spawn_detached_with` in `cli/system.rs`, `write_machine_toml` in `machine/mod.rs`, `write_removed_defaults` in `routines/defaults/mod.rs`, and `append_persisted_run` in `routines/run_history.rs`) each duplicated their own `path.parent().ok_or_else(...)`/`let Some(parent) = ... else { ... }` guard for a case none of this crate's real config/log/history paths ever hit. Extracted the shared guard into `utils::fs_perms::parent_or_err`, tested directly, so the duplicate unreachable branches at each call site disappear instead of each needing its own contrived test. Also adds a test for the sibling "unparsable bind address" branch in `http_request_core`. Cuts the coverage gate's missed-line count from 32 to 6; the remainder is an effectively unreachable `serde_json::to_string` failure branch in `run_history.rs` and two unrelated single-line gaps, left for a follow-up.

--- a/src/cli/system.rs
+++ b/src/cli/system.rs
@@ -55,9 +55,7 @@ pub(crate) fn rotate_daemon_log_if_due(log_path: &std::path::Path) {
 /// Write the current process PID into the pid file so `stop`/`status` and signals can find it.
 pub fn write_pid_file() -> anyhow::Result<()> {
     let path = crate::paths::pid_file();
-    let parent = path.parent().ok_or_else(|| {
-        anyhow::anyhow!("pid file path {} has no parent directory", path.display())
-    })?;
+    let parent = crate::utils::fs_perms::parent_or_err(&path, "pid file")?;
     crate::utils::fs_perms::create_private_dir_all(parent)?;
     ensure_config_gitignore();
     ensure_readme(&crate::paths::config_readme_path(), CONFIG_README);
@@ -127,9 +125,8 @@ fn ensure_readme(path: &std::path::Path, content: &str) {
     if path.exists() {
         return;
     }
-    let Some(parent) = path.parent() else {
-        return;
-    };
+    let parent = crate::utils::fs_perms::parent_or_err(path, "readme");
+    let Some(parent) = parent.ok() else { return };
     if crate::utils::fs_perms::create_private_dir_all(parent).is_err() {
         return;
     }
@@ -377,12 +374,7 @@ fn spawn_detached_with(configure: impl FnOnce(&mut std::process::Command)) -> an
     let exe = std::env::current_exe()
         .map_err(|err| anyhow::anyhow!("resolve current executable path: {err}"))?;
     let log_path = crate::paths::daemon_log_file();
-    let log_parent = log_path.parent().ok_or_else(|| {
-        anyhow::anyhow!(
-            "daemon log path {} has no parent directory",
-            log_path.display()
-        )
-    })?;
+    let log_parent = crate::utils::fs_perms::parent_or_err(&log_path, "daemon log")?;
     crate::utils::fs_perms::create_private_dir_all(log_parent)?;
     rotate_daemon_log_if_due(&log_path);
     let out = std::fs::OpenOptions::new()

--- a/src/cli/system_tests.rs
+++ b/src/cli/system_tests.rs
@@ -104,3 +104,44 @@ fn log_rotation_is_due_is_true_when_small_but_stale() {
 fn log_rotation_is_due_is_false_right_at_the_age_boundary() {
     assert!(!log_rotation_is_due(1024, DAEMON_LOG_MAX_AGE));
 }
+
+struct EnvGuard {
+    name: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvGuard {
+    fn set(name: &'static str, value: &str) -> Self {
+        let previous = std::env::var_os(name);
+        // SAFETY: tests in this crate run single-threaded per binary.
+        unsafe {
+            std::env::set_var(name, value);
+        }
+        Self { name, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: single-threaded test execution.
+        unsafe {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.name, value),
+                None => std::env::remove_var(self.name),
+            }
+        }
+    }
+}
+
+#[test]
+fn http_request_core_rejects_an_unparsable_bind_override() {
+    let _addr = EnvGuard::set(crate::cli::BIND_ADDR_ENV, "not-a-socket-addr");
+
+    let err = http_request_core("GET", "/health", None, Duration::from_millis(50)).unwrap_err();
+
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    assert!(
+        err.to_string().contains("invalid bind address"),
+        "unexpected message: {err}"
+    );
+}

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -160,12 +160,7 @@ fn machine_toml_lock() -> &'static Mutex<()> {
 fn write_machine_toml(toml: &MachineToml) -> std::io::Result<()> {
     let path = machine_config_path();
     // The machine-config path is always `<config dir>/machine.local.toml`, so it always has a parent.
-    let Some(parent) = path.parent() else {
-        return Err(std::io::Error::other(format!(
-            "machine config path {} has no parent directory",
-            path.display()
-        )));
-    };
+    let parent = crate::utils::fs_perms::parent_or_err(&path, "machine config")?;
     crate::utils::fs_perms::create_private_dir_all(parent)?;
     let text = toml::to_string_pretty(toml).map_err(std::io::Error::other)?;
     atomic_write(&path, text.as_bytes())

--- a/src/routines/defaults/mod.rs
+++ b/src/routines/defaults/mod.rs
@@ -225,12 +225,7 @@ fn read_removed_defaults() -> BTreeSet<String> {
 /// Persist `slugs` to the tombstone file, creating its parent directory if needed.
 fn write_removed_defaults(slugs: &BTreeSet<String>) -> std::io::Result<()> {
     let path = removed_default_routines_path();
-    let Some(parent) = path.parent() else {
-        return Err(std::io::Error::other(format!(
-            "removed-defaults tombstone path {} has no parent directory",
-            path.display()
-        )));
-    };
+    let parent = crate::utils::fs_perms::parent_or_err(&path, "removed-defaults tombstone")?;
     std::fs::create_dir_all(parent)?;
     let body = RemovedDefaults {
         slugs: slugs.clone(),

--- a/src/routines/run_history.rs
+++ b/src/routines/run_history.rs
@@ -80,11 +80,8 @@ pub(crate) fn append_persisted_run(id: &str, run: &PersistedRun) {
     };
     let path = routine_run_history_path(id);
     rotate_run_history_if_oversized(&path);
-    let Some(parent) = path.parent() else {
-        log::warn!("run history: path for routine {id:?} has no parent directory");
-        return;
-    };
-    let result = crate::utils::fs_perms::create_private_dir_all(parent)
+    let result = crate::utils::fs_perms::parent_or_err(&path, "run history")
+        .and_then(crate::utils::fs_perms::create_private_dir_all)
         .and_then(|()| open_history_append(&path).and_then(|mut file| writeln!(file, "{line}")));
     if let Err(err) = result {
         log::warn!("run history: failed to append for routine {id:?}: {err}");

--- a/src/utils/fs_perms.rs
+++ b/src/utils/fs_perms.rs
@@ -34,6 +34,20 @@ pub fn create_private_dir_all(path: &Path) -> io::Result<()> {
     }
 }
 
+/// Returns `path`'s parent directory, or an [`io::Error`] naming `what` (e.g. `"pid file"`) if
+/// `path` has no parent (i.e. `path` is `/` or empty) — a condition none of this crate's
+/// generated config/log/history paths hit in practice, but every writer needs an error arm for
+/// it rather than a panic. Centralized here so that arm is tested once instead of once per
+/// call site.
+pub fn parent_or_err<'a>(path: &'a Path, what: &str) -> io::Result<&'a Path> {
+    path.parent().ok_or_else(|| {
+        io::Error::other(format!(
+            "{what} path {} has no parent directory",
+            path.display()
+        ))
+    })
+}
+
 #[cfg(test)]
 #[path = "fs_perms_tests.rs"]
 mod fs_perms_tests;

--- a/src/utils/fs_perms_tests.rs
+++ b/src/utils/fs_perms_tests.rs
@@ -3,7 +3,7 @@
     reason = "test helpers and fixtures do not need doc comments"
 )]
 
-use super::create_private_dir_all;
+use super::{create_private_dir_all, parent_or_err};
 
 #[cfg(unix)]
 #[test]
@@ -30,4 +30,23 @@ fn create_private_dir_all_is_idempotent_on_existing_dir() {
     create_private_dir_all(&base).unwrap();
     assert!(base.is_dir());
     let _ = std::fs::remove_dir_all(&base);
+}
+
+#[test]
+fn parent_or_err_returns_the_parent_when_present() {
+    let path = std::path::Path::new("/tmp/moadim/pid");
+    assert_eq!(
+        parent_or_err(path, "pid file").unwrap(),
+        std::path::Path::new("/tmp/moadim")
+    );
+}
+
+#[test]
+fn parent_or_err_names_what_when_path_has_no_parent() {
+    let err = parent_or_err(std::path::Path::new("/"), "pid file").unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("pid file path / has no parent directory"),
+        "unexpected message: {err}"
+    );
 }


### PR DESCRIPTION
## Why

`cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` currently fails on `main` at 99.42% (32 missed lines). All of it traces to the same shape: five call sites each hand-roll their own `path.parent().ok_or_else(...)` / `let Some(parent) = ... else { ... }` guard for a "path has no parent directory" case that none of this crate's real config/log/history paths ever hit — so the guard's error-construction lines are permanently unreachable, and permanently uncovered.

## What

Extract the shared guard into `utils::fs_perms::parent_or_err(path, what) -> io::Result<&Path>`, with its own direct unit test (covers both the `Some` and `None` arms). Each of the five call sites shrinks to a single `?`/let-else line that no longer carries its own untested branch:

- `cli/system.rs`: `write_pid_file`, `ensure_readme`, `spawn_detached_with`
- `machine/mod.rs`: `write_machine_toml`
- `routines/defaults/mod.rs`: `write_removed_defaults`
- `routines/run_history.rs`: `append_persisted_run` — folded into the function's existing `.and_then` error chain, consistent with its own doc comment ("collapsed into a single chain so there is one failure path to reason about, not three")

Also adds a test for the sibling "unparsable `MOADIM_BIND_ADDR` override" branch in `http_request_core`, which was the other easily-testable gap in `cli/system.rs`.

## Result

Missed lines drop from 32 to 6. The remainder (`routines/run_history.rs:76-78`) is a `serde_json::to_string` failure branch that's effectively unreachable for `PersistedRun`'s field types (no floats, no non-string map keys) — forcing it would need a contrived `Serialize` impl, so it's left for a follow-up rather than bundled here. Two other single-line gaps in unrelated files (`service/common.rs`, `utils/claude_json.rs`) are likewise out of scope for this PR.

## Testing

- `cargo test --workspace` — 1080 + 340 passed
- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 32 → 6 missed lines (99.42% → 99.89%)