### PR TITLE
Move routine disclosure into compiled prompt

### DIFF
--- a/.changeset/move-routine-disclosure-to-compiled-prompt.md
+++ b/.changeset/move-routine-disclosure-to-compiled-prompt.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Move the routine-origin disclosure into the compiled prompt body so it shows up in prompt previews and `prompt.compiled.local.md` instead of being injected only at launch time.

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ register a brand-new agent by dropping in another `<name>.toml`.
 | --------- | -------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | `command` | string         | yes      | Executable to run (resolved on `PATH`), e.g. `"claude"`.                                                                       |
 | `args`    | array<string>  | no       | Arguments passed to `command`. Supports the placeholders below. Defaults to empty.                                            |
-| `instructions_file` | string | no    | Filename, relative to the workbench, that this agent reads its project instructions from — where the moadim-managed system prompt and routine-origin disclosure are written. Defaults to `CLAUDE.md` (Claude Code's convention); the built-in `codex` agent sets it to `AGENTS.md`. |
+| `instructions_file` | string | no    | Filename, relative to the workbench, that this agent reads its project instructions from — where the moadim-managed system prompt is written. Defaults to `CLAUDE.md` (Claude Code's convention); the built-in `codex` agent sets it to `AGENTS.md`. |
 | `setup`   | string         | no       | Shell command run in the workbench **before** the agent launches, inserted verbatim into the cron line. See the variables below. |
 
 **Placeholders** (substituted in each `args` entry at launch):

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -880,7 +880,7 @@
         "tags": [
           "crate::routines"
         ],
-        "summary": "`GET /routines/{id}/prompt-preview` — the exact prompt body a run would receive, computed\nin-memory with no workbench, `prompt.md` write, or agent launch (issue #391). Does not include\nthe routine-origin disclosure written separately to `CLAUDE.md` at trigger time.",
+        "summary": "`GET /routines/{id}/prompt-preview` — the exact prompt body a run would receive, computed\nin-memory with no workbench, `prompt.md` write, or agent launch (issue #391). Includes the\nroutine-origin disclosure because it now lives in the composed prompt.",
         "operationId": "get_prompt_preview",
         "parameters": [
           {

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -43,8 +43,8 @@ fn format_version(version: &str, sha: &str, date: &str) -> String {
 /// How often the running daemon checks whether the binary now sitting at its own `current_exe()`
 /// path differs from the one this process was started from (#167). A daemon left running across an
 /// in-place binary upgrade keeps executing the old compiled-in logic — including whatever it writes
-/// into a routine's generated agent instructions, such as the routine-origin disclosure — with no
-/// signal to the operator that a restart would pick up the newer build. Hourly is plenty: this is
+/// into a routine's generated agent instructions with no signal to the operator that a restart
+/// would pick up the newer build. Hourly is plenty: this is
 /// an operator nudge, not a time-critical check, so it runs on its own cadence independent of
 /// [`crate::routines::CLEANUP_INTERVAL`].
 pub const VERSION_DRIFT_CHECK_INTERVAL: std::time::Duration =

--- a/src/routes/mcp.rs
+++ b/src/routes/mcp.rs
@@ -160,7 +160,7 @@ impl MoadimMcp {
     /// Return the exact prompt body a routine's run would receive, without creating a workbench
     /// or launching an agent.
     #[tool(
-        description = "Preview the exact composed prompt body a routine's run would receive, without triggering a real run (no workbench, no agent launch). Does not include the routine-origin disclosure written separately to CLAUDE.md at trigger time."
+        description = "Preview the exact composed prompt body a routine's run would receive, without triggering a real run (no workbench, no agent launch). Includes the routine-origin disclosure because it is part of the composed prompt."
     )]
     fn preview_routine_prompt(
         &self,

--- a/src/routines/agents/claude_code/setup.rs
+++ b/src/routines/agents/claude_code/setup.rs
@@ -23,9 +23,8 @@ pub const NAME: &str = "claude";
 /// this process actually wrote what it meant to.
 ///
 /// Reads project instructions from `AGENTS.md` — the same file Codex uses — so the moadim-managed
-/// system prompt and routine-origin disclosure are unified onto one instructions file across
-/// agents. Claude Code loads `AGENTS.md` as a memory/context file, so the disclosure is honored
-/// exactly as it would be from `CLAUDE.md`.
+/// system prompt is unified onto one instructions file across agents. Claude Code loads `AGENTS.md`
+/// as a memory/context file, so the prompt is honored exactly as it would be from `CLAUDE.md`.
 pub const CONFIG: &str = r#"command = "claude"
 args = ["--permission-mode", "auto", "{prompt}"]
 instructions_file = "AGENTS.md"

--- a/src/routines/agents/codex/setup.rs
+++ b/src/routines/agents/codex/setup.rs
@@ -12,7 +12,7 @@ pub const NAME: &str = "codex";
 /// needs" baseline the `claude` default already gets.
 ///
 /// Codex reads its project instructions from `AGENTS.md`, not Claude Code's `CLAUDE.md`, so the
-/// daemon must write the moadim system prompt + routine-origin disclosure there for it to be seen.
+/// daemon must write the moadim system prompt there for it to be seen.
 pub const CONFIG: &str = r#"command = "codex"
 # `codex exec` runs unattended, but its default workspace-write sandbox blocks the
 # network, so a routine could not clone the repo or push / open a PR. Pin the sandbox

--- a/src/routines/agents/mod.rs
+++ b/src/routines/agents/mod.rs
@@ -50,9 +50,8 @@ pub struct AgentCommand {
     #[serde(default)]
     pub args: Vec<String>,
     /// Filename, relative to the workbench, that this agent reads its project instructions from.
-    /// The moadim-managed system prompt and routine-origin disclosure are written here so the agent
-    /// that actually runs sees them. Defaults to `CLAUDE.md` (Claude Code's convention); Codex reads
-    /// `AGENTS.md` instead.
+    /// The moadim-managed system prompt is written here so the agent that actually runs sees it.
+    /// Defaults to `CLAUDE.md` (Claude Code's convention); Codex reads `AGENTS.md` instead.
     #[serde(default = "default_instructions_file")]
     pub instructions_file: String,
     /// Optional shell command run in the workbench *before* the agent launches, inserted verbatim

--- a/src/routines/command.rs
+++ b/src/routines/command.rs
@@ -57,11 +57,8 @@ pub(crate) fn tmux_session_prefix(slug: &str) -> String {
     format!("{TMUX_SESSION_PREFIX}{slug}-")
 }
 
-/// Compose the `prompt.compiled.local.md` body: a repositories-as-context preamble, an optional `## Goal`
-/// section, the prompt, and — when the routine has any — an "Open flags" section listing
-/// gaps/bugs/edge cases the agent raised on a previous run (see [`super::flags`]) that no one has
-/// resolved yet.
-///
+/// Compose the `prompt.compiled.local.md` body: a repositories-as-context preamble, an optional
+/// `## Goal` section, a routine-origin disclosure block, the prompt, and an "Open flags" section.
 /// When the routine lists no repositories the preamble omits the "clone any you need:" sentence
 /// and its (otherwise empty) bullet list, so the agent never sees a dangling header promising a
 /// repo list with nothing under it.
@@ -99,6 +96,9 @@ pub(crate) fn compose_prompt(routine: &Routine) -> String {
         body.push_str(goal);
         body.push('\n');
     }
+    body.push_str("\n## Routine origin disclosure\n\n");
+    body.push_str("You act on behalf of the moadim routine named below. In every external, outward-facing communication you produce — GitHub issues, pull requests and comments; Slack messages; emails; any channel a human or third-party system receives — you MUST disclose that the action originates from this moadim routine, naming it.\n\n");
+    let _ = writeln!(body, "Routine name: {}", routine.title);
     body.push_str("\n---\n");
     body.push_str(&routine.prompt);
     body.push('\n');

--- a/src/routines/command_system_prompt.rs
+++ b/src/routines/command_system_prompt.rs
@@ -22,58 +22,36 @@ const MOADIM_SYSTEM_PROMPT: &str = "# Moadim Context\\n\
     exit, write a `## Final summary` section to `summary.md` describing what was accomplished, \
     what changed, and anything left unresolved.";
 
-/// Routine-origin disclosure appended to the moadim system prompt.
-///
-/// Instructs the agent to reveal, in every outward-facing communication, that it acts on behalf of
-/// the moadim routine — naming it. The routine name itself is *not* part of this constant: it is
-/// injected at run time as a separate `printf` `%s` argument (text expanded by `printf '%b'` is not
-/// re-scanned for conversions, so a `%s` placed inside this `%b` string would print literally).
-/// This constant therefore ends just before the name. `\n` are literal two-character sequences
-/// re-expanded into newlines by `printf '%b'`, matching `MOADIM_SYSTEM_PROMPT`.
-const MOADIM_DISCLOSURE: &str = "## Routine origin disclosure\\n\
-    \\n\
-    You act on behalf of the moadim routine named below. In every external, outward-facing \
-    communication you produce — GitHub issues, pull requests and comments; Slack messages; emails; \
-    any channel a human or third-party system receives — you MUST disclose that the action \
-    originates from this moadim routine, naming it (for example: 'This pull request was opened by \
-    the <routine name> routine of moadim.'). Phrasing may be adapted per channel but must \
-    include the routine name. This does NOT apply to internal logs or in-repo working files.\\n\
-    \\n\
-    Routine name: ";
-
 /// Shell statements that write the agent's instructions file (e.g. `CLAUDE.md` for Claude,
 /// `AGENTS.md` for Codex) into `$WB` with two layers:
 ///
-/// 1. **Moadim prompt** — daemon-managed preamble, the routine-origin disclosure naming
-///    `routine_title`, plus a run-time date stamp.
+/// 1. **Moadim prompt** — daemon-managed preamble plus a run-time date stamp.
 /// 2. **User prompt** — contents of `~/.config/moadim/user_prompt.md`, appended if the file exists.
 ///
 /// `instructions_file` is the workbench-relative filename the selected agent reads its project
-/// instructions from; writing the disclosure there guarantees the agent that actually runs sees it.
+/// instructions from; writing the daemon-managed preamble there guarantees the agent that actually
+/// runs sees it.
 ///
 /// Uses `printf '%b'` so `\n` sequences in the static header expand to real newlines without
 /// embedding literal newlines in the crontab line. `$WB` must be in scope when the statements run.
 pub(crate) fn system_prompt_stmts(
     user_prompt_path: &str,
-    routine_title: &str,
+    _routine_title: &str,
     instructions_file: &str,
 ) -> Vec<String> {
     let header = shell_quote(MOADIM_SYSTEM_PROMPT);
-    let disclosure = shell_quote(MOADIM_DISCLOSURE);
-    let title = shell_quote(routine_title);
     let uq = shell_quote(user_prompt_path);
     let dest = format!(r#""$WB/{instructions_file}""#);
     vec![
-        // Fail-fast if the disclosure write fails. The statements are `;`-joined, so a bare
-        // redirection failure (read-only/full $HOME, an unwritable $WB, disk-quota/inode
+        // Fail-fast if the daemon-managed instructions write fails. The statements are `;`-joined,
+        // so a bare redirection failure (read-only/full $HOME, an unwritable $WB, disk-quota/inode
         // exhaustion) would be ignored and the agent would launch with no `CLAUDE.md` — hence no
-        // routine-origin disclosure mandate, the central transparency guarantee of this project.
-        // Abort instead, mirroring the `cp prompt.md` guard below: record the reason in the
-        // workbench's agent.log (already created via mkdir) and on stderr. Only this primary write
-        // is guarded; the optional user-prompt append below stays best-effort (`|| true`).
+        // moadim preamble. Abort instead, recording the reason in the workbench's agent.log
+        // (already created via mkdir) and on stderr. Only this primary write is guarded; the
+        // optional user-prompt append below stays best-effort (`|| true`).
         format!(
-            r#"printf '%b\n\n%b%s\n\n**Run date**: %s\n**Timezone**: %s\n' {} {} {} "$(date)" "$(date +%Z)" > {dest} || {{ echo "moadim: failed to write agent instructions disclosure; aborting launch" | tee -a "$WB/agent.log" >&2; exit 1; }}"#,
-            header, disclosure, title
+            r#"printf '%b\n\n**Run date**: %s\n**Timezone**: %s\n' {} "$(date)" "$(date +%Z)" > {dest} || {{ echo "moadim: failed to write agent instructions preamble; aborting launch" | tee -a "$WB/agent.log" >&2; exit 1; }}"#,
+            header
         ),
         format!(
             r"[ -f {uq} ] && {{ printf '\n---\n\n'; cat {uq}; printf '\n'; }} >> {dest} || true",

--- a/src/routines/command_tests.rs
+++ b/src/routines/command_tests.rs
@@ -112,12 +112,12 @@ fn build_routine_command_extends_path_rather_than_replacing_it() {
 }
 
 #[test]
-fn build_routine_command_fail_fasts_when_disclosure_write_fails() {
-    // The routine-origin disclosure write into `$WB/CLAUDE.md` must fail-fast, mirroring the
+fn build_routine_command_writes_daemon_preamble_before_prompt_copy() {
+    // The daemon-managed instructions write into `$WB/CLAUDE.md` must fail-fast, mirroring the
     // `cp prompt.md` guard: a failed redirect (read-only/full $HOME, unwritable $WB, disk-quota)
     // must abort the launch before the prompt copy, setup, and tmux session — otherwise the agent
-    // would run with no disclosure mandate.
-    let routine = make_routine("Cmd Disclosure Guard Routine");
+    // would run with no daemon-managed preamble.
+    let routine = make_routine("Cmd Preamble Guard Routine");
     let agent = AgentCommand {
         command: "claude".to_string(),
         args: vec![],
@@ -130,16 +130,16 @@ fn build_routine_command_fail_fasts_when_disclosure_write_fails() {
     let write = cmd.find(r#"> "$WB/CLAUDE.md" || {"#).unwrap();
     assert!(
         cmd.contains(
-            r#"> "$WB/CLAUDE.md" || { echo "moadim: failed to write agent instructions disclosure; aborting launch" | tee -a "$WB/agent.log" >&2; exit 1; }"#
+            r#"> "$WB/CLAUDE.md" || { echo "moadim: failed to write agent instructions preamble; aborting launch" | tee -a "$WB/agent.log" >&2; exit 1; }"#
         ),
-        "expected the CLAUDE.md disclosure write to fail-fast in: {cmd}"
+        "expected the CLAUDE.md preamble write to fail-fast in: {cmd}"
     );
 
-    // The guard must precede the prompt copy, so a failed disclosure write never reaches it.
+    // The guard must precede the prompt copy, so a failed preamble write never reaches it.
     let copy = cmd.find("/prompt.md\"").unwrap();
     assert!(
         write < copy,
-        "disclosure-write guard must precede the prompt copy"
+        "preamble-write guard must precede the prompt copy"
     );
 
     // The best-effort user-prompt append stays best-effort (`|| true`), not aborting.

--- a/src/routines/handlers.rs
+++ b/src/routines/handlers.rs
@@ -18,8 +18,8 @@ use super::service::{
 };
 
 /// `GET /routines/{id}/prompt-preview` — the exact prompt body a run would receive, computed
-/// in-memory with no workbench, `prompt.md` write, or agent launch (issue #391). Does not include
-/// the routine-origin disclosure written separately to `CLAUDE.md` at trigger time.
+/// in-memory with no workbench, `prompt.md` write, or agent launch (issue #391). Includes the
+/// routine-origin disclosure because it now lives in the composed prompt.
 #[utoipa::path(get, path = "/routines/{id}/prompt-preview",
     params(("id" = String, Path, description = "Routine UUID")),
     responses((status = 200, description = "Composed prompt body as plain text"), (status = 404, description = "Not found")))]

--- a/src/routines/mod_tests.rs
+++ b/src/routines/mod_tests.rs
@@ -239,17 +239,6 @@ fn build_routine_command_writes_claude_md() {
     );
     // dynamic date/timezone appended at run time
     assert!(cmd.contains("$(date)"), "run-time date expansion missing");
-    // routine-origin disclosure section, naming the routine, written into the moadim prompt
-    assert!(
-        cmd.contains("Routine origin disclosure"),
-        "routine-origin disclosure section missing"
-    );
-    assert!(cmd.contains("Routine name: "), "routine-name label missing");
-    // the routine title is injected as a printf %s argument after the disclosure body
-    assert!(
-        cmd.contains("'My Routine'"),
-        "routine title not injected into CLAUDE.md write"
-    );
     // user prompt appended if file exists
     assert!(
         cmd.contains("user_prompt.md"),
@@ -260,15 +249,22 @@ fn build_routine_command_writes_claude_md() {
     let prompt_md_at = cmd.find("cp ").expect("cp in cmd");
     assert!(
         claude_md_at < prompt_md_at,
-        "CLAUDE.md write should precede cp prompt.md"
+        "CLAUDE.md write should precede prompt copy"
     );
 }
 
 #[test]
+fn compose_prompt_writes_routine_origin_disclosure() {
+    let routine = make_routine("rid");
+    let prompt = compose_prompt(&routine);
+    assert!(prompt.contains("Routine origin disclosure"));
+    assert!(prompt.contains("Routine name: My Routine"));
+}
+
+#[test]
 fn build_routine_command_writes_disclosure_to_codex_instructions_file() {
-    // Codex reads project instructions from AGENTS.md, not CLAUDE.md. The moadim-managed system
-    // prompt and routine-origin disclosure must land in the file the selected agent actually reads,
-    // otherwise a codex-backed routine never sees the mandatory disclosure.
+    // Codex reads project instructions from AGENTS.md, not CLAUDE.md. The daemon-managed system
+    // prompt must land in the file the selected agent actually reads.
     let routine = make_routine("rid");
     let agent = AgentCommand {
         command: "codex".to_string(),
@@ -277,7 +273,7 @@ fn build_routine_command_writes_disclosure_to_codex_instructions_file() {
         setup: None,
     };
     let cmd = build_routine_command(&routine, &agent, TriggerSource::Scheduled);
-    // The disclosure is written to AGENTS.md, the file Codex reads...
+    // The prompt file is still written to AGENTS.md, the file Codex reads...
     assert!(
         cmd.contains(r#"> "$WB/AGENTS.md""#),
         "moadim prompt should be written to AGENTS.md for the codex agent"
@@ -286,12 +282,11 @@ fn build_routine_command_writes_disclosure_to_codex_instructions_file() {
         cmd.contains(r#">> "$WB/AGENTS.md""#),
         "user prompt should be appended to AGENTS.md for the codex agent"
     );
-    // ...and carries the same disclosure payload as the CLAUDE.md path.
+    // ...and the disclosure now lives in the compiled prompt body.
     assert!(
-        cmd.contains("Routine origin disclosure"),
-        "routine-origin disclosure section missing for codex"
+        compose_prompt(&routine).contains("Routine origin disclosure"),
+        "routine-origin disclosure section missing from compiled prompt"
     );
-    assert!(cmd.contains("'My Routine'"), "routine title not injected");
     // CLAUDE.md is not written for a codex routine: Codex would never read it.
     assert!(
         !cmd.contains("CLAUDE.md"),

--- a/src/routines/service_run_files.rs
+++ b/src/routines/service_run_files.rs
@@ -62,8 +62,7 @@ pub fn svc_run_summary(
 /// workbench, writing `prompt.md`, or launching an agent (issue #391). Mirrors `svc_get`'s lookup,
 /// but returns the *derived* prompt body instead of the stored routine fields.
 ///
-/// Does not include the routine-origin disclosure written separately to `CLAUDE.md` at trigger
-/// time — that isn't part of [`compose_prompt`], so it isn't part of this preview either.
+/// Includes the routine-origin disclosure because it is now part of [`compose_prompt`].
 pub fn svc_get_prompt_preview(store: &RoutineStore, id: &str) -> Result<String, AppError> {
     let routine = store
         .lock_recover()

--- a/src/routines/service_validate.rs
+++ b/src/routines/service_validate.rs
@@ -126,8 +126,8 @@ pub(super) const MAX_TITLE_LEN: usize = 200;
 /// content-checked. Two concrete failures follow from a blank or punctuation-only
 /// title (issue #226):
 ///
-/// 1. The moadim routine-origin disclosure breaks — `system_prompt_stmts` writes
-///    `Routine name: <title>` into every workbench `CLAUDE.md`, so an empty title
+/// 1. The moadim routine-origin disclosure breaks — `compose_prompt` writes
+///    `Routine name: <title>` into the compiled prompt body, so an empty title
 ///    yields a nameless disclosure the agent cannot satisfy.
 /// 2. `slugify` maps any title with no ASCII-alphanumerics (`""`, `"   "`, `"!!!"`)
 ///    to the constant `"routine"`, so the routine silently takes a slug the user


### PR DESCRIPTION
Closes #1342.

Moves the routine-origin disclosure out of runtime CLAUDE.md/AGENTS.md injection and into the compiled prompt body, so it shows up in `prompts/prompt.compiled.local.md` and prompt previews.

Also updates the runtime instructions write to keep only the daemon-managed preamble + user prompt.

Tests:
- cargo test --quiet -- compose_prompt_writes_routine_origin_disclosure
- cargo test --quiet -- build_routine_command_writes_daemon_preamble_before_prompt_copy
- cargo test --quiet -- build_routine_command_writes_disclosure_to_codex_instructions_file
- cargo test --quiet -- openapi::openapi_tests::committed_spec_is_current