### PR TITLE
chore: add missing changeset

### DIFF
--- a/.changeset/enable-clippy-stable-sort-primitive.md
+++ b/.changeset/enable-clippy-stable-sort-primitive.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Enable clippy::stable_sort_primitive lint, rejecting stable sorts on primitive slices in favor of the faster unstable variant (#1396).


### PR DESCRIPTION
## Summary

- Adds a missing changeset for a merged PR that landed without one.

## Covers

- PR #1396 — chore(lint): enable clippy::stable_sort_primitive

## Baseline

Compared against tag `v1.6.1`. Of 7 non-bot PRs merged since then, 6 already had matching `.changeset/*.md` files; PR #1396 was the only gap.

_Opened by the **Changesets keeper (owned repos + my orgs)** moadim routine._