### PR TITLE
docs(security): fix stale pre-1.0/0.x claim in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,14 +2,14 @@
 
 ## Supported versions
 
-`moadim` is pre-1.0 and ships from a single release line. Security fixes land on
-the latest published `0.x` release; please upgrade to the newest version before
-reporting.
+`moadim` ships from a single release line (no maintained LTS branches). Security
+fixes land on the latest published release; please upgrade to the newest version
+before reporting.
 
-| Version        | Supported          |
-| -------------- | ------------------ |
-| Latest `0.x`   | :white_check_mark: |
-| Older releases | :x:                |
+| Version         | Supported          |
+| --------------- | ------------------ |
+| Latest release  | :white_check_mark: |
+| Older releases  | :x:                |
 
 ## Reporting a vulnerability
 


### PR DESCRIPTION
## Why

`SECURITY.md`'s "Supported versions" section still says:

> `moadim` is pre-1.0 and ships from a single release line. Security fixes land on the latest published `0.x` release

That was true once, but the project has been on a 1.x line since `v1.2.0` — the current release is `v1.5.0` (`Cargo.toml`, `package.json`, and the `v*` git tags that drive `crates.io`/npm publishing all agree). A security researcher who reads this literally would be looking for a `0.x` release that no longer exists, and the table's "Latest `0.x`" row is simply wrong.

## What

Rewrite the supported-versions statement to be version-line-agnostic ("latest release gets fixes") instead of hardcoding a version prefix that's already stale and will go stale again at the next major bump. No behavioral change — this only affects the vulnerability-reporting guidance text.

## Testing

- Docs-only change (`SECURITY.md`), no `src/`/`ui/`/`client/` touched, so no changeset is required (the `unreleased-entry` gate only fires on code changes).
- `cargo fmt --check`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: clean