### PR TITLE
fix(cleanup): apply multi-fire min-gap sampling to the cron-union path too

### DIFF
--- a/.changeset/fix-cron-union-interval-min-gap-sampling.md
+++ b/.changeset/fix-cron-union-interval-min-gap-sampling.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+fix(cleanup): `cron_interval_secs` now applies the same multi-fire minimum-gap sampling to the `cron-union` path, not just the `croner` fallback. Routing schedule math through `cron-union` (#1322) reintroduced the exact "next two fires from now" bug just fixed for the `croner` path (#1323): for an unevenly-spaced multi-fire-per-day schedule like `"0,30 9 * * *"`, the TTL/max-runtime ceiling still flipped between 1800s and 3600s depending on wall-clock time, since `cron-union` compiles almost every schedule (only `@keyword` and 7-field expressions fall back to `croner`). Both branches now go through a shared `min_gap_secs` helper.

--- a/src/routines/cleanup/ttl.rs
+++ b/src/routines/cleanup/ttl.rs
@@ -31,6 +31,23 @@ pub(crate) fn ttl_ceiling_secs(schedule: &str) -> u64 {
 /// there's no cost pressure to trim it further.
 const GAP_SAMPLE_FIRES: usize = 48;
 
+/// The minimum gap (seconds) between consecutive entries in `fires`, sampling up to
+/// [`GAP_SAMPLE_FIRES`] of them. `None` if `fires` yields fewer than two timestamps.
+///
+/// Shared by both branches of [`cron_interval_secs`] so the cron-union and croner-fallback
+/// paths sample the same way — see that function's doc for why a single "next two fires" diff
+/// isn't enough.
+fn min_gap_secs(mut fires: impl Iterator<Item = chrono::DateTime<Local>>) -> Option<u64> {
+    let mut prev = fires.next()?;
+    let mut min_gap: Option<i64> = None;
+    for next in fires.take(GAP_SAMPLE_FIRES) {
+        let gap = (next - prev).num_seconds();
+        min_gap = Some(min_gap.map_or(gap, |current_min| current_min.min(gap)));
+        prev = next;
+    }
+    u64::try_from(min_gap?).ok()
+}
+
 /// The shortest gap between consecutive scheduled runs of `schedule`, or `None` if it can't be
 /// parsed or fewer than two future fire times exist.
 ///
@@ -41,25 +58,16 @@ const GAP_SAMPLE_FIRES: usize = 48;
 /// is just before 09:00 and ~23.5 hours when `now` is just after 09:00. Sampling multiple fires
 /// keeps the result stable regardless of `now`, so sub-hour schedules (the only ones this
 /// affects, since the result is only ever used via `MAX_TTL_SECS.min(..)`) really do have a
-/// constant interval as callers assume.
+/// constant interval as callers assume. This applies equally to the `cron-union` path below
+/// (the common case) and the `croner` fallback (`@keyword`/7-field schedules) — both go through
+/// [`min_gap_secs`] so neither can regress back to a two-fire diff.
 pub(super) fn cron_interval_secs(schedule: &str) -> Option<u64> {
     if let Some(union) = crate::utils::cron::compiled_union(schedule) {
         let cron = union.iter().next()?.schedule();
-        let mut fires = cron.after(&Local::now());
-        let first = fires.next()?;
-        let second = fires.next()?;
-        return u64::try_from((second - first).num_seconds()).ok();
+        return min_gap_secs(cron.after(&Local::now()));
     }
     let cron = schedule.parse::<Cron>().ok()?;
-    let mut fires = cron.iter_after(Local::now());
-    let mut prev = fires.next()?;
-    let mut min_gap: Option<i64> = None;
-    for next in fires.take(GAP_SAMPLE_FIRES) {
-        let gap = (next - prev).num_seconds();
-        min_gap = Some(min_gap.map_or(gap, |current_min| current_min.min(gap)));
-        prev = next;
-    }
-    u64::try_from(min_gap?).ok()
+    min_gap_secs(cron.iter_after(Local::now()))
 }
 
 impl Routine {


### PR DESCRIPTION
## Why

`cron_interval_secs` (`src/routines/cleanup/ttl.rs`) feeds `ttl_ceiling_secs`/`max_runtime_ceiling_secs`, which derive their TTL/max-runtime ceiling from the routine schedule's minimum inter-fire gap. #1323 fixed this to sample up to `GAP_SAMPLE_FIRES` (48) consecutive fires and take the true minimum, because for an unevenly-spaced multi-fire-per-day schedule like `"0,30 9 * * *"` (fires at 09:00 and 09:30), "diff the next two fires from now" gives 30 minutes when `now` is just before 09:00 but ~23.5 hours when `now` is just after 09:00 — flipping the ceiling between 1800s and 3600s purely based on wall-clock time.

#1322 ("route cron math through `cron-union`"), merged ~20 seconds after #1323, added a *new* `cron-union` branch to the same function that only diffs the next two fires — reintroducing exactly the bug #1323 had just fixed, but now on the *common* path: `compiled_union()` compiles every schedule except `@keyword` and 7-field expressions, so nearly all routines hit the un-sampled branch. The existing regression test (`cron_interval_secs_is_stable_regardless_of_the_current_time`) still exists and asserts the correct 30-minute answer, but since it doesn't mock the clock it only fails in the ~30-minute wall-clock window between 09:00 and 09:30 local time — easy to miss in CI, easy to hit in production.

## What

Factored the min-gap sampling loop out into a shared `min_gap_secs` helper and route both the `cron-union` branch and the `croner` fallback branch through it, so neither can silently regress back to a two-fire diff.

## Testing

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — 1138 passed, including the existing `cron_interval_secs_is_stable_regardless_of_the_current_time` / `cron_interval_secs_returns_none_when_second_fire_not_found` tests, which now exercise the fixed union path deterministically-correct
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — passes, `ttl.rs` at 100% lines