### PR TITLE
docs: fix stale routine-firing description in Architecture.md

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -162,35 +162,36 @@ It carries `agent`, `prompt`, `repositories` (`{ repository, branch }`),
 and a `title`. Routines have their own store (`RoutineStore`), REST endpoints
 (`/routines`), MCP tools (`create_routine`, …), and crontab block.
 
-When a routine fires there is **no moadim process in the loop and no clone step**. At create/update
-time moadim writes the raw prompt to `prompts/prompt.pure.md` and composes `prompts/prompt.compiled.local.md`
-(a repositories-as-context preamble + the prompt) into `~/.config/moadim/routines/<id>/`, then writes a
-single self-contained shell command into a dedicated crontab block:
+At create/update time moadim writes the raw prompt to `prompts/prompt.pure.md` and composes
+`prompts/prompt.compiled.local.md` (a repositories-as-context preamble + the prompt) into
+`~/.config/moadim/routines/<id>/`, then writes a single line into a dedicated crontab block:
 
 ```
 # BEGIN MOADIM-ROUTINES
 # Managed by moadim — routines (agent tmux sessions)
-<sched> TS=$(date +\%s); WB=…/workbenches/<slug>-$TS; mkdir -p $WB; \
-  { cp …/prompts/prompt.compiled.local.md $WB/prompt.md; \
-    tmux new-session -d -s moadim-<slug>-$TS -c $WB '<agent-cmd>'; \
-    tmux pipe-pane -o -t … "cat >> $WB/agent.log"; } >> $WB/launch.log 2>&1   # moadim-routine:<id>
+<sched> '<moadim-exe-path>' schedule trigger '<id>' # moadim-routine:<id>
 # END MOADIM-ROUTINES
 ```
 
-OS cron runs that line directly: it makes a fresh empty workbench under `~/.moadim/workbenches/`,
-launches the agent **interactively** (no `-p`) in a detached tmux session rooted there, and captures
-output via `pipe-pane`. The prompt reaches the agent as a process **argument** (the `{prompt}`
-placeholder expands to `"$(cat prompt.md)"`), so there is no keystroke-injection readiness race. The
-agent decides whether to clone the listed repositories. `POST /routines/{id}/trigger` runs the
-identical command via `sh -c`.
+That crontab line does **not** launch the agent by itself — it invokes the `moadim` binary directly
+(`moadim schedule trigger <id>`, a thin HTTP client), which calls `POST
+/routines/{id}/scheduled-trigger` on the **running daemon**. Scheduled routines therefore require
+the daemon to be running (it is installed as an OS service — launchd/systemd user — for exactly
+this reason). That handler (`routines::service_trigger::svc_trigger_scheduled`) and the manual
+`POST /routines/{id}/trigger` handler both funnel into `spawn_routine_command`, which builds the
+launch script (`routines::command::build_routine_command`) and spawns it in-process: it makes a fresh empty
+workbench under `~/.moadim/workbenches/`, launches the agent **interactively** (no `-p`) in a
+detached tmux session rooted there, and captures output via `pipe-pane`. The prompt reaches the
+agent as a process **argument** (the `{prompt}` placeholder expands to `"$(cat prompt.md)"`), so
+there is no keystroke-injection readiness race. The agent decides whether to clone the listed
+repositories.
 
-Everything after the `mkdir` runs inside a `{ … } >> $WB/launch.log 2>&1` group, so a failure in the
-prompt copy, the agent's `setup` step, or the `tmux` launch itself is captured next to the run's other
-artifacts instead of going to cron's mail spool (silently discarded on the headless hosts this daemon
-targets). `agent.log` remains the agent's own output (via `pipe-pane`); `launch.log` is the wrapper's
-diagnostics for the steps that get the session running in the first place. Only the `PATH` export and
-the `mkdir` itself precede the redirect — a failure that early means `$WB` may not exist yet, so
-there's nowhere to write a launch log to.
+The spawned script runs under a *login* shell (`sh -lc`) so the user's `~/.profile` is sourced and
+the agent inherits their environment (`GH_TOKEN`, API keys, …). Everything after the workbench
+`mkdir` is redirected into `$WB/launch.log`, so a failure in the prompt copy, the agent's `setup`
+step, or the `tmux` launch itself is captured next to the run's other artifacts instead of being
+lost. `agent.log` remains the agent's own output (via `pipe-pane`); `launch.log` is the wrapper's
+diagnostics for the steps that get the session running in the first place.
 
 `agent.log` capture optimizes for **operator readability** over raw audit fidelity: `svc_logs` /
 `svc_run_log` (`src/routines/service_log_tail.rs`) strip ANSI/VT escape sequences and collapse

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ PUT    /routines/{id}         # replace
 PATCH  /routines/{id}         # update fields
 DELETE /routines/{id}         # delete
 POST   /routines/{id}/trigger # run now, outside the schedule
+POST   /routines/{id}/scheduled-trigger # daemon-side endpoint the generated crontab line invokes
 GET    /routines/{id}/prompt-preview # composed prompt body a run would receive, no run
 GET    /routines/{id}/logs    # newest workbench's agent.log as plain text
 POST   /routines/cleanup      # reap expired workbenches now


### PR DESCRIPTION
## Why

Architecture.md's "Routines" section describes the generated crontab line as a **self-contained shell one-liner** that OS cron runs directly — "no moadim process in the loop and no clone step" — showing an inline `TS=$(date +%s); WB=…; mkdir -p $WB; { cp …; tmux new-session …; } >> $WB/launch.log` command.

That's stale. The actual crontab line (`format_routine_line` in `src/sync/routines.rs`) is just:

```
<sched> '<moadim-exe-path>' schedule trigger '<id>' # moadim-routine:<id>
```

`moadim schedule trigger <id>` is a thin HTTP client that calls `POST /routines/{id}/scheduled-trigger` on the **running daemon** — the daemon itself builds and spawns the launch script in-process (`spawn_routine_command` / `build_routine_command`), not cron via an inline shell command. This directly contradicts `src/sync/routines.rs`'s own module doc, which says explicitly: *"scheduled routines require the daemon to be running."* Architecture.md said the opposite.

`POST /routines/{id}/scheduled-trigger` was also missing from README's REST endpoint table entirely — only the manual `POST /routines/{id}/trigger` route was listed.

## What

- Rewrite the crontab-block description in `Architecture.md` to match the current design: cron invokes `moadim schedule trigger <id>` against the running daemon, which builds and spawns the tmux session in-process. Kept the parts that are still accurate (interactive launch, `pipe-pane` capture, prompt-as-argument, `launch.log`/`agent.log` split).
- Add the missing `POST /routines/{id}/scheduled-trigger` row to README's REST table.

Docs-only change, no code touched. `typos` passes clean on both files.