### PR TITLE
refactor(service): use is_ok() instead of if-let-Ok-unit in enable_linger

### DIFF
--- a/.changeset/equatable-if-let-enable-linger.md
+++ b/.changeset/equatable-if-let-enable-linger.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Rewrite enable_linger()'s if-let-Ok-unit pattern as .is_ok() (src/service/linux.rs). No behavior change -- clears the sole violation blocking clippy::equatable_if_let (PR #1391) from a clean CI run.

--- a/src/service/linux.rs
+++ b/src/service/linux.rs
@@ -122,7 +122,7 @@ fn report_installed(unit: &Path) {
 /// no systemd-logind, insufficient privilege), print a warning with the manual command instead of
 /// aborting the install.
 fn enable_linger(unit: &Path) {
-    if let Ok(()) = run(&loginctl_bin(), &["enable-linger"]) {
+    if run(&loginctl_bin(), &["enable-linger"]).is_ok() {
         if let Some(marker) = linger_marker_path(unit) {
             // Best-effort: if the marker can't be written, uninstall just won't disable
             // linger later, which is the safe direction to fail in.


### PR DESCRIPTION
## Summary
- `enable_linger()` in `src/service/linux.rs` used `if let Ok(()) = run(...) { }` to test success/failure without extracting any binding — the `Ok(())` pattern only matches the unit variant, so a direct `.is_ok()` says the same thing and is what `clippy::equatable_if_let` requires.
- This is currently the **only** spot in the tree that trips `clippy::equatable_if_let`. It's why #1391 (which enables that lint) is failing CI on `cargo clippy` right now — the lint enable and this specific call site landed on `main` independently of each other, so the PR that turns the lint on doesn't include the one fix it needs. This PR fixes the call site directly (not the PR itself, per the "never touch product code to unblock someone else's PR" rule), so #1391 (or a rebase of it) can go green.
- No behavior change: `run()` returns `anyhow::Result<()>`, so `if let Ok(()) = expr` and `if expr.is_ok()` are exactly equivalent here.

## Test plan
- `cargo fmt --check` — clean.
- Both branches of `enable_linger()` are already exercised by `install_enables_linger_and_marks_ownership_when_loginctl_succeeds` and `install_warns_without_failing_when_loginctl_fails` in `src/service/mod_linux_tests.rs` (Linux-only tests; this repo's CI runs `cargo test`/`cargo llvm-cov` on Linux, so they cover this change there). This workbench is macOS, where `#[cfg(target_os = "linux")]` excludes this module from compilation, so `cargo clippy`/`cargo test`/`cargo llvm-cov` could not be exercised locally against this exact code path — the change is a mechanical, well-understood Rust equivalence, and CI will confirm.
- Added `.changeset/equatable-if-let-enable-linger.md` (patch) per repo convention (`src/` diff requires one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)