### PR TITLE
feat: npm bootstrapper for moadim

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ either is missing, so a misconfigured host is easy to spot. See the built-in
 cargo install --locked moadim
 ```
 
-Or, if you prefer npm, install the bootstrapper package and let it call Cargo for you:
+Or, if you prefer npm, install the bootstrapper package and run the same `moadim` command:
 
 ```sh
-npm install -g moadim && moadim-install
+npm install -g moadim && moadim
 ```
 
 `--locked` installs the exact dependency graph published and tested with this
@@ -63,7 +63,7 @@ release (from the crate's `Cargo.lock`) instead of re-resolving every dependency
 to the newest semver-compatible version at install time — so a bad or breaking
 transitive bump can't fail an otherwise-unchanged install.
 
-If `moadim` is not found after install, add Cargo's bin directory to your PATH:
+If `cargo install` is not found after install, add Cargo's bin directory to your PATH:
 
 ```sh
 echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ either is missing, so a misconfigured host is easy to spot. See the built-in
 cargo install --locked moadim
 ```
 
+Or, if you prefer npm, install the bootstrapper package and let it call Cargo for you:
+
+```sh
+npm install -g moadim && moadim-install
+```
+
 `--locked` installs the exact dependency graph published and tested with this
 release (from the crate's `Cargo.lock`) instead of re-resolving every dependency
 to the newest semver-compatible version at install time — so a bad or breaking

--- a/npm/moadim/README.md
+++ b/npm/moadim/README.md
@@ -1,0 +1,10 @@
+# moadim npm bootstrapper
+
+Install this package globally to bootstrap the `moadim` daemon with Cargo:
+
+```sh
+npm install -g moadim
+moadim-install
+```
+
+It installs the published `moadim` crate version that matches this package.

--- a/npm/moadim/package.json
+++ b/npm/moadim/package.json
@@ -4,7 +4,7 @@
   "description": "Bootstrapper that installs the moadim daemon with cargo",
   "type": "module",
   "bin": {
-    "moadim-install": "scripts/install.mjs"
+    "moadim": "scripts/install.mjs"
   },
   "files": [
     "README.md",

--- a/npm/moadim/package.json
+++ b/npm/moadim/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "moadim",
+  "version": "1.5.0",
+  "description": "Bootstrapper that installs the moadim daemon with cargo",
+  "type": "module",
+  "bin": {
+    "moadim-install": "scripts/install.mjs"
+  },
+  "files": [
+    "README.md",
+    "scripts/install.mjs"
+  ],
+  "engines": {
+    "node": ">=18.17"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/moadim-io/daemon.git",
+    "directory": "npm/moadim"
+  },
+  "homepage": "https://moadim.io",
+  "keywords": [
+    "moadim",
+    "daemon",
+    "scheduler",
+    "mcp",
+    "automation"
+  ],
+  "scripts": {
+    "test": "node scripts/install.test.mjs"
+  }
+}

--- a/npm/moadim/scripts/install.mjs
+++ b/npm/moadim/scripts/install.mjs
@@ -1,74 +1,72 @@
 #!/usr/bin/env node
-import { spawnSync } from "node:child_process";
-import { pathToFileURL } from "node:url";
+import { spawnSync } from 'node:child_process';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
-const expectedVersion = "1.5.0";
+const expectedVersion = '1.5.0';
 
 export function installedVersion(stdout) {
-	const match = stdout
-		.trim()
-		.match(/\b(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)\b/);
-	return match?.[1] ?? null;
+  const match = stdout.trim().match(/\b(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)\b/);
+  return match?.[1] ?? null;
 }
 
 export function needsInstall(stdout, version) {
-	return installedVersion(stdout) !== version;
+  return installedVersion(stdout) !== version;
+}
+
+export function cargoBinaryPath() {
+  return join(process.env.CARGO_HOME ?? join(homedir(), '.cargo'), 'bin', 'moadim');
 }
 
 function run(command, args) {
-	return spawnSync(command, args, { encoding: "utf8" });
+  return spawnSync(command, args, { encoding: 'utf8' });
 }
 
-function checkInstalled() {
-	const result = run("moadim", ["--version"]);
-	if (result.error || result.status !== 0) {
-		return null;
-	}
+function installedBinaryVersion() {
+  const result = run(cargoBinaryPath(), ['--version']);
+  if (result.error || result.status !== 0) {
+    return null;
+  }
 
-	return installedVersion(result.stdout);
+  return installedVersion(result.stdout);
 }
 
-export function main() {
-	if (process.platform === "win32") {
-		process.stderr.write(
-			"moadim needs a Unix-like host with tmux and crontab.\n",
-		);
-		return 1;
-	}
+function installCargoBinary() {
+  const cargo = run('cargo', ['install', '--locked', '--force', '--version', expectedVersion, 'moadim']);
+  if (cargo.error) {
+    process.stderr.write('cargo is required to install moadim. Install Rust from https://rustup.rs/ and rerun `npm install -g moadim`.\n');
+    return false;
+  }
 
-	const currentVersion = checkInstalled();
-	if (currentVersion === expectedVersion) {
-		return 0;
-	}
+  if (cargo.status !== 0) {
+    if (cargo.stderr) {
+      process.stderr.write(cargo.stderr);
+    }
+    return false;
+  }
 
-	const cargo = run("cargo", [
-		"install",
-		"--locked",
-		"--force",
-		"--version",
-		expectedVersion,
-		"moadim",
-	]);
-	if (cargo.error) {
-		process.stderr.write(
-			"cargo is required to install moadim. Install Rust from https://rustup.rs/ and rerun `moadim-install`.\n",
-		);
-		return 1;
-	}
-
-	if (cargo.status !== 0) {
-		if (cargo.stderr) {
-			process.stderr.write(cargo.stderr);
-		}
-		return cargo.status ?? 1;
-	}
-
-	return 0;
+  return true;
 }
 
-if (
-	process.argv[1] &&
-	import.meta.url === pathToFileURL(process.argv[1]).href
-) {
-	process.exitCode = main();
+function runInstalledBinary(args) {
+  const result = spawnSync(cargoBinaryPath(), args, { stdio: 'inherit' });
+  return result.status ?? 1;
+}
+
+export function main(args = process.argv.slice(2)) {
+  if (process.platform === 'win32') {
+    process.stderr.write('moadim needs a Unix-like host with tmux and crontab.\n');
+    return 1;
+  }
+
+  if (needsInstall(installedBinaryVersion() ?? '', expectedVersion) && !installCargoBinary()) {
+    return 1;
+  }
+
+  return runInstalledBinary(args);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exitCode = main();
 }

--- a/npm/moadim/scripts/install.mjs
+++ b/npm/moadim/scripts/install.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+const expectedVersion = "1.5.0";
+
+export function installedVersion(stdout) {
+	const match = stdout
+		.trim()
+		.match(/\b(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)\b/);
+	return match?.[1] ?? null;
+}
+
+export function needsInstall(stdout, version) {
+	return installedVersion(stdout) !== version;
+}
+
+function run(command, args) {
+	return spawnSync(command, args, { encoding: "utf8" });
+}
+
+function checkInstalled() {
+	const result = run("moadim", ["--version"]);
+	if (result.error || result.status !== 0) {
+		return null;
+	}
+
+	return installedVersion(result.stdout);
+}
+
+export function main() {
+	if (process.platform === "win32") {
+		process.stderr.write(
+			"moadim needs a Unix-like host with tmux and crontab.\n",
+		);
+		return 1;
+	}
+
+	const currentVersion = checkInstalled();
+	if (currentVersion === expectedVersion) {
+		return 0;
+	}
+
+	const cargo = run("cargo", [
+		"install",
+		"--locked",
+		"--force",
+		"--version",
+		expectedVersion,
+		"moadim",
+	]);
+	if (cargo.error) {
+		process.stderr.write(
+			"cargo is required to install moadim. Install Rust from https://rustup.rs/ and rerun `moadim-install`.\n",
+		);
+		return 1;
+	}
+
+	if (cargo.status !== 0) {
+		if (cargo.stderr) {
+			process.stderr.write(cargo.stderr);
+		}
+		return cargo.status ?? 1;
+	}
+
+	return 0;
+}
+
+if (
+	process.argv[1] &&
+	import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+	process.exitCode = main();
+}

--- a/npm/moadim/scripts/install.test.mjs
+++ b/npm/moadim/scripts/install.test.mjs
@@ -1,8 +1,42 @@
-import assert from "node:assert/strict";
-import { installedVersion, needsInstall } from "./install.mjs";
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { cargoBinaryPath, installedVersion, main, needsInstall } from './install.mjs';
 
-assert.equal(installedVersion("moadim 1.5.0"), "1.5.0");
-assert.equal(installedVersion("moadim 1.5.0 (abc123)"), "1.5.0");
-assert.equal(installedVersion(""), null);
-assert.equal(needsInstall("moadim 1.5.0", "1.5.0"), false);
-assert.equal(needsInstall("", "1.5.0"), true);
+assert.equal(installedVersion('moadim 1.5.0'), '1.5.0');
+assert.equal(installedVersion('moadim 1.5.0 (abc123)'), '1.5.0');
+assert.equal(installedVersion(''), null);
+assert.equal(needsInstall('moadim 1.5.0', '1.5.0'), false);
+assert.equal(needsInstall('', '1.5.0'), true);
+
+const home = mkdtempSync(join(tmpdir(), 'moadim-npm-'));
+const binDir = join(home, '.cargo', 'bin');
+mkdirSync(binDir, { recursive: true });
+const cargoBinary = join(binDir, 'moadim');
+writeFileSync(
+  cargoBinary,
+  '#!/bin/sh\nif [ "$1" = "--version" ]; then\n  echo "moadim 1.5.0"\nelse\n  echo "$@" > "$MOADIM_ARGS_FILE"\nfi\n',
+);
+chmodSync(cargoBinary, 0o755);
+
+const originalHome = process.env.HOME;
+const originalCargoHome = process.env.CARGO_HOME;
+const originalPath = process.env.PATH;
+const originalArgs = process.env.MOADIM_ARGS_FILE;
+process.env.HOME = home;
+delete process.env.CARGO_HOME;
+process.env.PATH = '';
+process.env.MOADIM_ARGS_FILE = join(home, 'args.txt');
+assert.equal(cargoBinaryPath(), cargoBinary);
+assert.equal(main(['--help']), 0);
+assert.equal(readFileSync(join(home, 'args.txt'), 'utf8').trim(), '--help');
+process.env.HOME = originalHome;
+process.env.CARGO_HOME = originalCargoHome;
+process.env.PATH = originalPath;
+if (originalArgs === undefined) {
+  delete process.env.MOADIM_ARGS_FILE;
+} else {
+  process.env.MOADIM_ARGS_FILE = originalArgs;
+}
+rmSync(home, { recursive: true, force: true });

--- a/npm/moadim/scripts/install.test.mjs
+++ b/npm/moadim/scripts/install.test.mjs
@@ -1,0 +1,8 @@
+import assert from "node:assert/strict";
+import { installedVersion, needsInstall } from "./install.mjs";
+
+assert.equal(installedVersion("moadim 1.5.0"), "1.5.0");
+assert.equal(installedVersion("moadim 1.5.0 (abc123)"), "1.5.0");
+assert.equal(installedVersion(""), null);
+assert.equal(needsInstall("moadim 1.5.0", "1.5.0"), false);
+assert.equal(needsInstall("", "1.5.0"), true);


### PR DESCRIPTION
Adds a tiny npm package that boots the published moadim daemon via cargo install, plus README docs for the npm install path. Verified with dry-run packaging and a fake-binary install check.