### PR TITLE
chore(lint): enable clippy::suspicious_operation_groupings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -404,3 +404,9 @@ missing_panics_doc = "deny"
 # without reading the body (or every function it transitively calls). The codebase is already
 # clean, so `deny` locks that in.
 missing_errors_doc = "deny"
+# Reject a chain of similar binary-op expressions (e.g. `a.x + a.x + a.y`) where one operand looks
+# like a copy-paste that should have referenced a different variable/field — the same bug class
+# `redundant_clone` above guards elsewhere in the file, just for arithmetic/comparison groupings
+# instead of clones. This is a real correctness lint (catches silent logic bugs), not a style
+# preference. The codebase is already clean, so `deny` locks that in.
+suspicious_operation_groupings = "deny"


### PR DESCRIPTION
## Why

This codebase already locks in a series of individually-reasoned clippy
lints beyond `clippy::all` (`redundant_clone`, `missing_panics_doc`,
`missing_errors_doc`, ...), each denying a real bug class the moment the
tree is clean for it. `suspicious_operation_groupings` is the next one:
it flags a chain of similar binary-op expressions (e.g. `a.x + a.x + a.y`,
or `a.x < a.y && a.x < a.z` with a copy-pasted-but-wrong operand) where one
operand looks like it should reference a different variable/field. It's
the same silent-copy-paste-bug class `redundant_clone` already guards
elsewhere in this list — arithmetic/comparison groupings instead of
clones — and unlike most of this crate's other lints it's a correctness
lint, not a style preference.

## What

- Add `suspicious_operation_groupings = "deny"` to `[lints.clippy]` in
  `Cargo.toml`, with a rationale comment matching the existing entries'
  style.

## Verification

- `cargo clippy --all-targets -- -D warnings` — clean, zero violations
  (pure lock-in, no code changes needed).
- `cargo fmt --check` — clean.
- `cargo test` — 1145 passed, 0 failed.
- `cargo doc --workspace --no-deps --document-private-items`
  (`RUSTDOCFLAGS=-D warnings`, matching `.github/workflows/doc.yml`) —
  clean.

No changeset added: this PR only touches `Cargo.toml` (root lint
config), not `src/` or `client/`, matching #1352/#1353's precedent (the
`unreleased-entry` changelog gate only fires on `src/`/`client/` diffs).