### PR TITLE
chore(lint): enable clippy::undocumented_unsafe_blocks

### DIFF
--- a/.changeset/enable-clippy-undocumented-unsafe-blocks.md
+++ b/.changeset/enable-clippy-undocumented-unsafe-blocks.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+chore(lint): enable `clippy::undocumented_unsafe_blocks` workspace-wide, requiring a reasoned `// SAFETY:` comment for every `unsafe` block. This locks in the existing convention as a compiler-checked rule instead of an unenforced habit.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -360,3 +360,13 @@ manual_assert = "deny"
 # AST instead, so it also runs in `cargo clippy` (CI's `lint.yml` job) and can't be skipped by a
 # contributor who bypasses git hooks. The codebase is already clean, so `deny` locks that in.
 tests_outside_test_module = "deny"
+# Require every `unsafe` block to carry a `// SAFETY: ...` comment immediately above it explaining
+# why the block upholds the invariants `unsafe` asks the author to uphold. The codebase already
+# follows this convention almost everywhere (env-var overrides in single-threaded tests, the
+# `flock` FFI call in `utils/claude_json.rs`), but nothing enforced it, so it could silently lapse
+# as new `unsafe` blocks were added. Fixed the 39 violations this surfaced — all in test helpers
+# (`std::env::set_var`/`remove_var` restoring a previous env var after a single-threaded test, and
+# one `libc::kill` cleaning up a test-spawned child process) — by adding the same `// SAFETY:`
+# comment already used at the many documented call sites. No behavior change. `deny` locks in that
+# every future `unsafe` block stays documented.
+undocumented_unsafe_blocks = "deny"

--- a/src/cli/spawn_error_tests.rs
+++ b/src/cli/spawn_error_tests.rs
@@ -108,6 +108,7 @@ fn spawn_detached_rotates_oversized_daemon_log() {
     );
     // The detached child is a real process; kill it so the test doesn't leak one.
     #[cfg(unix)]
+    // SAFETY: `pid` is this test's own detached child process; sending it SIGKILL is safe cleanup.
     unsafe {
         libc::kill(pid as libc::pid_t, libc::SIGKILL);
     }

--- a/src/routes/http_listener_tests.rs
+++ b/src/routes/http_listener_tests.rs
@@ -374,11 +374,13 @@ fn shutdown_grace_honors_env_override_then_falls_back() {
     }
     assert_eq!(shutdown_grace(), Duration::from_millis(42));
     // An unparseable value falls back to the compiled default.
+    // SAFETY: single-threaded test execution.
     unsafe {
         std::env::set_var(SHUTDOWN_GRACE_MS_ENV, "not-a-number");
     }
     assert_eq!(shutdown_grace(), SHUTDOWN_GRACE);
     // An unset value also falls back.
+    // SAFETY: single-threaded test execution.
     unsafe {
         std::env::remove_var(SHUTDOWN_GRACE_MS_ENV);
     }

--- a/src/routine_storage_compiled_prompt_migration_tests.rs
+++ b/src/routine_storage_compiled_prompt_migration_tests.rs
@@ -22,6 +22,7 @@ fn with_override_home(body: impl FnOnce(&std::path::Path)) {
         std::env::set_var("MOADIM_HOME_OVERRIDE", &home);
     }
     body(&home);
+    // SAFETY: single-threaded test execution.
     unsafe {
         match previous {
             Some(value) => std::env::set_var("MOADIM_HOME_OVERRIDE", value),

--- a/src/routine_storage_migration_tests.rs
+++ b/src/routine_storage_migration_tests.rs
@@ -49,6 +49,7 @@ fn with_override_home(body: impl FnOnce(&std::path::Path)) {
         std::env::set_var("MOADIM_HOME_OVERRIDE", &home);
     }
     body(&home);
+    // SAFETY: single-threaded test execution.
     unsafe {
         match previous {
             Some(value) => std::env::set_var("MOADIM_HOME_OVERRIDE", value),

--- a/src/routine_storage_more_tests.rs
+++ b/src/routine_storage_more_tests.rs
@@ -19,6 +19,7 @@ fn with_override_home(body: impl FnOnce(&std::path::Path)) {
         std::env::set_var("MOADIM_HOME_OVERRIDE", &home);
     }
     body(&home);
+    // SAFETY: single-threaded test execution.
     unsafe {
         match previous {
             Some(value) => std::env::set_var("MOADIM_HOME_OVERRIDE", value),

--- a/src/routine_storage_prompt_file_migration_tests.rs
+++ b/src/routine_storage_prompt_file_migration_tests.rs
@@ -22,6 +22,7 @@ fn with_override_home(body: impl FnOnce(&std::path::Path)) {
         std::env::set_var("MOADIM_HOME_OVERRIDE", &home);
     }
     body(&home);
+    // SAFETY: single-threaded test execution.
     unsafe {
         match previous {
             Some(value) => std::env::set_var("MOADIM_HOME_OVERRIDE", value),

--- a/src/routine_storage_prompt_sidecar_tests.rs
+++ b/src/routine_storage_prompt_sidecar_tests.rs
@@ -19,6 +19,7 @@ fn with_override_home(body: impl FnOnce(&std::path::Path)) {
         std::env::set_var("MOADIM_HOME_OVERRIDE", &home);
     }
     body(&home);
+    // SAFETY: single-threaded test execution.
     unsafe {
         match previous {
             Some(value) => std::env::set_var("MOADIM_HOME_OVERRIDE", value),

--- a/src/routine_storage_sidecar_state_tests.rs
+++ b/src/routine_storage_sidecar_state_tests.rs
@@ -19,6 +19,7 @@ fn with_override_home(body: impl FnOnce(&std::path::Path)) {
         std::env::set_var("MOADIM_HOME_OVERRIDE", &home);
     }
     body(&home);
+    // SAFETY: single-threaded test execution.
     unsafe {
         match previous {
             Some(value) => std::env::set_var("MOADIM_HOME_OVERRIDE", value),

--- a/src/routine_storage_slug_collision_tests.rs
+++ b/src/routine_storage_slug_collision_tests.rs
@@ -19,6 +19,7 @@ fn with_override_home(body: impl FnOnce(&std::path::Path)) {
         std::env::set_var("MOADIM_HOME_OVERRIDE", &home);
     }
     body(&home);
+    // SAFETY: single-threaded test execution.
     unsafe {
         match previous {
             Some(value) => std::env::set_var("MOADIM_HOME_OVERRIDE", value),

--- a/src/routine_storage_snooze_tests.rs
+++ b/src/routine_storage_snooze_tests.rs
@@ -51,6 +51,7 @@ fn with_override_home(body: impl FnOnce(&std::path::Path)) {
         std::env::set_var("MOADIM_HOME_OVERRIDE", &home);
     }
     body(&home);
+    // SAFETY: single-threaded test execution.
     unsafe {
         match previous {
             Some(value) => std::env::set_var("MOADIM_HOME_OVERRIDE", value),
@@ -337,11 +338,13 @@ fn append_manual_trigger_log_warns_on_write_failure() {
 
     // Override home so routine_manual_log_path resolves into our scratch dir.
     let previous = std::env::var_os("MOADIM_HOME_OVERRIDE");
+    // SAFETY: single-threaded test execution.
     unsafe {
         std::env::set_var("MOADIM_HOME_OVERRIDE", &dir);
     }
     // Should not panic; just logs a warning.
     append_manual_trigger_log("rs-manual-log-fail-routine", 42);
+    // SAFETY: single-threaded test execution.
     unsafe {
         match previous {
             Some(value) => std::env::set_var("MOADIM_HOME_OVERRIDE", value),
@@ -380,11 +383,13 @@ fn append_skip_log_warns_on_write_failure() {
     std::fs::create_dir_all(&blocker).unwrap();
 
     let previous = std::env::var_os("MOADIM_HOME_OVERRIDE");
+    // SAFETY: single-threaded test execution.
     unsafe {
         std::env::set_var("MOADIM_HOME_OVERRIDE", &dir);
     }
     // Should not panic; just logs a warning.
     append_skip_log("rs-skip-log-fail-routine", 42, "agent load failure");
+    // SAFETY: single-threaded test execution.
     unsafe {
         match previous {
             Some(value) => std::env::set_var("MOADIM_HOME_OVERRIDE", value),

--- a/src/routine_storage_tests.rs
+++ b/src/routine_storage_tests.rs
@@ -19,6 +19,7 @@ fn with_override_home(body: impl FnOnce(&std::path::Path)) {
         std::env::set_var("MOADIM_HOME_OVERRIDE", &home);
     }
     body(&home);
+    // SAFETY: single-threaded test execution.
     unsafe {
         match previous {
             Some(value) => std::env::set_var("MOADIM_HOME_OVERRIDE", value),

--- a/src/routine_storage_trigger_log_migration_tests.rs
+++ b/src/routine_storage_trigger_log_migration_tests.rs
@@ -22,6 +22,7 @@ fn with_override_home(body: impl FnOnce(&std::path::Path)) {
         std::env::set_var("MOADIM_HOME_OVERRIDE", &home);
     }
     body(&home);
+    // SAFETY: single-threaded test execution.
     unsafe {
         match previous {
             Some(value) => std::env::set_var("MOADIM_HOME_OVERRIDE", value),

--- a/src/routines/cleanup/disk_cap_tests.rs
+++ b/src/routines/cleanup/disk_cap_tests.rs
@@ -68,6 +68,7 @@ fn max_disk_bytes_defaults_to_zero_when_unset() {
         std::env::remove_var(MAX_DISK_BYTES_ENV);
     }
     assert_eq!(max_disk_bytes(), 0);
+    // SAFETY: single-threaded test execution.
     unsafe {
         match prev {
             Some(value) => std::env::set_var(MAX_DISK_BYTES_ENV, value),
@@ -84,6 +85,7 @@ fn max_disk_bytes_parses_a_valid_value() {
         std::env::set_var(MAX_DISK_BYTES_ENV, "1234");
     }
     assert_eq!(max_disk_bytes(), 1234);
+    // SAFETY: single-threaded test execution.
     unsafe {
         match prev {
             Some(value) => std::env::set_var(MAX_DISK_BYTES_ENV, value),
@@ -100,6 +102,7 @@ fn max_disk_bytes_falls_back_to_zero_on_garbage() {
         std::env::set_var(MAX_DISK_BYTES_ENV, "not-a-number");
     }
     assert_eq!(max_disk_bytes(), 0);
+    // SAFETY: single-threaded test execution.
     unsafe {
         match prev {
             Some(value) => std::env::set_var(MAX_DISK_BYTES_ENV, value),

--- a/src/routines/command_bin_resolution_tests.rs
+++ b/src/routines/command_bin_resolution_tests.rs
@@ -16,6 +16,7 @@ fn with_path(value: &std::path::Path, body: impl FnOnce()) {
         std::env::set_var("PATH", value);
     }
     body();
+    // SAFETY: single-threaded test execution.
     unsafe {
         match saved {
             Some(prev) => std::env::set_var("PATH", prev),
@@ -83,6 +84,7 @@ fn tmux_available_false_when_path_unset() {
         std::env::remove_var("PATH");
     }
     assert!(!tmux_available());
+    // SAFETY: single-threaded test execution.
     unsafe {
         if let Some(prev) = saved {
             std::env::set_var("PATH", prev);
@@ -230,6 +232,7 @@ fn agent_command_available_false_when_path_unset() {
         std::env::remove_var("PATH");
     }
     assert!(!agent_command_available("definitely-not-a-real-binary-xyz"));
+    // SAFETY: single-threaded test execution.
     unsafe {
         if let Some(prev) = saved {
             std::env::set_var("PATH", prev);
@@ -251,6 +254,7 @@ fn resolve_tmux_bin_falls_back_to_root_home_when_home_unset() {
 
     let _ = resolve_tmux_bin();
 
+    // SAFETY: single-threaded test execution.
     unsafe {
         match saved {
             Some(prev) => std::env::set_var("HOME", prev),
@@ -268,6 +272,7 @@ fn bin_dir_returns_none_when_path_unset() {
         std::env::remove_var("PATH");
     }
     assert!(bin_dir("definitely-not-a-real-binary-xyz").is_none());
+    // SAFETY: single-threaded test execution.
     unsafe {
         if let Some(prev) = saved {
             std::env::set_var("PATH", prev);

--- a/src/routines/command_tests.rs
+++ b/src/routines/command_tests.rs
@@ -44,6 +44,7 @@ fn with_path(value: &std::path::Path, body: impl FnOnce()) {
         std::env::set_var("PATH", value);
     }
     body();
+    // SAFETY: single-threaded test execution.
     unsafe {
         match saved {
             Some(prev) => std::env::set_var("PATH", prev),
@@ -212,6 +213,7 @@ fn cron_path_falls_back_to_root_home_when_home_unset() {
         "expected /root-anchored fallback dirs in: {path}"
     );
 
+    // SAFETY: single-threaded test execution.
     unsafe {
         match saved {
             Some(prev) => std::env::set_var("HOME", prev),

--- a/src/routines/defaults/lock_tests.rs
+++ b/src/routines/defaults/lock_tests.rs
@@ -26,6 +26,7 @@ fn with_redirected_home(body: impl FnOnce(&std::path::Path)) {
         std::env::set_var("XDG_CONFIG_HOME", home.join(".config"));
     }
     body(&home);
+    // SAFETY: single-threaded test execution.
     unsafe {
         match previous_home {
             Some(value) => std::env::set_var("HOME", value),

--- a/src/routines/defaults/mod_tests.rs
+++ b/src/routines/defaults/mod_tests.rs
@@ -213,6 +213,7 @@ fn with_redirected_home(body: impl FnOnce(&std::path::Path)) {
         std::env::set_var("XDG_CONFIG_HOME", home.join(".config"));
     }
     body(&home);
+    // SAFETY: single-threaded test execution.
     unsafe {
         match previous_home {
             Some(value) => std::env::set_var("HOME", value),

--- a/src/routines/model_tests.rs
+++ b/src/routines/model_tests.rs
@@ -44,6 +44,7 @@ fn with_path(value: &std::path::Path, body: impl FnOnce()) {
         std::env::set_var("PATH", value);
     }
     body();
+    // SAFETY: single-threaded test execution.
     unsafe {
         match saved {
             Some(prev) => std::env::set_var("PATH", prev),

--- a/src/routines/service_flag_tests.rs
+++ b/src/routines/service_flag_tests.rs
@@ -286,6 +286,7 @@ fn sh_bin_never_resolves_to_real_sh_in_test_builds() {
         std::env::remove_var("MOADIM_SH_BIN");
     }
     let bin = sh_bin();
+    // SAFETY: single-threaded test execution.
     unsafe {
         match saved {
             Some(value) => std::env::set_var("MOADIM_SH_BIN", value),
@@ -307,6 +308,7 @@ fn sh_bin_honors_override() {
         std::env::set_var("MOADIM_SH_BIN", "/custom/shim/sh");
     }
     let bin = sh_bin();
+    // SAFETY: single-threaded test execution.
     unsafe {
         match saved {
             Some(value) => std::env::set_var("MOADIM_SH_BIN", value),

--- a/src/service/mod_linux_tests.rs
+++ b/src/service/mod_linux_tests.rs
@@ -107,6 +107,7 @@ fn install_errors_when_write_unit_fails() {
         std::env::set_var("XDG_CONFIG_HOME", &base);
     }
     let result = install();
+    // SAFETY: single-threaded test execution.
     unsafe {
         match prev_xdg {
             Some(val) => std::env::set_var("XDG_CONFIG_HOME", val),
@@ -137,6 +138,7 @@ fn install_errors_when_enable_unit_fails() {
         std::env::set_var("MOADIM_SYSTEMCTL_BIN", &shim);
     }
     let result = install();
+    // SAFETY: single-threaded test execution.
     unsafe {
         match prev_xdg {
             Some(val) => std::env::set_var("XDG_CONFIG_HOME", val),
@@ -178,6 +180,7 @@ fn uninstall_errors_when_remove_unit_fails() {
     let result = uninstall();
     // Restore write permission so the directory can be cleaned up.
     let _ = std::fs::set_permissions(&unit_dir, std::fs::Permissions::from_mode(0o755));
+    // SAFETY: single-threaded test execution.
     unsafe {
         match prev_xdg {
             Some(val) => std::env::set_var("XDG_CONFIG_HOME", val),

--- a/src/service/mod_tests.rs
+++ b/src/service/mod_tests.rs
@@ -251,6 +251,7 @@ fn install_errors_when_write_plist_fails() {
         std::env::set_var("MOADIM_HOME_OVERRIDE", &base);
     }
     let result = install();
+    // SAFETY: single-threaded test execution.
     unsafe {
         match prev_home {
             Some(val) => std::env::set_var("HOME", val),
@@ -287,6 +288,7 @@ fn install_errors_when_reload_agent_fails() {
         std::env::set_var("MOADIM_LAUNCHCTL_BIN", &shim);
     }
     let result = install();
+    // SAFETY: single-threaded test execution.
     unsafe {
         match prev_home {
             Some(val) => std::env::set_var("HOME", val),
@@ -335,6 +337,7 @@ fn uninstall_errors_when_remove_plist_fails() {
     let result = uninstall();
     // Restore write permission so the directory can be cleaned up.
     let _ = std::fs::set_permissions(&launch_agents, std::fs::Permissions::from_mode(0o755));
+    // SAFETY: single-threaded test execution.
     unsafe {
         match prev_home {
             Some(val) => std::env::set_var("HOME", val),

--- a/src/sync/mod_tests.rs
+++ b/src/sync/mod_tests.rs
@@ -251,6 +251,7 @@ fn crontab_bin_never_resolves_to_real_crontab_in_test_builds() {
         std::env::remove_var("MOADIM_CRONTAB_BIN");
     }
     let bin = crontab_bin();
+    // SAFETY: single-threaded test execution.
     unsafe {
         match saved {
             Some(value) => std::env::set_var("MOADIM_CRONTAB_BIN", value),


### PR DESCRIPTION
## Summary

- Adds `undocumented_unsafe_blocks = "deny"` to `[lints.clippy]` in `Cargo.toml`, requiring every `unsafe` block/fn/impl to carry a `// SAFETY: ...` comment.
- Fixes the 39 `unsafe` sites this surfaced (all in test helpers): `std::env::set_var`/`remove_var` calls restoring a previous env var after a single-threaded test, and one `libc::kill` cleaning up a test-spawned child process. Each gets the same `// SAFETY:` phrasing already used at the many already-documented call sites in this codebase. No behavior change.

Closes #1284

## Test plan

- [x] `cargo clippy --all-targets --all-features` — clean, no warnings
- [x] `cargo build` — succeeds
- [x] `cargo test` — 1098 passed, 0 failed