### PR TITLE
docs(architecture): fix stale routes/ endpoint-split claim

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -65,10 +65,9 @@ src/
 │       ├── logic.rs                 response type(s) + the pure function that builds them (no framework code)
 │       ├── http.rs                  thin Axum handler: extracts state, calls logic, wraps in Json
 │       └── mcp.rs                   thin MCP tool: calls logic, wraps in the MCP result type
-│           (e.g. health/, create_routine/, list_routines/, get_routine/, delete_routine/,
-│            list_routine_runs/, list_agents/, get_lock_status/, cleanup_workbenches/,
-│            restart/, shutdown/ — see src/routes/CONTRIBUTING.md. Not every endpoint is
-│            split out yet; e.g. update_routine, MCP-only, is still inline in mcp.rs)
+│           (every REST+MCP endpoint is split out this way now — see the `use
+│            super::<name>;` list at the top of src/routes/http.rs for the current
+│            set of folders, and src/routes/CONTRIBUTING.md for the convention)
 │
 ├── middlewares/
 │   ├── host_validation.rs    guards against DNS-rebinding / cross-origin abuse of the loopback API


### PR DESCRIPTION
## Problem

`Architecture.md`'s "Source layout" tree claimed:

> Not every endpoint is split out yet; e.g. update_routine, MCP-only, is
> still inline in mcp.rs

That's stale. A series of "move X HTTP + MCP endpoints into routes/X"
refactors (#1288, #1290, #1294, #1296, #1298, #1300, and one more for
`resolve_flag/` that landed while this PR was in progress) finished
splitting every REST+MCP endpoint into its own
`<name>/{mod,logic,http,mcp}.rs` folder per `src/routes/CONTRIBUTING.md`.
`src/routes/mcp.rs` is router wiring only now (`MoadimMcp` composing each
endpoint's `mcp.rs`) — there's no inline per-endpoint logic left to point
at.

The tree also hand-enumerated a handful of example folder names, which is
exactly the kind of list that goes stale again the moment a new endpoint
gets split out — which is literally what happened mid-PR here.

## Fix

- Drop the "not every endpoint is split out yet" claim.
- Replace the hand-enumerated folder list with a pointer to the `use
  super::<name>;` block at the top of `src/routes/http.rs` — the actual
  source of truth for "which endpoints have their own folder" — so this
  note can't drift out of sync with the code again.

Docs-only change (`Architecture.md`), no `src/`/`client/` diff, so no
changeset per `.githooks/pre-push`'s changelog gate.

## Verification

- `cargo fmt --check`, `cargo build`, `cargo test`, `cargo clippy
  --all-targets -- -D warnings` — all clean (unaffected by a docs-only
  change, confirmed for completeness).
- `typos Architecture.md` — clean.
- `lychee --config lychee.toml Architecture.md` — 0 errors.