### PR TITLE
chore: lower linecheck gate to 400

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -78,9 +78,9 @@ if ! command -v linecheck >/dev/null 2>&1; then
   exit 1
 fi
 
-echo "Checking .rs files do not exceed 500 lines..."
+echo "Checking .rs files do not exceed 400 lines..."
 # shellcheck disable=SC2046
-linecheck --max-lines 500 $(find src -name '*.rs')
+linecheck --max-lines 400 $(find src -name '*.rs')
 echo "Line-count check passed."
 
 # ── 7. Client (React) checks ────────────────────────────────────────────────────

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -126,11 +126,11 @@ jobs:
       - name: Install linecheck
         run: cargo install linecheck --locked
 
-      - name: Check .rs files do not exceed 500 lines
+      - name: Check .rs files do not exceed 400 lines
         # Match the local pre-push hook exactly (same paths, same limit).
         run: |
           # shellcheck disable=SC2046
-          linecheck --max-lines 500 $(find src -name '*.rs')
+          linecheck --max-lines 400 $(find src -name '*.rs')
 
   readme-check:
     name: readme-check


### PR DESCRIPTION
Reduce the repository line-count gate from 500 to 400 in both the local pre-push hook and the CI lint workflow.

Checks:
- bash -n .githooks/pre-push
- git diff --check