### PR TITLE
test(routes): cover spawn_blocking join-failure path via a shared helper

### DIFF
--- a/.changeset/cover-spawn-blocking-join-error.md
+++ b/.changeset/cover-spawn-blocking-join-error.md
@@ -1,0 +1,18 @@
+---
+"moadim": patch
+---
+
+test: cover the `spawn_blocking` join-failure branch shared by routine route handlers
+
+`create_routine`, `delete_routine`, `lock_routines`, `trigger_routine`, `unlock_routines`,
+`update_routine`, and the scheduled-trigger handler each repeated the same
+`tokio::task::spawn_blocking(..).await.map_err(|_| AppError::Internal)??` idiom (#360) to keep
+blocking `crontab`/`tmux`/filesystem I/O off the async worker thread. The `map_err` branch — hit
+only when the blocking task itself panics — was duplicated seven times and untested at every call
+site, since the poison-tolerant stores (`LockRecover`) never actually panic through normal use.
+That left `cargo llvm-cov --fail-under-lines 100` (the repo's own CI and pre-push gate) short of
+100%.
+
+Extracts the idiom into one `crate::error::run_blocking` helper used by all seven call sites, and
+adds direct unit tests for it (including one that deliberately panics the blocking closure) so the
+branch is written, and covered, exactly once. No behavior change; purely a dedup + coverage fix.

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,6 +55,25 @@ impl IntoResponse for AppError {
     }
 }
 
+/// Runs `blocking_fn` on Tokio's blocking thread pool, folding a cancelled-or-panicked task into
+/// [`AppError::Internal`].
+///
+/// Several route handlers shell out to `crontab`(1)/`tmux`(1) or do blocking filesystem I/O
+/// (#360) and previously each repeated `tokio::task::spawn_blocking(..).await.map_err(|_|
+/// AppError::Internal)??` inline. That copy-pasted the one branch that only fires when the
+/// blocking task itself panics into every call site — untested at all of them, since none can
+/// make the poison-tolerant stores (`LockRecover`) actually panic. Centralizing it here means the
+/// branch is written, and covered, exactly once.
+pub async fn run_blocking<F, T>(blocking_fn: F) -> Result<T, AppError>
+where
+    F: FnOnce() -> Result<T, AppError> + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(blocking_fn)
+        .await
+        .map_err(|_| AppError::Internal)?
+}
+
 #[cfg(test)]
 #[path = "error_tests.rs"]
 mod error_tests;

--- a/src/error_tests.rs
+++ b/src/error_tests.rs
@@ -150,3 +150,20 @@ async fn into_response_body_carries_forbidden_message() {
         "forbidden: nope"
     );
 }
+
+#[tokio::test]
+async fn run_blocking_returns_the_closures_ok() {
+    assert_eq!(run_blocking(|| Ok::<_, AppError>(42)).await.unwrap(), 42);
+}
+
+#[tokio::test]
+async fn run_blocking_passes_through_the_closures_err() {
+    let result = run_blocking(|| Err::<(), _>(AppError::NotFound)).await;
+    assert!(matches!(result, Err(AppError::NotFound)));
+}
+
+#[tokio::test]
+async fn run_blocking_maps_a_panicked_task_to_internal() {
+    let result = run_blocking(|| -> Result<(), AppError> { panic!("boom") }).await;
+    assert!(matches!(result, Err(AppError::Internal)));
+}

--- a/src/routes/create_routine/http.rs
+++ b/src/routes/create_routine/http.rs
@@ -1,7 +1,7 @@
 //! `POST /routines` HTTP handler.
 
 use super::logic;
-use crate::error::AppError;
+use crate::error::{run_blocking, AppError};
 use axum::{extract::State, http::StatusCode, Json};
 use logic::{CreateRoutineRequest, RoutineResponse, RoutineStore};
 
@@ -15,9 +15,7 @@ pub async fn create_routine(
 ) -> Result<(StatusCode, Json<RoutineResponse>), AppError> {
     // `svc_create` syncs the crontab, which shells out to `crontab`(1) (#360) — keep that
     // off the async worker thread.
-    let resp = tokio::task::spawn_blocking(move || logic::build(&store, body))
-        .await
-        .map_err(|_| AppError::Internal)??;
+    let resp = run_blocking(move || logic::build(&store, body)).await?;
     Ok((StatusCode::CREATED, Json(resp)))
 }
 

--- a/src/routes/delete_routine/http.rs
+++ b/src/routes/delete_routine/http.rs
@@ -1,7 +1,7 @@
 //! `DELETE /routines/{id}` HTTP handler.
 
 use super::logic;
-use crate::error::AppError;
+use crate::error::{run_blocking, AppError};
 use axum::{
     extract::{Path, State},
     Json,
@@ -17,9 +17,7 @@ pub async fn delete_routine(
     Path(id): Path<String>,
 ) -> Result<Json<RoutineResponse>, AppError> {
     // `svc_delete` syncs the crontab (#360); keep it off the async executor thread.
-    let resp = tokio::task::spawn_blocking(move || logic::build(&store, &id))
-        .await
-        .map_err(|_| AppError::Internal)??;
+    let resp = run_blocking(move || logic::build(&store, &id)).await?;
     Ok(Json(resp))
 }
 

--- a/src/routes/lock_routines/http.rs
+++ b/src/routes/lock_routines/http.rs
@@ -1,7 +1,7 @@
 //! `POST /routines/lock` HTTP handler.
 
 use super::logic;
-use crate::error::AppError;
+use crate::error::{run_blocking, AppError};
 use axum::{extract::State, Json};
 use logic::{LockRequest, LockStatus, RoutineStore};
 
@@ -15,9 +15,7 @@ pub async fn lock_routines(
 ) -> Result<Json<LockStatus>, AppError> {
     // Crontab sync shells out to `crontab`(1); run it on the blocking pool so a slow or
     // hung invocation can't pin a Tokio worker thread (#360).
-    let resp = tokio::task::spawn_blocking(move || logic::build(&store, &body.scope))
-        .await
-        .map_err(|_| AppError::Internal)??;
+    let resp = run_blocking(move || logic::build(&store, &body.scope)).await?;
     Ok(Json(resp))
 }
 

--- a/src/routes/trigger_routine/http.rs
+++ b/src/routes/trigger_routine/http.rs
@@ -1,7 +1,7 @@
 //! `POST /routines/{id}/trigger` HTTP handler.
 
 use super::logic;
-use crate::error::AppError;
+use crate::error::{run_blocking, AppError};
 use axum::{
     extract::{Path, State},
     Json,
@@ -22,9 +22,7 @@ pub async fn trigger_routine(
     // `svc_trigger` shells out to `tmux`(1) (overlap guard, concurrency cap, session spawn) and
     // does blocking fs I/O — keep that off the async worker thread (#360), same as create/update/
     // delete.
-    let resp = tokio::task::spawn_blocking(move || logic::build(&store, &id))
-        .await
-        .map_err(|_| AppError::Internal)??;
+    let resp = run_blocking(move || logic::build(&store, &id)).await?;
     Ok(Json(resp))
 }
 

--- a/src/routes/unlock_routines/http.rs
+++ b/src/routes/unlock_routines/http.rs
@@ -1,7 +1,7 @@
 //! `DELETE /routines/lock` HTTP handler.
 
 use super::logic;
-use crate::error::AppError;
+use crate::error::{run_blocking, AppError};
 use axum::{
     extract::{Query, State},
     Json,
@@ -18,9 +18,7 @@ pub async fn unlock_routines(
 ) -> Result<Json<LockStatus>, AppError> {
     // See `crate::routes::lock_routines::lock_routines`: crontab sync must not run inline on the
     // async worker thread (#360).
-    let resp = tokio::task::spawn_blocking(move || logic::build(&store, &query.scope))
-        .await
-        .map_err(|_| AppError::Internal)??;
+    let resp = run_blocking(move || logic::build(&store, &query.scope)).await?;
     Ok(Json(resp))
 }
 

--- a/src/routes/update_routine/http.rs
+++ b/src/routes/update_routine/http.rs
@@ -1,7 +1,7 @@
 //! `PATCH /routines/{id}` and `PUT /routines/{id}` HTTP handlers.
 
 use super::logic;
-use crate::error::AppError;
+use crate::error::{run_blocking, AppError};
 use axum::{
     extract::{Path, State},
     Json,
@@ -20,9 +20,7 @@ pub async fn update_routine(
 ) -> Result<Json<RoutineResponse>, AppError> {
     // `svc_update` syncs the crontab, which shells out to `crontab`(1) (#360) — keep that off the
     // async worker thread.
-    let resp = tokio::task::spawn_blocking(move || logic::build(&store, &id, body))
-        .await
-        .map_err(|_| AppError::Internal)??;
+    let resp = run_blocking(move || logic::build(&store, &id, body)).await?;
     Ok(Json(resp))
 }
 

--- a/src/routines/handlers.rs
+++ b/src/routines/handlers.rs
@@ -8,7 +8,7 @@ use axum::{
 };
 use serde::Deserialize;
 
-use crate::error::AppError;
+use crate::error::{run_blocking, AppError};
 
 use super::ical::{svc_ical, svc_ical_routine};
 use super::model::{FleetRunSummary, IcalFeedQuery, Routine, RoutineStore};
@@ -46,9 +46,7 @@ pub async fn scheduled_trigger(
     // See `crate::routes::trigger_routine::trigger_routine`: `svc_trigger_scheduled` shells
     // out to `tmux`(1) too (#360). This is the endpoint the generated crontab line invokes, so
     // a `*/N` herd of scheduled fires is exactly the thundering-herd case #360 is about.
-    let resp = tokio::task::spawn_blocking(move || svc_trigger_scheduled(&store, &id))
-        .await
-        .map_err(|_| AppError::Internal)??;
+    let resp = run_blocking(move || svc_trigger_scheduled(&store, &id)).await?;
     Ok(Json(resp))
 }
 


### PR DESCRIPTION
## Why

`cargo llvm-cov --fail-under-lines 100` (the repo's own CI \`Test\` job and the local pre-push hook) is currently at **99.39%** on \`main\`, short of the 100% floor. The gap is spread across many files, but the single largest recurring piece of it is one duplicated, untested branch:

\`create_routine\`, \`delete_routine\`, \`lock_routines\`, \`trigger_routine\`, \`unlock_routines\`, \`update_routine\`, and the scheduled-trigger handler (\`routines/handlers.rs\`) each repeat:

\`\`\`rust
let resp = tokio::task::spawn_blocking(move || logic::build(&store, ...))
    .await
    .map_err(|_| AppError::Internal)??;
\`\`\`

to keep blocking \`crontab\`(1)/\`tmux\`(1)/filesystem I/O off the async worker thread (#360). The \`map_err\` arm only fires if the *blocking task itself panics* — but every store lock in this codebase is deliberately poison-tolerant (\`LockRecover\`, see \`src/utils/lock.rs\`), so that panic can never actually happen through any normal caller. The branch was copy-pasted into 7 call sites and left uncovered at every one.

## What

- Extracts the idiom into one helper, \`crate::error::run_blocking\`, used by all 7 call sites.
- Adds direct unit tests for the helper in \`src/error_tests.rs\`, including one that deliberately panics the blocking closure to exercise the join-failure branch — now covered once, at the source, instead of copy-pasted-and-untested seven times.
- No behavior change: same offload-to-blocking-pool + same error mapping at every call site.

## Verification

- \`cargo fmt --check\`, \`cargo clippy --all-targets -- -D warnings\`, \`cargo test\` (1141 passed), \`cargo doc --no-deps\` all pass locally.
- \`cargo llvm-cov --ignore-filename-regex 'src/main\.rs'\`: total line coverage improves from 99.39% (8671 lines, 53 missed) to 99.47% (8664 lines, 46 missed); every touched file (\`error.rs\`, and all 7 route/handler files) is now at 100% line coverage. The repo's other pre-existing coverage gaps (\`cli/system.rs\`, \`http_listener.rs\`, etc.) are unrelated to this change and left for a follow-up.
- Added a changeset (\`.changeset/cover-spawn-blocking-join-error.md\`) for the \`unreleased-entry\` check.

Small, test-only, mechanical refactor — no product behavior changes.