### PR TITLE
chore: add missing changeset for #1314

### DIFF
--- a/.changeset/bump-jiff-syn-patch.md
+++ b/.changeset/bump-jiff-syn-patch.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Bump `jiff`, `jiff-static` (0.2.33 → 0.2.34), and `syn` (3.0.0 → 3.0.2) to their latest compatible patch releases (#1314).


### PR DESCRIPTION
## Why

PR #1314 (chore: bump jiff, jiff-static, syn to latest patch) merged without a changeset. That PR's own description argued `Cargo.lock`-only changes aren't covered by the `unreleased-entry` gate (scoped to `src/**`/`client/**`), but comparable manual Cargo dependency bumps in this repo — `.changeset/bump-clap-tokio-patch.md` and `.changeset/bump-cron-union-1.0.2.md` — each got their own changeset, so this backfills the same treatment for consistency.

## What

Adds `.changeset/bump-jiff-syn-patch.md` (patch bump for `moadim`) summarizing the version changes from #1314:

- `jiff` 0.2.33 → 0.2.34
- `jiff-static` 0.2.33 → 0.2.34
- `syn` 3.0.0 → 3.0.2

No other files touched — no CHANGELOG.md changes, no `changeset version`/`publish` run.