### PR TITLE
Enable clippy::struct_excessive_bools lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -510,3 +510,15 @@ equatable_if_let = "deny"
 # unlike the stable one, sorts in place without allocating a scratch buffer. The codebase is
 # already clean, so `deny` locks that in.
 stable_sort_primitive = "deny"
+# Reject a struct with more than 3 `bool` fields — past that count, a call site constructing or
+# reading the struct positionally (or a `Default`-then-mutate sequence) can no longer tell which
+# `true`/`false` means what without cross-checking field names, and the 2^n combinations invite
+# states that were never meant to be reachable together. The one violation this surfaced,
+# `routines::model::RoutineResponse`, is a `#[serde(flatten)]` HTTP response DTO whose four bools
+# (`agent_registered`, `agent_command_available`, `agent_setup_available`, `is_running`) are
+# independent, already-documented probes with their own doc comments, not combinatorial state —
+# collapsing them into an enum would also break the JSON shape existing API clients parse. Kept as
+# a scoped, reasoned `#[allow]` on that struct, the same pattern already used for
+# `mem_forget`/`clippy::zombie_processes` above. The rest of the codebase is already clean, so
+# `deny` locks that in.
+struct_excessive_bools = "deny"

--- a/src/routines/model.rs
+++ b/src/routines/model.rs
@@ -205,6 +205,13 @@ pub struct Routine {
 
 /// A [`Routine`] enriched with derived, non-persisted fields for API responses.
 #[derive(Debug, Clone, Serialize, JsonSchema, utoipa::ToSchema)]
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "the four bools here are independent, documented probes (agent_registered, \
+              agent_command_available, agent_setup_available, is_running), not combinatorial \
+              state — this is a #[serde(flatten)] response DTO, so collapsing them into an enum \
+              would also break the JSON shape existing API clients parse"
+)]
 pub struct RoutineResponse {
     /// The underlying routine.
     #[serde(flatten)]


### PR DESCRIPTION
## Summary
- Enables `clippy::struct_excessive_bools` (pedantic) in `[lints.clippy]`, denying structs with more than 3 `bool` fields — past that count a caller can't tell which flag means what without cross-checking field names, and the `2^n` combinations invite unreachable-in-practice states.
- Fixes the one violation this surfaced: `routines::model::RoutineResponse` (a `#[serde(flatten)]` HTTP response DTO) carries four independent, already-documented probe bools (`agent_registered`, `agent_command_available`, `agent_setup_available`, `is_running`). These aren't combinatorial state, and collapsing them into an enum would change the JSON shape existing API clients parse — so it's exempted with a scoped, reasoned `#[allow]`, matching the `mem_forget`/`clippy::zombie_processes` pattern already used in `Cargo.toml`.

Closes #1401

## Test plan
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo build` — passes
- [x] `cargo test` — 1164 passed, 0 failed

---
Opened by the moadim routine **"Clippy lint improvements → issue + PR (Rust repos) → Slack"**.