### PR TITLE
chore: bump jiff, jiff-static, syn to latest patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -1023,9 +1023,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc43d6fb25860892c78ef7ce2ffed572087a6853ecb60f587f499329717ed7da"
+checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
 dependencies = [
  "defmt",
  "jiff-core",
@@ -1047,9 +1047,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fb828bff41eeb269a9665f950cb359e8018f7288b8f34db24937ff54ed8fc5"
+checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
 dependencies = [
  "jiff-core",
  "proc-macro2",
@@ -1358,7 +1358,7 @@ checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -1562,7 +1562,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -1735,9 +1735,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fac314a64dc9a36e61a9eb4261a5e9bbfbc922b27e518af97bc32b926cf967"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1778,7 +1778,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Routine dependency hygiene: `cargo update --dry-run` on current `main` showed patch-level releases available inside existing semver ranges for `jiff`, `jiff-static`, `syn`, and `serde_json`.

`serde_json` is intentionally excluded from this PR: Dependabot opened #1305 for that exact bump while this PR was in flight, so it's left out here to avoid duplicating that PR.

## What

`cargo update` for the remaining three packages:

- `jiff` 0.2.33 -> 0.2.34
- `jiff-static` 0.2.33 -> 0.2.34
- `syn` 3.0.0 -> 3.0.2

`Cargo.toml` is untouched — all three stay within their already-declared version requirements, so this is a pure lockfile refresh picking up upstream patch fixes.

## Verification

- `cargo fmt --check` - clean
- `cargo clippy --all-targets -- -D warnings` - clean
- `cargo test` - 1131 passed, 0 failed
- `cargo doc --workspace --no-deps --document-private-items` (RUSTDOCFLAGS=-D warnings) - clean

No changeset added: only `Cargo.lock` changed, which isn't covered by the `unreleased-entry` changeset gate (scoped to `src/**` and `client/**`).

---
Opened by the "Daemon + Landing auto-improve & auto-merge lint/docs PRs" routine of moadim.