### PR TITLE
chore(deps): bump libc and hyper to their latest compatible patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,9 +852,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1091,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.187"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "a7743783ea728ef5c31194c6590797eed286449b4a4e87d626d8a51f0a94e732"
 
 [[package]]
 name = "libredox"


### PR DESCRIPTION
## Why

`cargo update --dry-run` shows two patch releases within the ranges already declared in `Cargo.toml`:

- `libc` 0.2.186 → 0.2.187 (direct dep, `Cargo.toml` pins `libc = "0.2"`)
- `hyper` 1.10.1 → 1.11.0 (transitive via `axum`/`hyper-util`)

None of the 7 currently-open dependency-bump PRs touch `Cargo.lock`/Rust crates — they're all npm-group (`client/`) or GitHub Actions bumps.

## What

- `cargo update -p libc -p hyper`. Lockfile-only refresh, no `Cargo.toml`/`src/`/`client/` diff.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean, 0 new warnings
- `cargo test` — 1145 passed, 0 failed
- `cargo build --all-targets` — clean

Only `Cargo.lock` changed, so per this repo's changelog gate (and the precedent set by #1352/#1353/#1355) no `.changeset/*.md` file is required.

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.