### PR TITLE
test(routines): cover next_run_at's impossible-date branch

### DIFF
--- a/.changeset/cover-next-run-at-impossible-date.md
+++ b/.changeset/cover-next-run-at-impossible-date.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Add a unit test covering `next_run_at`'s "no upcoming fire" branch (an impossible calendar date like `0 0 30 2 *`, which parses fine but never fires), closing one of the gaps in the repo's 100%-line-coverage floor.

--- a/src/routines/model_tests.rs
+++ b/src/routines/model_tests.rs
@@ -286,6 +286,14 @@ fn next_run_at_none_for_unparseable_schedule() {
 }
 
 #[test]
+fn next_run_at_none_for_impossible_calendar_date() {
+    // Feb 30 never occurs, so a schedule pinned to it parses fine but has no upcoming fire —
+    // covers `next_run_at`'s "no upcoming fire" branch, distinct from the unparseable-schedule
+    // case above.
+    assert!(next_run_at("0 0 30 2 *", true).is_none());
+}
+
+#[test]
 fn from_routine_populates_derived_fields() {
     let routine = Routine {
         id: "rid".into(),


### PR DESCRIPTION
## Why

`next_run_at`'s doc comment says it returns `None` when a schedule "has no upcoming fire" — distinct from the unparseable-schedule case, which is already tested. Nothing exercised that branch, so `cron.after(&Local::now()).next()` returning `None` was one of the gaps behind the repo's 100%-line-coverage floor (`cargo llvm-cov --fail-under-lines 100`) currently sitting at ~99.5%.

## What

Adds one test: `"0 0 30 2 *"` (Feb 30 never occurs on any calendar) parses as a valid cron expression but never fires, so it hits the documented "no upcoming fire" `None` branch without needing any I/O fault injection or mocking.

Verified locally: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` (1159 passed) are all clean. Coverage on `src/routines/model.rs` moves from 2 missed lines to 1 (the remaining gap, `union.iter().next()?`, looks practically unreachable given `cron-union` is fed a single already-validated expression — left alone rather than forcing it).

Added a changeset (`patch`) since this touches `src/`.