### PR TITLE
chore(lint): enable clippy::missing_panics_doc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -391,3 +391,10 @@ ignore_without_reason = "deny"
 # used for `mem_forget`/`clippy::zombie_processes` above. The rest of the codebase is already
 # clean, so `deny` locks that in.
 verbose_file_reads = "deny"
+# Require a `# Panics` doc section on any function that can transitively panic (calls `.unwrap()`/
+# `.expect()`, or a bare `panic!()`/`assert!()`), so a caller can tell without reading the body.
+# `unwrap_used`/`expect_used`/`panic` above already ban all three outside tests and the handful of
+# documented, `#[allow]`-scoped exemptions for a genuinely unavoidable panic — this closes the loop
+# on that convention: an exemption must now also surface in the function's public docs, not just a
+# comment next to the call site. The codebase is already clean, so `deny` locks that in.
+missing_panics_doc = "deny"


### PR DESCRIPTION
## Why

This crate already denies `unwrap_used`, `expect_used`, and `panic` outside
tests (see the rationale comments in `Cargo.toml`), with a small number of
genuinely-unavoidable panics allowed through a documented, scoped
`#[allow(clippy::expect_used, reason = "...")]` at the call site. That
justification currently lives only as an inline comment next to the call —
invisible to a caller who reads the function's public docs but never opens
its body.

`clippy::missing_panics_doc` closes that gap: it requires a `# Panics`
section on any function that can transitively `.unwrap()`/`.expect()`/
`panic!()`/`assert!()`, so the same discipline this repo already applies to
lint suppressions (`allow_attributes_without_reason`) and skipped tests
(`ignore_without_reason`) also covers panic exemptions, surfaced where a
caller actually looks.

## What

- Add `missing_panics_doc = "deny"` to `[lints.clippy]` in `Cargo.toml`, with
  a rationale comment matching the style of the existing entries.

## Verification

- `cargo clippy --all-targets -- -D warnings` — clean, zero violations (the
  codebase has no `pub fn` that transitively panics outside the already-
  documented exemptions, so this is a pure lock-in, no code changes needed).
- `cargo fmt --check` — clean.
- `cargo test` — 1145 passed, 0 failed.
- `cargo doc --no-deps` — succeeds.

No changeset added: this PR only touches `Cargo.toml` (root lint config),
not `src/**` or `client/**`.