### PR TITLE
test(routines): cover run-history rotation's write-failure branch

### DIFF
--- a/.changeset/test-run-history-rotation-write-failure.md
+++ b/.changeset/test-run-history-rotation-write-failure.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+test(routines): cover `rotate_run_history_if_oversized`'s rotated-write-failure branch — when the `.1` sibling can't be written (e.g. it turns out to be a directory), the oversized source `runs.log` must survive rather than being removed, since removal is gated on the write actually succeeding. This branch previously had no test, unlike its sibling I/O-failure branches elsewhere in `cleanup::log_cap`.

--- a/src/routines/run_history_tests.rs
+++ b/src/routines/run_history_tests.rs
@@ -188,6 +188,30 @@ fn rotate_run_history_if_oversized_rolls_the_file_past_the_cap() {
     let _ = std::fs::remove_dir_all(&base);
 }
 
+/// `rotated_path`'s `std::fs::write` can fail (permissions, a race) even though the oversized
+/// source file's own `metadata()`/`read()` just succeeded — e.g. `rotated_path` itself turns out to
+/// be a directory. `rotate_run_history_if_oversized` must leave the source file in place rather than
+/// remove it, since removal is gated on the write actually succeeding (mirrors the directory-target
+/// technique `cap_agent_log_propagates_an_open_error_for_a_directory` uses for the same class of
+/// error in `cleanup::log_cap`).
+#[test]
+fn rotate_run_history_if_oversized_keeps_the_source_when_the_rotated_write_fails() {
+    let base = std::env::temp_dir().join(format!("moadim-runs-writefail-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&base).unwrap();
+    let path = base.join("runs.log");
+    std::fs::write(&path, vec![b'z'; (RUN_HISTORY_MAX_BYTES + 1) as usize]).unwrap();
+    let rotated = path.with_extension("log.1");
+    std::fs::create_dir(&rotated).unwrap(); // a directory can't be `fs::write`-n over
+
+    rotate_run_history_if_oversized(&path);
+
+    assert!(
+        path.exists(),
+        "the source file must survive a failed rotation write"
+    );
+    let _ = std::fs::remove_dir_all(&base);
+}
+
 #[test]
 fn rotate_run_history_if_oversized_merges_with_a_previous_1_file() {
     let base = std::env::temp_dir().join(format!("moadim-runs-merge-{}", uuid::Uuid::new_v4()));


### PR DESCRIPTION
## Why

`rotate_run_history_if_oversized` (`src/routines/run_history.rs`) only removes the oversized source `runs.log` after the rotated `.1` sibling's write succeeds — removal is gated on `std::fs::write(&rotated_path, combined).is_ok()`. No existing test exercised the write-failure branch, so a regression that removed the source unconditionally (losing run history on a rotation race/permissions issue) would not be caught.

Found while checking `cargo llvm-cov` region coverage on current `main` — line coverage is already at the CI-enforced 100% floor, but this branch's region was one of a handful still uncovered at the region level.

## What

Adds one test using the same "make the target path a directory so `fs::write` fails" technique `cleanup::log_cap`'s tests already use for the equivalent class of I/O error. Asserts the source file survives when the rotated write can't succeed.

## Testing

- `cargo test` — 1132 passed (was 1131), all green
- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- Included a changeset (`patch`) since this touches `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)