### PR TITLE
chore(lint): enable clippy::tests_outside_test_module workspace-wide

### DIFF
--- a/.changeset/enable-clippy-tests-outside-test-module.md
+++ b/.changeset/enable-clippy-tests-outside-test-module.md
@@ -1,0 +1,17 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::tests_outside_test_module` workspace-wide
+
+Rejects a `#[test]` function declared outside a `#[cfg(test)]` module. This formalizes, at the
+AST level, this repo's existing `*_tests.rs` convention: `.githooks/pre-push` step 1 already
+greps for tests living outside a `#[cfg(test)] mod foo_tests;` sibling, but that check is
+text-pattern-based and only runs locally, pre-push. Enabling this lint means `cargo clippy`
+(CI's `lint.yml` job) enforces the same invariant from the compiler's own AST, so it can't be
+skipped by a contributor who bypasses git hooks.
+
+Enabled in both the root `Cargo.toml` and `ui/Cargo.toml` (the `ui` crate has its own
+`[lints.clippy]` table and doesn't inherit root's deny-list), mirroring the parity pattern
+already used for `unreachable`, `redundant_type_annotations`, and others. The workspace
+(`src/` and `ui/src`) was already clean, so `deny` locks that in with no behavior change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -362,3 +362,10 @@ redundant_type_annotations = "deny"
 # clippy.toml, same as `panic` above (an inverted `assert!` in a test reads the same either way).
 # The codebase is already clean, so `deny` locks that in.
 manual_assert = "deny"
+# Reject a `#[test]` function declared outside a `#[cfg(test)]` module. This is the compiler-
+# enforced half of this repo's existing `*_tests.rs` convention: `.githooks/pre-push` step 1
+# already greps for tests living outside a `#[cfg(test)] mod foo_tests;` sibling, but that check is
+# text-pattern-based and only runs locally pre-push. This lint checks the same invariant from the
+# AST instead, so it also runs in `cargo clippy` (CI's `lint.yml` job) and can't be skipped by a
+# contributor who bypasses git hooks. The codebase is already clean, so `deny` locks that in.
+tests_outside_test_module = "deny"

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -391,3 +391,9 @@ unreachable = "deny"
 # deny-list, so this never applied to `ui/src` despite CI's `clippy` job running `--workspace`.
 # The `ui` crate is already clean, so `deny` locks that in.
 redundant_type_annotations = "deny"
+# Reject a `#[test]` function declared outside a `#[cfg(test)]` module. Mirrors the root crate's
+# `tests_outside_test_module = "deny"` (see Cargo.toml), which formalizes this repo's existing
+# `*_tests.rs` convention at the AST level. The `ui` crate has its own `[lints.clippy]` table and
+# doesn't inherit root's extended deny-list, so this never applied to `ui/src` despite CI's
+# `clippy` job running `--workspace`. The `ui` crate is already clean, so `deny` locks that in.
+tests_outside_test_module = "deny"


### PR DESCRIPTION
## Summary

- Enables `clippy::tests_outside_test_module = "deny"` in both `Cargo.toml` and `ui/Cargo.toml`.
- This lint rejects a `#[test]` function declared outside a `#[cfg(test)]` module.

## Why

This repo already has a hand-written convention that tests must live in `*_tests.rs` files, referenced via a `#[cfg(test)] mod foo_tests;` sibling — enforced today by a text-pattern `grep` in `.githooks/pre-push` step 1 ("Checking test-file convention"). That check is:
- text-pattern based (can have false negatives on unusual formatting),
- local-only — it runs pre-push, not in CI, and a contributor can skip git hooks entirely.

`clippy::tests_outside_test_module` checks the same underlying invariant (a `#[test]` fn must live inside a `#[cfg(test)]`-tagged module) from the compiler's own AST instead, so it's also enforced by `cargo clippy` — CI's `lint.yml` job — with no way to bypass it short of an explicit `#[allow]`.

`ui/Cargo.toml` needs its own explicit entry since the `ui` crate has its own `[lints.clippy]` table and doesn't inherit the root's extended deny-list — mirroring the parity pattern already used for `unreachable`, `redundant_type_annotations`, and the other lints listed there.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (workspace, including `ui/src`, was already compliant; zero violations surfaced)
- `cargo test --workspace` — 340 passed
- A changeset is included (`.changeset/enable-clippy-tests-outside-test-module.md`)

No behavior change — this only adds compile-time enforcement of an already-true invariant.