### PR TITLE
chore(lint): enable clippy::inefficient_to_string

### DIFF
--- a/.changeset/enable-clippy-inefficient-to-string.md
+++ b/.changeset/enable-clippy-inefficient-to-string.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Enable `clippy::inefficient_to_string` to reject calling `.to_string()` on a `&&T` (e.g. `&&str`) in favour of calling it on the dereferenced `&T` directly, avoiding an unnecessary extra indirection through `Display`/`ToString`. The codebase already had zero violations, so this is a lock-in with no behavior change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -430,3 +430,9 @@ struct_field_names = "deny"
 # receiver types, is measurably slower than calling `Clone::clone` directly. The codebase is
 # already clean, so `deny` locks that in.
 implicit_clone = "deny"
+# Reject `.to_string()` on a `&&T` (a reference to a reference — e.g. iterating `&Vec<&str>`
+# yields `&&str`) in favour of calling `.to_string()` on the dereferenced `&T` directly. The
+# extra `&` forces an unnecessary auto-deref through `Display`/`ToString` on every call; spelling
+# it on the inner reference is the same result without that indirection. The codebase is already
+# clean, so `deny` locks that in.
+inefficient_to_string = "deny"


### PR DESCRIPTION
## Why

Continues this repo's incremental clippy-lint-enablement convention (see `struct_field_names`, `missing_errors_doc`, `missing_panics_doc`, `suspicious_operation_groupings`, `single_char_pattern`, `implicit_clone` — all landed the same way).

`clippy::inefficient_to_string` rejects calling `.to_string()` on a `&&T` (a reference to a reference, e.g. `&&str` from iterating `&Vec<&str>`) in favour of calling `.to_string()` on the dereferenced `&T` directly. The `&&T` spelling forces an extra, unnecessary auto-deref through `Display`/`ToString` on every call site.

## What

- Add `inefficient_to_string = "deny"` to `[lints.clippy]` in `Cargo.toml`.
- The codebase already had **zero violations** — this is a pure lock-in, no behavior change.

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test` — 1145 passed, 0 failed

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.