### PR TITLE
chore: remove dead cargo dependabot entry for removed ui/ directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,17 +21,6 @@ updates:
           - "minor"
           - "patch"
 
-  - package-ecosystem: "cargo"
-    directory: "/ui"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    groups:
-      cargo-ui:
-        update-types:
-          - "minor"
-          - "patch"
-
   - package-ecosystem: "npm"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Why

bc9da2e (\"feat(ui): remove the legacy Yew UI, make the React client the default UI\", merged 2026-07-19) deleted the entire `ui/` Cargo workspace member, but `.github/dependabot.yml` still had a `cargo` ecosystem entry pointed at `directory: "/ui"`. Since that directory no longer exists, this entry has been silently failing on every weekly Dependabot run instead of updating anything — dead config nobody would notice without checking the Dependabot run logs.

## What

Removes the stale `cargo` / `/ui` entry from `.github/dependabot.yml`. The remaining `cargo` (`/`), `npm` (`/`, which covers the `client/` pnpm workspace member via `pnpm-workspace.yaml`), and `github-actions` entries are untouched.

No `src/` or `client/` changes, so no changeset is needed.

---
This pull request was opened by the "Daemon + Landing auto-improve & auto-merge lint/docs PRs" routine of moadim.