### PR TITLE
test(client): add coverage for SettingsPage's persistent-prompt editor

### DIFF
--- a/.changeset/cover-settings-page.md
+++ b/.changeset/cover-settings-page.md
@@ -1,0 +1,15 @@
+---
+"moadim": patch
+---
+
+test(client): add coverage for `SettingsPage`'s persistent-prompt editor
+
+`SettingsPage.tsx` had zero test coverage (`pnpm --filter client
+test:coverage` showed 0% statements/branches/lines) despite carrying real
+logic — seeding the draft from the loaded prompt, tracking dirty state, and
+gating the Save button on it. Adds `SettingsPage.test.tsx` covering: the
+loading state before the prompt query resolves, the textarea seeding from a
+loaded prompt with Save disabled until edited, and Save enabling plus the
+"unsaved changes" hint once the draft diverges from the loaded value.
+
+No behavior change — test-only.

--- a/client/src/pages/settings/SettingsPage.test.tsx
+++ b/client/src/pages/settings/SettingsPage.test.tsx
@@ -1,0 +1,43 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ToastProvider } from "../../shell/toasts";
+import { SettingsPage } from "./SettingsPage";
+
+function renderPage(seedPrompt?: string) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  if (seedPrompt !== undefined) {
+    queryClient.setQueryData(["config", "user-prompt"], seedPrompt);
+  }
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ToastProvider>
+        <SettingsPage />
+      </ToastProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("SettingsPage", () => {
+  it("shows a loading state before the prompt loads", () => {
+    renderPage();
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/always run/)).not.toBeInTheDocument();
+  });
+
+  it("seeds the textarea from the loaded prompt and disables save until edited", () => {
+    renderPage("existing prompt");
+    expect(screen.getByPlaceholderText(/always run/)).toHaveValue("existing prompt");
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    expect(screen.queryByText("unsaved changes")).not.toBeInTheDocument();
+  });
+
+  it("marks the draft dirty and enables save once edited", () => {
+    renderPage("existing prompt");
+    fireEvent.change(screen.getByPlaceholderText(/always run/), {
+      target: { value: "existing prompt, edited" },
+    });
+    expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled();
+    expect(screen.getByText("unsaved changes")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Why

`SettingsPage.tsx` (the persistent-prompt editor under Settings) had zero test coverage — `pnpm --filter client test:coverage` showed 0% statements/branches/functions/lines — despite carrying real logic: seeding the draft from the loaded prompt, tracking dirty state relative to the loaded value, and gating the Save button on that.

## What

Adds `client/src/pages/settings/SettingsPage.test.tsx`, following this repo's existing component-test conventions (`QueryClientProvider` + seeding the query cache directly, as in `RoutineForm.test.tsx`/`App.test.tsx` — no new mocking pattern introduced):

- Loading state renders before the `user-prompt` query resolves.
- The textarea seeds from a loaded prompt, and Save stays disabled until edited.
- Editing the draft enables Save and shows the "unsaved changes" hint.

No behavior change — test-only. Includes a changeset per `.changeset/config.json`.

## Verification

- `pnpm --filter client typecheck` — clean
- `pnpm --filter client lint` — clean
- `pnpm --filter client test` — 370 passed (was 367)

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.