### PR TITLE
chore(lint): enable clippy::float_cmp

### DIFF
--- a/.changeset/enable-clippy-float-cmp.md
+++ b/.changeset/enable-clippy-float-cmp.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Enable `clippy::float_cmp` to reject a direct `==`/`!=` comparison between floating-point values. Binary floating-point can't represent most decimal fractions exactly, so two values computed by equivalent-looking paths can differ in the last bit and silently fail an exact-equality check that was meant to test "close enough". The codebase is already clean, so `deny` locks that in. No behavior change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -488,3 +488,11 @@ cast_precision_loss = "deny"
 # `routines::service_log_tail::LogWithMeta::empty`) by adding `const`. No behavior change. The rest
 # of the codebase is already clean, so `deny` locks that in.
 missing_const_for_fn = "deny"
+# Reject a direct `==`/`!=` comparison between floating-point values. Binary floating-point can't
+# represent most decimal fractions exactly, so two values computed by equivalent-looking paths
+# (e.g. `0.1 + 0.2` vs `0.3`) can differ in the last bit and silently fail an exact-equality check
+# that was meant to test "close enough". Callers who really do need bit-exact comparison (e.g.
+# comparing a value against itself, or against a literal it was assigned from verbatim) should use
+# `f64::to_bits`/`==` explicitly, or an epsilon-based comparison otherwise. The codebase is already
+# clean, so `deny` locks that in.
+float_cmp = "deny"


### PR DESCRIPTION
## Why

The integer-cast lint family (`cast_sign_loss`, `cast_possible_wrap`, `cast_precision_loss`) is already enabled to catch numeric-invariant gaps that `as`-casts leave silent. `clippy::float_cmp` closes a related gap: a direct `==`/`!=` comparison between floats. Binary floating-point can't represent most decimal fractions exactly, so two values computed by equivalent-looking paths (e.g. `0.1 + 0.2` vs `0.3`) can differ in the last bit and silently fail an exact-equality check that was meant to test "close enough".

## What

- Add `float_cmp = "deny"` to `[lints.clippy]` in `Cargo.toml`, with a reasoned comment matching the existing cast-lint entries.
- No violations surfaced — the codebase is already clean, so this just locks the invariant in for future code, following the same pattern as `cast_possible_wrap`/`cast_precision_loss`.
- No behavior change.
- Changeset included.

## Test plan
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean, 0 violations
- [x] `cargo test` — 1155/1155 passing

---
This pull request was opened by the Daemon + Landing auto-improve & auto-merge lint/docs PRs routine of moadim.