### PR TITLE
docs: fix validation findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ register a brand-new agent by dropping in another `<name>.toml`.
 | --------- | -------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | `command` | string         | yes      | Executable to run (resolved on `PATH`), e.g. `"claude"`.                                                                       |
 | `args`    | array<string>  | no       | Arguments passed to `command`. Supports the placeholders below. Defaults to empty.                                            |
+| `instructions_file` | string | no    | Filename, relative to the workbench, that this agent reads its project instructions from — where the moadim-managed system prompt and routine-origin disclosure are written. Defaults to `CLAUDE.md` (Claude Code's convention); the built-in `codex` agent sets it to `AGENTS.md`. |
 | `setup`   | string         | no       | Shell command run in the workbench **before** the agent launches, inserted verbatim into the cron line. See the variables below. |
 
 **Placeholders** (substituted in each `args` entry at launch):
@@ -412,6 +413,9 @@ moadim status --wait   # poll until a server answers (or 30s elapse) instead of 
 moadim cleanup         # reap finished, expired routine workbenches now
 moadim cleanup --json  # same, as a machine-readable JSON object
 moadim trigger <id>    # trigger a routine to run now, outside its schedule
+moadim logs <id>       # print a routine's newest run log (agent.log) to stdout
+moadim install         # register moadim as an OS service (launchd / systemd user)
+moadim uninstall       # remove the OS service registration and the managed crontab block
 moadim restart         # stop a running server (if any) and start a fresh one
 moadim restart --quiet # same, printing only the `restarted: pid <old> -> <new>` line
 moadim restart -i      # same, but bring the fresh instance up in the foreground

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -111,7 +111,7 @@ groups off a literal string per file instead.
 
 **The version-bump script had a silent, permanent gap: `docs/moadim.1` was
 never synced.** A test (`man_page_version_matches_cargo_pkg_version` in
-`src/cli_tests.rs`) asserts the hand-maintained man page's `.TH` header
+`src/cli/spawn_tests.rs`) asserts the hand-maintained man page's `.TH` header
 matches `Cargo.toml`'s version — it was always fixed by a human noticing
 post-hoc (see #848, a standalone "sync moadim.1" PR). Once the bump was
 actually running in CI instead of by hand, this became a hard failure on

--- a/docs/moadim.1
+++ b/docs/moadim.1
@@ -1,5 +1,5 @@
 .\" Man page for moadim.
-.\" Mirrors the built-in `moadim --help` output (src/cli.rs::print_help).
+.\" Mirrors the built-in `moadim --help` output (src/cli/mod.rs::print_help).
 .\" View with:  man ./docs/moadim.1   or install into share/man/man1/.
 .TH MOADIM 1 "2026-07-20" "moadim 1.5.0" "Moadim Manual"
 .SH NAME


### PR DESCRIPTION
README.md:340 — Agent config table omits the `instructions_file` field (added to `AgentCommand`, defaults to `CLAUDE.md`, `codex.toml` sets `AGENTS.md`) — added a row documenting it.
README.md:415 — Command reference omits the top-level `moadim logs <id>`, `moadim install`, and `moadim uninstall` commands (present in `moadim --help` and the man page) — added them.
RELEASING.md:114 — References `src/cli_tests.rs` for `man_page_version_matches_cargo_pkg_version`, but the test now lives in `src/cli/spawn_tests.rs` after the `cli.rs` -> `cli/` module split — fixed the path.
docs/moadim.1:2 — Header comment points at `src/cli.rs::print_help`, which no longer exists (now `src/cli/mod.rs::print_help`) — fixed the path.

No source/product code changed.