### PR TITLE
fix(routines): svc_logs no longer 500s on invalid UTF-8 in a small agent.log

### DIFF
--- a/.changeset/svc-logs-lossy-small-file-utf8.md
+++ b/.changeset/svc-logs-lossy-small-file-utf8.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Fix `svc_logs` returning a 500 for a small `agent.log` containing invalid UTF-8 (e.g. binary tool output, or a multi-byte character split by a `tmux pipe-pane` write): the under-cap read path now uses a lossy UTF-8 decode, matching the truncated-tail path's existing behavior, instead of erroring out via `read_to_string`.

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -289,6 +289,9 @@ pub fn svc_delete(store: &RoutineStore, id: &str) -> Result<RoutineResponse, App
 mod service_log_tail;
 #[cfg(test)]
 pub(crate) use service_log_tail::{read_log_tail, strip_ansi_noise, MAX_LOG_TAIL_BYTES};
+#[cfg(test)]
+#[path = "service_log_tail_tests.rs"]
+mod service_log_tail_tests;
 
 #[path = "service_trigger.rs"]
 mod service_trigger;

--- a/src/routines/service_log_tail.rs
+++ b/src/routines/service_log_tail.rs
@@ -70,7 +70,14 @@ pub(crate) fn read_log_tail(path: &std::path::Path) -> std::io::Result<String> {
 fn read_log_tail_of_len(path: &std::path::Path, len: u64) -> std::io::Result<String> {
     use std::io::{Read, Seek, SeekFrom};
     if len <= MAX_LOG_TAIL_BYTES {
-        return std::fs::read_to_string(path).map(|contents| strip_ansi_noise(&contents));
+        // Lossy, like the truncated path below: a raw `tmux pipe-pane` capture can contain a byte
+        // sequence that isn't valid UTF-8 (e.g. binary output from some CLI tool, or a multi-byte
+        // character split across a pipe write), and `read_to_string` errors out on the first
+        // invalid byte. That turned "log had one bad byte" into "log endpoint returns 500 with no
+        // content at all" for a small file, while a large file serving its truncated tail already
+        // degraded gracefully via `from_utf8_lossy`. Read raw bytes so both paths behave the same.
+        let bytes = std::fs::read(path)?;
+        return Ok(strip_ansi_noise(&String::from_utf8_lossy(&bytes)));
     }
     let omitted = len - MAX_LOG_TAIL_BYTES;
     let mut file = std::fs::File::open(path)?;

--- a/src/routines/service_log_tail_tests.rs
+++ b/src/routines/service_log_tail_tests.rs
@@ -1,0 +1,39 @@
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and fixtures do not need doc comments"
+)]
+
+use super::*;
+
+fn temp_log_path(tag: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!(
+        "moadim-log-tail-test-{tag}-{}",
+        uuid::Uuid::new_v4()
+    ))
+}
+
+#[test]
+fn read_log_tail_is_lossy_on_invalid_utf8_when_under_the_cap() {
+    let path = temp_log_path("small-invalid-utf8");
+    // A lone continuation byte (0x80) is never valid UTF-8 on its own, and this file is well
+    // under `MAX_LOG_TAIL_BYTES`, so this exercises the non-truncated read path.
+    std::fs::write(&path, b"before\xFFafter\n").expect("write temp log");
+
+    let result = read_log_tail(&path);
+
+    std::fs::remove_file(&path).ok();
+    let content = result.expect("invalid UTF-8 in a small log must not error the whole read");
+    assert!(content.contains("before"));
+    assert!(content.contains("after"));
+}
+
+#[test]
+fn read_log_tail_still_reads_valid_utf8_when_under_the_cap() {
+    let path = temp_log_path("small-valid-utf8");
+    std::fs::write(&path, b"hello world\n").expect("write temp log");
+
+    let result = read_log_tail(&path);
+
+    std::fs::remove_file(&path).ok();
+    assert_eq!(result.expect("valid UTF-8 read"), "hello world\n");
+}


### PR DESCRIPTION
## Why

`read_log_tail_of_len`'s under-cap path (`src/routines/service_log_tail.rs`) reads a small `agent.log` with `std::fs::read_to_string`, which errors on the first byte that isn't valid UTF-8. A raw `tmux pipe-pane -o` capture can contain such a byte — binary output from some CLI tool, or a multi-byte UTF-8 character split across a pipe write — so a small log with a single bad byte turned `GET /routines/{id}/logs` into a 500 with **no content at all**.

The truncated-tail path for large logs already handles this gracefully via `String::from_utf8_lossy`. The under-cap path was the odd one out: whether a log's content survives an invalid byte depended on file size, which is an accident of implementation rather than an intended behavior.

## What

Read raw bytes and decode lossily (`from_utf8_lossy`) on the under-cap path too, matching the truncated path. Added two regression tests: one asserting a small log with an invalid UTF-8 byte still returns its content instead of erroring, one asserting the existing valid-UTF-8 behavior is unchanged.

Verified locally: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` (1161 passed) are all clean. Added a changeset (`patch`) since this touches `src/`.