### PR TITLE
chore(release): v1.7.0

### DIFF
--- a/.changeset/cover-next-run-at-impossible-date.md
+++ b/.changeset/cover-next-run-at-impossible-date.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-Add a unit test covering `next_run_at`'s "no upcoming fire" branch (an impossible calendar date like `0 0 30 2 *`, which parses fine but never fires), closing one of the gaps in the repo's 100%-line-coverage floor.

--- a/.changeset/cover-unwrapvoid-generic-message.md
+++ b/.changeset/cover-unwrapvoid-generic-message.md
@@ -1,9 +1,0 @@
----
-"moadim": patch
----
-
-test(client): cover `unwrapVoid`'s generic-message fallback branch
-
-`pnpm --filter client test:coverage` showed `src/api/client.ts` at 100% lines but only 92.85% branches, missing `unwrapVoid`'s `error?.error ?? \`HTTP ${response.status}\`` fallback — the sibling `unwrap` function already had a test for this exact branch ("throws a generic message when the error body has no message"), but `unwrapVoid` never got the matching one. Adds it, mirroring the existing `unwrap` test one-for-one.
-
-No behavior change — test-only. `src/api/client.ts` is now at 100% branch coverage.

--- a/.changeset/enable-clippy-equatable-if-let.md
+++ b/.changeset/enable-clippy-equatable-if-let.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-Enable `clippy::equatable_if_let`, rejecting an `if let PAT = expr` that only tests a single unit-like variant with no bindings extracted in favor of a direct `==` comparison. No behavior change — the codebase is already clean, so `deny` locks that in.

--- a/.changeset/equatable-if-let-enable-linger.md
+++ b/.changeset/equatable-if-let-enable-linger.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-Rewrite enable_linger()'s if-let-Ok-unit pattern as .is_ok() (src/service/linux.rs). No behavior change -- clears the sole violation blocking clippy::equatable_if_let (PR #1391) from a clean CI run.

--- a/.changeset/machines-glob-wildcards.md
+++ b/.changeset/machines-glob-wildcards.md
@@ -1,5 +1,0 @@
----
-"moadim": minor
----
-
-Support glob-style wildcards in a routine's `machines` targeting list: an entry containing `*` now matches the resolved machine name as a glob (`*` standing for any run of characters) instead of requiring an exact string. `machines = ["*"]` runs a routine on any machine; `machines = ["box-*"]` matches a whole family without enumerating each name. Plain entries with no `*` still match by exact equality, unchanged. Closes #1393.

--- a/.changeset/svc-logs-lossy-small-file-utf8.md
+++ b/.changeset/svc-logs-lossy-small-file-utf8.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-Fix `svc_logs` returning a 500 for a small `agent.log` containing invalid UTF-8 (e.g. binary tool output, or a multi-byte character split by a `tmux pipe-pane` write): the under-cap read path now uses a lossy UTF-8 decode, matching the truncated-tail path's existing behavior, instead of erroring out via `read_to_string`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-07-23
+
+Add a unit test covering `next_run_at`'s "no upcoming fire" branch (an impossible calendar date like `0 0 30 2 *`, which parses fine but never fires), closing one of the gaps in the repo's 100%-line-coverage floor.
+
+test(client): cover `unwrapVoid`'s generic-message fallback branch
+
+`pnpm --filter client test:coverage` showed `src/api/client.ts` at 100% lines but only 92.85% branches, missing `unwrapVoid`'s `error?.error ?? \`HTTP ${response.status}\`` fallback — the sibling `unwrap` function already had a test for this exact branch ("throws a generic message when the error body has no message"), but `unwrapVoid` never got the matching one. Adds it, mirroring the existing `unwrap` test one-for-one.
+
+No behavior change — test-only. `src/api/client.ts` is now at 100% branch coverage.
+
+Enable `clippy::equatable_if_let`, rejecting an `if let PAT = expr` that only tests a single unit-like variant with no bindings extracted in favor of a direct `==` comparison. No behavior change — the codebase is already clean, so `deny` locks that in.
+
+Rewrite enable_linger()'s if-let-Ok-unit pattern as .is_ok() (src/service/linux.rs). No behavior change -- clears the sole violation blocking clippy::equatable_if_let (PR #1391) from a clean CI run.
+
+Support glob-style wildcards in a routine's `machines` targeting list: an entry containing `*` now matches the resolved machine name as a glob (`*` standing for any run of characters) instead of requiring an exact string. `machines = ["*"]` runs a routine on any machine; `machines = ["box-*"]` matches a whole family without enumerating each name. Plain entries with no `*` still match by exact equality, unchanged. Closes #1393.
+
+Fix `svc_logs` returning a 500 for a small `agent.log` containing invalid UTF-8 (e.g. binary tool output, or a multi-byte character split by a `tmux pipe-pane` write): the under-cap read path now uses a lossy UTF-8 decode, matching the truncated-tail path's existing behavior, instead of erroring out via `read_to_string`.
+
 ## [1.6.1] - 2026-07-21
 
 Bump `jiff`, `jiff-static` (0.2.33 → 0.2.34), and `syn` (3.0.0 → 3.0.2) to their latest compatible patch releases (#1314).
@@ -4827,7 +4845,8 @@ Enable `clippy::match_same_arms` and merge the two duplicate-body arms it flagge
 - Ship the prebuilt UI in the published crate.
 - Rename the binary to `moadim` and add install docs.
 
-[Unreleased]: https://github.com/moadim-io/daemon/compare/v1.6.1...HEAD
+[Unreleased]: https://github.com/moadim-io/daemon/compare/v1.7.0...HEAD
+[1.7.0]: https://github.com/moadim-io/daemon/compare/v1.6.1...v1.7.0
 [1.6.1]: https://github.com/moadim-io/daemon/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/moadim-io/daemon/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/moadim-io/daemon/compare/v1.4.1...v1.5.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "1.6.1"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moadim"
-version = "1.6.1"
+version = "1.7.0"
 edition = "2021"
 # Floor set by the transitive proc-macro build dependency `darling 0.23`
 # (pulled in via `rmcp-macros` <- `rmcp`), which itself declares

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "1.6.1"
+    "version": "1.7.0"
   },
   "servers": [
     {

--- a/docs/moadim.1
+++ b/docs/moadim.1
@@ -1,7 +1,7 @@
 .\" Man page for moadim.
 .\" Mirrors the built-in `moadim --help` output (src/cli/mod.rs::print_help).
 .\" View with:  man ./docs/moadim.1   or install into share/man/man1/.
-.TH MOADIM 1 "2026-07-21" "moadim 1.6.1" "Moadim Manual"
+.TH MOADIM 1 "2026-07-23" "moadim 1.7.0" "Moadim Manual"
 .SH NAME
 moadim \- routine scheduler with an MCP/REST API and a web control panel
 .SH SYNOPSIS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moadim",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "scripts": {


### PR DESCRIPTION
## Summary

Manual fallback release cut — no `changeset-release.yml` bot PR was open (org disables Actions opening PRs, per CONTRIBUTING.md). Ran `pnpm version-packages` locally to roll up the 6 pending changesets into a new dated CHANGELOG section and bump versions.

- 5 patch changesets (test coverage, clippy lint, `svc_logs` UTF-8 fix) + 1 minor changeset (glob-style `machines` targeting, #1393) → **1.6.1 → 1.7.0**
- Bumps `package.json`, `Cargo.toml`, `Cargo.lock`, `apis/openapi.json` (regenerated, was stale), `docs/moadim.1` (version + date)
- `.changeset/*.md` files consumed and removed

On merge, `auto-release.yml` will detect the version bump, tag `v1.7.0`, and publish to crates.io + cut the GitHub Release.

---
🤖 Cut by the **Nightly release cutter (moadim daemon)** routine.