### PR TITLE
chore(lint): enable clippy::manual_is_variant_and

### DIFF
--- a/.changeset/enable-clippy-manual-is-variant-and.md
+++ b/.changeset/enable-clippy-manual-is-variant-and.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Enable `clippy::manual_is_variant_and` to reject a `match`/`if let` that manually re-derives what `Option::is_some_and`/`is_none_or` or `Result::is_ok_and`/`is_err_and` already compute (e.g. `match opt { Some(x) => pred(x), None => false }`) instead of calling the combinator directly. The codebase was already clean against this lint; `deny` locks that in.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -452,3 +452,9 @@ cast_sign_loss = "deny"
 # arms to drift out of sync on a future edit. The codebase is already clean,
 # so `deny` locks that in.
 manual_ok_or = "deny"
+# Reject a `match`/`if let` that manually re-derives what `Option::is_some_and`/`is_none_or` or
+# `Result::is_ok_and`/`is_err_and` already compute (e.g. `match opt { Some(x) => pred(x), None =>
+# false }`) instead of calling the combinator directly. Same rationale as `manual_ok_or` above: the
+# manual form spells out in several lines what the combinator says in one, and invites the arms to
+# drift out of sync on a future edit. The codebase is already clean, so `deny` locks that in.
+manual_is_variant_and = "deny"


### PR DESCRIPTION
## What

Continues the incremental clippy-lint-enablement series already underway on `main` (`clippy::cast_sign_loss`, `clippy::manual_ok_or`, `clippy::implicit_clone`, ...). Adds `clippy::manual_is_variant_and = "deny"` to `[lints.clippy]` in `Cargo.toml`.

## Why

`clippy::manual_is_variant_and` rejects a `match`/`if let` that manually re-derives what `Option::is_some_and`/`is_none_or` or `Result::is_ok_and`/`is_err_and` already compute (e.g. `match opt { Some(x) => pred(x), None => false }`) instead of calling the combinator directly. The manual form spells out in several lines what the combinator says in one, and invites the arms to drift out of sync on a future edit — the same rationale as the already-enabled `manual_ok_or`, `manual_assert`, `manual_let_else`, and `manual_string_new`.

Running `cargo clippy --all-targets --all-features -- -W clippy::manual_is_variant_and` against current `main` surfaces **zero violations** — the codebase is already clean, so `deny` just locks in that state, matching every prior lint-enablement PR in this series.

Config-only change — no source files touched, no behavior change.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean (with the new lint enabled)
- `cargo test` — 1145 passed, 0 failed
- `.changeset/enable-clippy-manual-is-variant-and.md` added (patch bump), matching this repo's changeset convention

---

This pull request was opened by an automated repo-improvement routine.