### PR TITLE
chore(lint): enable clippy::single_char_pattern

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -404,3 +404,10 @@ missing_panics_doc = "deny"
 # without reading the body (or every function it transitively calls). The codebase is already
 # clean, so `deny` locks that in.
 missing_errors_doc = "deny"
+# Reject a single-character string literal used as a `.replace`/`.split`/`.trim_matches`-style
+# pattern (e.g. `"o"`) in favour of the equivalent `char` literal (`'o'`) — the `char` pattern
+# skips the generic multi-byte substring-search machinery `&str` patterns go through, so it's a
+# free micro-optimization alongside this file's other already-enabled perf lints
+# (`cloned_instead_of_copied`, `format_push_string`, `format_collect`). The codebase is already
+# clean, so `deny` locks that in.
+single_char_pattern = "deny"


### PR DESCRIPTION
## Why

This continues the pattern from #1352 (`missing_panics_doc`) and #1353
(`missing_errors_doc`): the `[lints.clippy]` block in `Cargo.toml` has been
growing one deliberately-chosen lint at a time, each locking in an invariant
the codebase already satisfies so it can't silently regress.

`clippy::single_char_pattern` flags a single-character string literal used
as a `.replace`/`.split`/`.trim_matches`/`.starts_with`-style pattern (e.g.
`"o"`) in favor of the equivalent `char` literal (`'o'`). A `char` pattern
is matched directly, while a `&str` pattern (even one byte long) goes
through the generic multi-byte substring-search machinery — so the `char`
form is a free micro-optimization with identical behavior. This sits right
next to this file's other already-enabled perf-driven lints
(`cloned_instead_of_copied`, `format_push_string`, `format_collect`).

## What

- Add `single_char_pattern = "deny"` to `[lints.clippy]` in `Cargo.toml`,
  with a comment in the same style as the surrounding entries.

## Verification

The codebase has zero violations today, so this is a pure lock-in — no
source changes needed. Ran the full local gate the pre-push hook enforces:

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean, 0 new warnings
- `cargo test` — 1145 passed, 0 failed
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% lines (unaffected, config-only change)
- `linecheck --max-lines 500 $(find src -name '*.rs')` — clean (unaffected, config-only change)

Only `Cargo.toml` changed (no `src/`/`client/` diff), so per this repo's own
changelog gate no `.changeset/*.md` file is required — matching the
precedent set by #1352/#1353, which made the same kind of change with no
changeset.

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.