### PR TITLE
fix(ci): stop publish job failing on no-op prebuilt.html commit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -110,12 +110,13 @@ jobs:
       - name: Verify prebuilt UI ships in the published tarball
         run: cargo package --list --allow-dirty | grep -qx prebuilt.html || (echo "prebuilt.html not in package tarball" && exit 1)
 
-      - name: Commit prebuilt UI so cargo publish includes it
-        run: |
-          git config user.email "actions@github.com"
-          git config user.name "GitHub Actions"
-          git add prebuilt.html
-          git commit -m "ci: bundle prebuilt UI"
+      # No commit step for prebuilt.html here: it used to be an untracked build
+      # artifact committed on the runner, but it's tracked in the repo now (kept
+      # in lockstep with client/src by prebuilt.yml), so the fresh build is
+      # normally byte-identical and a bare `git commit` fails the job with
+      # "nothing to commit" — which silently blocked the v1.5.0/v1.6.0 crates.io
+      # publishes. `cargo publish --allow-dirty` below packages the working-tree
+      # file either way, so a commit was never needed for tarball inclusion.
 
       - name: Verify tag matches Cargo.toml version
         run: |


### PR DESCRIPTION
## Why

crates.io is stuck at **1.4.1** — the v1.5.0 and v1.6.0 publishes both silently failed:

- v1.6.0: [run 29789315467](https://github.com/moadim-io/daemon/actions/runs/29789315467)
- v1.5.0: [run 29708962535](https://github.com/moadim-io/daemon/actions/runs/29708962535)

Both died in publish.yml at the **"Commit prebuilt UI so cargo publish includes it"** step with `nothing to commit, working tree clean` → exit 1, before `cargo publish` ever ran.

## Root cause

That step dates from when `prebuilt.html` was an untracked build artifact that had to be committed on the runner. It's now a tracked file kept in lockstep with `client/src` by the `prebuilt.yml` freshness gate — so the fresh build at publish time is byte-identical to the committed file, `git add` stages nothing, and a bare `git commit` treats that as an error.

## Fix

Drop the commit step (replaced with a comment explaining why it's gone). `cargo publish --allow-dirty` already packages the working-tree file, so the commit was never needed for tarball inclusion — the `cargo package --list` verification step that guards this stays.

## After merging

Re-run the publish for the v1.6.0 tag via the manual tag-push escape hatch to get 1.6.0 onto crates.io; 1.5.0 can be skipped or published the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)