### PR TITLE
chore(lint): enable clippy::missing_errors_doc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -398,3 +398,9 @@ verbose_file_reads = "deny"
 # on that convention: an exemption must now also surface in the function's public docs, not just a
 # comment next to the call site. The codebase is already clean, so `deny` locks that in.
 missing_panics_doc = "deny"
+# Require an `# Errors` doc section on any function returning `Result` explaining when it errors,
+# the `Err`-side companion to `missing_panics_doc` above. A caller deciding whether to `?` a result
+# or handle it inline should be able to tell what can go wrong from the signature's docs alone,
+# without reading the body (or every function it transitively calls). The codebase is already
+# clean, so `deny` locks that in.
+missing_errors_doc = "deny"


### PR DESCRIPTION
## Why

`missing_panics_doc` (#1352) requires a `# Panics` section on any function
that can transitively panic. `missing_errors_doc` is the same discipline
for the other side of the coin: it requires an `# Errors` section on any
function returning `Result`, explaining when/why it errors. Without it, a
caller deciding whether to propagate or handle a `Result` has to read the
function's body (and everything it transitively calls) to find out what can
go wrong — the docs alone don't say.

## What

- Add `missing_errors_doc = "deny"` to `[lints.clippy]` in `Cargo.toml`,
  with a rationale comment matching the existing entries' style.

## Verification

- `cargo clippy --all-targets -- -D warnings` — clean, zero violations
  (pure lock-in, no code changes needed).
- `cargo fmt --check` — clean.
- `cargo test` — 1145 passed, 0 failed.
- `cargo doc --workspace --no-deps --document-private-items` (RUSTDOCFLAGS=-D
  warnings, matching `.github/workflows/doc.yml`) — clean.

No changeset added: this PR only touches `Cargo.toml` (root lint config),
not `src/**` or `client/**`, matching #1352's precedent.