### PR TITLE
chore(release): v1.7.4

### DIFF
--- a/.changeset/install-hint-on-start.md
+++ b/.changeset/install-hint-on-start.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-feat(cli): print a one-time hint on a bare `moadim` start ("run `moadim install` to fix that") when the daemon isn't registered as an OS service yet, so it doesn't silently fail to survive a reboot or crash-restart. Non-interactive — no stdin prompt — and fires at most once per install, tracked via `~/.config/moadim/install_prompt.local.marker`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+## [1.7.4] - 2026-07-27
+
+feat(cli): print a one-time hint on a bare `moadim` start ("run `moadim install` to fix that") when the daemon isn't registered as an OS service yet, so it doesn't silently fail to survive a reboot or crash-restart. Non-interactive — no stdin prompt — and fires at most once per install, tracked via `~/.config/moadim/install_prompt.local.marker`.
+
 ## [1.7.3] - 2026-07-26
 
 feat(client): persistent notification center — a bell icon in the header with an unread-count badge and a dropdown inbox of recent fleet-wide run failures, always polling regardless of which page is open and persisted via localStorage so it survives navigation/reload. Frontend-only, built entirely on `GET /routines/runs`, which the client already fetches elsewhere.
@@ -4869,7 +4873,8 @@ Enable `clippy::match_same_arms` and merge the two duplicate-body arms it flagge
 - Ship the prebuilt UI in the published crate.
 - Rename the binary to `moadim` and add install docs.
 
-[Unreleased]: https://github.com/moadim-io/daemon/compare/v1.7.3...HEAD
+[Unreleased]: https://github.com/moadim-io/daemon/compare/v1.7.4...HEAD
+[1.7.4]: https://github.com/moadim-io/daemon/compare/v1.7.3...v1.7.4
 [1.7.3]: https://github.com/moadim-io/daemon/compare/v1.7.2...v1.7.3
 [1.7.2]: https://github.com/moadim-io/daemon/compare/v1.7.1...v1.7.2
 [1.7.1]: https://github.com/moadim-io/daemon/compare/v1.7.0...v1.7.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moadim"
-version = "1.7.3"
+version = "1.7.4"
 edition = "2021"
 # Floor set by the transitive proc-macro build dependency `darling 0.23`
 # (pulled in via `rmcp-macros` <- `rmcp`), which itself declares

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "1.7.3"
+    "version": "1.7.4"
   },
   "servers": [
     {

--- a/docs/moadim.1
+++ b/docs/moadim.1
@@ -1,7 +1,7 @@
 .\" Man page for moadim.
 .\" Mirrors the built-in `moadim --help` output (src/cli/mod.rs::print_help).
 .\" View with:  man ./docs/moadim.1   or install into share/man/man1/.
-.TH MOADIM 1 "2026-07-26" "moadim 1.7.3" "Moadim Manual"
+.TH MOADIM 1 "2026-07-27" "moadim 1.7.4" "Moadim Manual"
 .SH NAME
 moadim \- routine scheduler with an MCP/REST API and a web control panel
 .SH SYNOPSIS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moadim",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "scripts": {


### PR DESCRIPTION
## Summary
- Manual-fallback release cut (the bot Version-Packages PR workflow is disabled for this org per `CONTRIBUTING.md#releasing` / #849).
- Ran `pnpm version-packages` to bump `Cargo.toml`/`Cargo.lock`/`package.json` to **1.7.4** (patch — single changeset, no feature/breaking content) and roll `.changeset/install-hint-on-start.md` into a new dated `CHANGELOG.md` section.
- Synced `apis/openapi.json` and `docs/moadim.1` (`.TH` version + date) to match.

This PR was opened automatically by the moadim routine **Nightly release cutter (moadim daemon)**.

## Test plan
- [x] `pnpm version-packages` ran clean (self-healed a stale `apis/openapi.json` via the regenerating test)
- [x] `git diff` reviewed — only version/changelog/doc files touched, no `prebuilt.html` diff
- [x] Pre-push hook (full test suite + coverage gate) passed
- [ ] CI green on this PR before merge