### PR TITLE
chore(deps): bump libc and tokio-util to their latest compatible patch

### DIFF
--- a/.changeset/bump-libc-tokio-util-patch.md
+++ b/.changeset/bump-libc-tokio-util-patch.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Bump `libc` (0.2.187 → 0.2.188) and `tokio-util` (0.7.18 → 0.7.19) to their latest compatible patch releases. Lockfile-only refresh via `cargo update -p libc -p tokio-util`; no `Cargo.toml`/`src`/`client` diff.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.187"
+version = "0.2.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7743783ea728ef5c31194c6590797eed286449b4a4e87d626d8a51f0a94e732"
+checksum = "22053b6a34f84abc97f9129e61334f40174659a1b9bd18c970b83db6a9a6348b"
 
 [[package]]
 name = "libredox"
@@ -1917,13 +1917,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]


### PR DESCRIPTION
## Why

`cargo update --dry-run` shows two dependencies with patch releases available inside the ranges already declared in `Cargo.toml`: `libc` (0.2.187 → 0.2.188) and `tokio-util` (0.7.18 → 0.7.19). Keeping patch-level bumps current picks up upstream bugfixes with effectively zero API-compatibility risk, and this repo already has an established, uncontroversial pattern of landing these as their own small PR (see #1356 "bump libc and hyper to their latest compatible patch", and the pending `bump-jiff-syn-patch` changeset). Neither dependency is covered by any currently-open PR (the open `chore(deps)` PRs are for the npm group and GitHub Actions, not Cargo.lock).

## What

- `cargo update -p libc -p tokio-util` — lockfile-only refresh, no `Cargo.toml`/`src`/`client` diff.
- Added a `patch` changeset.

No behavior change. `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (1145 tests), and `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` (100% line coverage maintained) all pass.