### PR TITLE
test(client): cover the ViewToggle list/calendar/day switcher

### DIFF
--- a/.changeset/cover-view-toggle.md
+++ b/.changeset/cover-view-toggle.md
@@ -1,0 +1,16 @@
+---
+"moadim": patch
+---
+
+test(client): add coverage for the routines-page `ViewToggle` (list/calendar/day switcher)
+
+`ViewToggle.tsx` had zero test coverage (`pnpm --filter client test:coverage`
+showed 25% statements / 0% branches, lines 16-23 uncovered) even though it
+carries real interactive logic — which button renders active and which view
+value gets passed back on click. Adds `ViewToggle.test.tsx` covering: all
+three buttons render with their labels, only the current view's button gets
+the `active` class, and clicking a button calls `onSetView` with that
+button's view (including re-clicking the already-active one, which is a
+no-op passthrough rather than a toggle-off like `StatsBar`'s facets).
+
+No behavior change — test-only. `ViewToggle.tsx` is now at 100% coverage.

--- a/client/src/pages/routines/ViewToggle.test.tsx
+++ b/client/src/pages/routines/ViewToggle.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ViewToggle, type RView } from "./ViewToggle";
+
+function renderToggle(view: RView) {
+  const onSetView = vi.fn();
+  render(<ViewToggle view={view} onSetView={onSetView} />);
+  return onSetView;
+}
+
+describe("ViewToggle", () => {
+  it("renders a button for each view with its label", () => {
+    renderToggle("table");
+    expect(screen.getByText("LIST")).toBeInTheDocument();
+    expect(screen.getByText("CALENDAR")).toBeInTheDocument();
+    expect(screen.getByText("DAY")).toBeInTheDocument();
+  });
+
+  it("marks only the current view's button active", () => {
+    renderToggle("calendar");
+    expect(screen.getByText("LIST")).not.toHaveClass("active");
+    expect(screen.getByText("CALENDAR")).toHaveClass("active");
+    expect(screen.getByText("DAY")).not.toHaveClass("active");
+  });
+
+  it("calls onSetView with the clicked view", () => {
+    const onSetView = renderToggle("table");
+    fireEvent.click(screen.getByText("DAY"));
+    expect(onSetView).toHaveBeenCalledWith("day");
+  });
+
+  it("still calls onSetView when clicking the already-active view", () => {
+    // Unlike StatsBar's toggle-off facets, ViewToggle has no "none" state — re-clicking
+    // the active view is a no-op for the caller to handle, not something this component
+    // should suppress.
+    const onSetView = renderToggle("table");
+    fireEvent.click(screen.getByText("LIST"));
+    expect(onSetView).toHaveBeenCalledWith("table");
+  });
+});


### PR DESCRIPTION
## Why

`client/`'s test suite (`pnpm --filter client test`) passes today, but it
isn't gated on coverage — running `pnpm --filter client test:coverage`
surfaces plenty of untested components, `ViewToggle.tsx` among them (was
25% statements / 0% branches, lines 16-23 uncovered). It's small but not
trivial: it decides which of the three view buttons gets the `active`
class and what value is passed back to the caller on click — exactly the
kind of interaction bug a refactor could silently break with nothing
catching it.

All the mechanical gates (`cargo fmt --check`, `cargo clippy --all-targets
-- -D warnings`, `cargo test`, `cargo llvm-cov --fail-under-lines 100`,
`linecheck`, `pnpm --filter client typecheck/lint/test`) already pass clean
on `main` as of this PR, so this isn't fixing a broken gate — it's closing
a real, verified coverage gap the gates don't currently enforce.

## What

Adds `client/src/pages/routines/ViewToggle.test.tsx`, mirroring the shape
of the existing `StatsBar.test.tsx`:
- all three buttons (LIST/CALENDAR/DAY) render with their labels
- only the current view's button carries the `active` class
- clicking a button calls `onSetView` with that button's view
- re-clicking the already-active view still calls back (no implicit
  toggle-off, unlike `StatsBar`'s facets — documented in the test)

No behavior change — test-only. `ViewToggle.tsx` is now at 100% coverage.
Includes a changeset (`.changeset/cover-view-toggle.md`, `"moadim": patch`,
matching this repo's existing convention for test-only changes).

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 1145 passed
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% lines, passes
- `linecheck --max-lines 500` over `src/` — passes
- `pnpm --filter client typecheck` — clean
- `pnpm --filter client lint` — clean
- `pnpm --filter client test` — 367 passed (was 363)
- Ran the full `.githooks/pre-push` hook end-to-end locally — all green, including the changeset check

🤖 Generated with [Claude Code](https://claude.com/claude-code)