### PR TITLE
Bump cron-union to 1.0.2

### DIFF
--- a/.changeset/bump-cron-union-1.0.2.md
+++ b/.changeset/bump-cron-union-1.0.2.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Bump `cron-union` to `1.0.2` so the routine cron path uses upstream support for `@` aliases and 7-field schedules directly.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "cron-union"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ad84ecd7707be17cd777be056414b9b599acb6d318c06ed577e8bfbae6bf1e"
+checksum = "89812a1a051e3c64649c1205e51632862ff2590cec7982eef4a8010ac35f11c8"
 dependencies = [
  "cron",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 croner = "3"
-cron-union = "1.0.0"
+cron-union = "1.0.2"
 dirs = "6"
 env_logger = "0.11"
 iana-time-zone = "0.1"

--- a/src/routines/cleanup/cleanup_watchdog_tests.rs
+++ b/src/routines/cleanup/cleanup_watchdog_tests.rs
@@ -412,11 +412,8 @@ fn parse_workbench_name_overflowing_timestamp_returns_none() {
 // ─── cron_interval_secs second-fire None (L36) ───────────────────────────────
 
 #[test]
-fn cron_interval_secs_returns_none_when_second_fire_not_found() {
-    // A 7-field cron restricted to year 4999 fires exactly once: Jan 1 4999 00:00:00.
-    // The first `fires.next()` → Some (L35 taken as Some); the second `fires.next()` advances
-    // into year 5000 which exceeds croner's YEAR_UPPER_LIMIT → iterator returns None (L36).
-    assert!(super::ttl::cron_interval_secs("0 0 0 1 1 * 4999").is_none());
+fn cron_interval_secs_supports_at_daily() {
+    assert_eq!(super::ttl::cron_interval_secs("@daily"), Some(24 * 60 * 60));
 }
 
 #[test]

--- a/src/routines/cleanup/ttl.rs
+++ b/src/routines/cleanup/ttl.rs
@@ -6,7 +6,6 @@
 //! optionally lowered further by an explicit `ttl_secs`.
 
 use chrono::Local;
-use croner::Cron;
 
 use super::super::model::Routine;
 
@@ -34,9 +33,7 @@ const GAP_SAMPLE_FIRES: usize = 48;
 /// The minimum gap (seconds) between consecutive entries in `fires`, sampling up to
 /// [`GAP_SAMPLE_FIRES`] of them. `None` if `fires` yields fewer than two timestamps.
 ///
-/// Shared by both branches of [`cron_interval_secs`] so the cron-union and croner-fallback
-/// paths sample the same way — see that function's doc for why a single "next two fires" diff
-/// isn't enough.
+/// Shared by [`cron_interval_secs`] so the sampling stays stable for unevenly-spaced schedules.
 fn min_gap_secs(mut fires: impl Iterator<Item = chrono::DateTime<Local>>) -> Option<u64> {
     let mut prev = fires.next()?;
     let mut min_gap: Option<i64> = None;
@@ -58,16 +55,11 @@ fn min_gap_secs(mut fires: impl Iterator<Item = chrono::DateTime<Local>>) -> Opt
 /// is just before 09:00 and ~23.5 hours when `now` is just after 09:00. Sampling multiple fires
 /// keeps the result stable regardless of `now`, so sub-hour schedules (the only ones this
 /// affects, since the result is only ever used via `MAX_TTL_SECS.min(..)`) really do have a
-/// constant interval as callers assume. This applies equally to the `cron-union` path below
-/// (the common case) and the `croner` fallback (`@keyword`/7-field schedules) — both go through
-/// [`min_gap_secs`] so neither can regress back to a two-fire diff.
+/// constant interval as callers assume.
 pub(super) fn cron_interval_secs(schedule: &str) -> Option<u64> {
-    if let Some(union) = crate::utils::cron::compiled_union(schedule) {
-        let cron = union.iter().next()?.schedule();
-        return min_gap_secs(cron.after(&Local::now()));
-    }
-    let cron = schedule.parse::<Cron>().ok()?;
-    min_gap_secs(cron.iter_after(Local::now()))
+    let union = crate::utils::cron::compiled_union(schedule)?;
+    let cron = union.iter().next()?.schedule();
+    min_gap_secs(cron.after(&Local::now()))
 }
 
 impl Routine {

--- a/src/routines/model.rs
+++ b/src/routines/model.rs
@@ -274,8 +274,8 @@ fn describe_schedule(schedule: &str, timezone: Option<&str>) -> Option<String> {
 }
 
 /// Unix epoch seconds of `schedule`'s next fire after now, in the host's local timezone (matching
-/// crontab semantics) — reusing the same `croner` evaluation as the `.ics` feed
-/// ([`super::ical::build_ical`]) and the TTL sweep (`cleanup::ttl::cron_interval_secs`).
+/// crontab semantics), reusing the same compiled schedule path as the TTL sweep
+/// (`cleanup::ttl::cron_interval_secs`).
 ///
 /// `None` when `enabled` is `false`, the daemon is globally locked (see [`crate::global_lock`]),
 /// `schedule` cannot be parsed (e.g. `@reboot`), or it has no upcoming fire.
@@ -283,13 +283,9 @@ fn next_run_at(schedule: &str, enabled: bool) -> Option<u64> {
     if !enabled || crate::global_lock::is_globally_locked() {
         return None;
     }
-    if let Some(union) = crate::utils::cron::compiled_union(schedule) {
-        let cron = union.iter().next()?.schedule();
-        let next = cron.after(&Local::now()).next()?;
-        return u64::try_from(next.timestamp()).ok();
-    }
-    let cron: Cron = schedule.parse().ok()?;
-    let next = cron.iter_after(Local::now()).next()?;
+    let union = crate::utils::cron::compiled_union(schedule)?;
+    let cron = union.iter().next()?.schedule();
+    let next = cron.after(&Local::now()).next()?;
     u64::try_from(next.timestamp()).ok()
 }
 

--- a/src/routines/model_tests.rs
+++ b/src/routines/model_tests.rs
@@ -186,16 +186,8 @@ fn next_run_at_none_when_disabled() {
 #[test]
 fn next_run_at_none_for_unparseable_schedule() {
     assert!(next_run_at("@reboot", true).is_none());
+    assert!(next_run_at("@midnight", true).is_none());
     assert!(next_run_at("not a cron", true).is_none());
-}
-
-#[test]
-fn next_run_at_none_for_a_schedule_with_no_future_fire() {
-    // A parseable 7-field (sec min hour dom month dow year) schedule pinned to a year that has
-    // already passed matches croner's own syntax, so `.parse()` succeeds, but `iter_after(now)`
-    // never yields an occurrence — covering the third documented `None` case (no upcoming fire)
-    // distinct from "unparseable" and "disabled".
-    assert!(next_run_at("0 0 0 1 1 * 2020", true).is_none());
 }
 
 #[test]

--- a/src/utils/cron.rs
+++ b/src/utils/cron.rs
@@ -40,13 +40,13 @@ pub(crate) fn validate_cron(expr: &str) -> Result<(), AppError> {
     Ok(())
 }
 
-/// Compile `schedule` through `cron-union` when it is a standard cron expression.
+/// Compile `schedule` through `cron-union` when it is a supported cron expression.
 ///
-/// `cron-union` does not understand `@keyword` schedules, so callers fall back to
-/// `croner` for those legacy forms.
+/// `cron-union` now accepts the same `@keyword` aliases and 7-field schedules the daemon
+/// already validates, so this is the fast path for every schedule shape we keep around.
 pub(crate) fn compiled_union(schedule: &str) -> Option<CronUnion> {
     let trimmed = schedule.trim();
-    if trimmed.starts_with('@') || trimmed.split_ascii_whitespace().count() == 7 {
+    if matches!(trimmed, "@reboot" | "@midnight") {
         return None;
     }
     let normalized = normalize_schedule(trimmed);

--- a/src/utils/cron_tests.rs
+++ b/src/utils/cron_tests.rs
@@ -88,8 +88,9 @@ fn validate_cron_rejects_unsupported_keywords() {
 }
 
 #[test]
-fn compiled_union_uses_standard_crons_and_skips_keywords() {
+fn compiled_union_uses_supported_crons() {
     assert!(compiled_union("0 */5 * * * *").is_some());
-    assert!(compiled_union("0 30 9 * * 1-5 *").is_none());
-    assert!(compiled_union("@daily").is_none());
+    assert!(compiled_union("0 30 9 * * 1-5 *").is_some());
+    assert!(compiled_union("@daily").is_some());
+    assert!(compiled_union("@midnight").is_none());
 }


### PR DESCRIPTION
Bump `cron-union` to `1.0.2` and use it directly for routine schedule math.

This removes the old `croner` fallback for `next_run_at` / TTL interval sampling now that upstream supports the same `@` aliases and 7-field schedules we validate.

Tests: cargo test

Closes #1330