### PR TITLE
chore(lint): enable clippy::stable_sort_primitive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -503,3 +503,10 @@ float_cmp = "deny"
 # having to confirm no fields are actually being destructured. The codebase is already clean, so
 # `deny` locks that in.
 equatable_if_let = "deny"
+# Reject `.sort()`/`.sort_by()`/`.sort_by_key()` on a slice of primitives (integers, floats,
+# chars, bools) in favour of the `_unstable` variant. A stable sort only matters when equal
+# elements must keep their relative order, which is meaningless for primitives — two `5`s are
+# indistinguishable regardless of which one came first. The unstable variant is faster and,
+# unlike the stable one, sorts in place without allocating a scratch buffer. The codebase is
+# already clean, so `deny` locks that in.
+stable_sort_primitive = "deny"


### PR DESCRIPTION
## Summary
- Adds `stable_sort_primitive = "deny"` to `[lints.clippy]` in `Cargo.toml`.
- Rejects `.sort()`/`.sort_by()`/`.sort_by_key()` on primitive slices in favour of the `_unstable` variant — a stable sort's ordering guarantee is meaningless for indistinguishable primitives, and the unstable form is faster with no scratch allocation.
- Zero existing violations across the 7 current `.sort()` call sites, so this is a pure lock-in with no code changes needed.

Closes #1395

## Test plan
- [x] `cargo build --release` — passes
- [x] `cargo clippy --release --all-targets` — passes, no new violations
- [x] `cargo test --release` — 1164 passed, 0 failed

---
Opened by the moadim routine *"Clippy lint improvements → issue + PR (Rust repos) → Slack"*.