### PR TITLE
test(cli): fix ensure_readme test to actually hit its no-parent branch

### DIFF
--- a/.changeset/fix-ensure-readme-test-parent-path.md
+++ b/.changeset/fix-ensure-readme-test-parent-path.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+test(cli): fix `ensure_readme_returns_early_when_the_path_has_no_parent` to actually exercise its named branch. `Path::new("this-file-should-not-exist").parent()` is `Some("")`, not `None`, so the old test never hit `ensure_readme`'s `parent_or_err` early-return arm — it silently fell through `create_private_dir_all("")` (a no-op) into `std::fs::write`, dropping a stray `this-file-should-not-exist` file into the process's current directory on every `cargo test` run (reproduced: present, untracked, and un-gitignored at the repo root). Switched the test to `Path::new("")`, one of the few paths whose `.parent()` is genuinely `None`, so the branch is actually covered and the run no longer leaves a stray file behind. No production code change.

--- a/src/cli/system_tests.rs
+++ b/src/cli/system_tests.rs
@@ -148,8 +148,12 @@ fn http_request_core_rejects_an_unparsable_bind_override() {
 
 #[test]
 fn ensure_readme_returns_early_when_the_path_has_no_parent() {
-    ensure_readme(
-        std::path::Path::new("this-file-should-not-exist"),
-        "ignored",
-    );
+    // `Path::new("<bare-name>").parent()` is `Some("")`, not `None` — a relative
+    // single-component path still "has a parent" (the empty/current-dir path), so it
+    // does not exercise this branch. `""` (like `/`) is one of the few paths whose
+    // `.parent()` is genuinely `None`, which is what routes `ensure_readme` through
+    // `parent_or_err`'s error arm and back out early — without this, the call falls
+    // through to `std::fs::write`, dropping a stray file in the process's current
+    // directory (as a bare relative path previously did here).
+    ensure_readme(std::path::Path::new(""), "ignored");
 }


### PR DESCRIPTION
## Problem

`ensure_readme_returns_early_when_the_path_has_no_parent` (`src/cli/system_tests.rs`) calls:

```rust
ensure_readme(std::path::Path::new("this-file-should-not-exist"), "ignored");
```

intending to exercise `ensure_readme`'s early-return when `parent_or_err` fails because the
path has no parent directory. But `Path::new("this-file-should-not-exist").parent()` is
`Some("")`, not `None` — a bare relative single-component path still "has a parent" (the
empty/current-dir path). So `parent_or_err` succeeds, and the call falls through:

```rust
fn ensure_readme(path: &std::path::Path, content: &str) {
    if path.exists() { return; }
    let parent = crate::utils::fs_perms::parent_or_err(path, "readme");
    let Some(parent) = parent.ok() else { return }; // never taken by the old test
    if crate::utils::fs_perms::create_private_dir_all(parent).is_err() { return; }
    let _ = std::fs::write(path, content);
}
```

`create_private_dir_all("")` is a silent no-op (`DirBuilder::create("")` returns `Ok(())`),
so execution reaches `std::fs::write(path, content)` and actually writes
`this-file-should-not-exist` (7 bytes, content `"ignored"`) into the process's **current
working directory** — the repo root when running `cargo test` locally.

I reproduced this: after running the existing test suite, an untracked, un-gitignored
`this-file-should-not-exist` file was sitting at the repo root (`git status` shows `??`, not
`!!`). Any contributor who runs `cargo test` locally gets this file dropped into their working
tree, where a careless `git add -A`/`git add .` could sweep it into a commit.

## Fix

Switch the test to `Path::new("")` — one of the few paths whose `.parent()` is genuinely
`None` (same as `/`). This actually routes through `parent_or_err`'s error arm and the early
`return`, so:
- The branch the test is named for is now actually covered (line coverage previously stayed
  green regardless, since `cargo llvm-cov`'s gate is line-based, not branch-based, and the
  `let Some(parent) = ... else { return }` line executes either way).
- `cargo test` no longer leaves a stray file in the working directory.

No production code changes — `ensure_readme`/`parent_or_err`/`create_private_dir_all` are
unchanged. In production, `ensure_readme` is always called with the daemon's absolute config
directory path, so this test bug had no real runtime impact — it's purely a test-hygiene fix.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — 1126 passed, 0 failed; confirmed no `this-file-should-not-exist` artifact after the run
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% line coverage maintained
- `linecheck --max-lines 500 $(find src -name '*.rs')` — clean
- Full `.githooks/pre-push` run — passes end to end

A changeset is included (`.changeset/fix-ensure-readme-test-parent-path.md`, patch bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)