### PR TITLE
fix(client): patch high-severity js-yaml audit finding via scoped pnpm override

### DIFF
--- a/.changeset/pin-redocly-js-yaml-patch.md
+++ b/.changeset/pin-redocly-js-yaml-patch.md
@@ -1,0 +1,17 @@
+---
+"moadim": patch
+---
+
+fix(client): pin the `@redocly/openapi-core` → `js-yaml` transitive dependency to a patched version
+
+`openapi-typescript` (used by `client`'s `generate:api` script, which `build`/`typecheck`/`lint`/`test`
+all run through their `pre*` hooks) pulls in `@redocly/openapi-core@1.34.17`, which resolves
+`js-yaml@4.2.0` — a version affected by [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m)
+(quadratic CPU consumption via YAML merge-key chains), flagged `high` by `pnpm audit`.
+
+Adds a scoped `pnpm.overrides` entry (`"@redocly/openapi-core>js-yaml": ">=4.3.0"`) rather than a
+blanket `js-yaml` override, since the tree also carries `js-yaml@3.15.0` via `@changesets/cli`'s
+`read-yaml-file` dependency — a global override would force that 3.x consumer onto an incompatible
+4.x API. `@redocly/openapi-core` itself already declares `js-yaml: ^4.2.0`, so 4.3.0 satisfies its
+own declared range; codegen output (`schema.gen.ts`), `pnpm --filter client typecheck`, `lint`, and
+`test` (347 tests) are all unchanged. `pnpm audit` now reports no known vulnerabilities.

--- a/package.json
+++ b/package.json
@@ -10,5 +10,10 @@
   "devDependencies": {
     "@changesets/cli": "^2.31.0",
     "block-no-verify": "^1.3.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "@redocly/openapi-core>js-yaml": ">=4.3.0"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@redocly/openapi-core>js-yaml': '>=4.3.0'
+
 importers:
 
   .:
@@ -1346,10 +1349,6 @@ packages:
     resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
-    hasBin: true
-
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
@@ -2488,7 +2487,7 @@ snapshots:
       colorette: 1.4.0
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       js-levenshtein: 1.1.6
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       minimatch: 5.1.9
       pluralize: 8.0.0
       yaml-ast-parser: 0.0.43
@@ -3252,10 +3251,6 @@ snapshots:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
-
-  js-yaml@4.2.0:
-    dependencies:
-      argparse: 2.0.1
 
   js-yaml@4.3.0:
     dependencies:


### PR DESCRIPTION
## What

`pnpm audit` reports one **high**-severity finding: [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) (quadratic CPU consumption via YAML merge-key chains) in `js-yaml@4.2.0`, pulled in via `client > openapi-typescript > @redocly/openapi-core > js-yaml`.

Adds a scoped `pnpm.overrides` entry in the root `package.json`:

```json
"pnpm": {
  "overrides": {
    "@redocly/openapi-core>js-yaml": ">=4.3.0"
  }
}
```

instead of a blanket `js-yaml` override, since the tree also carries `js-yaml@3.15.0` via `@changesets/cli`'s `read-yaml-file` dependency — a global override would force that unrelated 3.x consumer onto an incompatible 4.x API for no reason. `@redocly/openapi-core` already declares `js-yaml: ^4.2.0` itself, so resolving to `4.3.0` satisfies its own declared range — this is a patch-version resolution bump, not a forced major jump.

## Why

`openapi-typescript` backs `client`'s `generate:api` script, which every one of `build`/`typecheck`/`lint`/`test` runs through its `pre*` hook (and which the pre-push hook and CI both exercise on every push). A known-vulnerable transitive dependency sitting in that path is worth closing even though it's dev-tooling-only (not shipped in the built client bundle) — `pnpm audit` is part of the repo's overall supply-chain hygiene, and no open PR currently addresses this specific finding (the other open dependency PRs bump `vite`, `typescript`, `zod`, `@vitejs/plugin-react`, and the npm/codeql-action groups — none touch `openapi-typescript`/`@redocly/openapi-core`/`js-yaml`).

## Verification

- `pnpm audit` — before: 1 high-severity finding; after: **no known vulnerabilities found**.
- `pnpm why js-yaml --recursive` confirms only `3.15.0` (unaffected, untouched) and `4.3.0` (patched) resolve now — no more `4.2.0`.
- `pnpm --filter client typecheck` — clean, codegen output (`schema.gen.ts`) byte-identical.
- `pnpm --filter client lint` — clean.
- `pnpm --filter client test` — 347/347 passing.
- No `src/` changes, so the Rust side (`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo llvm-cov --fail-under-lines 100`, `linecheck`) is unaffected — verified all green on `main` before this change.
- Added `.changeset/pin-redocly-js-yaml-patch.md`.

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim. The repo owner can tag/ping @tupe12334 if needed.