### PR TITLE
chore: format rmcp dependency list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,12 @@ log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1.1"
-rmcp = { version = "2.0.0", features = ["server", "macros", "transport-io", "transport-streamable-http-server"] }
+rmcp = { version = "2.0.0", features = [
+  "server",
+  "macros",
+  "transport-io",
+  "transport-streamable-http-server",
+] }
 schemars = "1"
 tokio = { version = "1", features = ["full"] }
 tower = { version = "0.5", features = ["limit", "util"] }


### PR DESCRIPTION
Formatting-only change to keep Cargo.toml consistent.