### PR TITLE
chore(deps): bump clap and tokio to latest patch releases

### DIFF
--- a/.changeset/bump-clap-tokio-patch.md
+++ b/.changeset/bump-clap-tokio-patch.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Bump `clap` (4.6.2 → 4.6.3) and `tokio` (1.53.0 → 1.53.1) to their latest compatible patch releases. Both are Rust/Cargo dependencies not covered by the existing npm-focused Dependabot PRs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.2"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -291,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1878,9 +1878,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.53.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",


### PR DESCRIPTION
## Why

`cargo outdated` flags two Rust/Cargo dependencies with newer compatible patch releases available: `clap` (4.6.2 → 4.6.3, pulling `clap_derive` along) and `tokio` (1.53.0 → 1.53.1). Neither is covered by the repo's existing Dependabot PRs, which only track the npm/JS toolchain and GitHub Actions — Cargo deps have no automated bump path here.

## Changes
- `cargo update -p clap -p tokio`
- Changeset noting the patch bump

## Testing
- `cargo build`
- `cargo test` (1138 passed)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.