### PR TITLE
test(routine_storage): cover blank schedule.cron load short-circuit

### DIFF
--- a/.changeset/test-blank-schedule-cron-coverage.md
+++ b/.changeset/test-blank-schedule-cron-coverage.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+test(routine_storage): cover `read_routine_cron`'s empty-file branch — a `schedule.cron` sidecar with no non-empty line (e.g. truncated by a crash mid-write) now has a regression test asserting the whole routine load short-circuits to `None` instead of silently loading with a blank schedule, closing a gap in the pre-push 100%-line-coverage gate.

--- a/src/routine_storage_tests.rs
+++ b/src/routine_storage_tests.rs
@@ -222,6 +222,26 @@ fn load_routine_falls_back_to_legacy_schedule_in_routine_toml() {
 }
 
 #[test]
+fn load_routine_blank_schedule_cron_with_no_legacy_schedule_returns_none() {
+    // A `schedule.cron` with no non-empty line (e.g. truncated by a crash mid-write) parses to
+    // `None` rather than an empty string, and with no legacy `schedule` field in `routine.toml`
+    // either, the whole load short-circuits to `None` instead of a routine with a blank schedule.
+    with_override_home(|_home| {
+        let slug = "rs-blank-schedule-cron-routine";
+        let dir = crate::paths::routine_dir(slug);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            crate::paths::routine_toml_path(slug),
+            "title = \"Rs Blank Schedule Cron\"\nagent = \"claude\"\n",
+        )
+        .unwrap();
+        std::fs::write(crate::paths::routine_cron_path(slug), "\n\n").unwrap();
+
+        assert!(load_routine_from_dir(slug).is_none());
+    });
+}
+
+#[test]
 fn load_routine_ignores_unparsable_sidecar() {
     // A malformed `state.local.toml` parses to `None` (rather than crashing the load), and with no
     // legacy field in `routine.toml` the routine loads with no trigger timestamp.


### PR DESCRIPTION
## Why

`read_routine_cron`'s `?` on an all-blank `schedule.cron` (e.g. a sidecar truncated by a crash mid-write) had no test, leaving the pre-push 100%-line-coverage gate (`cargo llvm-cov --fail-under-lines 100`) red on current `main`.

## What

Adds a regression test asserting `load_routine_from_dir` returns `None` when `schedule.cron` has no non-empty line and `routine.toml` has no legacy `schedule` field either — the whole load correctly short-circuits instead of silently producing a routine with a blank schedule.

Includes a `patch` changeset per the repo's Changesets setup.

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.