### PR TITLE
chore(lint): enable clippy::manual_ok_or

### DIFF
--- a/.changeset/enable-clippy-manual-ok-or.md
+++ b/.changeset/enable-clippy-manual-ok-or.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Enable `clippy::manual_ok_or` to reject a `match`/`if let` that manually converts an `Option` to a `Result` (`Some(x) => Ok(x), None => Err(e)`) instead of `.ok_or(e)`. The codebase was already clean against this lint; `deny` locks that in.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -446,3 +446,9 @@ inefficient_to_string = "deny"
 # theoretical negative case instead of silently wrapping. No behavior change. The codebase is
 # otherwise already clean, so `deny` locks that in.
 cast_sign_loss = "deny"
+# Reject a `match`/`if let` that manually converts an `Option` to a `Result`
+# (`Some(x) => Ok(x), None => Err(e)`) instead of `.ok_or(e)`. The manual form
+# spells out in several lines what `.ok_or` says in one, and invites the two
+# arms to drift out of sync on a future edit. The codebase is already clean,
+# so `deny` locks that in.
+manual_ok_or = "deny"


### PR DESCRIPTION
## What

Continues the incremental clippy-lint-enablement series already underway on `main` (`clippy::cast_sign_loss`, `clippy::inefficient_to_string`, `clippy::implicit_clone`, ...). Adds `clippy::manual_ok_or = "deny"` to `[lints.clippy]` in `Cargo.toml`.

## Why

`clippy::manual_ok_or` rejects a `match`/`if let` that manually converts an `Option` to a `Result` (`Some(x) => Ok(x), None => Err(e)`) instead of the equivalent `.ok_or(e)`. The manual form spells out in several lines what `.ok_or` says in one, and invites the two arms to drift out of sync on a future edit.

Running `cargo clippy --all-targets -- -W clippy::manual_ok_or` against current `main` surfaces **zero violations** — the codebase is already clean, so `deny` just locks in that state, matching every prior lint-enablement PR in this series.

Config-only change — no source files touched, no behavior change.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean (with the new lint enabled)
- `cargo test` — 1145 passed, 0 failed
- `.changeset/enable-clippy-manual-ok-or.md` added (patch bump), matching this repo's changeset convention

---

This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.