### PR TITLE
fix(cleanup): sample multiple fires to find cron interval's true minimum gap

### DIFF
--- a/.changeset/fix-cron-interval-min-gap-sampling.md
+++ b/.changeset/fix-cron-interval-min-gap-sampling.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+fix(cleanup): `cron_interval_secs` now samples multiple fires to find the schedule's true minimum gap, instead of just the next two — fixes TTL/max-runtime ceilings silently flipping between values depending on wall-clock time for unevenly-spaced multi-fire-per-day schedules (e.g. `"0,30 9 * * *"`).

--- a/src/routines/cleanup/cleanup_watchdog_tests.rs
+++ b/src/routines/cleanup/cleanup_watchdog_tests.rs
@@ -418,3 +418,15 @@ fn cron_interval_secs_returns_none_when_second_fire_not_found() {
     // into year 5000 which exceeds croner's YEAR_UPPER_LIMIT → iterator returns None (L36).
     assert!(super::ttl::cron_interval_secs("0 0 0 1 1 * 4999").is_none());
 }
+
+#[test]
+fn cron_interval_secs_is_stable_regardless_of_the_current_time() {
+    // Fires at 09:00 and 09:30 daily: the true minimum gap is always 30 minutes, but "the next two
+    // fires from now" alone gives 30 minutes when `now` is just before 09:00 and ~23.5 hours when
+    // `now` is just after 09:00 — sampling only two fires makes the result flip depending on
+    // wall-clock time. Run at any real `now`, this must always resolve to the 30-minute minimum.
+    assert_eq!(
+        super::ttl::cron_interval_secs("0,30 9 * * *"),
+        Some(30 * 60)
+    );
+}

--- a/src/routines/cleanup/ttl.rs
+++ b/src/routines/cleanup/ttl.rs
@@ -25,16 +25,34 @@ pub(crate) fn ttl_ceiling_secs(schedule: &str) -> u64 {
     MAX_TTL_SECS.min(cron_interval_secs(schedule).unwrap_or(MAX_TTL_SECS))
 }
 
-/// Seconds between the next two scheduled runs of `schedule`, or `None` if it can't be parsed or two
-/// future fire times can't be computed. For irregular schedules this is the interval starting now;
-/// since it only matters when below [`MAX_TTL_SECS`], sub-hour schedules (the only ones it changes)
-/// have a constant interval regardless of `now`.
+/// How many consecutive future fires to sample when hunting for `schedule`'s shortest gap.
+/// Comfortably covers multi-fire-per-day schedules (the only ones where the gap can dip below
+/// [`MAX_TTL_SECS`]) across a multi-day look-ahead window; iterating a cron schedule is cheap, so
+/// there's no cost pressure to trim it further.
+const GAP_SAMPLE_FIRES: usize = 48;
+
+/// The shortest gap between consecutive scheduled runs of `schedule`, or `None` if it can't be
+/// parsed or fewer than two future fire times exist.
+///
+/// Takes the *minimum* gap across up to [`GAP_SAMPLE_FIRES`] consecutive fires after `now`,
+/// rather than just the next two — for an unevenly-spaced schedule, "the next two fires from now"
+/// alone depends on where `now` falls. E.g. `"0,30 9 * * *"` (fires at 09:00 and 09:30 daily) has
+/// a true 30-minute minimum gap, but sampling only the next two fires gives 30 minutes when `now`
+/// is just before 09:00 and ~23.5 hours when `now` is just after 09:00. Sampling multiple fires
+/// keeps the result stable regardless of `now`, so sub-hour schedules (the only ones this
+/// affects, since the result is only ever used via `MAX_TTL_SECS.min(..)`) really do have a
+/// constant interval as callers assume.
 pub(super) fn cron_interval_secs(schedule: &str) -> Option<u64> {
     let cron = schedule.parse::<Cron>().ok()?;
     let mut fires = cron.iter_after(Local::now());
-    let first = fires.next()?;
-    let second = fires.next()?;
-    u64::try_from((second - first).num_seconds()).ok()
+    let mut prev = fires.next()?;
+    let mut min_gap: Option<i64> = None;
+    for next in fires.take(GAP_SAMPLE_FIRES) {
+        let gap = (next - prev).num_seconds();
+        min_gap = Some(min_gap.map_or(gap, |current_min| current_min.min(gap)));
+        prev = next;
+    }
+    u64::try_from(min_gap?).ok()
 }
 
 impl Routine {


### PR DESCRIPTION
## Why

`ttl_ceiling_secs` and `max_runtime_ceiling_secs` both derive their retention/watchdog cap from `cron_interval_secs`, which computed the gap between only the *next two* fires after `Local::now()`.

For an unevenly-spaced multi-fire-per-day schedule this makes the result depend on wall-clock time. E.g. `"0,30 9 * * *"` (fires at 09:00 and 09:30 daily) has a true 30-minute minimum gap between its fires, but:
- Computed just before 09:00 → next two fires are 09:00, 09:30 → 30-minute gap.
- Computed just after 09:00 → next two fires are 09:30, next-day 09:00 → ~23.5-hour gap → clamps to `MAX_TTL_SECS`/`MAX_RUNTIME_SECS` (1h).

So the same routine's TTL/max-runtime ceiling silently flips between 1800s and 3600s depending purely on when the cleanup sweep happens to run — contradicting `cron_interval_secs`'s own doc comment claim that "sub-hour schedules... have a constant interval regardless of `now`".

## What

- `cron_interval_secs` now samples up to 48 consecutive future fires and takes the **minimum** gap across them, instead of just the next two. This is stable regardless of `now` and correctly reflects the schedule's true shortest interval.
- Added a regression test (`cron_interval_secs_is_stable_regardless_of_the_current_time`) asserting `"0,30 9 * * *"` always resolves to a 1800s gap — this would have been flaky (failing depending on time-of-day) against the old implementation.
- Existing `cron_interval_secs_returns_none_when_second_fire_not_found` test is unaffected: the function still returns `None` on the very first missing fire.
- Added a changeset (`patch`, since this only fixes a latent correctness bug, no API/behavior contract change).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (1135 passed, up from 1134)
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'`
- [x] `linecheck --max-lines 500 $(find src -name '*.rs')`

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.