### PR TITLE
perf(cli): avoid redundant clone in ensure_config_gitignore

### DIFF
--- a/.changeset/gitignore-avoid-redundant-clone.md
+++ b/.changeset/gitignore-avoid-redundant-clone.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Avoid a redundant `String` clone in `ensure_config_gitignore()`: `existing` is only borrowed (via `lines()`) before the clone site and is never read again afterward, so the buffer can be moved into `content` instead of cloned. No behavior change; this runs on every daemon start/restart.

--- a/src/cli/system.rs
+++ b/src/cli/system.rs
@@ -150,7 +150,7 @@ fn ensure_config_gitignore() {
     if missing.is_empty() {
         return;
     }
-    let mut content = existing.clone();
+    let mut content = existing;
     if !content.is_empty() && !content.ends_with('\n') {
         content.push('\n');
     }


### PR DESCRIPTION
## Why

`ensure_config_gitignore()` runs on every daemon start/restart. It reads the
existing `.gitignore`, borrows it via `.lines()` to compute which required
patterns are missing, then builds the file content to write back:

```rust
let existing = std::fs::read_to_string(&gitignore).unwrap_or_default();
let lines: Vec<&str> = existing.lines().collect();
// ... lines used here to compute `missing` ...
let mut content = existing.clone();
```

`existing` is never read again after the `lines` borrow is done, so cloning
it into `content` allocates a second copy of the file contents for no
reason. Moving it instead avoids that allocation.

## What

- `existing.clone()` → `existing` (move). No behavior change — same
  function, same output.
- Added a changeset (`.changeset/gitignore-avoid-redundant-clone.md`).

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test` (full suite) — all passing, including the pre-existing
  `cli::cli_spawn_tests::write_pid_file_seeds_readmes_without_clobbering_edits`
  which exercises this path