### PR TITLE
test(routine_storage_walk): cover the with_home restore branch, restore 100% line-coverage gate

### DIFF
--- a/.changeset/cover-with-home-restore-branch.md
+++ b/.changeset/cover-with-home-restore-branch.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+test: de-genericize the `with_home` test helper in `routine_storage_walk` and add a nested-call test so its `MOADIM_HOME_OVERRIDE` restore branch is exercised, restoring the repo's 100%-line-coverage gate (`cargo llvm-cov --fail-under-lines 100`) to green.

--- a/src/routine_storage_walk.rs
+++ b/src/routine_storage_walk.rs
@@ -52,7 +52,12 @@ mod tests {
         std::env::temp_dir().join(format!("moadim-walk-{}", uuid::Uuid::new_v4()))
     }
 
-    fn with_home(body: impl FnOnce()) {
+    // `body` is a `&dyn Fn()` rather than a generic `impl FnOnce()` so every call site shares one
+    // non-generic function body (and one set of coverage counters) instead of each closure
+    // monomorphizing its own copy of `with_home` — with per-call-site copies, this function's
+    // `Some`/`None` restore branches (below) could each be satisfied by a *different* copy and
+    // still leave individual copies under 100% line coverage.
+    fn with_home(body: &dyn Fn()) {
         let home = scratch_home();
         std::fs::create_dir_all(&home).unwrap();
         let previous = std::env::var_os("MOADIM_HOME_OVERRIDE");
@@ -100,7 +105,7 @@ mod tests {
 
     #[test]
     fn walk_routines_recurses_into_nested_dirs() {
-        with_home(|| {
+        with_home(&|| {
             write_routine(&make_routine("walk-nested-id", "team/ops/nightly triage")).unwrap();
             let mut routines = HashMap::new();
             walk_routines(
@@ -116,8 +121,21 @@ mod tests {
     }
 
     #[test]
+    fn with_home_restores_a_pre_existing_home_override() {
+        // `with_home` is nested here so the inner call's `previous` capture is
+        // `Some(outer_home)`, exercising the restore-a-prior-value branch that
+        // no other test reaches (every other caller starts from an unset
+        // MOADIM_HOME_OVERRIDE, so only the `None` branch ever ran).
+        with_home(&|| {
+            let outer_home = std::env::var_os("MOADIM_HOME_OVERRIDE").unwrap();
+            with_home(&|| {});
+            assert_eq!(std::env::var_os("MOADIM_HOME_OVERRIDE"), Some(outer_home));
+        });
+    }
+
+    #[test]
     fn walk_routines_skips_plain_dirs_without_routine_toml() {
-        with_home(|| {
+        with_home(&|| {
             std::fs::create_dir_all(crate::paths::routines_dir().join("archive/old")).unwrap();
             write_routine(&make_routine("walk-flat-id", "flat routine")).unwrap();
             let mut routines = HashMap::new();


### PR DESCRIPTION
## Why

`cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — the same command the required `cargo llvm-cov (100% line floor)` CI check runs — currently fails on `main` (verified fresh on `0d5521d`, exit code 1, 99.98% line coverage, exactly one file/line short).

The gap is in `src/routine_storage_walk.rs`'s test-only `with_home` helper:

```rust
match previous {
    Some(value) => std::env::set_var("MOADIM_HOME_OVERRIDE", value),
    None => std::env::remove_var("MOADIM_HOME_OVERRIDE"),
}
```

The `Some(value)` restore branch only fires when `MOADIM_HOME_OVERRIDE` was already set before `with_home` runs. Every existing test calls it from a clean, unset baseline, so that branch never executed.

## What

- Added `with_home_restores_a_pre_existing_home_override`, which nests one `with_home` call inside another so the inner call's `previous` capture is `Some(outer_home)`, and asserts the outer value is correctly restored afterward.
- Changed `with_home`'s parameter from a generic `impl FnOnce()` to `&dyn Fn()` (matching the sibling `load: &dyn Fn(...)` parameter already used in this same file). `impl FnOnce()` monomorphizes a separate copy of the function (with independent coverage counters) per call site, so a naive nested-call test would still leave the *other* three call sites' own copies short of the `Some` branch and the gate red. With a single non-generic function body, every call site shares one set of counters and the new test covers the branch for all of them.

Test-only change — no production behavior affected.

## Verification (all run fresh on this branch)

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 1145 passed
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — **exit 0**, 100.00% lines (was exit 1 / 99.98% on `main`)
- `linecheck --max-lines 500 $(find src ui/src -name '*.rs')` — clean

Added `.changeset/cover-with-home-restore-branch.md` (patch) since this touches `src/`.

🤖 Generated with automated repo-maintenance routine.