### PR TITLE
fix(observability): escape the machine label in GET /api/v1/metrics

### DIFF
--- a/.changeset/fix-metrics-escape-machine-label.md
+++ b/.changeset/fix-metrics-escape-machine-label.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+fix(observability): escape the `machine` label in `GET /api/v1/metrics`'s `moadim_build_info` series for Prometheus text-exposition syntax. `machine` is the only label value in `src/routes/metrics.rs` sourced from free-form user input (`moadim machine set <name>` / `MOADIM_MACHINE`, trimmed but otherwise unrestricted — see `src/machine/mod.rs`); an operator-chosen name containing `"` or `\` was emitted into the label literally, producing unparseable exposition text that would fail the whole scrape, not just that one line. Adds `escape_label_value` (backslash, double-quote, and newline escaping per the exposition format) and applies it to `machine`; `version`/`git_sha` are compile-time constants and don't need it.

--- a/src/routes/metrics.rs
+++ b/src/routes/metrics.rs
@@ -99,6 +99,22 @@ struct RunStatusCounts {
     unknown: u64,
 }
 
+/// Escape a value for use inside a Prometheus text-exposition label (`name="value"`): backslash
+/// and double-quote must themselves be backslash-escaped, and a literal newline is written as the
+/// two-character `\n` sequence, per the exposition format's label-value grammar.
+///
+/// `machine` (set via `moadim machine set <name>` or `MOADIM_MACHINE`, see `crate::machine`) is
+/// the only label value in this file sourced from free-form user input — trimmed but otherwise
+/// unrestricted — so it's the only one that needs this: an operator-chosen name containing `"` or
+/// `\` would otherwise emit unparseable exposition text and break the whole scrape, not just this
+/// one line. `version`/`git_sha` are compile-time constants and never need it.
+fn escape_label_value(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+}
+
 /// Render `snapshot` as Prometheus text exposition format (one `# HELP`/`# TYPE` pair per
 /// series, then its sample line(s)).
 fn render(snapshot: &MetricsSnapshot<'_>) -> String {
@@ -119,7 +135,9 @@ fn render(snapshot: &MetricsSnapshot<'_>) -> String {
     let _ = writeln!(
         out,
         r#"moadim_build_info{{version="{}",git_sha="{}",machine="{}"}} 1"#,
-        snapshot.version, snapshot.git_sha, snapshot.machine
+        snapshot.version,
+        snapshot.git_sha,
+        escape_label_value(snapshot.machine)
     );
 
     let _ = writeln!(

--- a/src/routes/metrics_tests.rs
+++ b/src/routes/metrics_tests.rs
@@ -80,6 +80,22 @@ fn render_emits_help_and_type_for_every_gauge_and_counter() {
 }
 
 #[test]
+fn render_escapes_a_machine_name_containing_prometheus_label_syntax() {
+    let mut snapshot = empty_snapshot(&[]);
+    snapshot.machine = "weird\"machine\\name\nwith-newline";
+    let text = render(&snapshot);
+    assert!(
+        text.contains(
+            r#"moadim_build_info{version="1.2.3",git_sha="abc123",machine="weird\"machine\\name\nwith-newline"} 1"#
+        ),
+        "machine label was not escaped as expected in:\n{text}"
+    );
+    // The raw quote/backslash must not appear unescaped anywhere in the output — an unescaped
+    // one would break every other metric on the same scrape, not just this line.
+    assert!(!text.contains(r#"machine="weird"machine"#));
+}
+
+#[test]
 fn render_runs_total_counts_each_status_independently() {
     let runs = [
         run(100, Some(110), RunStatus::Success),


### PR DESCRIPTION
## Why

`GET /api/v1/metrics` (added in #414) emits a `moadim_build_info{version="...",git_sha="...",machine="..."} 1` gauge. `machine` is the only label value in `src/routes/metrics.rs` sourced from free-form user input — set via `moadim machine set <name>` or the `MOADIM_MACHINE` env var, trimmed but otherwise unrestricted (`src/machine/mod.rs`). `version`/`git_sha` are compile-time constants and can't contain anything unusual.

Prometheus's text-exposition format requires label values to backslash-escape `\` and `"`, and to write a literal newline as the two-character `\n` sequence. This endpoint didn't do that: an operator who names a machine with a double-quote or backslash (e.g. `my"machine`) gets that character written straight into the label literal, producing exposition text a scraper can't parse — which fails the *entire* scrape, not just this one series, since Prometheus's client libraries typically reject a target's whole response on a parse error.

## What

- Add `escape_label_value` in `src/routes/metrics.rs`, escaping backslash, double-quote, and newline per the exposition grammar.
- Apply it to the `machine` label in the `moadim_build_info` line (the only free-form-input label value in this file).
- Add a test asserting a machine name containing `"`, `\`, and a newline round-trips through `render` correctly escaped, and that the raw unescaped form never appears in the output.

## Testing

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — 1107 passed (was 1106; added 1)
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — `routes/metrics.rs` is 100% line-covered (146/146); the new function and its call site are fully exercised by the new test
- Added `.changeset/fix-metrics-escape-machine-label.md` (patch bump) per this repo's Changesets workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)