### PR TITLE
fix(routines): restore schedule field in routine.toml, keep schedule.cron as inert mirror

### DIFF
--- a/.changeset/restore-schedule-in-routine-toml.md
+++ b/.changeset/restore-schedule-in-routine-toml.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Restore the `schedule` field in `routine.toml`. The schedule-to-`schedule.cron` split made the sidecar the source of truth prematurely; `routine.toml` now carries the authoritative `schedule` again (written and read first), while the `schedule.cron` sidecar keeps being written as a mirror with a comment on top stating it is not functional yet. Dirs written during the sidecar-only era still load via a cron-file fallback (comment lines are skipped) until the next repersist heals them, and the JSON Schema requires `schedule` again.

--- a/.changeset/restore-schedule-in-routine-toml.md
+++ b/.changeset/restore-schedule-in-routine-toml.md
@@ -2,4 +2,4 @@
 "moadim": patch
 ---
 
-Restore the `schedule` field in `routine.toml`. The schedule-to-`schedule.cron` split made the sidecar the source of truth prematurely; `routine.toml` now carries the authoritative `schedule` again (written and read first), while the `schedule.cron` sidecar keeps being written as a mirror with a comment on top stating it is not functional yet. Dirs written during the sidecar-only era still load via a cron-file fallback (comment lines are skipped) until the next repersist heals them, and the JSON Schema requires `schedule` again.
+Restore the `schedule` field in `routine.toml`. The schedule-to-`schedule.cron` split made the sidecar the source of truth prematurely; `routine.toml` now carries the authoritative `schedule` again (written and read first), while the `schedule.cron` sidecar keeps being written as a mirror of the cron entry (not functional yet). Dirs written during the sidecar-only era still load via a cron-file fallback (comment lines are skipped) until the next repersist heals them, and the JSON Schema requires `schedule` again.

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ install -Dm644 docs/moadim.1 "$HOME/.local/share/man/man1/moadim.1"
 ~/.config/moadim/
 ├── routines/                  # scheduled AI-agent tasks (see ## Routines)
 │   └── nightly-triage/
-│       ├── routine.toml       # tracked — metadata (agent, repositories, [env], …)
-│       ├── schedule.cron      # tracked — one cron entry
+│       ├── routine.toml       # tracked — schedule, agent, repositories, [env], …
+│       ├── schedule.cron      # tracked — cron-entry mirror, not functional yet
 │       ├── routine.local.toml # gitignored, optional — secret/local env var overrides
 │       ├── prompts/
 │       │   ├── prompt.pure.md      # tracked — the raw, user-authored prompt
@@ -146,8 +146,9 @@ Moadim owns a single block inside your crontab for routines. Everything outside 
 
 A **routine** is a scheduled AI-agent task: it fires a prompt at a coding
 agent (e.g. Claude) on a cron schedule, each run inside its own throwaway
-workbench. The schedule lives in a sibling `schedule.cron` file; the rest of
-the routine metadata stays in `routine.toml`.
+workbench. The schedule lives in `routine.toml` with the rest of the routine
+metadata; a sibling `schedule.cron` file mirrors the cron entry but is not
+functional yet.
 
 Routines are stored as folders under `~/.config/moadim/routines/<id>/`,
 git-trackable:
@@ -155,8 +156,8 @@ git-trackable:
 ```
 ~/.config/moadim/routines/
 └── nightly-triage/
-    ├── routine.toml       # tracked — metadata (agent, repositories, [env], …)
-    ├── schedule.cron      # tracked — one cron entry
+    ├── routine.toml       # tracked — schedule, agent, repositories, [env], …
+    ├── schedule.cron      # tracked — cron-entry mirror, not functional yet
     ├── routine.local.toml # gitignored, optional — secret/local env var overrides
     ├── prompts/
     │   ├── prompt.pure.md      # tracked — the raw, user-authored prompt
@@ -166,7 +167,7 @@ git-trackable:
 
 | Field          | Type   | Required | Description                                                                                  |
 | -------------- | ------ | -------- | -------------------------------------------------------------------------------------------- |
-| `schedule`     | string | yes      | Cron expression (`min hour dom month dow` or `@daily`, …), stored in `schedule.cron` and evaluated in the host's local timezone — **not** UTC. |
+| `schedule`     | string | yes      | Cron expression (`min hour dom month dow` or `@daily`, …), evaluated in the host's local timezone — **not** UTC. Mirrored into `schedule.cron`, which is not functional yet. |
 | `title`        | string | yes      | Human name; slugified to name the run workbench and tmux session.                            |
 | `agent`        | string | yes      | Agent registry key (e.g. `claude`), resolved from `~/.config/moadim/agents/<agent>.toml`.    |
 | `model`        | string | no       | Model ID to run the agent with (e.g. `claude-sonnet-4-6`), passed as `--model` on the agent invocation. `None`/omitted uses the agent's own default. |

--- a/schemas/routine.example.toml
+++ b/schemas/routine.example.toml
@@ -1,6 +1,6 @@
 #:schema ./routine.schema.json
 
-# schedule.cron (next to this file) holds the cron entry.
+schedule = "30 9 * * 1-5"
 title    = "My routine"
 agent    = "claude"
 prompt   = "Describe the task for the agent here."

--- a/schemas/routine.schema.json
+++ b/schemas/routine.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
-  "description": "A scheduled AI-agent task. Normally written and maintained by the daemon (one routine.toml + one schedule.cron per routine); this schema documents the TOML sidecar's on-disk shape and powers editor validation. Runtime trigger state lives in a gitignored state.local.toml sidecar, not here.",
+  "description": "A scheduled AI-agent task. Normally written and maintained by the daemon (one routine.toml per routine); this schema documents its on-disk shape and powers editor validation. Runtime trigger state lives in a gitignored state.local.toml sidecar, not here.",
   "properties": {
     "agent": {
       "description": "Agent registry key (e.g. \"claude\") resolved from the agents config directory.",
@@ -62,7 +62,7 @@
       "type": "array"
     },
     "schedule": {
-      "description": "Legacy/read-only. The cron expression now lives in the tracked schedule.cron sidecar next to routine.toml, where schedule-only edits stay isolated.",
+      "description": "Cron expression for when the routine runs, evaluated in the host's local system timezone (the OS crontab timezone), not UTC. Also mirrored into the sibling schedule.cron sidecar, which is not functional yet — this field stays authoritative.",
       "examples": [
         "@hourly",
         "@daily",
@@ -86,6 +86,7 @@
     }
   },
   "required": [
+    "schedule",
     "title",
     "agent",
     "prompt"

--- a/src/build/routine_schema.rs
+++ b/src/build/routine_schema.rs
@@ -16,9 +16,9 @@ pub fn generate(manifest_dir: &str) {
     let routine_schema = json!({
         "$schema": "https://json-schema.org/draft-07/schema#",
         "title": "Routine",
-        "description": "A scheduled AI-agent task. Normally written and maintained by the daemon (one routine.toml + one schedule.cron per routine); this schema documents the TOML sidecar's on-disk shape and powers editor validation. Runtime trigger state lives in a gitignored state.local.toml sidecar, not here.",
+        "description": "A scheduled AI-agent task. Normally written and maintained by the daemon (one routine.toml per routine); this schema documents its on-disk shape and powers editor validation. Runtime trigger state lives in a gitignored state.local.toml sidecar, not here.",
         "type": "object",
-        "required": ["title", "agent", "prompt"],
+        "required": ["schedule", "title", "agent", "prompt"],
         "properties": {
             "id": {
                 "type": "string",
@@ -26,7 +26,7 @@ pub fn generate(manifest_dir: &str) {
             },
             "schedule": {
                 "type": "string",
-                "description": "Legacy/read-only. The cron expression now lives in the tracked schedule.cron sidecar next to routine.toml, where schedule-only edits stay isolated.",
+                "description": "Cron expression for when the routine runs, evaluated in the host's local system timezone (the OS crontab timezone), not UTC. Also mirrored into the sibling schedule.cron sidecar, which is not functional yet — this field stays authoritative.",
                 "examples": ["@hourly", "@daily", "30 9 * * 1-5"]
             },
             "title": {
@@ -108,7 +108,7 @@ pub fn generate(manifest_dir: &str) {
     let example_toml = concat!(
         "#:schema ./routine.schema.json\n",
         "\n",
-        "# schedule.cron (next to this file) holds the cron entry.\n",
+        "schedule = \"30 9 * * 1-5\"\n",
         "title    = \"My routine\"\n",
         "agent    = \"claude\"\n",
         "prompt   = \"Describe the task for the agent here.\"\n",

--- a/src/cli/system.rs
+++ b/src/cli/system.rs
@@ -90,6 +90,8 @@ const ROUTINES_README: &str = "\
 Each subdirectory here is one routine (a prompt + schedule + agent, run on a cron schedule).
 
 - `<id>/routine.toml` — the schedule, agent, and repositories.
+- `<id>/schedule.cron` — a tracked mirror of the cron entry; not functional yet, the daemon
+  reads `schedule` from `routine.toml`.
 - `<id>/prompts/prompt.pure.md` — the prompt you wrote.
 - `<id>/prompts/prompt.compiled.local.md` — the composed prompt (repositories preamble +
   pure prompt) copied into each run's workbench. Gitignored (`.local.` matches the

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -27,8 +27,7 @@ struct RoutineToml {
     /// UUID that uniquely identifies this routine (stable across renames).
     id: Option<String>,
     /// Cron expression. Authoritative: the daemon reads the schedule from here. It is also
-    /// mirrored into the tracked `schedule.cron` sidecar, which is not functional yet (see
-    /// [`CRON_SIDECAR_HEADER`]).
+    /// mirrored into the tracked `schedule.cron` sidecar, which is not functional yet.
     #[serde(default)]
     schedule: Option<String>,
     /// Human name.
@@ -142,14 +141,8 @@ fn read_routine_toml(path: &std::path::PathBuf) -> Option<RoutineToml> {
     toml::from_str(&text).ok()
 }
 
-/// Comment written at the top of every `schedule.cron` sidecar. The sidecar mirrors
-/// `routine.toml`'s `schedule` field but is not consumed anywhere yet — `routine.toml` stays the
-/// source of truth until the sidecar is wired up.
-const CRON_SIDECAR_HEADER: &str =
-    "# NOTE: this file is not functional yet — the daemon reads `schedule` from routine.toml.";
-
 /// Read a routine's tracked cron entry from `schedule.cron`, returning the first line that is
-/// neither empty nor a `#` comment (so the [`CRON_SIDECAR_HEADER`] is skipped).
+/// neither empty nor a `#` comment.
 fn read_routine_cron(path: &std::path::PathBuf) -> Option<String> {
     let text = std::fs::read_to_string(path).ok()?;
     let schedule = text
@@ -302,7 +295,7 @@ pub fn write_routine(routine: &Routine) -> std::io::Result<()> {
     atomic_write(&routine_toml_path(&slug), text.as_bytes())?;
     atomic_write(
         &routine_cron_path(&slug),
-        format!("{CRON_SIDECAR_HEADER}\n{}\n", routine.schedule).as_bytes(),
+        format!("{}\n", routine.schedule).as_bytes(),
     )?;
     atomic_write(&routine_pure_prompt_path(&slug), routine.prompt.as_bytes())?;
     atomic_write(

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -26,11 +26,10 @@ use crate::utils::atomic::atomic_write;
 struct RoutineToml {
     /// UUID that uniquely identifies this routine (stable across renames).
     id: Option<String>,
-    /// Cron expression.
-    ///
-    /// **Read-only / legacy.** The schedule now lives in the tracked `schedule.cron` sidecar so
-    /// it stays diff-friendly and smaller than the rest of the routine metadata.
-    #[serde(default, skip_serializing)]
+    /// Cron expression. Authoritative: the daemon reads the schedule from here. It is also
+    /// mirrored into the tracked `schedule.cron` sidecar, which is not functional yet (see
+    /// [`CRON_SIDECAR_HEADER`]).
+    #[serde(default)]
     schedule: Option<String>,
     /// Human name.
     title: Option<String>,
@@ -143,10 +142,20 @@ fn read_routine_toml(path: &std::path::PathBuf) -> Option<RoutineToml> {
     toml::from_str(&text).ok()
 }
 
-/// Read a routine's tracked cron entry from `schedule.cron`, returning the first non-empty line.
+/// Comment written at the top of every `schedule.cron` sidecar. The sidecar mirrors
+/// `routine.toml`'s `schedule` field but is not consumed anywhere yet — `routine.toml` stays the
+/// source of truth until the sidecar is wired up.
+const CRON_SIDECAR_HEADER: &str =
+    "# NOTE: this file is not functional yet — the daemon reads `schedule` from routine.toml.";
+
+/// Read a routine's tracked cron entry from `schedule.cron`, returning the first line that is
+/// neither empty nor a `#` comment (so the [`CRON_SIDECAR_HEADER`] is skipped).
 fn read_routine_cron(path: &std::path::PathBuf) -> Option<String> {
     let text = std::fs::read_to_string(path).ok()?;
-    let schedule = text.lines().find(|line| !line.trim().is_empty())?.trim();
+    let schedule = text
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty() && !line.starts_with('#'))?;
     Some(schedule.to_string())
 }
 
@@ -219,7 +228,8 @@ fn ensure_routine_gitignore(path: &std::path::Path) -> std::io::Result<()> {
     std::fs::write(path, &content)
 }
 
-/// Write `routine` to disk: `routine.toml` (tracked config), `schedule.cron` (tracked cron entry),
+/// Write `routine` to disk: `routine.toml` (tracked config, including the authoritative
+/// `schedule`), `schedule.cron` (tracked cron mirror, not functional yet),
 /// the `prompts/prompt.pure.md` (raw) and `prompts/prompt.compiled.local.md` (composed) sidecars,
 /// the gitignored `state.local.toml` runtime sidecar, and `.gitignore` (created or reconciled — see
 /// [`ensure_routine_gitignore`]).
@@ -264,7 +274,7 @@ pub fn write_routine(routine: &Routine) -> std::io::Result<()> {
 
     let toml_routine = RoutineToml {
         id: Some(routine.id.clone()),
-        schedule: None,
+        schedule: Some(routine.schedule.clone()),
         title: Some(routine.title.clone()),
         agent: Some(routine.agent.clone()),
         model: routine.model.clone(),
@@ -292,7 +302,7 @@ pub fn write_routine(routine: &Routine) -> std::io::Result<()> {
     atomic_write(&routine_toml_path(&slug), text.as_bytes())?;
     atomic_write(
         &routine_cron_path(&slug),
-        format!("{}\n", routine.schedule).as_bytes(),
+        format!("{CRON_SIDECAR_HEADER}\n{}\n", routine.schedule).as_bytes(),
     )?;
     atomic_write(&routine_pure_prompt_path(&slug), routine.prompt.as_bytes())?;
     atomic_write(

--- a/src/routine_storage_load.rs
+++ b/src/routine_storage_load.rs
@@ -72,10 +72,12 @@ fn load_routine_from_base(base: &std::path::Path, dir_name: &str) -> Option<Rout
     let title = toml.title?;
     let id = toml.id.unwrap_or_else(|| dir_name.to_string());
     let runtime_state = read_runtime_state(base, dir_name);
-    // Prefer the tracked cron file; fall back to legacy routine.toml, then routines that predate
-    // the split keep loading until repersisted.
-    let schedule =
-        read_routine_cron(&base.join(dir_name).join("schedule.cron")).or(toml.schedule)?;
+    // routine.toml is authoritative (schedule.cron only mirrors it and is not functional yet);
+    // fall back to the cron sidecar so dirs written while the schedule lived only there keep
+    // loading until repersisted.
+    let schedule = toml
+        .schedule
+        .or_else(|| read_routine_cron(&base.join(dir_name).join("schedule.cron")))?;
     // Prefer the log file; fall back to legacy state.local.toml field then routine.toml field for
     // routines that predate the log-file migration.
     let last_manual_trigger_at = read_manual_state(base, dir_name)

--- a/src/routine_storage_tests.rs
+++ b/src/routine_storage_tests.rs
@@ -93,16 +93,21 @@ fn write_then_load_round_trips() {
         assert!(crate::paths::routine_gitignore_path(&slug).exists());
         let toml_text = std::fs::read_to_string(crate::paths::routine_toml_path(&slug)).unwrap();
         assert!(
-            !toml_text.contains("schedule"),
-            "routine.toml must not carry the schedule: {toml_text}"
+            toml_text.contains("schedule = \"@daily\""),
+            "routine.toml must carry the authoritative schedule: {toml_text}"
         );
         assert!(
             !toml_text.contains("prompt"),
             "routine.toml must not carry the prompt: {toml_text}"
         );
-        assert_eq!(
-            std::fs::read_to_string(crate::paths::routine_cron_path(&slug)).unwrap(),
-            "@daily\n"
+        let cron_text = std::fs::read_to_string(crate::paths::routine_cron_path(&slug)).unwrap();
+        assert!(
+            cron_text.starts_with("# NOTE: this file is not functional yet"),
+            "schedule.cron must open with the not-functional-yet comment: {cron_text}"
+        );
+        assert!(
+            cron_text.ends_with("\n@daily\n"),
+            "schedule.cron must mirror the cron entry after the comment: {cron_text}"
         );
         assert_eq!(
             std::fs::read_to_string(crate::paths::routine_pure_prompt_path(&slug)).unwrap(),
@@ -147,19 +152,18 @@ fn tags_round_trip_through_routine_toml() {
 
 #[test]
 fn load_routine_from_dir_applies_defaults_for_absent_optional_fields() {
-    // A minimal current-layout routine (schedule.cron + routine.toml) that omits prompt, enabled,
-    // timestamps, and id exercises the default-fallback arms in load_routine_from_dir:
-    // prompt -> "", enabled -> true, created_at/updated_at -> 0, and id -> dir_name (legacy fallback).
+    // A minimal routine.toml that omits prompt, enabled, timestamps, and id exercises the
+    // default-fallback arms in load_routine_from_dir: prompt -> "", enabled -> true,
+    // created_at/updated_at -> 0, and id -> dir_name (legacy fallback).
     with_override_home(|_home| {
         let slug = "rs-defaults-routine";
         let dir = crate::paths::routine_dir(slug);
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(
             crate::paths::routine_toml_path(slug),
-            "title = \"Rs Defaults Routine\"\nagent = \"claude\"\n",
+            "schedule = \"@daily\"\ntitle = \"Rs Defaults Routine\"\nagent = \"claude\"\n",
         )
         .unwrap();
-        std::fs::write(crate::paths::routine_cron_path(slug), "@daily\n").unwrap();
 
         let loaded = load_routine_from_dir(slug).unwrap();
         assert_eq!(loaded.id, slug, "absent id falls back to the dir name");
@@ -202,30 +206,54 @@ fn load_routine_falls_back_to_legacy_last_triggered_in_routine_toml() {
 }
 
 #[test]
-fn load_routine_falls_back_to_legacy_schedule_in_routine_toml() {
-    // Older routine dirs kept the schedule in routine.toml; the loader still accepts that until
-    // the next repersist writes schedule.cron.
+fn load_routine_prefers_routine_toml_schedule_over_cron_sidecar() {
+    // routine.toml is the authoritative schedule source; the schedule.cron mirror is not
+    // functional yet, so a diverging sidecar must lose.
     with_override_home(|_home| {
-        let slug = "rs-legacy-schedule-routine";
+        let slug = "rs-toml-schedule-wins-routine";
         let dir = crate::paths::routine_dir(slug);
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(
             crate::paths::routine_toml_path(slug),
-            "schedule = \"@hourly\"\ntitle = \"Rs Legacy Schedule\"\nagent = \"claude\"\n",
+            "schedule = \"@hourly\"\ntitle = \"Rs Toml Schedule Wins\"\nagent = \"claude\"\n",
+        )
+        .unwrap();
+        std::fs::write(crate::paths::routine_cron_path(slug), "@weekly\n").unwrap();
+
+        assert_eq!(load_routine_from_dir(slug).unwrap().schedule, "@hourly");
+    });
+}
+
+#[test]
+fn load_routine_falls_back_to_cron_sidecar_when_routine_toml_has_no_schedule() {
+    // Dirs written while the schedule lived only in schedule.cron keep loading until the next
+    // repersist restores the field in routine.toml. Comment lines (like the not-functional-yet
+    // header the daemon writes) are skipped when reading the sidecar.
+    with_override_home(|_home| {
+        let slug = "rs-cron-fallback-routine";
+        let dir = crate::paths::routine_dir(slug);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            crate::paths::routine_toml_path(slug),
+            "title = \"Rs Cron Fallback\"\nagent = \"claude\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            crate::paths::routine_cron_path(slug),
+            "# some comment\n\n@hourly\n",
         )
         .unwrap();
 
-        let loaded = load_routine_from_dir(slug).unwrap();
-        assert_eq!(loaded.schedule, "@hourly");
-        assert!(!crate::paths::routine_cron_path(slug).exists());
+        assert_eq!(load_routine_from_dir(slug).unwrap().schedule, "@hourly");
     });
 }
 
 #[test]
 fn load_routine_blank_schedule_cron_with_no_legacy_schedule_returns_none() {
-    // A `schedule.cron` with no non-empty line (e.g. truncated by a crash mid-write) parses to
-    // `None` rather than an empty string, and with no legacy `schedule` field in `routine.toml`
-    // either, the whole load short-circuits to `None` instead of a routine with a blank schedule.
+    // A `schedule.cron` with no cron line — only blanks and comments (e.g. truncated by a crash
+    // mid-write, leaving just the header) — parses to `None` rather than an empty string, and with
+    // no `schedule` field in `routine.toml` either, the whole load short-circuits to `None`
+    // instead of a routine with a blank schedule.
     with_override_home(|_home| {
         let slug = "rs-blank-schedule-cron-routine";
         let dir = crate::paths::routine_dir(slug);
@@ -235,7 +263,11 @@ fn load_routine_blank_schedule_cron_with_no_legacy_schedule_returns_none() {
             "title = \"Rs Blank Schedule Cron\"\nagent = \"claude\"\n",
         )
         .unwrap();
-        std::fs::write(crate::paths::routine_cron_path(slug), "\n\n").unwrap();
+        std::fs::write(
+            crate::paths::routine_cron_path(slug),
+            "# not functional yet\n\n",
+        )
+        .unwrap();
 
         assert!(load_routine_from_dir(slug).is_none());
     });

--- a/src/routine_storage_tests.rs
+++ b/src/routine_storage_tests.rs
@@ -100,14 +100,9 @@ fn write_then_load_round_trips() {
             !toml_text.contains("prompt"),
             "routine.toml must not carry the prompt: {toml_text}"
         );
-        let cron_text = std::fs::read_to_string(crate::paths::routine_cron_path(&slug)).unwrap();
-        assert!(
-            cron_text.starts_with("# NOTE: this file is not functional yet"),
-            "schedule.cron must open with the not-functional-yet comment: {cron_text}"
-        );
-        assert!(
-            cron_text.ends_with("\n@daily\n"),
-            "schedule.cron must mirror the cron entry after the comment: {cron_text}"
+        assert_eq!(
+            std::fs::read_to_string(crate::paths::routine_cron_path(&slug)).unwrap(),
+            "@daily\n"
         );
         assert_eq!(
             std::fs::read_to_string(crate::paths::routine_pure_prompt_path(&slug)).unwrap(),
@@ -227,8 +222,8 @@ fn load_routine_prefers_routine_toml_schedule_over_cron_sidecar() {
 #[test]
 fn load_routine_falls_back_to_cron_sidecar_when_routine_toml_has_no_schedule() {
     // Dirs written while the schedule lived only in schedule.cron keep loading until the next
-    // repersist restores the field in routine.toml. Comment lines (like the not-functional-yet
-    // header the daemon writes) are skipped when reading the sidecar.
+    // repersist restores the field in routine.toml. Comment lines are skipped when reading the
+    // sidecar.
     with_override_home(|_home| {
         let slug = "rs-cron-fallback-routine";
         let dir = crate::paths::routine_dir(slug);
@@ -251,9 +246,9 @@ fn load_routine_falls_back_to_cron_sidecar_when_routine_toml_has_no_schedule() {
 #[test]
 fn load_routine_blank_schedule_cron_with_no_legacy_schedule_returns_none() {
     // A `schedule.cron` with no cron line — only blanks and comments (e.g. truncated by a crash
-    // mid-write, leaving just the header) — parses to `None` rather than an empty string, and with
-    // no `schedule` field in `routine.toml` either, the whole load short-circuits to `None`
-    // instead of a routine with a blank schedule.
+    // mid-write) — parses to `None` rather than an empty string, and with no `schedule` field in
+    // `routine.toml` either, the whole load short-circuits to `None` instead of a routine with a
+    // blank schedule.
     with_override_home(|_home| {
         let slug = "rs-blank-schedule-cron-routine";
         let dir = crate::paths::routine_dir(slug);


### PR DESCRIPTION
## Summary

#1281 split the schedule out of `routine.toml` into a `schedule.cron` sidecar and made the sidecar the source of truth. That was premature — this PR restores `schedule` in `routine.toml` while keeping the sidecar around for the eventual switch:

- `routine.toml` carries the authoritative `schedule` field again: it is written on every persist and read first on load.
- `schedule.cron` is still written next to it, holding just the cron expression. It is not functional yet — the daemon reads the schedule from `routine.toml`.
- The cron-file reader skips `#` comment lines and stays as a load **fallback**, so routine dirs written during the sidecar-only era keep loading until the next startup repersist heals them.
- The generated JSON Schema requires `schedule` again with its original description (plus a note about the inert mirror); `routine.example.toml` shows the field again.
- README and the seeded `routines/README.md` document `routine.toml` as the schedule's home and mark `schedule.cron` as a not-yet-functional mirror.

## Tests

- Round-trip test asserts `routine.toml` carries the schedule and `schedule.cron` holds the cron entry.
- New tests: `routine.toml` wins over a diverging sidecar; sidecar-only dirs (with comment lines) still load.
- Blank-cron short-circuit test now also covers a comment-only sidecar.
- `cargo test` (1156 passed) and `cargo clippy --all-targets` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)