### PR TITLE
test(client): cover failureNotify.ts's localStorage error-handling branch

### DIFF
--- a/.changeset/failurenotify-storage-error-coverage.md
+++ b/.changeset/failurenotify-storage-error-coverage.md
@@ -1,0 +1,17 @@
+---
+"moadim": patch
+---
+
+test(client): cover failureNotify.ts's localStorage error-handling branch
+
+`pnpm --filter client test:coverage` showed `src/lib/failureNotify.ts`'s
+`loadNotifyFailures` `catch` (falling back to notifications-off) untested,
+even though it exists specifically to keep a blocked `localStorage`
+(private browsing, quota exceeded, disabled storage) from crashing the
+failure-notification preference read. Mirrors the same gap already closed
+for `theme.ts` (see the `theme-storage-error-coverage` changeset): adds
+tests that mock `Storage.prototype.getItem`/`setItem` to throw and assert
+the fallback/no-throw behavior each catch is there for.
+
+No behavior change — test-only. `failureNotify.ts` is now at 100% line
+coverage.

--- a/client/src/lib/failureNotify.test.ts
+++ b/client/src/lib/failureNotify.test.ts
@@ -61,6 +61,29 @@ describe("notify-failures preference", () => {
     saveNotifyFailures(false);
     expect(loadNotifyFailures()).toBe(false);
   });
+
+  // Mirrors theme.ts's equivalent guard (see theme.test.ts): both preferences are read/written
+  // through the same try/catch-and-fall-back shape, so a private-mode/quota storage error must
+  // not crash the app either.
+  describe("when localStorage throws (private mode / quota)", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("falls back to off instead of propagating the error", () => {
+      vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+        throw new DOMException("blocked", "SecurityError");
+      });
+      expect(loadNotifyFailures()).toBe(false);
+    });
+
+    it("saveNotifyFailures swallows the error instead of propagating it", () => {
+      vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+        throw new DOMException("blocked", "SecurityError");
+      });
+      expect(() => saveNotifyFailures(true)).not.toThrow();
+    });
+  });
 });
 
 describe("notification support/permission", () => {


### PR DESCRIPTION
## Why

`loadNotifyFailures`/`saveNotifyFailures` (`client/src/lib/failureNotify.ts`) wrap `localStorage` reads/writes in a `try`/`catch` specifically so a blocked store — private browsing, quota exceeded, storage disabled by policy — falls back gracefully (notifications off) instead of crashing the dashboard. `pnpm --filter client test:coverage` showed the `catch` branch untested, leaving the file at 94% line coverage: the safety net itself had no test proving it actually catches anything.

`theme.ts` has the exact same shape (`loadThemeLight`/`saveThemeLight`), and its equivalent gap was just closed in #1376 (merged as `a1668ba`). This PR applies the identical fix to `failureNotify.ts`: mock `Storage.prototype.getItem`/`setItem` to throw and assert the fallback/no-throw behavior each `catch` exists for.

## What

- Added two tests to `client/src/lib/failureNotify.test.ts` mirroring `theme.test.ts`'s pattern.
- `.changeset/failurenotify-storage-error-coverage.md` (patch).

No behavior change — test-only. `failureNotify.ts` is now at 100% line coverage.

## Test plan

- [x] `pnpm --filter client test` — 375/375 pass (18/18 in `failureNotify.test.ts`, up from 16).
- [x] `pnpm --filter client typecheck` — clean.
- [x] `pnpm --filter client lint` — clean.
- [x] `pnpm --filter client test:coverage` — `failureNotify.ts` no longer appears in the under-covered file list.
- [x] `cargo fmt --all -- --check` / `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean (no Rust files touched).
- [x] `cargo check` — `prebuilt.html` unchanged (test-only client change, not part of the built bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)