### PR TITLE
test(client): cover theme.ts's localStorage error-handling branches

### DIFF
--- a/.changeset/theme-storage-error-coverage.md
+++ b/.changeset/theme-storage-error-coverage.md
@@ -1,0 +1,16 @@
+---
+"moadim": patch
+---
+
+test(client): cover theme.ts's localStorage error-handling branches
+
+`pnpm --filter client test:coverage` showed `src/lib/theme.ts` at 85.71%
+lines: `loadThemeLight`'s `catch` (line 13, falling back to dark) and
+`saveThemeLight`'s `catch` (swallowing the write failure) were both
+untested, even though they exist specifically to keep a blocked
+`localStorage` (private browsing, quota exceeded, disabled storage) from
+crashing the theme toggle. Adds two tests that mock `Storage.prototype`'s
+`getItem`/`setItem` to throw and assert the fallback/no-throw behavior each
+catch is there for.
+
+No behavior change — test-only. `theme.ts` is now at 100% coverage.

--- a/client/src/lib/theme.test.ts
+++ b/client/src/lib/theme.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { applyTheme, loadThemeLight, saveThemeLight } from "./theme";
 
 beforeEach(() => {
@@ -23,5 +23,25 @@ describe("theme", () => {
     expect(document.documentElement.classList.contains("theme-light")).toBe(true);
     applyTheme(false);
     expect(document.documentElement.classList.contains("theme-light")).toBe(false);
+  });
+
+  describe("when localStorage throws (private mode / quota)", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("falls back to dark instead of propagating the error", () => {
+      vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+        throw new DOMException("blocked", "SecurityError");
+      });
+      expect(loadThemeLight()).toBe(false);
+    });
+
+    it("saveThemeLight swallows the error instead of propagating it", () => {
+      vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+        throw new DOMException("blocked", "SecurityError");
+      });
+      expect(() => saveThemeLight(true)).not.toThrow();
+    });
   });
 });


### PR DESCRIPTION
## Why

`pnpm --filter client test:coverage` showed `client/src/lib/theme.ts` at 85.71% lines. The two uncovered branches were `loadThemeLight`'s and `saveThemeLight`'s `catch` blocks — both exist specifically to keep a blocked `localStorage` (private browsing, quota exceeded, disabled storage) from crashing the theme toggle, but neither had a test forcing that path.

## What

- Mock `Storage.prototype.getItem`/`setItem` to throw and assert `loadThemeLight()` falls back to `false` (dark) and `saveThemeLight()` swallows the error instead of propagating it.
- Test-only, no behavior change. `theme.ts` is now at 100% coverage.
- Changeset included (touches `client/`).

## Test plan
- [x] `pnpm vitest run src/lib/theme.test.ts` — 5/5 passing
- [x] `pnpm run lint` — clean
- [x] `pnpm run typecheck` — clean