### PR TITLE
fix(routines): fold run_history serialize error into its append chain

### DIFF
--- a/.changeset/run-history-serialize-error-coverage.md
+++ b/.changeset/run-history-serialize-error-coverage.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+fix(routines): fold `run_history`'s serialize failure into its existing best-effort append chain, closing the coverage gate's last `run_history.rs` gap. `append_persisted_run` logged and returned early on a `serde_json::to_string` failure via its own dedicated `match`, separate from the `Result` chain already covering directory-creation/open/write failures for the same best-effort append — and since `PersistedRun`'s fields can never actually fail to serialize, that separate branch was untestable, leaving 3 lines permanently below `cargo llvm-cov`'s 100% line floor. Folding it into the same chain (one log call, one failure path, matching the function's own doc comment) removes the untestable branch entirely instead of contriving a test for it. This was the last of three follow-ups named by #1268; the remaining two (`cli/system.rs`, `service/common.rs`, `utils/claude_json.rs`, one line each) are unrelated and left for their own PRs.

--- a/src/routines/run_history.rs
+++ b/src/routines/run_history.rs
@@ -66,23 +66,22 @@ fn rotate_run_history_if_oversized(path: &Path) {
 ///
 /// Rotates the log first if it's grown past [`RUN_HISTORY_MAX_BYTES`] (see
 /// [`rotate_run_history_if_oversized`]), then the append itself is best-effort: a write failure
-/// (creating the routine's directory, opening the log, or the write itself — collapsed into a
-/// single chain so there is one failure path to reason about, not three) is logged and swallowed
-/// rather than blocking the reap sweep that triggered it — losing one history entry is far
-/// cheaper than a stuck cleanup loop.
+/// (serializing `run`, creating the routine's directory, opening the log, or the write itself —
+/// collapsed into a single chain so there is one failure path to reason about, not four) is
+/// logged and swallowed rather than blocking the reap sweep that triggered it — losing one
+/// history entry is far cheaper than a stuck cleanup loop.
 pub(crate) fn append_persisted_run(id: &str, run: &PersistedRun) {
-    let line = match serde_json::to_string(run) {
-        Ok(line) => line,
-        Err(err) => {
-            log::warn!("run history: failed to serialize run for routine {id:?}: {err}");
-            return;
-        }
-    };
     let path = routine_run_history_path(id);
     rotate_run_history_if_oversized(&path);
-    let result = crate::utils::fs_perms::parent_or_err(&path, "run history")
-        .and_then(crate::utils::fs_perms::create_private_dir_all)
-        .and_then(|()| open_history_append(&path).and_then(|mut file| writeln!(file, "{line}")));
+    let result = serde_json::to_string(run)
+        .map_err(std::io::Error::other)
+        .and_then(|line| {
+            crate::utils::fs_perms::parent_or_err(&path, "run history")
+                .and_then(crate::utils::fs_perms::create_private_dir_all)
+                .and_then(|()| {
+                    open_history_append(&path).and_then(|mut file| writeln!(file, "{line}"))
+                })
+        });
     if let Err(err) = result {
         log::warn!("run history: failed to append for routine {id:?}: {err}");
     }


### PR DESCRIPTION
## Why

`cargo llvm-cov --fail-under-lines 100` (the pre-push/CI coverage gate) currently fails on a clean `main` checkout: 6 lines short of 100%. Half of that gap is a named, known follow-up from #1268 ("cover the parent-directory error branches"), whose changeset explicitly called out:

> the remainder is an effectively unreachable `serde_json::to_string` failure branch in `run_history.rs` and two unrelated single-line gaps, left for a follow-up.

This PR closes the `run_history.rs` part of that follow-up.

## What

`append_persisted_run` handled a `serde_json::to_string(run)` failure via its own dedicated `match` with an early return and log call, kept separate from the `Result` chain that already handles the directory-creation/open/write failures for the same best-effort append (per the function's own doc comment, which already described that chain as "one failure path to reason about"). Since `PersistedRun`'s fields (`String`, `u64`, an enum, `Option<i32>`) can never actually fail to serialize, that separate branch was permanently unreachable in tests — 3 lines stuck at 0% coverage.

Folded the serialization step into the same chain instead of leaving it as a separate branch: one `Result`, one log call on failure, matching the doc comment's stated intent (updated from "not three" to "not four" since it now covers 4 failure sources instead of 3). This makes the branch's failure-logging code path already exercised by the existing `append_persisted_run_is_best_effort_when_path_unwritable` test (which hits a different failure source through the same now-shared arm), rather than requiring a contrived/impossible test for an unreachable case.

## Scope

Intentionally narrow: this closes only the `run_history.rs` piece. Two unrelated single-line gaps remain (`cli/system.rs`, `service/common.rs`, `utils/claude_json.rs`) — each its own small, independent fix, left out here to keep this PR focused and reviewable.

## Checks (local, clean checkout of this branch)

- `cargo fmt --check` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — pass, no warnings
- `cargo test --workspace` — 340 passed, 0 failed
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — `routines/run_history.rs` now at 100.00% line coverage (was 96.00%, 3 missed lines). Total missed lines across the workspace drops from 6 to 3.
- `.changeset/run-history-serialize-error-coverage.md` added (patch bump, `moadim` package), matching the format of existing changesets including #1268's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)