### PR TITLE
chore(lint): enable clippy::cast_precision_loss

### DIFF
--- a/.changeset/enable-clippy-cast-precision-loss.md
+++ b/.changeset/enable-clippy-cast-precision-loss.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Enable `clippy::cast_precision_loss` to catch an `as`-cast from an integer to a floating-point type that can't represent every value of the source exactly (e.g. `u64 as f64`, past 2^52 the cast silently rounds to the nearest representable `f64`), the same "no indication of the invariant" gap `cast_sign_loss` and `cast_possible_wrap` already close for the other integer-cast directions. Fixes the 2 violations this surfaced: `cli::query::humanize_bytes`'s `u64` byte count cast to `f64` for display, which is deliberately an approximation already rounded to one decimal place and is kept as `as f64` behind a scoped, reasoned `#[allow]`; and a test's `delay_ms` shim parameter, narrowed from `u64` to `u32` and converted via `f64::from` so the cast is lossless by construction instead of merely lossless in practice. No behavior change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -468,6 +468,17 @@ manual_is_variant_and = "deny"
 # `MAX` on the theoretical overflow case instead of silently wrapping. No behavior change. The rest
 # of the codebase is already clean, so `deny` locks that in.
 cast_possible_wrap = "deny"
+# Reject an `as`-cast from an integer to a floating-point type that can't represent every value of
+# the source exactly (e.g. `u64 as f64`, `i64 as f64`) — past 2^52 the cast silently rounds to the
+# nearest representable `f64`, the same "no indication of the invariant" gap `cast_sign_loss` and
+# `cast_possible_wrap` above already close for the other integer-cast directions. Fixed the 2
+# violations this surfaced: `cli::query::humanize_bytes`'s `u64` byte count cast to `f64` for
+# display, which is deliberately an approximation (already rounded to one decimal place) and is
+# kept as `as f64` behind a scoped, reasoned `#[allow]`; and a test's `delay_ms` shim parameter,
+# narrowed from `u64` to `u32` and converted via `f64::from` so the cast is lossless by
+# construction instead of merely lossless in practice. No behavior change. The rest of the
+# codebase is already clean, so `deny` locks that in.
+cast_precision_loss = "deny"
 # Reject a function whose body could run in `const` context but isn't marked `const fn`. A
 # non-`const` function can't be called from a `const`/`static` initializer or another `const fn`,
 # closing off callers unnecessarily when nothing about the body actually requires runtime

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -55,6 +55,13 @@ pub(super) fn humanize_bytes(bytes: u64) -> String {
     if bytes < 1024 {
         return format!("{bytes} B");
     }
+    // Approximating a byte count for human display never needs exact precision above 2^52 —
+    // any `moadim` workbench/log total that large would already be a many-petabyte anomaly, and
+    // the rendered value is rounded to one decimal place anyway.
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "human-readable size display, not an exact value"
+    )]
     let mut size = bytes as f64;
     let mut unit = 0;
     while size >= 1024.0 && unit < UNITS.len() - 1 {

--- a/src/sync/routines_sync_tests.rs
+++ b/src/sync/routines_sync_tests.rs
@@ -138,7 +138,7 @@ impl CronShim {
     /// `crontab -` write on stdin and installing it, widening the window for concurrency
     /// regression tests that must observe two `sync_routines_to_crontab` calls overlapping (or
     /// not) in wall-clock time.
-    fn new_with_write_delay(initial: &str, delay_ms: u64) -> Self {
+    fn new_with_write_delay(initial: &str, delay_ms: u32) -> Self {
         use std::os::unix::fs::PermissionsExt;
 
         let base = std::env::temp_dir().join(format!("moadim-rcronshim-{}", uuid::Uuid::new_v4()));
@@ -147,7 +147,7 @@ impl CronShim {
         std::fs::write(&store_file, initial).unwrap();
         let store_display = store_file.to_string_lossy().into_owned();
         let script_path = base.join("crontab-shim.sh");
-        let delay_secs = delay_ms as f64 / 1000.0;
+        let delay_secs = f64::from(delay_ms) / 1000.0;
         std::fs::write(
             &script_path,
             format!(
@@ -378,7 +378,7 @@ fn sync_routines_to_crontab_serializes_concurrent_calls() {
     // sleeps a fixed delay on every `crontab -` write, so two *unserialized* read-modify-write
     // round trips would overlap and finish in roughly one delay; serialized by the lock, they run
     // back to back and take roughly two.
-    const DELAY_MS: u64 = 150;
+    const DELAY_MS: u32 = 150;
 
     let agent_name = "test-sync-agent-concurrent-lock";
     std::fs::create_dir_all(crate::paths::agents_dir()).unwrap();


### PR DESCRIPTION
## Summary

Continues the incremental clippy-lint-enablement series (most recently `#1366` `missing_const_for_fn`, `#1365` `cast_possible_wrap`, `#1364` `manual_is_variant_and`). Adds `clippy::cast_precision_loss`, closing the remaining gap in the integer-cast lint family: `cast_lossless`, `cast_sign_loss`, and `cast_possible_wrap` are already enabled, but nothing yet caught an `as`-cast from an integer to a float that can't represent every source value exactly — past 2^52 the cast silently rounds to the nearest representable `f64`, with no indication of that invariant at the call site.

Fixes the 2 violations this surfaced:
- `cli::query::humanize_bytes`'s `u64` byte-count cast to `f64` for display — a deliberate approximation (the result is already rounded to one decimal place), kept as `as f64` behind a scoped, reasoned `#[allow(clippy::cast_precision_loss, ...)]`.
- A test helper's `delay_ms` shim parameter (`src/sync/routines_sync_tests.rs`), narrowed from `u64` to `u32` and converted via `f64::from(delay_ms)` so the cast is lossless by construction instead of merely lossless in practice (the value is always a small test timing delay, never near `u32::MAX` milliseconds).

No behavior change.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (1145 passed)
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (100% line floor holds, unchanged from main)
- [x] `linecheck --max-lines 500 $(find src -name '*.rs')`
- [x] `cargo doc --workspace --no-deps --document-private-items` (`RUSTDOCFLAGS=-D warnings`)
- Client (`pnpm` typecheck/lint/test) not touched by this PR — no files under `client/` changed.

Added `.changeset/enable-clippy-cast-precision-loss.md` (patch bump), matching the format of prior lint-enablement changesets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)