### PR TITLE
test(client): cover unwrapVoid's generic-message fallback branch

### DIFF
--- a/.changeset/cover-unwrapvoid-generic-message.md
+++ b/.changeset/cover-unwrapvoid-generic-message.md
@@ -1,0 +1,9 @@
+---
+"moadim": patch
+---
+
+test(client): cover `unwrapVoid`'s generic-message fallback branch
+
+`pnpm --filter client test:coverage` showed `src/api/client.ts` at 100% lines but only 92.85% branches, missing `unwrapVoid`'s `error?.error ?? \`HTTP ${response.status}\`` fallback — the sibling `unwrap` function already had a test for this exact branch ("throws a generic message when the error body has no message"), but `unwrapVoid` never got the matching one. Adds it, mirroring the existing `unwrap` test one-for-one.
+
+No behavior change — test-only. `src/api/client.ts` is now at 100% branch coverage.

--- a/client/src/api/client.test.ts
+++ b/client/src/api/client.test.ts
@@ -37,4 +37,8 @@ describe("unwrapVoid", () => {
   it("throws ApiError on failure", () => {
     expect(() => unwrapVoid({ error: { error: "nope" }, response: resp(404) })).toThrow("nope");
   });
+
+  it("throws a generic message when the error body has no message", () => {
+    expect(() => unwrapVoid({ response: resp(500) })).toThrow("HTTP 500");
+  });
 });


### PR DESCRIPTION
## Why

`pnpm --filter client test:coverage` shows `src/api/client.ts` at 100% line coverage but only 92.85% branch coverage. The gap is `unwrapVoid`'s `error?.error ?? \`HTTP ${response.status}\`` fallback (client.ts:49) — the sibling `unwrap` function already has a test for this exact branch ("throws a generic message when the error body has no message"), but the equivalent test for `unwrapVoid` was never added, even though the two functions share the same shape and the same fallback expression.

## What

Adds the missing `unwrapVoid` test, mirroring the existing `unwrap` test one-for-one:

```ts
it("throws a generic message when the error body has no message", () => {
  expect(() => unwrapVoid({ response: resp(500) })).toThrow("HTTP 500");
});
```

`src/api/client.ts` is now at 100% branch coverage. Test-only, no behavior change.

## Verification

- `pnpm --filter client typecheck` — pass
- `pnpm --filter client lint` — pass
- `pnpm --filter client test` — 385 passed (was 384)
- `pnpm vitest run --coverage` — `src/api/client.ts` no longer appears in the "less than 100%" coverage table (previously 100/92.85/100/100, missing line 49)
- Full local `.githooks/pre-push` run (fmt, clippy, `cargo test`, `cargo llvm-cov --fail-under-lines 100`, linecheck, client typecheck/lint/test, changeset check) — all pass
- Added `.changeset/cover-unwrapvoid-generic-message.md` (`"moadim": patch`), matching the format of the precedent PR for this exact pattern (#1383)

🤖 Generated with [Claude Code](https://claude.com/claude-code)