### PR TITLE
chore(release): version packages

### DIFF
--- a/.changeset/notification-center.md
+++ b/.changeset/notification-center.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-feat(client): persistent notification center — a bell icon in the header with an unread-count badge and a dropdown inbox of recent fleet-wide run failures, always polling regardless of which page is open and persisted via localStorage so it survives navigation/reload. Frontend-only, built entirely on `GET /routines/runs`, which the client already fetches elsewhere.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+## [1.7.3] - 2026-07-26
+
+feat(client): persistent notification center — a bell icon in the header with an unread-count badge and a dropdown inbox of recent fleet-wide run failures, always polling regardless of which page is open and persisted via localStorage so it survives navigation/reload. Frontend-only, built entirely on `GET /routines/runs`, which the client already fetches elsewhere.
+
 ## [1.7.2] - 2026-07-25
 
 feat(client): keyboard-first navigation — `g` then a letter jumps straight to any page (o/r/h/l/m/s), and `?` opens a shortcuts cheat sheet listing every binding, including the existing ⌘K command palette. Both live entirely on data the client already has (routes/nav are static), so no daemon changes were needed.
@@ -4865,7 +4869,8 @@ Enable `clippy::match_same_arms` and merge the two duplicate-body arms it flagge
 - Ship the prebuilt UI in the published crate.
 - Rename the binary to `moadim` and add install docs.
 
-[Unreleased]: https://github.com/moadim-io/daemon/compare/v1.7.2...HEAD
+[Unreleased]: https://github.com/moadim-io/daemon/compare/v1.7.3...HEAD
+[1.7.3]: https://github.com/moadim-io/daemon/compare/v1.7.2...v1.7.3
 [1.7.2]: https://github.com/moadim-io/daemon/compare/v1.7.1...v1.7.2
 [1.7.1]: https://github.com/moadim-io/daemon/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/moadim-io/daemon/compare/v1.6.1...v1.7.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moadim"
-version = "1.7.2"
+version = "1.7.3"
 edition = "2021"
 # Floor set by the transitive proc-macro build dependency `darling 0.23`
 # (pulled in via `rmcp-macros` <- `rmcp`), which itself declares

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "1.7.2"
+    "version": "1.7.3"
   },
   "servers": [
     {

--- a/docs/moadim.1
+++ b/docs/moadim.1
@@ -1,7 +1,7 @@
 .\" Man page for moadim.
 .\" Mirrors the built-in `moadim --help` output (src/cli/mod.rs::print_help).
 .\" View with:  man ./docs/moadim.1   or install into share/man/man1/.
-.TH MOADIM 1 "2026-07-25" "moadim 1.7.2" "Moadim Manual"
+.TH MOADIM 1 "2026-07-26" "moadim 1.7.3" "Moadim Manual"
 .SH NAME
 moadim \- routine scheduler with an MCP/REST API and a web control panel
 .SH SYNOPSIS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moadim",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "scripts": {


### PR DESCRIPTION
## Summary
- Manual fallback release cut by the **Nightly release cutter (moadim daemon)** routine — no `changeset-release.yml` bot PR was open, but `.changeset/notification-center.md` had a pending patch-level changeset.
- Bumps `moadim` 1.7.2 → 1.7.3 via `pnpm version-packages`, rolling the changeset into `CHANGELOG.md` and syncing `Cargo.toml`/`Cargo.lock`/`apis/openapi.json`.
- Manually fixed `docs/moadim.1`'s `.TH` date (the sync script updates the version there but leaves the date stale).

## Test plan
- [x] `cargo test committed_spec_is_current` — openapi.json in sync
- [x] `cargo test man_page_version_matches_cargo_pkg_version` — man page version matches
- [x] Full `.githooks/pre-push` (coverage gate, linecheck, client typecheck/lint/test, changeset check) passed locally