### PR TITLE
chore(lint): enable clippy::missing_const_for_fn

### DIFF
--- a/.changeset/enable-clippy-missing-const-for-fn.md
+++ b/.changeset/enable-clippy-missing-const-for-fn.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Enable `clippy::missing_const_for_fn` to catch functions whose bodies could run in `const` context but weren't marked `const fn`, closing off callers that need a `const`/`static` initializer or another `const fn` for no reason. Fixes the 7 violations this surfaced (`cli::liveness_exit_code`, `machine::MachineSource::label`, `routes::mcp::MoadimMcp::new`, `routines::cleanup::is_expired`, `routines::flags::FlagScope::suffix`, `routines::model::bool_true`, `routines::service_log_tail::LogWithMeta::empty`) by adding `const`. No behavior change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -468,3 +468,12 @@ manual_is_variant_and = "deny"
 # `MAX` on the theoretical overflow case instead of silently wrapping. No behavior change. The rest
 # of the codebase is already clean, so `deny` locks that in.
 cast_possible_wrap = "deny"
+# Reject a function whose body could run in `const` context but isn't marked `const fn`. A
+# non-`const` function can't be called from a `const`/`static` initializer or another `const fn`,
+# closing off callers unnecessarily when nothing about the body actually requires runtime
+# evaluation. Fixed the 7 violations this surfaced (`cli::liveness_exit_code`,
+# `machine::MachineSource::label`, `routes::mcp::MoadimMcp::new`, `routines::cleanup::is_expired`,
+# `routines::flags::FlagScope::suffix`, `routines::model::bool_true`,
+# `routines::service_log_tail::LogWithMeta::empty`) by adding `const`. No behavior change. The rest
+# of the codebase is already clean, so `deny` locks that in.
+missing_const_for_fn = "deny"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -21,7 +21,7 @@ pub const EXIT_USAGE: i32 = 2;
 
 /// Map a server-liveness flag to the script-friendly process exit code: `0` when a server is
 /// reachable, [`EXIT_NOT_RUNNING`] when it is not.
-fn liveness_exit_code(running: bool) -> i32 {
+const fn liveness_exit_code(running: bool) -> i32 {
     if running {
         0
     } else {

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -46,7 +46,7 @@ pub enum MachineSource {
 
 impl MachineSource {
     /// Short human label used in CLI output.
-    pub fn label(self) -> &'static str {
+    pub const fn label(self) -> &'static str {
         match self {
             Self::Env => "MOADIM_MACHINE env",
             Self::File => "machine.local.toml",

--- a/src/routes/mcp.rs
+++ b/src/routes/mcp.rs
@@ -143,7 +143,7 @@ fn err(msg: impl std::fmt::Display) -> CallToolResult {
 #[tool_router]
 impl MoadimMcp {
     /// Create a new `MoadimMcp` handler connected to the given routine store.
-    pub fn new(
+    pub const fn new(
         routines: RoutineStore,
         routines_dir: std::path::PathBuf,
         uptime_start: u64,

--- a/src/routines/cleanup/mod.rs
+++ b/src/routines/cleanup/mod.rs
@@ -89,7 +89,7 @@ pub(super) fn parse_workbench_name(name: &str) -> Option<(&str, u64)> {
 
 /// Whether a workbench triggered at `ts` has outlived `ttl` as of `now` (saturating, so clock skew
 /// that puts `ts` in the future reads as age 0, never expired).
-fn is_expired(now: u64, ts: u64, ttl: u64) -> bool {
+const fn is_expired(now: u64, ts: u64, ttl: u64) -> bool {
     now.saturating_sub(ts) > ttl
 }
 

--- a/src/routines/flags.rs
+++ b/src/routines/flags.rs
@@ -36,7 +36,7 @@ pub enum FlagScope {
 
 impl FlagScope {
     /// The filename suffix (including the leading `.`) this scope's flag files carry.
-    fn suffix(self) -> &'static str {
+    const fn suffix(self) -> &'static str {
         match self {
             Self::General => ".md",
             Self::Local => ".local.md",

--- a/src/routines/model.rs
+++ b/src/routines/model.rs
@@ -412,7 +412,7 @@ pub fn new_store() -> RoutineStore {
 }
 
 /// Serde default for boolean fields that should default to `true`.
-pub(crate) fn bool_true() -> bool {
+pub(crate) const fn bool_true() -> bool {
     true
 }
 

--- a/src/routines/service_log_tail.rs
+++ b/src/routines/service_log_tail.rs
@@ -21,7 +21,7 @@ pub(crate) struct LogWithMeta {
 
 impl LogWithMeta {
     /// An empty log tail: no content, zero size, not truncated.
-    pub(crate) fn empty() -> Self {
+    pub(crate) const fn empty() -> Self {
         Self {
             content: String::new(),
             total_bytes: 0,


### PR DESCRIPTION
## Summary

Continues the incremental clippy-lint-enablement series (most recently `#1365` `cast_possible_wrap`, `#1364` `manual_is_variant_and`, `#1363` `manual_ok_or`). Adds `clippy::missing_const_for_fn`, which flags a function whose body could already run in `const` context but isn't marked `const fn` — closing off callers that need a `const`/`static` initializer or another `const fn` for no reason.

Fixes the 7 violations this surfaced by adding `const`:
- `cli::liveness_exit_code`
- `machine::MachineSource::label`
- `routes::mcp::MoadimMcp::new`
- `routines::cleanup::is_expired`
- `routines::flags::FlagScope::suffix`
- `routines::model::bool_true`
- `routines::service_log_tail::LogWithMeta::empty`

No behavior change — every fixed body was already free of anything non-`const` (simple matches, struct literals, `String::new()`).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (1145 passed)
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (100% line floor holds, unchanged from main)
- [x] `linecheck --max-lines 500 $(find src -name '*.rs')`
- [x] `cargo doc --no-deps`
- Client (`pnpm` typecheck/lint/test) not touched by this PR — no files under `client/` changed.

Added `.changeset/enable-clippy-missing-const-for-fn.md` (patch bump), matching the format of prior lint-enablement changesets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)