### PR TITLE
chore(lint): enable clippy::implicit_clone

### DIFF
--- a/.changeset/enable-clippy-implicit-clone.md
+++ b/.changeset/enable-clippy-implicit-clone.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Enable `clippy::implicit_clone` to reject an indirect `.to_string()`/`.to_owned()`-style clone of a value that's already the target type, in favour of calling `.clone()` directly. The codebase already had zero violations, so this is a lock-in with no behavior change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -424,3 +424,9 @@ suspicious_operation_groupings = "deny"
 # ("Free-text category"). The wire format is unchanged — the field already carries
 # `#[serde(rename = "type")]`. The rest of the codebase is already clean, so `deny` locks that in.
 struct_field_names = "deny"
+# Reject `.to_string()`/`.to_owned()`-style conversions on a value that's already the target type
+# (e.g. cloning a `String` via `.to_string()` instead of `.clone()`, or a `Vec` via `.to_vec()`
+# instead of `.clone()`) — the indirect spelling obscures that it's a plain clone and, for some
+# receiver types, is measurably slower than calling `Clone::clone` directly. The codebase is
+# already clean, so `deny` locks that in.
+implicit_clone = "deny"


### PR DESCRIPTION
## Why

Continues this repo's incremental clippy-lint-enablement convention (see `struct_field_names`, `missing_errors_doc`, `missing_panics_doc`, `suspicious_operation_groupings`, `single_char_pattern` — all landed the same way).

`clippy::implicit_clone` rejects an indirect `.to_string()`/`.to_owned()`-style clone of a value that's already the target type (e.g. cloning a `String` via `.to_string()` instead of `.clone()`), in favour of calling `.clone()` directly. The indirect spelling obscures that it's a plain clone and, for some receiver types, is measurably slower than `Clone::clone`.

## What

- Add `implicit_clone = "deny"` to `[lints.clippy]` in `Cargo.toml`.
- The codebase already had **zero violations** — this is a pure lock-in, no behavior change.

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test` — 1145 passed, 0 failed