### PR TITLE
chore(lint): enable clippy::manual_assert workspace-wide

### DIFF
--- a/.changeset/enable-clippy-manual-assert.md
+++ b/.changeset/enable-clippy-manual-assert.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+Enable `clippy::manual_assert` workspace-wide, continuing this crate's incremental clippy-lint
+enablement (see `enable-clippy-expect-used`, the `redundant_type_annotations`/
+`unseparated_literal_suffix` lints, etc.). Rejects `if !cond { panic!("msg") }` in favour of
+`assert!(cond, "msg")`, which states the invariant directly instead of making the reader invert
+the condition. The codebase already had zero violations, so this is a lint-only change with no
+behavior change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -356,3 +356,9 @@ panic = "deny"
 # so it's noise a reader has to cross-check against the inferred type instead of trusting. The
 # codebase is already clean, so `deny` locks that in.
 redundant_type_annotations = "deny"
+# Reject `if !cond { panic!("msg") }` in favour of `assert!(cond, "msg")` — the assert form states
+# the invariant being checked directly instead of making the reader invert the condition to find
+# it, and collapses two lines into one. Test code is exempt via `allow-panic-in-tests` in
+# clippy.toml, same as `panic` above (an inverted `assert!` in a test reads the same either way).
+# The codebase is already clean, so `deny` locks that in.
+manual_assert = "deny"


### PR DESCRIPTION
## Why

Continuing this crate's established pattern of incrementally enabling clippy pedantic/restriction lints one at a time (see `enable-clippy-expect-used`, `unseparated_literal_suffix`, `redundant_type_annotations`, and others already in `Cargo.toml`'s `[lints.clippy]`).

`clippy::manual_assert` rejects `if !cond { panic!("msg") }` in favour of `assert!(cond, "msg")` — the assert form states the invariant being checked directly instead of making the reader invert the condition to find it, and collapses two lines into one.

## What

- Added `manual_assert = "deny"` to `[lints.clippy]` in `Cargo.toml`, with a doc comment matching this section's existing style.
- Added a changeset noting the lint enablement.

## Testing

All run against the workspace, matching CONTRIBUTING.md's pre-push checklist:
- `cargo fmt --all -- --check` — passes
- `cargo clippy --workspace --all-targets -- -D warnings` — passes (zero violations; codebase was already clean for this lint)
- `cargo clippy -p ui --target wasm32-unknown-unknown --all-targets -- -D warnings` — passes
- `cargo test --workspace` — 1081 + 340 passed, 0 failed

No behavior change — lint-only.

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.