### PR TITLE
chore(lint): enable clippy::cast_sign_loss

### DIFF
--- a/.changeset/enable-clippy-cast-sign-loss.md
+++ b/.changeset/enable-clippy-cast-sign-loss.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Enable `clippy::cast_sign_loss` to reject an `as`-cast from a signed integer to an unsigned one, which silently wraps a negative value into a huge positive one instead of erroring. Fixes the 2 violations this surfaced — a Unix-timestamp `i64` cast to the `u64` seconds this crate stores timestamps as, in `logging::format_json_line` and `ical::feed` — by converting to `u64::try_from(...)` instead.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -436,3 +436,13 @@ implicit_clone = "deny"
 # it on the inner reference is the same result without that indirection. The codebase is already
 # clean, so `deny` locks that in.
 inefficient_to_string = "deny"
+# Reject an `as`-cast from a signed integer to an unsigned one (e.g. `i64 as u64`), which silently
+# wraps a negative value into a huge positive one instead of erroring. Fixed the 2 violations this
+# surfaced, both a Unix-timestamp `i64` (`DateTime::timestamp()`) cast to the `u64` seconds this
+# crate's timestamps are stored as: `logging::format_json_line`'s `ts_local` field and
+# `ical::feed`'s snooze-deadline comparison. Neither value can go negative in practice (both come
+# from "now" or a future cron fire, always post-1970), but the cast gave no indication of that
+# invariant to a reader — converted to `u64::try_from(...)`, clamped to `0`/`false` on the
+# theoretical negative case instead of silently wrapping. No behavior change. The codebase is
+# otherwise already clean, so `deny` locks that in.
+cast_sign_loss = "deny"

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -35,7 +35,7 @@ fn format_json_line(record: &log::Record<'_>) -> String {
     let now = chrono::Utc::now();
     serde_json::json!({
         "ts": now.to_rfc3339(),
-        "ts_local": crate::utils::time::format_local(now.timestamp() as u64),
+        "ts_local": crate::utils::time::format_local(u64::try_from(now.timestamp()).unwrap_or(0)),
         "level": record.level().to_string(),
         "target": record.target(),
         "msg": record.args().to_string(),

--- a/src/routines/ical.rs
+++ b/src/routines/ical.rs
@@ -262,7 +262,10 @@ fn build_ical_core_with_tz(
         let mut fires = cron
             .iter_after(now)
             .take_while(|dt| *dt <= horizon)
-            .filter(move |dt| snoozed_until.is_none_or(|until| dt.timestamp() as u64 >= until))
+            .filter(move |dt| {
+                snoozed_until
+                    .is_none_or(|until| u64::try_from(dt.timestamp()).is_ok_and(|ts| ts >= until))
+            })
             .skip(skip_runs);
         let mut emitted = 0_usize;
         for fire in fires.by_ref().take(max_events) {


### PR DESCRIPTION
## What

Continues the incremental clippy-lint-enablement series already underway on `main` (`clippy::inefficient_to_string`, `clippy::implicit_clone`, `clippy::struct_field_names`, `clippy::single_char_pattern`, ...). Adds `clippy::cast_sign_loss = "deny"` to `[lints.clippy]` in `Cargo.toml`.

`clippy::cast_sign_loss` rejects an `as`-cast from a signed integer to an unsigned one (e.g. `i64 as u64`), which silently wraps a negative value into a huge positive one instead of erroring.

## Why

Running `cargo clippy --all-targets -- -W clippy::cast_sign_loss` against current `main` surfaces exactly 2 violations, both a Unix-timestamp `i64` (`DateTime::timestamp()`) cast to the `u64` seconds this crate stores timestamps as:

- `src/logging/mod.rs` — `format_json_line`'s `ts_local` field: `now.timestamp() as u64`
- `src/routines/ical.rs` — `build_ical_core_with_tz`'s snooze-deadline filter: `dt.timestamp() as u64 >= until`

Neither value can actually go negative in practice — both come from "now" or a future cron fire, always post-1970 — but the bare `as` cast gave no indication of that invariant to a reader, and silently wraps instead of failing loudly if it ever were violated (e.g. a corrected pre-1970 host clock, mirroring the exact class of hazard already documented and guarded against in `utils/time.rs::secs_since_epoch`).

Fixed both by converting to `u64::try_from(...)`, following the same idiom already used elsewhere in this file family (`routines/model.rs::next_run_at`'s `u64::try_from(next.timestamp()).ok()`), clamping to `0`/`false` on the theoretical negative case instead of wrapping. No behavior change — verified with `cargo test` (1145 passed) and `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (still 100% line coverage, 0 missed lines).

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean (with the new lint enabled)
- `cargo test` — 1145 passed, 0 failed
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — 100% line coverage, gate passes
- `linecheck --max-lines 500 $(find src -name '*.rs')` — passes
- `pnpm --filter client typecheck && pnpm --filter client lint && pnpm --filter client test` — all pass (client untouched by this change)
- `.changeset/enable-clippy-cast-sign-loss.md` added (patch bump), matching this repo's changeset convention for the prior lint-enablement PRs

---

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.