### PR TITLE
chore(lint): enable clippy::struct_field_names

### DIFF
--- a/.changeset/enable-clippy-struct-field-names.md
+++ b/.changeset/enable-clippy-struct-field-names.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Enable `clippy::struct_field_names` to reject a struct field whose name redundantly repeats the struct's own name. Fixes the one violation this surfaced: `Flag::flag_type` (`src/routines/flags.rs`) renamed to `Flag::category`, matching its doc comment ("Free-text category"). The wire format is unchanged — the field already carries `#[serde(rename = "type")]`. No behavior change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -417,3 +417,10 @@ single_char_pattern = "deny"
 # instead of clones. This is a real correctness lint (catches silent logic bugs), not a style
 # preference. The codebase is already clean, so `deny` locks that in.
 suspicious_operation_groupings = "deny"
+# Reject a struct field whose name starts with the struct's own name (e.g. `Flag::flag_type`) —
+# the prefix is redundant at every access site, since the struct name is already spelled out right
+# before the field name (`flag.flag_type` repeats "flag"). Fixed the one violation this surfaced:
+# `Flag::flag_type` (`routines/flags.rs`) renamed to `Flag::category`, matching its doc comment
+# ("Free-text category"). The wire format is unchanged — the field already carries
+# `#[serde(rename = "type")]`. The rest of the codebase is already clean, so `deny` locks that in.
+struct_field_names = "deny"

--- a/src/routines/command_prompt.rs
+++ b/src/routines/command_prompt.rs
@@ -65,7 +65,7 @@ pub(crate) fn compose_prompt(routine: &Routine) -> String {
             let _ = writeln!(
                 body,
                 "- **{}** ({scope}): {}",
-                flag.flag_type, flag.description
+                flag.category, flag.description
             );
         }
     }

--- a/src/routines/flags.rs
+++ b/src/routines/flags.rs
@@ -51,7 +51,7 @@ pub struct Flag {
     pub filename: String,
     /// Free-text category, e.g. `"bug"`, `"gap"`, `"edge_case"`, `"question"`.
     #[serde(rename = "type")]
-    pub flag_type: String,
+    pub category: String,
     /// Free-text body describing what's unclear.
     pub description: String,
     /// Whether this flag is committed (general) or machine-local.
@@ -139,7 +139,7 @@ pub fn create_flag(
 
     Ok(Flag {
         filename,
-        flag_type: flag_type.to_string(),
+        category: flag_type.to_string(),
         description: description.to_string(),
         scope,
         created_at,
@@ -166,7 +166,7 @@ pub fn list_flags(slug: &str) -> Vec<Flag> {
             let description = parts.next().unwrap_or_default().trim().to_string();
             Some(Flag {
                 filename,
-                flag_type,
+                category: flag_type,
                 description,
                 scope,
                 created_at,

--- a/src/routines/flags_tests.rs
+++ b/src/routines/flags_tests.rs
@@ -41,7 +41,7 @@ fn create_flag_writes_general_file_with_md_suffix() {
         .extension()
         .is_some_and(|ext| ext.eq_ignore_ascii_case("md")));
     assert!(!flag.filename.ends_with(".local.md"));
-    assert_eq!(flag.flag_type, "bug");
+    assert_eq!(flag.category, "bug");
     assert_eq!(flag.description, "the thing is broken");
     assert_eq!(flag.scope, FlagScope::General);
     assert!(crate::paths::routine_flags_dir("r1")
@@ -61,7 +61,7 @@ fn create_flag_writes_local_file_with_local_md_suffix() {
 fn create_flag_trims_type_and_description() {
     let _home = TempHome::set();
     let flag = create_flag("r1", "  bug  ", "  broken  ", FlagScope::General).unwrap();
-    assert_eq!(flag.flag_type, "bug");
+    assert_eq!(flag.category, "bug");
     assert_eq!(flag.description, "broken");
 }
 
@@ -76,7 +76,7 @@ fn create_flag_slugifies_type_in_filename_but_keeps_exact_type_in_body() {
     )
     .unwrap();
     assert!(flag.filename.starts_with("missing-auth-check-"));
-    assert_eq!(flag.flag_type, "Missing Auth Check!");
+    assert_eq!(flag.category, "Missing Auth Check!");
 }
 
 #[test]
@@ -190,10 +190,10 @@ fn list_flags_round_trips_type_description_and_scope() {
 
     let flags = list_flags("r1");
     assert_eq!(flags.len(), 2);
-    assert!(flags.iter().any(|flag| flag.flag_type == "bug"
+    assert!(flags.iter().any(|flag| flag.category == "bug"
         && flag.description == "broken thing"
         && flag.scope == FlagScope::General));
-    assert!(flags.iter().any(|flag| flag.flag_type == "gap"
+    assert!(flags.iter().any(|flag| flag.category == "gap"
         && flag.description == "missing thing"
         && flag.scope == FlagScope::Local));
 }
@@ -267,7 +267,7 @@ fn list_flags_defaults_missing_description_to_empty() {
 
     let flags = list_flags("r1");
     assert_eq!(flags.len(), 1);
-    assert_eq!(flags[0].flag_type, "bug");
+    assert_eq!(flags[0].category, "bug");
     assert_eq!(flags[0].description, "");
 }
 

--- a/src/routines/service_flag_tests.rs
+++ b/src/routines/service_flag_tests.rs
@@ -103,7 +103,7 @@ fn svc_create_flag_persists_and_refreshes_prompt() {
     let id = created.routine.id;
 
     let flag = svc_create_flag(&store, &id, "bug", "broken thing", "general").unwrap();
-    assert_eq!(flag.flag_type, "bug");
+    assert_eq!(flag.category, "bug");
     assert_eq!(flag.description, "broken thing");
 
     // prompt.compiled.local.md is refreshed with the new open flag so the next run sees it.


### PR DESCRIPTION
## What

Enables `clippy::struct_field_names`, continuing this repo's incremental clippy-lint-enablement series (see recent `chore(lint): enable clippy::*` PRs).

The lint rejects a struct field whose name redundantly repeats the struct's own name — the prefix adds nothing at any access site, since the struct name is already spelled out right before it (`flag.flag_type` repeats "flag").

## Why

Fixes the one violation this surfaced: `Flag::flag_type` in `src/routines/flags.rs`, renamed to `Flag::category` (matching its existing doc comment, "Free-text category"). All internal read/construction sites (`command_prompt.rs`, `flags.rs`, and the `flags`/`service_flag` test modules) are updated to match.

The wire format is unchanged — the field already carries `#[serde(rename = "type")]`, so JSON/OpenAPI output is identical. No behavior change.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo test` — 1145 passed, 0 failed
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — both touched files remain at 100% line coverage; overall total unchanged from the pre-existing main baseline (99.47%, unrelated pre-existing gaps this PR doesn't touch)