### PR TITLE
chore(lint): enable clippy::cast_possible_wrap

### DIFF
--- a/.changeset/enable-clippy-cast-possible-wrap.md
+++ b/.changeset/enable-clippy-cast-possible-wrap.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Enable `clippy::cast_possible_wrap`, the mirror image of `clippy::cast_sign_loss`, to reject an `as`-cast from an unsigned integer to a signed one, which silently wraps a value past the target's positive range into a negative one instead of erroring. Fixes the 2 violations this surfaced — `utils::time::format_local`'s Unix-seconds `u64` cast to the `i64` `chrono::Local::timestamp_opt` takes, and a test's `u32` child-process id cast to the `libc::pid_t` (`i32`) `libc::kill` takes — by converting to `<target>::try_from(...)`, clamped to the target's `MAX` on the theoretical overflow case instead of silently wrapping.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -458,3 +458,13 @@ manual_ok_or = "deny"
 # manual form spells out in several lines what the combinator says in one, and invites the arms to
 # drift out of sync on a future edit. The codebase is already clean, so `deny` locks that in.
 manual_is_variant_and = "deny"
+# Reject an `as`-cast from an unsigned integer to a signed one (e.g. `u64 as i64`), the mirror
+# image of `cast_sign_loss` above: a value past the target's positive range silently wraps into a
+# negative one instead of erroring. Fixed the 2 violations this surfaced:
+# `utils::time::format_local`'s Unix-seconds `u64` cast to the `i64` `chrono::Local::timestamp_opt`
+# takes, and a test's `u32` child-process id cast to the `libc::pid_t` (`i32`) `libc::kill` takes.
+# Neither value can realistically exceed the target's range today, but the cast gave no indication
+# of that invariant to a reader — converted to `<target>::try_from(...)`, clamped to the target's
+# `MAX` on the theoretical overflow case instead of silently wrapping. No behavior change. The rest
+# of the codebase is already clean, so `deny` locks that in.
+cast_possible_wrap = "deny"

--- a/src/cli/spawn_error_tests.rs
+++ b/src/cli/spawn_error_tests.rs
@@ -110,7 +110,10 @@ fn spawn_detached_rotates_oversized_daemon_log() {
     #[cfg(unix)]
     // SAFETY: `pid` is this test's own detached child process; sending it SIGKILL is safe cleanup.
     unsafe {
-        libc::kill(pid as libc::pid_t, libc::SIGKILL);
+        libc::kill(
+            libc::pid_t::try_from(pid).unwrap_or(libc::pid_t::MAX),
+            libc::SIGKILL,
+        );
     }
     #[cfg(not(unix))]
     let _ = pid;

--- a/src/utils/time.rs
+++ b/src/utils/time.rs
@@ -11,7 +11,8 @@ pub fn now_secs() -> u64 {
 /// e.g. `"2026-07-13 14:30:05 +0300"`. The offset is included since "local" is the *daemon
 /// process's* timezone, which a remote reader can't otherwise infer.
 pub(crate) fn format_local(ts: u64) -> String {
-    Local.timestamp_opt(ts as i64, 0).single().map_or_else(
+    let ts = i64::try_from(ts).unwrap_or(i64::MAX);
+    Local.timestamp_opt(ts, 0).single().map_or_else(
         || "—".to_string(),
         |dt| dt.format("%Y-%m-%d %H:%M:%S %z").to_string(),
     )


### PR DESCRIPTION
## Summary

Continues the incremental clippy-lint-enablement series (most recently `#1363` `manual_ok_or`, `#1361` `cast_sign_loss`, `#1359` `inefficient_to_string`, ...). This adds `clippy::cast_possible_wrap`, the mirror image of the already-enabled `clippy::cast_sign_loss`: it rejects an `as`-cast from an unsigned integer to a signed one, which silently wraps a value past the target's positive range into a negative one instead of erroring.

- `cast_sign_loss` already guards `i64 -> u64` casts (signed → unsigned).
- `cast_possible_wrap` closes the other direction: `u64 -> i64` (unsigned → signed).

Fixes the 2 violations this surfaced:
- `utils::time::format_local`'s Unix-seconds `u64` cast to the `i64` `chrono::Local::timestamp_opt` takes.
- A test's `u32` child-process id cast to the `libc::pid_t` (`i32`) `libc::kill` takes.

Both converted to `<target>::try_from(...)`, clamped to the target's `MAX` on the theoretical overflow case instead of silently wrapping — same pattern as the `cast_sign_loss` fix. No behavior change; `format_local`'s existing `format_local_falls_back_to_dash_for_an_out_of_range_instant` test already covers the boundary near `i64::MAX`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (1145 passed)
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (100% line floor holds)
- [x] `linecheck --max-lines 500 $(find src -name '*.rs')`
- [x] `pnpm --filter client typecheck / lint / test` (363 passed)
- [x] Ran the full `.githooks/pre-push` hook end to end — passes

Added `.changeset/enable-clippy-cast-possible-wrap.md` (patch bump), matching the format of prior lint-enablement changesets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)