### PR TITLE
feat(observability): add GET /api/v1/metrics Prometheus endpoint

### DIFF
--- a/.changeset/prometheus-metrics-endpoint.md
+++ b/.changeset/prometheus-metrics-endpoint.md
@@ -1,0 +1,18 @@
+---
+"moadim": minor
+---
+
+feat(observability): add `GET /api/v1/metrics`, a Prometheus text-exposition endpoint (#414)
+
+Exposes `moadim_uptime_seconds`, `moadim_build_info`, `moadim_active_sessions`,
+`moadim_workbench_bytes`, `moadim_runs_total{status=...}`,
+`moadim_run_duration_seconds` (histogram), `moadim_cleanup_removed_total`, and
+`moadim_cleanup_freed_bytes_total`. Run counts/durations and active sessions are
+derived at scrape time from the same durable run history (`runs.log` + live
+workbenches) and live tmux session count the REST "recent runs" view and the
+concurrency cap already read, rather than a second, parallel counter that could
+drift from it. Cleanup-sweep totals are tracked as process-lifetime atomics,
+incremented at the one function both the periodic sweep and the on-demand
+`POST /routines/cleanup` route already funnel through, so they reflect real
+sweeps and not just on-demand snapshots. `GET /health` is unchanged — it stays
+the cheap liveness probe, `/metrics` is the richer scrape surface.

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ override when both are set.
 
 ```
 GET    /health                 # liveness + uptime/version, used by status/--wait and the UI health badge
+GET    /metrics                # Prometheus text-exposition metrics: run counts/failures/durations, active sessions, workbench disk usage
 POST   /shutdown               # graceful stop, used by `moadim stop` and the UI STOP button
 POST   /restart                # stop this server and start a fresh instance, used by `moadim restart`
 GET    /routines              # list (filter by ?repository=, sort by ?sort=/&order=)

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -238,6 +238,27 @@
         }
       }
     },
+    "/metrics": {
+      "get": {
+        "tags": [
+          "crate::routes::metrics"
+        ],
+        "summary": "`GET /api/v1/metrics` — Prometheus text-exposition metrics. See the module doc for how each\nseries is derived; `/health` remains the cheap liveness probe, this is the richer surface.",
+        "operationId": "metrics",
+        "responses": {
+          "200": {
+            "description": "Prometheus text exposition format (version 0.0.4)",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/restart": {
       "post": {
         "tags": [

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -11,6 +11,7 @@
     servers((url = "/api/v1", description = "This server")),
     paths(
         crate::routes::health::health,
+        crate::routes::metrics::metrics,
         crate::routes::shutdown::shutdown,
         crate::routes::restart::restart,
         crate::routes::http::get_current_machine,

--- a/src/routes/http.rs
+++ b/src/routes/http.rs
@@ -5,6 +5,7 @@ use super::get_lock_status;
 use super::health;
 use super::list_agents;
 use super::mcp::MoadimMcp;
+use super::metrics;
 use super::restart;
 use super::shutdown;
 use crate::error::AppError;
@@ -212,6 +213,7 @@ pub(crate) fn build_app_with_shutdown(
     // client-routed web UI (e.g. `/routines` resolves to a UI page, not JSON).
     let api = Router::new()
         .route("/health", get(health::health))
+        .route("/metrics", get(metrics::metrics))
         .route("/shutdown", post(shutdown::shutdown))
         .route("/restart", post(restart::restart))
         .route("/machine", get(get_current_machine).put(put_machine))

--- a/src/routes/metrics.rs
+++ b/src/routes/metrics.rs
@@ -1,0 +1,244 @@
+//! `GET /api/v1/metrics` — Prometheus text-exposition metrics: run counts by outcome, run
+//! duration distribution, live agent sessions, workbench disk usage, and cleanup-sweep totals
+//! (issue #414).
+//!
+//! No MCP tool mirrors this route — a raw Prometheus text dump isn't a meaningful
+//! agent-callable action the way `health`/`restart`/`list_agents` are — so per
+//! `src/routes/CONTRIBUTING.md`'s "small routes ... can go straight into `http.rs`" guidance it
+//! lives in its own flat file rather than the `logic.rs`/`http.rs`/`mcp.rs` folder split those
+//! routes use.
+//!
+//! Every series here is derived at scrape time from state the daemon already tracks durably:
+//! run counts and durations come from [`crate::routines::svc_list_all_runs`] (the same merged
+//! live-workbench + `runs.log` view the "recent runs" REST/UI surface already reads), active
+//! sessions from the same live tmux count the concurrency cap uses, and workbench disk usage
+//! from a walk of `~/.moadim/workbenches/`. That keeps this endpoint a read model over existing
+//! ground truth rather than a second, parallel set of counters that could drift from it. The one
+//! exception is `moadim_cleanup_removed_total`/`moadim_cleanup_freed_bytes_total`: a cleanup
+//! sweep leaves no durable per-sweep log to replay, so those two are process-lifetime atomics
+//! (see `crate::routines::cleanup::counters`) incremented at the one function
+//! (`cleanup_expired_workbenches`) both the periodic sweep and the on-demand
+//! `POST /routines/cleanup` route already funnel through.
+
+use std::fmt::Write as _;
+
+use axum::extract::State;
+use axum::http::header::CONTENT_TYPE;
+use axum::response::IntoResponse;
+
+use crate::routes::http::AppState;
+use crate::routines::{svc_list_all_runs, FleetRunSummary, RunStatus};
+use crate::utils::time::now_secs;
+
+/// `Content-Type` for the Prometheus text exposition format (version `0.0.4`).
+const PROMETHEUS_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
+
+/// Upper bounds (seconds) of the `moadim_run_duration_seconds` histogram's finite buckets,
+/// narrowest first — chosen to span a quick agent turn (a few seconds) through an hour-long one.
+/// Prometheus histograms always carry an implicit final `+Inf` bucket beyond these.
+const DURATION_BUCKETS_SECS: [u64; 9] = [5, 15, 30, 60, 120, 300, 600, 1800, 3600];
+
+/// Everything [`render`] needs to produce the exposition text, gathered once by [`metrics`] so
+/// the formatting logic itself stays a pure function of its inputs (and independently testable).
+struct MetricsSnapshot<'input> {
+    /// Seconds since the daemon started.
+    uptime_secs: u64,
+    /// Daemon version (`CARGO_PKG_VERSION`).
+    version: &'input str,
+    /// Short git commit SHA the daemon was built from.
+    git_sha: &'input str,
+    /// Resolved name of this machine.
+    machine: &'input str,
+    /// Number of live tmux agent sessions right now.
+    active_sessions: usize,
+    /// Total size in bytes of the workbench tree on disk.
+    workbench_bytes: u64,
+    /// Every run across every routine, live and historical (see
+    /// [`crate::routines::svc_list_all_runs`]).
+    runs: &'input [FleetRunSummary],
+    /// Workbenches removed by cleanup sweeps since this process started.
+    cleanup_removed_total: u64,
+    /// Bytes freed by cleanup sweeps since this process started.
+    cleanup_freed_bytes_total: u64,
+}
+
+/// `GET /api/v1/metrics` — Prometheus text-exposition metrics. See the module doc for how each
+/// series is derived; `/health` remains the cheap liveness probe, this is the richer surface.
+#[utoipa::path(get, path = "/metrics",
+    responses((status = 200, description = "Prometheus text exposition format (version 0.0.4)", body = str)))]
+pub async fn metrics(State(state): State<AppState>) -> impl IntoResponse {
+    let runs = svc_list_all_runs(&state.routines, Some(usize::MAX));
+    let machine = crate::machine::current_machine();
+    let (cleanup_removed_total, cleanup_freed_bytes_total) =
+        crate::routines::cleanup_sweep_totals();
+    let snapshot = MetricsSnapshot {
+        uptime_secs: now_secs().saturating_sub(state.uptime_start),
+        version: crate::build_info::VERSION,
+        git_sha: crate::build_info::GIT_SHA,
+        machine: machine.as_str(),
+        active_sessions: crate::routines::tmux_session_count(crate::routines::TMUX_SESSION_PREFIX),
+        workbench_bytes: crate::routines::workbenches_total_bytes(),
+        runs: &runs,
+        cleanup_removed_total,
+        cleanup_freed_bytes_total,
+    };
+    ([(CONTENT_TYPE, PROMETHEUS_CONTENT_TYPE)], render(&snapshot))
+}
+
+/// Count of runs at each [`RunStatus`], tallied by [`render`] from a [`MetricsSnapshot`]'s runs.
+#[derive(Default)]
+struct RunStatusCounts {
+    /// Runs whose agent process exited `0`.
+    success: u64,
+    /// Runs whose agent process exited non-zero.
+    failed: u64,
+    /// Runs whose tmux session is still alive.
+    running: u64,
+    /// Runs whose session ended with no exit code recorded (killed, crashed, or from a build
+    /// predating exit-code capture).
+    unknown: u64,
+}
+
+/// Render `snapshot` as Prometheus text exposition format (one `# HELP`/`# TYPE` pair per
+/// series, then its sample line(s)).
+fn render(snapshot: &MetricsSnapshot<'_>) -> String {
+    let mut out = String::new();
+
+    let _ = writeln!(
+        out,
+        "# HELP moadim_uptime_seconds Seconds since the daemon started."
+    );
+    let _ = writeln!(out, "# TYPE moadim_uptime_seconds gauge");
+    let _ = writeln!(out, "moadim_uptime_seconds {}", snapshot.uptime_secs);
+
+    let _ = writeln!(
+        out,
+        "# HELP moadim_build_info Daemon build metadata; the sample value is always 1."
+    );
+    let _ = writeln!(out, "# TYPE moadim_build_info gauge");
+    let _ = writeln!(
+        out,
+        r#"moadim_build_info{{version="{}",git_sha="{}",machine="{}"}} 1"#,
+        snapshot.version, snapshot.git_sha, snapshot.machine
+    );
+
+    let _ = writeln!(
+        out,
+        "# HELP moadim_active_sessions Number of live tmux agent sessions right now."
+    );
+    let _ = writeln!(out, "# TYPE moadim_active_sessions gauge");
+    let _ = writeln!(out, "moadim_active_sessions {}", snapshot.active_sessions);
+
+    let _ = writeln!(
+        out,
+        "# HELP moadim_workbench_bytes Total size in bytes of the workbench tree on disk."
+    );
+    let _ = writeln!(out, "# TYPE moadim_workbench_bytes gauge");
+    let _ = writeln!(out, "moadim_workbench_bytes {}", snapshot.workbench_bytes);
+
+    render_runs_total(&mut out, snapshot.runs);
+    render_run_duration_histogram(&mut out, snapshot.runs);
+
+    let _ = writeln!(
+        out,
+        "# HELP moadim_cleanup_removed_total Workbenches removed by cleanup sweeps since the daemon started."
+    );
+    let _ = writeln!(out, "# TYPE moadim_cleanup_removed_total counter");
+    let _ = writeln!(
+        out,
+        "moadim_cleanup_removed_total {}",
+        snapshot.cleanup_removed_total
+    );
+
+    let _ = writeln!(
+        out,
+        "# HELP moadim_cleanup_freed_bytes_total Bytes freed by cleanup sweeps since the daemon started."
+    );
+    let _ = writeln!(out, "# TYPE moadim_cleanup_freed_bytes_total counter");
+    let _ = writeln!(
+        out,
+        "moadim_cleanup_freed_bytes_total {}",
+        snapshot.cleanup_freed_bytes_total
+    );
+
+    out
+}
+
+/// Append the `moadim_runs_total{status=...}` counter series, one sample per [`RunStatus`].
+fn render_runs_total(out: &mut String, runs: &[FleetRunSummary]) {
+    let mut counts = RunStatusCounts::default();
+    for run in runs {
+        match run.status {
+            RunStatus::Success => counts.success += 1,
+            RunStatus::Failed => counts.failed += 1,
+            RunStatus::Running => counts.running += 1,
+            RunStatus::Unknown => counts.unknown += 1,
+        }
+    }
+    let _ = writeln!(
+        out,
+        "# HELP moadim_runs_total Total routine runs observed, by outcome."
+    );
+    let _ = writeln!(out, "# TYPE moadim_runs_total counter");
+    let _ = writeln!(
+        out,
+        r#"moadim_runs_total{{status="success"}} {}"#,
+        counts.success
+    );
+    let _ = writeln!(
+        out,
+        r#"moadim_runs_total{{status="failed"}} {}"#,
+        counts.failed
+    );
+    let _ = writeln!(
+        out,
+        r#"moadim_runs_total{{status="running"}} {}"#,
+        counts.running
+    );
+    let _ = writeln!(
+        out,
+        r#"moadim_runs_total{{status="unknown"}} {}"#,
+        counts.unknown
+    );
+}
+
+/// Append the `moadim_run_duration_seconds` histogram, over every run with a recorded
+/// `finished_at` (i.e. every non-[`RunStatus::Running`] run, regardless of outcome).
+fn render_run_duration_histogram(out: &mut String, runs: &[FleetRunSummary]) {
+    let durations: Vec<u64> = runs
+        .iter()
+        .filter_map(|run| {
+            run.finished_at
+                .map(|finished| finished.saturating_sub(run.started_at))
+        })
+        .collect();
+
+    let _ = writeln!(
+        out,
+        "# HELP moadim_run_duration_seconds Duration of finished routine runs, in seconds."
+    );
+    let _ = writeln!(out, "# TYPE moadim_run_duration_seconds histogram");
+    // Each bucket is the count of *every* duration <= its bound (Prometheus histogram buckets
+    // are cumulative from `le="+Inf"` downward, not per-range), recomputed fresh rather than
+    // accumulated across the loop — with only a handful of runs per scrape, a second `filter`
+    // pass per bucket is cheaper to get right than threading a running total through.
+    for bound in DURATION_BUCKETS_SECS {
+        let cumulative = durations.iter().filter(|&&secs| secs <= bound).count();
+        let _ = writeln!(
+            out,
+            r#"moadim_run_duration_seconds_bucket{{le="{bound}"}} {cumulative}"#
+        );
+    }
+    let _ = writeln!(
+        out,
+        r#"moadim_run_duration_seconds_bucket{{le="+Inf"}} {}"#,
+        durations.len()
+    );
+    let sum: u64 = durations.iter().sum();
+    let _ = writeln!(out, "moadim_run_duration_seconds_sum {sum}");
+    let _ = writeln!(out, "moadim_run_duration_seconds_count {}", durations.len());
+}
+
+#[cfg(test)]
+#[path = "metrics_tests.rs"]
+mod metrics_tests;

--- a/src/routes/metrics_tests.rs
+++ b/src/routes/metrics_tests.rs
@@ -1,0 +1,150 @@
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and fixtures do not need doc comments"
+)]
+
+use axum::{
+    body::Body,
+    http::{header::CONTENT_TYPE, Request, StatusCode},
+};
+use tower::ServiceExt;
+
+use super::{render, MetricsSnapshot, PROMETHEUS_CONTENT_TYPE};
+use crate::routes::http::build_app;
+use crate::routines::{FleetRunSummary, RunStatus};
+
+/// A minimal [`FleetRunSummary`] fixture; `started_at`/`finished_at`/`status` are the only
+/// fields [`render`] reads, but every field is required to construct one.
+fn run(started_at: u64, finished_at: Option<u64>, status: RunStatus) -> FleetRunSummary {
+    FleetRunSummary {
+        routine_id: "routine-1".to_string(),
+        routine_title: "Test routine".to_string(),
+        workbench: format!("test-routine-{started_at}"),
+        started_at,
+        started_at_local: String::new(),
+        finished_at,
+        finished_at_local: None,
+        status,
+        exit_code: match status {
+            RunStatus::Success => Some(0),
+            RunStatus::Failed => Some(1),
+            RunStatus::Running | RunStatus::Unknown => None,
+        },
+    }
+}
+
+fn empty_snapshot(runs: &[FleetRunSummary]) -> MetricsSnapshot<'_> {
+    MetricsSnapshot {
+        uptime_secs: 42,
+        version: "1.2.3",
+        git_sha: "abc123",
+        machine: "test-machine",
+        active_sessions: 2,
+        workbench_bytes: 1024,
+        runs,
+        cleanup_removed_total: 5,
+        cleanup_freed_bytes_total: 2048,
+    }
+}
+
+#[test]
+fn render_emits_help_and_type_for_every_gauge_and_counter() {
+    let text = render(&empty_snapshot(&[]));
+    for name in [
+        "moadim_uptime_seconds",
+        "moadim_build_info",
+        "moadim_active_sessions",
+        "moadim_workbench_bytes",
+        "moadim_runs_total",
+        "moadim_run_duration_seconds",
+        "moadim_cleanup_removed_total",
+        "moadim_cleanup_freed_bytes_total",
+    ] {
+        assert!(
+            text.contains(&format!("# HELP {name} ")),
+            "missing HELP line for {name} in:\n{text}"
+        );
+        assert!(
+            text.contains(&format!("# TYPE {name} ")),
+            "missing TYPE line for {name} in:\n{text}"
+        );
+    }
+    assert!(text.contains("moadim_uptime_seconds 42"));
+    assert!(text.contains(
+        r#"moadim_build_info{version="1.2.3",git_sha="abc123",machine="test-machine"} 1"#
+    ));
+    assert!(text.contains("moadim_active_sessions 2"));
+    assert!(text.contains("moadim_workbench_bytes 1024"));
+    assert!(text.contains("moadim_cleanup_removed_total 5"));
+    assert!(text.contains("moadim_cleanup_freed_bytes_total 2048"));
+}
+
+#[test]
+fn render_runs_total_counts_each_status_independently() {
+    let runs = [
+        run(100, Some(110), RunStatus::Success),
+        run(200, Some(210), RunStatus::Success),
+        run(300, Some(310), RunStatus::Failed),
+        run(400, None, RunStatus::Running),
+        run(500, Some(510), RunStatus::Unknown),
+    ];
+    let text = render(&empty_snapshot(&runs));
+    assert!(text.contains(r#"moadim_runs_total{status="success"} 2"#));
+    assert!(text.contains(r#"moadim_runs_total{status="failed"} 1"#));
+    assert!(text.contains(r#"moadim_runs_total{status="running"} 1"#));
+    assert!(text.contains(r#"moadim_runs_total{status="unknown"} 1"#));
+}
+
+#[test]
+fn render_run_duration_histogram_buckets_cumulatively_by_le() {
+    // Durations of 3s and 100s land in different buckets; the still-running run (no
+    // `finished_at`) must be excluded from the histogram entirely.
+    let runs = [
+        run(0, Some(3), RunStatus::Success),
+        run(0, Some(100), RunStatus::Failed),
+        run(0, None, RunStatus::Running),
+    ];
+    let text = render(&empty_snapshot(&runs));
+    // The 3s run is <= every finite bucket bound (5, 15, 30, ...).
+    assert!(text.contains(r#"moadim_run_duration_seconds_bucket{le="5"} 1"#));
+    assert!(text.contains(r#"moadim_run_duration_seconds_bucket{le="15"} 1"#));
+    assert!(text.contains(r#"moadim_run_duration_seconds_bucket{le="30"} 1"#));
+    // The 100s run joins once the bound reaches 120.
+    assert!(text.contains(r#"moadim_run_duration_seconds_bucket{le="60"} 1"#));
+    assert!(text.contains(r#"moadim_run_duration_seconds_bucket{le="120"} 2"#));
+    assert!(text.contains(r#"moadim_run_duration_seconds_bucket{le="300"} 2"#));
+    assert!(text.contains(r#"moadim_run_duration_seconds_bucket{le="600"} 2"#));
+    assert!(text.contains(r#"moadim_run_duration_seconds_bucket{le="1800"} 2"#));
+    assert!(text.contains(r#"moadim_run_duration_seconds_bucket{le="3600"} 2"#));
+    assert!(text.contains(r#"moadim_run_duration_seconds_bucket{le="+Inf"} 2"#));
+    assert!(text.contains("moadim_run_duration_seconds_sum 103"));
+    assert!(text.contains("moadim_run_duration_seconds_count 2"));
+}
+
+#[tokio::test]
+async fn build_app_serves_metrics_with_prometheus_content_type() {
+    let app = build_app(crate::routines::new_store());
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers().get(CONTENT_TYPE).unwrap(),
+        PROMETHEUS_CONTENT_TYPE,
+    );
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let text = String::from_utf8(bytes.to_vec()).unwrap();
+    assert!(text.starts_with("# HELP moadim_uptime_seconds"));
+    // A fresh in-memory store with no routines still reports every series (all zero), not an
+    // error or an empty body.
+    assert!(text.contains("moadim_runs_total{status=\"success\"} 0"));
+    assert!(text.contains("moadim_run_duration_seconds_count 0"));
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -9,5 +9,6 @@ pub mod health;
 pub mod http;
 pub mod list_agents;
 pub mod mcp;
+pub mod metrics;
 pub mod restart;
 pub mod shutdown;

--- a/src/routines/cleanup/counters.rs
+++ b/src/routines/cleanup/counters.rs
@@ -1,0 +1,36 @@
+//! Process-lifetime counters backing the cleanup-sweep metrics (`moadim_cleanup_removed_total`,
+//! `moadim_cleanup_freed_bytes_total`) exposed by `GET /api/v1/metrics`
+//! (`crate::routes::metrics`). Both the periodic background sweep and the on-demand
+//! `POST /routines/cleanup` route funnel through `cleanup_expired_workbenches` (see
+//! `super::cleanup_expired_workbenches`), so recording a sweep once there covers both triggers.
+//!
+//! Deliberately in-memory rather than persisted: like the run-duration histogram in
+//! `crate::routes::metrics`, these are process-lifetime counters that reset to `0` on a daemon
+//! restart, which matches how an operator reads a Prometheus counter after a scrape target
+//! restarts (a reset, not a decrease).
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Total workbenches removed by every cleanup sweep since this process started.
+static REMOVED_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+/// Total bytes freed by every cleanup sweep since this process started.
+static FREED_BYTES_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+/// Add one sweep's `removed`/`freed_bytes` ([`super::ReapStats`]) to the running totals.
+pub(crate) fn record_sweep(removed: u64, freed_bytes: u64) {
+    REMOVED_TOTAL.fetch_add(removed, Ordering::Relaxed);
+    FREED_BYTES_TOTAL.fetch_add(freed_bytes, Ordering::Relaxed);
+}
+
+/// Current `(removed_total, freed_bytes_total)` snapshot, read by `GET /api/v1/metrics`.
+pub(crate) fn totals() -> (u64, u64) {
+    (
+        REMOVED_TOTAL.load(Ordering::Relaxed),
+        FREED_BYTES_TOTAL.load(Ordering::Relaxed),
+    )
+}
+
+#[cfg(test)]
+#[path = "counters_tests.rs"]
+mod counters_tests;

--- a/src/routines/cleanup/counters_tests.rs
+++ b/src/routines/cleanup/counters_tests.rs
@@ -1,0 +1,30 @@
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and fixtures do not need doc comments"
+)]
+
+use super::{record_sweep, totals};
+
+// These counters are process-global (`static AtomicU64`), and `cargo test` runs the whole
+// binary's tests concurrently on multiple threads within one process — including other cleanup
+// tests that call `cleanup_expired_workbenches` (and so `record_sweep`) directly. Asserting an
+// exact before/after delta would be flaky under that concurrency, so this only checks the
+// monotonic "increased by at least what we just recorded" property, which holds regardless of
+// what any other test thread adds concurrently.
+#[test]
+fn record_sweep_increments_totals_by_at_least_the_recorded_amount() {
+    let (removed_before, freed_before) = totals();
+    record_sweep(3, 400);
+    let (removed_after, freed_after) = totals();
+    assert!(removed_after >= removed_before + 3);
+    assert!(freed_after >= freed_before + 400);
+}
+
+#[test]
+fn record_sweep_of_zero_never_decreases_totals() {
+    let before = totals();
+    record_sweep(0, 0);
+    let after = totals();
+    assert!(after.0 >= before.0);
+    assert!(after.1 >= before.1);
+}

--- a/src/routines/cleanup/mod.rs
+++ b/src/routines/cleanup/mod.rs
@@ -27,6 +27,7 @@ use crate::utils::time::now_secs;
 use super::model::{RoutineStore, RunStatus};
 use super::run_history::{append_persisted_run, has_persisted_run, read_exit_code, PersistedRun};
 
+mod counters;
 mod disk_cap;
 mod log_cap;
 mod runtime;
@@ -36,11 +37,19 @@ mod ttl;
 
 use session::{note_forced_kill, tmux_kill_session, tmux_session_alive};
 
+pub(crate) use counters::totals as cleanup_sweep_totals;
 pub(crate) use runtime::max_runtime_ceiling_secs;
 pub(crate) use session::tmux_session_alive as run_session_alive;
 pub(crate) use session::tmux_session_count;
 pub(crate) use session::tmux_session_prefix_alive;
 pub(crate) use ttl::ttl_ceiling_secs;
+
+/// Total size in bytes of the whole `~/.moadim/workbenches/` tree, live and reaped-but-not-yet
+/// -swept alike. Backs the `moadim_workbench_bytes` metric (`crate::routes::metrics`); a thin
+/// wrapper so that route doesn't need to know this module's private [`dir_size`] walker exists.
+pub(crate) fn workbenches_total_bytes() -> u64 {
+    dir_size(&workbenches_dir())
+}
 
 /// How often the background task scans for expired workbenches.
 ///
@@ -367,10 +376,15 @@ pub fn cleanup_expired_workbenches(store: &RoutineStore) -> ReapStats {
         &tmux_session_alive,
         &agent_log_finish_time,
     );
-    ReapStats {
+    let stats = ReapStats {
         removed: ttl_stats.removed + cap_stats.removed,
         freed_bytes: ttl_stats.freed_bytes + cap_stats.freed_bytes,
-    }
+    };
+    // Record this sweep for `moadim_cleanup_removed_total`/`moadim_cleanup_freed_bytes_total`
+    // (see `counters`) — both the periodic background task and the on-demand `svc_cleanup` route
+    // call this one function, so recording here covers both triggers.
+    counters::record_sweep(stats.removed as u64, stats.freed_bytes);
+    stats
 }
 
 /// Force-kill hung run sessions under `~/.moadim/workbenches/` that have exceeded their routine's


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/metrics`, returning Prometheus text-exposition format (`text/plain; version=0.0.4`): `moadim_uptime_seconds`, `moadim_build_info`, `moadim_active_sessions`, `moadim_workbench_bytes`, `moadim_runs_total{status="success|failed|running|unknown"}`, `moadim_run_duration_seconds` (histogram), `moadim_cleanup_removed_total`, `moadim_cleanup_freed_bytes_total`.
- Run counts/durations and active sessions are derived at scrape time from state the daemon already tracks durably — `svc_list_all_runs` (the same merged `runs.log` + live-workbench view the "recent runs" REST/UI surface reads) and the live tmux session count the concurrency cap already uses — rather than a second, parallel set of counters that could drift from it.
- Cleanup-sweep totals (`moadim_cleanup_removed_total`/`moadim_cleanup_freed_bytes_total`) have no durable per-sweep log to replay, so they're tracked as process-lifetime atomics (`src/routines/cleanup/counters.rs`), incremented inside `cleanup_expired_workbenches` — the one function both the periodic 5-minute sweep and the on-demand `POST /routines/cleanup` route already funnel through — so they reflect real sweeps, not just on-demand snapshots.
- `GET /health` is unchanged; it stays the cheap liveness probe, `/metrics` is the richer scrape surface.
- No new dependency: hand-rolled the small Prometheus text format (repo's `Cargo.toml` has no Prometheus-compatible crate already).
- Documented in the OpenAPI spec (`apis/openapi.json`, regenerated), the README route table, and route table wiring in `src/routes/http.rs`.
- No MCP tool added (a raw Prometheus text dump isn't a meaningful agent-callable action, unlike `health`/`restart`/`list_agents`); per `src/routes/CONTRIBUTING.md` this keeps it a flat one-off file instead of the `logic.rs`/`http.rs`/`mcp.rs` folder split those routes use.

Closes #414

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build -p ui --target wasm32-unknown-unknown` / `cargo clippy -p ui --target wasm32-unknown-unknown --all-targets -- -D warnings`
- [x] `cargo test --workspace` (1090 + 340 passed)
- [x] `linecheck --max-lines 500 ...`
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — new code (`src/routes/metrics.rs`, `src/routines/cleanup/counters.rs`) is 100% covered; the workspace total (99.95% lines / 3 missed) is unchanged from the `main` baseline in this sandbox (same 3 missed lines before and after this change — pre-existing, unrelated to this PR, likely from platform-specific code paths needing real `crontab`/`launchctl` binaries not present in this environment).
- [x] Manually verified `GET /api/v1/metrics` output shape via unit + HTTP-level tests in `src/routes/metrics_tests.rs`.