### PR TITLE
chore(release): v1.7.2

### DIFF
--- a/.changeset/keyboard-nav-shortcuts.md
+++ b/.changeset/keyboard-nav-shortcuts.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-feat(client): keyboard-first navigation — `g` then a letter jumps straight to any page (o/r/h/l/m/s), and `?` opens a shortcuts cheat sheet listing every binding, including the existing ⌘K command palette. Both live entirely on data the client already has (routes/nav are static), so no daemon changes were needed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+## [1.7.2] - 2026-07-25
+
+feat(client): keyboard-first navigation — `g` then a letter jumps straight to any page (o/r/h/l/m/s), and `?` opens a shortcuts cheat sheet listing every binding, including the existing ⌘K command palette. Both live entirely on data the client already has (routes/nav are static), so no daemon changes were needed.
+
 ## [1.7.1] - 2026-07-24
 
 feat(client): command palette covers every page and can trigger a routine inline
@@ -4861,7 +4865,8 @@ Enable `clippy::match_same_arms` and merge the two duplicate-body arms it flagge
 - Ship the prebuilt UI in the published crate.
 - Rename the binary to `moadim` and add install docs.
 
-[Unreleased]: https://github.com/moadim-io/daemon/compare/v1.7.1...HEAD
+[Unreleased]: https://github.com/moadim-io/daemon/compare/v1.7.2...HEAD
+[1.7.2]: https://github.com/moadim-io/daemon/compare/v1.7.1...v1.7.2
 [1.7.1]: https://github.com/moadim-io/daemon/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/moadim-io/daemon/compare/v1.6.1...v1.7.0
 [1.6.1]: https://github.com/moadim-io/daemon/compare/v1.6.0...v1.6.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moadim"
-version = "1.7.1"
+version = "1.7.2"
 edition = "2021"
 # Floor set by the transitive proc-macro build dependency `darling 0.23`
 # (pulled in via `rmcp-macros` <- `rmcp`), which itself declares

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "1.7.1"
+    "version": "1.7.2"
   },
   "servers": [
     {

--- a/docs/moadim.1
+++ b/docs/moadim.1
@@ -1,7 +1,7 @@
 .\" Man page for moadim.
 .\" Mirrors the built-in `moadim --help` output (src/cli/mod.rs::print_help).
 .\" View with:  man ./docs/moadim.1   or install into share/man/man1/.
-.TH MOADIM 1 "2026-07-24" "moadim 1.7.1" "Moadim Manual"
+.TH MOADIM 1 "2026-07-25" "moadim 1.7.2" "Moadim Manual"
 .SH NAME
 moadim \- routine scheduler with an MCP/REST API and a web control panel
 .SH SYNOPSIS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moadim",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "scripts": {


### PR DESCRIPTION
## Summary
- Manual fallback release: this repo's bot PR flow (`changeset-release.yml`) doesn't exist, and `cut-release.yml` pushes straight to `main` with no PR — so per this routine's mandate, cut via the manual fallback path documented in CONTRIBUTING.md instead.
- `pnpm version-packages` bumped `1.7.1` → `1.7.2` (patch, per the `keyboard-nav-shortcuts` changeset's `patch` bump) and rolled it into `CHANGELOG.md`.
- Synced `Cargo.toml`, `Cargo.lock`, `apis/openapi.json` to `1.7.2`.
- Fixed `docs/moadim.1`'s `.TH` date (the sync script left it stale at `2026-07-24`; bumped to today, `2026-07-25`, to match the new CHANGELOG heading).
- Full pre-push suite (fmt, clippy, cargo test, 100% line coverage, linecheck, client typecheck/lint/test, changeset check) run locally and green.

🤖 Generated by the "Nightly release cutter (moadim daemon)" moadim routine.

## Test plan
- [x] `cargo check` / `cargo test` (including `openapi::openapi_tests::committed_spec_is_current` and the man-page version regression test)
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'`
- [x] `linecheck --max-lines 500`
- [x] `pnpm --filter client typecheck / lint / test`
- [x] CHANGELOG topmost heading (`1.7.2`) matches `Cargo.toml` version