### PR TITLE
docs(architecture): fix stale routes/ source-layout tree

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -53,8 +53,21 @@ src/
 ├── routine_storage.rs   routine.toml + prompts/ (pure/compiled) persistence
 │
 ├── routes/
-│   ├── http.rs          Axum router assembly + run_with_listener_until
-│   └── mcp.rs           MoadimMcp — rmcp tool_router
+│   ├── http.rs                  Axum router assembly, re-exports run_with_listener_until
+│   ├── mcp.rs                   MoadimMcp — rmcp tool_router, composes each endpoint's mcp.rs
+│   ├── http_listener.rs         listener bind + graceful shutdown + run_with_listener_until
+│   ├── http_settings_routes.rs  machine identity + persistent user-prompt settings routes
+│   ├── metrics.rs               GET /api/v1/metrics — Prometheus-format process/routine metrics
+│   ├── CONTRIBUTING.md          when/how to give an endpoint its own <name>/ folder
+│   └── <name>/                  one folder per endpoint with both a REST route and an MCP tool
+│       ├── mod.rs                   wiring only: declares submodules, re-exports the public surface
+│       ├── logic.rs                 response type(s) + the pure function that builds them (no framework code)
+│       ├── http.rs                  thin Axum handler: extracts state, calls logic, wraps in Json
+│       └── mcp.rs                   thin MCP tool: calls logic, wraps in the MCP result type
+│           (e.g. health/, create_routine/, list_routines/, get_routine/, delete_routine/,
+│            list_routine_runs/, list_agents/, get_lock_status/, cleanup_workbenches/,
+│            restart/, shutdown/ — see src/routes/CONTRIBUTING.md. Not every endpoint is
+│            split out yet; e.g. update_routine, MCP-only, is still inline in mcp.rs)
 │
 ├── middlewares/
 │   ├── host_validation.rs    guards against DNS-rebinding / cross-origin abuse of the loopback API


### PR DESCRIPTION
## Why

`Architecture.md`'s "Source layout" tree still documents `src/routes/` as just two files:

```
├── routes/
│   ├── http.rs          Axum router assembly + run_with_listener_until
│   └── mcp.rs           MoadimMcp — rmcp tool_router
```

That's stale. A series of "move X HTTP + MCP endpoints into `routes/X`" refactors (e.g. #1288, #1290 and earlier ones) split most endpoints out into their own `routes/<name>/{mod,logic,http,mcp}.rs` folders, following the convention documented in `src/routes/CONTRIBUTING.md`. `src/routes/` now has 11 such per-endpoint folders (`health/`, `create_routine/`, `list_routines/`, `get_routine/`, `delete_routine/`, `list_routine_runs/`, `list_agents/`, `get_lock_status/`, `cleanup_workbenches/`, `restart/`, `shutdown/`), plus `http_listener.rs`, `http_settings_routes.rs`, and `metrics.rs` at the top level — none of which the doc mentioned. A new contributor reading this file gets a materially wrong picture of where handler code actually lives.

## What

Docs-only change — updated the `routes/` block of the source-layout tree to show the current per-endpoint folder convention (with named examples) plus the top-level files that don't fit that pattern. Also noted that `update_routine` (MCP-only) hasn't been split out yet, so the doc doesn't imply 100% coverage that isn't there.

No code changes, so no changeset needed (only touches a doc file, not `src/`/`ui/`).

## Test plan

- [x] `typos` — clean
- [x] `lychee --config lychee.toml Architecture.md` — no links, clean
- N/A `cargo fmt`/`clippy`/`cargo test` — no source files touched