### PR TITLE
feat(routines): route cron math through cron-union

### DIFF
--- a/.changeset/use-cron-union-for-routines.md
+++ b/.changeset/use-cron-union-for-routines.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Use `cron-union` for routine schedule math so the routine cron path already routes through the union helper that future multi-cron support can build on.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
-- use `cron-union` for routine schedule interval calculation so the routine cron path already routes through the union helper that future multi-cron support can build on.
-
 ## [1.5.0] - 2026-07-20
 
 Add a built-in `pi` agent config and seed `pi.toml` alongside the existing `claude`, `codex`, and `hermes` defaults.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+- use `cron-union` for routine schedule interval calculation so the routine cron path already routes through the union helper that future multi-cron support can build on.
+
 ## [1.5.0] - 2026-07-20
 
 Add a built-in `pi` agent config and seed `pi.toml` alongside the existing `claude`, `codex`, and `hermes` defaults.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -358,6 +358,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cron"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5dcd6f69605c2956916ce24e8af637b754964c9a83f4662d3a2361654cdba09"
+dependencies = [
+ "chrono",
+ "once_cell",
+ "phf",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "cron-union"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ad84ecd7707be17cd777be056414b9b599acb6d318c06ed577e8bfbae6bf1e"
+dependencies = [
+ "cron",
 ]
 
 [[package]]
@@ -760,7 +781,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1168,6 +1189,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "cron-union",
  "croner",
  "dirs",
  "env_logger",
@@ -1251,6 +1273,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.7",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,14 +1370,29 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
- "rand_core",
+ "rand_core 0.10.1",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -1406,7 +1485,7 @@ dependencies = [
  "http-body-util",
  "pastey",
  "pin-project-lite",
- "rand",
+ "rand 0.10.2",
  "rmcp-macros",
  "schemars",
  "serde",
@@ -1655,6 +1734,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1855,7 +1940,7 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -1873,7 +1958,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -2197,6 +2282,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 croner = "3"
+cron-union = "1.0.0"
 dirs = "6"
 env_logger = "0.11"
 iana-time-zone = "0.1"

--- a/src/routines/cleanup/ttl.rs
+++ b/src/routines/cleanup/ttl.rs
@@ -30,6 +30,13 @@ pub(crate) fn ttl_ceiling_secs(schedule: &str) -> u64 {
 /// since it only matters when below [`MAX_TTL_SECS`], sub-hour schedules (the only ones it changes)
 /// have a constant interval regardless of `now`.
 pub(super) fn cron_interval_secs(schedule: &str) -> Option<u64> {
+    if let Some(union) = crate::utils::cron::compiled_union(schedule) {
+        let cron = union.iter().next()?.schedule();
+        let mut fires = cron.after(&Local::now());
+        let first = fires.next()?;
+        let second = fires.next()?;
+        return u64::try_from((second - first).num_seconds()).ok();
+    }
     let cron = schedule.parse::<Cron>().ok()?;
     let mut fires = cron.iter_after(Local::now());
     let first = fires.next()?;

--- a/src/routines/model.rs
+++ b/src/routines/model.rs
@@ -283,6 +283,11 @@ fn next_run_at(schedule: &str, enabled: bool) -> Option<u64> {
     if !enabled || crate::global_lock::is_globally_locked() {
         return None;
     }
+    if let Some(union) = crate::utils::cron::compiled_union(schedule) {
+        let cron = union.iter().next()?.schedule();
+        let next = cron.after(&Local::now()).next()?;
+        return u64::try_from(next.timestamp()).ok();
+    }
     let cron: Cron = schedule.parse().ok()?;
     let next = cron.iter_after(Local::now()).next()?;
     u64::try_from(next.timestamp()).ok()

--- a/src/routines/model_tests.rs
+++ b/src/routines/model_tests.rs
@@ -174,6 +174,11 @@ fn next_run_at_some_for_enabled_parseable_schedule() {
 }
 
 #[test]
+fn next_run_at_uses_cron_union_for_standard_crons() {
+    assert!(next_run_at("*/5 * * * *", true).is_some());
+}
+
+#[test]
 fn next_run_at_none_when_disabled() {
     assert!(next_run_at("@daily", false).is_none());
 }

--- a/src/utils/cron.rs
+++ b/src/utils/cron.rs
@@ -1,5 +1,6 @@
 //! Cron expression normalization and validation, shared by routine scheduling.
 
+use cron_union::{union as union_crons, CronUnion};
 use croner::Cron;
 
 use crate::error::AppError;
@@ -37,6 +38,19 @@ pub(crate) fn validate_cron(expr: &str) -> Result<(), AppError> {
         .parse::<Cron>()
         .map_err(|err| AppError::BadRequest(format!("invalid cron expression: {err}")))?;
     Ok(())
+}
+
+/// Compile `schedule` through `cron-union` when it is a standard cron expression.
+///
+/// `cron-union` does not understand `@keyword` schedules, so callers fall back to
+/// `croner` for those legacy forms.
+pub(crate) fn compiled_union(schedule: &str) -> Option<CronUnion> {
+    let trimmed = schedule.trim();
+    if trimmed.starts_with('@') || trimmed.split_ascii_whitespace().count() == 7 {
+        return None;
+    }
+    let normalized = normalize_schedule(trimmed);
+    union_crons([normalized.as_str()]).ok()
 }
 
 #[cfg(test)]

--- a/src/utils/cron_tests.rs
+++ b/src/utils/cron_tests.rs
@@ -86,3 +86,10 @@ fn validate_cron_rejects_unsupported_keywords() {
         );
     }
 }
+
+#[test]
+fn compiled_union_uses_standard_crons_and_skips_keywords() {
+    assert!(compiled_union("0 */5 * * * *").is_some());
+    assert!(compiled_union("0 30 9 * * 1-5 *").is_none());
+    assert!(compiled_union("@daily").is_none());
+}


### PR DESCRIPTION
Uses cron-union for standard routine schedules so the cron path already goes through a union helper that can grow into multi-cron support later.

Keeps the existing croner fallback for @keywords and legacy 7-field schedules.

Closes #1319.