### PR TITLE
feat(routines): pre-clone/cache declared repositories into the workbench (#466)

### DIFF
--- a/.changeset/precache-routine-repos.md
+++ b/.changeset/precache-routine-repos.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+feat(routines): pre-clone/cache declared repositories into the workbench before the agent launches (#466), instead of only printing them as a "clone any you need" prompt preamble. Each declared repository is backed by a persistent local mirror under `~/.config/moadim/cache/`, keyed by its URL — the first run clones the mirror, every later run of any routine referencing the same URL only `git fetch`es it, so repeated fires reuse already-downloaded objects instead of re-cloning from the remote. A clone/fetch failure (bad URL, unreachable host, a `branch` that doesn't exist upstream) now aborts the run with the reason recorded in `agent.log`, the same as the existing prompt-copy/setup/tmux guards, instead of failing silently inside the agent session.

--- a/Architecture.md
+++ b/Architecture.md
@@ -179,12 +179,16 @@ That crontab line does **not** launch the agent by itself — it invokes the `mo
 the daemon to be running (it is installed as an OS service — launchd/systemd user — for exactly
 this reason). That handler (`routines::service_trigger::svc_trigger_scheduled`) and the manual
 `POST /routines/{id}/trigger` handler both funnel into `spawn_routine_command`, which builds the
-launch script (`routines::command::build_routine_command`) and spawns it in-process: it makes a fresh empty
-workbench under `~/.moadim/workbenches/`, launches the agent **interactively** (no `-p`) in a
-detached tmux session rooted there, and captures output via `pipe-pane`. The prompt reaches the
-agent as a process **argument** (the `{prompt}` placeholder expands to `"$(cat prompt.md)"`), so
-there is no keystroke-injection readiness race. The agent decides whether to clone the listed
-repositories.
+launch script (`routines::command::build_routine_command`) and spawns it in-process: it makes a fresh
+workbench under `~/.moadim/workbenches/`, pre-clones each declared repository into it
+(`routines::command_repositories::clone_repository_stmts`, #466) from a persistent local mirror
+under `~/.config/moadim/cache/` — the first run of a given repo URL clones the mirror, every later
+run (of any routine referencing the same URL) only fetches it — then launches the agent
+**interactively** (no `-p`) in a detached tmux session rooted there, and captures output via
+`pipe-pane`. The prompt reaches the agent as a process **argument** (the `{prompt}` placeholder
+expands to `"$(cat prompt.md)"`), so there is no keystroke-injection readiness race. A clone/fetch
+failure (bad URL, unreachable host, missing `branch`) aborts the run and is recorded in `agent.log`,
+the same as a failed prompt copy or `setup` step.
 
 The spawned script runs under a *login* shell (`sh -lc`) so the user's `~/.profile` is sourced and
 the agent inherits their environment (`GH_TOKEN`, API keys, …). Everything after the workbench

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ whole tree — routine directories don't carry their own.
 | `agent`        | string | yes      | Agent registry key (e.g. `claude`), resolved from `~/.config/moadim/agents/<agent>.toml`.    |
 | `model`        | string | no       | Model ID to run the agent with (e.g. `claude-sonnet-4-6`), passed as `--model` on the agent invocation. `None`/omitted uses the agent's own default. |
 | `goal`         | string | no       | A very short (≤5 lines) statement of the routine's goal — the "why" behind the prompt. Rendered into `prompt.md` as a `## Goal` preamble. |
-| `repositories` | list   | no       | Git repos listed in the prompt as context. Moadim does **not** clone them — the agent does.   |
+| `repositories` | list   | no       | Git repos pre-cloned into the workbench before the agent launches (via a persistent local mirror cache under `~/.config/moadim/cache/`, reused across runs). A clone/fetch failure — bad URL, unreachable host, missing `branch` — aborts the run and is recorded in `agent.log`. |
 | `machines`     | list   | no       | Machine identities this routine runs on (matched against this install's resolved machine name — see below). An entry may be an exact name or a glob containing `*` (e.g. `"*"` for any machine, `"box-*"` for a family). Defaults to empty — **an empty list runs nowhere**, so a new routine is dormant until explicitly assigned. |
 | `enabled`      | bool   | no       | Defaults to `true`. Set `false` to pause without deleting.                                    |
 | `ttl_secs`     | int    | no       | How long a finished run's workbench is retained before auto-cleanup. Caps the cron-derived retention lower — it can only shorten, never extend it. `None` uses the cron-derived value. |

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -1513,7 +1513,7 @@
       },
       "Repository": {
         "type": "object",
-        "description": "A git repository made available to a routine's agent as prompt context (not cloned by moadim).",
+        "description": "A git repository the daemon pre-clones (via a persistent local mirror, see\n[`crate::paths::repo_cache_dir`]) into the workbench before the agent launches (#466).",
         "required": [
           "repository"
         ],

--- a/schemas/routine.schema.json
+++ b/schemas/routine.schema.json
@@ -41,7 +41,7 @@
       "type": "string"
     },
     "repositories": {
-      "description": "Git repositories listed to the agent as prompt context (not cloned by moadim).",
+      "description": "Git repositories the daemon pre-clones (via a persistent local mirror cache) into the workbench before the agent launches.",
       "items": {
         "additionalProperties": false,
         "properties": {

--- a/src/build/routine_schema.rs
+++ b/src/build/routine_schema.rs
@@ -43,7 +43,7 @@ pub fn generate(manifest_dir: &str) {
             },
             "repositories": {
                 "type": "array",
-                "description": "Git repositories listed to the agent as prompt context (not cloned by moadim).",
+                "description": "Git repositories the daemon pre-clones (via a persistent local mirror cache) into the workbench before the agent launches.",
                 "items": {
                     "type": "object",
                     "required": ["repository"],

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -326,6 +326,44 @@ pub fn user_prompt_path() -> PathBuf {
     config_dir().join("user_prompt.md")
 }
 
+// ─── Repository cache ────────────────────────────────────────────────────────
+
+/// Returns the path to `{config_dir}/cache/<sanitized-url>`, the persistent local mirror clone of
+/// a declared repository (issue #466) — shared across every run, of every routine, that references
+/// the same `url`, so a repository is fetched from the remote at most once per fresh URL rather
+/// than re-cloned in full on every fire.
+///
+/// `url` is turned into a directory name by replacing every byte outside `[A-Za-z0-9._-]` with
+/// `_`, rather than parsed into host/owner/repo segments: this keeps every valid git remote form
+/// (`https://…`, `git@host:owner/repo.git`, `ssh://…`, a local path) supported without a URL
+/// parser, at the cost of a longer, less pretty directory name than a host/owner/repo tree would
+/// give.
+#[must_use]
+pub fn repo_cache_dir(url: &str) -> PathBuf {
+    config_dir()
+        .join("cache")
+        .join(sanitize_repo_cache_name(url))
+}
+
+/// Sanitize `url` into a single filesystem-safe path segment for [`repo_cache_dir`].
+fn sanitize_repo_cache_name(url: &str) -> String {
+    let sanitized: String = url
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if sanitized.is_empty() {
+        "repo".to_string()
+    } else {
+        sanitized
+    }
+}
+
 // ─── Workbenches ─────────────────────────────────────────────────────────────
 
 /// Returns the path to `~/.moadim/`.

--- a/src/routes/http_routing_tests.rs
+++ b/src/routes/http_routing_tests.rs
@@ -107,7 +107,7 @@ async fn router_routine_full_lifecycle() {
     let preview = String::from_utf8(bytes.to_vec()).unwrap();
     // The routine's own prompt body and its declared repository both flow into the preview
     // verbatim (see `compose_prompt`), same as they would in a real run's `prompt.md`.
-    assert!(preview.contains("- r (branch main)\n"));
+    assert!(preview.contains("- ./r — r (branch main)\n"));
     assert!(preview.trim_end().ends_with('p'));
 
     // PATCH

--- a/src/routines/command.rs
+++ b/src/routines/command.rs
@@ -59,6 +59,10 @@ pub(crate) fn tmux_session_prefix(slug: &str) -> String {
 mod command_prompt;
 pub(crate) use command_prompt::*;
 
+#[path = "command_repositories.rs"]
+mod command_repositories;
+pub(crate) use command_repositories::*;
+
 #[path = "command_path_resolution.rs"]
 mod command_path_resolution;
 pub(crate) use command_path_resolution::*;
@@ -277,6 +281,11 @@ pub(crate) fn build_routine_command(
             src = shell_quote(&prompt_path)
         ),
     ]);
+    // Pre-clone/fetch each declared repository into the workbench, before the agent's own setup
+    // step runs, so a `setup` step (or the agent itself) that expects the repos already present
+    // sees them from its first command (#466). A no-repositories routine emits nothing here,
+    // leaving today's empty-workbench behaviour untouched.
+    inner_stmts.extend(clone_repository_stmts(&routine.repositories));
     if let Some(setup) = &agent.setup {
         // Fail-fast if the agent's setup step fails, mirroring the `cp prompt.md` guard above. The
         // statements are `;`-joined (no `set -e`), so a bare `setup` failure would be ignored and

--- a/src/routines/command_prompt.rs
+++ b/src/routines/command_prompt.rs
@@ -3,6 +3,7 @@
 
 use std::fmt::Write as _;
 
+use super::repo_dir_name;
 use super::slugify;
 use crate::routines::agents::AgentCommand;
 use crate::routines::flags::{list_flags, FlagScope};
@@ -10,28 +11,32 @@ use crate::routines::model::Routine;
 
 /// Compose the `prompt.compiled.local.md` body: a repositories-as-context preamble, an optional
 /// `## Goal` section, a routine-origin disclosure block, the prompt, and an "Open flags" section.
-/// When the routine lists no repositories the preamble omits the "clone any you need:" sentence
-/// and its (otherwise empty) bullet list, so the agent never sees a dangling header promising a
-/// repo list with nothing under it.
+/// When the routine lists no repositories the preamble omits the "already cloned" sentence and
+/// its (otherwise empty) bullet list, so the agent never sees a dangling header promising a repo
+/// list with nothing under it.
 pub(crate) fn compose_prompt(routine: &Routine) -> String {
     let mut body = String::from("# Workbench\n");
     if routine.repositories.is_empty() {
         body.push_str("You are working in an empty directory.\n");
     } else {
+        // These repos are pre-cloned by `build_routine_command` (via `clone_repository_stmts`,
+        // #466) before the agent ever launches, so the preamble points at where they already
+        // live instead of instructing the agent to clone them itself.
         body.push_str(
-            "You are working in an empty directory. These repositories are relevant — clone any you need:\n",
+            "These repositories are already cloned into the workbench — cd into them, don't re-clone:\n",
         );
         for repo in &routine.repositories {
+            let dir = repo_dir_name(&repo.repository);
             // `write!` into the existing `String` directly rather than `format!` + `push_str`,
             // which would allocate a throwaway `String` per repository just to copy it into
             // `body` immediately after. Writing to a `String` is infallible, so the `Result` is
             // deliberately discarded.
             match &repo.branch {
                 Some(branch) => {
-                    let _ = writeln!(body, "- {} (branch {})", repo.repository, branch);
+                    let _ = writeln!(body, "- ./{dir} — {} (branch {branch})", repo.repository);
                 }
                 None => {
-                    let _ = writeln!(body, "- {}", repo.repository);
+                    let _ = writeln!(body, "- ./{dir} — {}", repo.repository);
                 }
             }
         }

--- a/src/routines/command_repositories.rs
+++ b/src/routines/command_repositories.rs
@@ -1,0 +1,76 @@
+//! Pre-clone/fetch each of a routine's declared `repositories` into the workbench before the
+//! agent launches, backed by a persistent local mirror cache — split out of `command.rs` to keep
+//! that file under the line-count gate. See issue #466.
+
+use super::shell_quote;
+use crate::routines::model::Repository;
+
+/// Directory name a repository's working copy is cloned into under the workbench: the last path
+/// segment of its URL (after the final `/` or `:`), minus a trailing `.git`, with every byte
+/// outside `[A-Za-z0-9._-]` replaced by `_` so the result is safe to splice, unquoted, into the
+/// double-quoted `"$WB/<name>"` shell strings [`clone_repository_stmts`] emits.
+///
+/// Two declared repositories that happen to share a basename (e.g. `github.com/a/x` and
+/// `example.com/b/x`) collide on this name: the second `git clone` then fails because the target
+/// directory already holds the first repository, which aborts the launch the same way any other
+/// clone failure does (see [`clone_repository_stmts`]) rather than silently overwriting one with
+/// the other.
+pub(crate) fn repo_dir_name(url: &str) -> String {
+    let trimmed = url.trim_end_matches('/');
+    let last = trimmed.rsplit(['/', ':']).next().unwrap_or(trimmed);
+    let stem = last.strip_suffix(".git").unwrap_or(last);
+    let sanitized: String = stem
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if sanitized.is_empty() {
+        "repo".to_string()
+    } else {
+        sanitized
+    }
+}
+
+/// Build the shell statements that materialize `repositories` into the workbench (`$WB`) before
+/// the agent launches, instead of leaving an empty directory and a "clone any you need" prose
+/// instruction for the agent to (re-)act on every single fire (#466).
+///
+/// Each repository is backed by a persistent local mirror at
+/// [`crate::paths::repo_cache_dir`], keyed by its exact URL: the first run clones the mirror with
+/// `git clone --mirror`, every later run — of any routine referencing that same URL — only
+/// `git fetch`es it, so repeated fires reuse already-downloaded objects instead of re-cloning from
+/// the remote. The workbench copy is then a fast, local `git clone` *from that mirror* (no
+/// network), checked out at the declared `branch` when set.
+///
+/// A failure at either step — a bad URL, an unreachable host, or a `branch` that does not exist
+/// upstream — aborts the run with the reason recorded in `agent.log`, mirroring the existing
+/// `cp prompt.md`/`setup`/`tmux` guards in [`super::build_routine_command`], rather than the
+/// failure surfacing only inside the agent session (or not at all).
+pub(crate) fn clone_repository_stmts(repositories: &[Repository]) -> Vec<String> {
+    repositories
+        .iter()
+        .map(|repo| {
+            let url = shell_quote(&repo.repository);
+            let cache = shell_quote(&crate::paths::repo_cache_dir(&repo.repository).to_string_lossy());
+            let dir_name = repo_dir_name(&repo.repository);
+            let branch_arg = match &repo.branch {
+                Some(branch) => format!(" -b {}", shell_quote(branch)),
+                None => String::new(),
+            };
+            let branch_desc = match &repo.branch {
+                Some(branch) => format!(" (branch {branch})"),
+                None => String::new(),
+            };
+            format!(
+                r#"mkdir -p {cache_parent} && {{ if [ -d {cache} ]; then git -C {cache} fetch --prune --quiet origin; else git clone --mirror --quiet {url} {cache}; fi; }} || {{ echo "moadim: failed to sync cached repository {url}; aborting launch" | tee -a "$WB/agent.log" >&2; exit 1; }}; git clone --local --quiet{branch_arg} {cache} "$WB/{dir_name}" || {{ echo "moadim: failed to materialize repository {url}{branch_desc}; aborting launch" | tee -a "$WB/agent.log" >&2; exit 1; }}"#,
+                cache_parent =
+                    shell_quote(&crate::paths::config_dir().join("cache").to_string_lossy()),
+            )
+        })
+        .collect()
+}

--- a/src/routines/command_repositories_tests.rs
+++ b/src/routines/command_repositories_tests.rs
@@ -1,0 +1,179 @@
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and fixtures do not need doc comments"
+)]
+
+use super::*;
+use crate::routines::model::Repository;
+
+#[test]
+fn repo_dir_name_https_url_strips_git_suffix() {
+    assert_eq!(
+        repo_dir_name("https://github.com/octocat/Hello-World.git"),
+        "Hello-World"
+    );
+}
+
+#[test]
+fn repo_dir_name_scp_style_url() {
+    assert_eq!(
+        repo_dir_name("git@github.com:octocat/Hello-World"),
+        "Hello-World"
+    );
+}
+
+#[test]
+fn repo_dir_name_trailing_slash_ignored() {
+    assert_eq!(
+        repo_dir_name("https://github.com/octocat/Hello-World/"),
+        "Hello-World"
+    );
+}
+
+#[test]
+fn repo_dir_name_sanitizes_unsafe_chars() {
+    // Anything outside [A-Za-z0-9._-] becomes '_' so the name is safe to splice unquoted into a
+    // double-quoted "$WB/<name>" shell string.
+    assert_eq!(repo_dir_name("weird repo name!"), "weird_repo_name_");
+}
+
+#[test]
+fn repo_dir_name_empty_falls_back() {
+    assert_eq!(repo_dir_name(""), "repo");
+    assert_eq!(repo_dir_name("/"), "repo");
+}
+
+#[test]
+fn repo_dir_name_bare_host_uses_host_as_name() {
+    // No path segment beyond the host still yields a real (if unusual) name, not the fallback.
+    assert_eq!(repo_dir_name("https://example.com/"), "example.com");
+}
+
+#[test]
+fn clone_repository_stmts_empty_for_no_repositories() {
+    assert!(clone_repository_stmts(&[]).is_empty());
+}
+
+#[test]
+fn clone_repository_stmts_caches_by_url_and_fails_loudly() {
+    let repos = vec![Repository {
+        repository: "https://github.com/octocat/Hello-World.git".to_string(),
+        branch: Some("main".to_string()),
+    }];
+    let stmts = clone_repository_stmts(&repos);
+    assert_eq!(stmts.len(), 1);
+    let stmt = &stmts[0];
+
+    let cache = crate::paths::repo_cache_dir("https://github.com/octocat/Hello-World.git")
+        .to_string_lossy()
+        .into_owned();
+
+    // First run mirror-clones the cache; a later run of any routine sharing this URL only fetches
+    // it, reusing already-downloaded objects instead of re-cloning from the remote (#466).
+    assert!(
+        stmt.contains(&format!(
+            "git clone --mirror --quiet {} ",
+            shell_quote("https://github.com/octocat/Hello-World.git")
+        )),
+        "expected a mirror clone fallback in: {stmt}"
+    );
+    assert!(
+        stmt.contains(&format!(
+            "git -C {} fetch --prune --quiet origin",
+            shell_quote(&cache)
+        )),
+        "expected a cache fetch in: {stmt}"
+    );
+    // The workbench copy is a local clone from the cache, at the declared branch.
+    assert!(
+        stmt.contains(&format!(
+            "git clone --local --quiet -b {} {}",
+            shell_quote("main"),
+            shell_quote(&cache)
+        )),
+        "expected a branch-scoped local clone from the cache in: {stmt}"
+    );
+    assert!(
+        stmt.contains(r#""$WB/Hello-World""#),
+        "expected the workbench target directory in: {stmt}"
+    );
+    // Both the cache sync and the workbench materialization abort the launch loudly on failure,
+    // recording the reason in agent.log — mirroring the existing cp/setup/tmux guards.
+    assert!(
+        stmt.contains("failed to sync cached repository")
+            && stmt.contains(r#"tee -a "$WB/agent.log" >&2; exit 1; }"#),
+        "expected a loud abort on cache-sync failure in: {stmt}"
+    );
+    assert!(
+        stmt.contains("failed to materialize repository") && stmt.contains("(branch main)"),
+        "expected a loud abort naming the branch on materialize failure in: {stmt}"
+    );
+}
+
+#[test]
+fn clone_repository_stmts_no_branch_omits_dash_b() {
+    let repos = vec![Repository {
+        repository: "https://github.com/octocat/Hello-World.git".to_string(),
+        branch: None,
+    }];
+    let stmts = clone_repository_stmts(&repos);
+    assert!(
+        stmts[0].contains("git clone --local --quiet ") && !stmts[0].contains(" -b "),
+        "no declared branch must not emit a -b flag: {}",
+        stmts[0]
+    );
+}
+
+#[test]
+fn clone_repository_stmts_one_entry_per_repository() {
+    let repos = vec![
+        Repository {
+            repository: "https://github.com/a/a.git".to_string(),
+            branch: None,
+        },
+        Repository {
+            repository: "https://github.com/b/b.git".to_string(),
+            branch: None,
+        },
+    ];
+    assert_eq!(clone_repository_stmts(&repos).len(), 2);
+}
+
+#[test]
+fn build_routine_command_embeds_repository_clone_stmts() {
+    let routine = {
+        let mut routine = make_routine("Cmd Repo Clone Routine");
+        routine.repositories = vec![Repository {
+            repository: "https://github.com/octocat/Hello-World.git".to_string(),
+            branch: Some("main".to_string()),
+        }];
+        routine
+    };
+    let agent = AgentCommand {
+        command: "claude".to_string(),
+        args: vec![],
+        setup: None,
+        instructions_file: "CLAUDE.md".to_string(),
+    };
+    let cmd = build_routine_command(&routine, &agent, TriggerSource::Scheduled);
+    assert!(
+        cmd.contains(r#""$WB/Hello-World""#),
+        "expected the repo clone step in the built command: {cmd}"
+    );
+}
+
+#[test]
+fn build_routine_command_no_repositories_emits_no_clone_stmts() {
+    let routine = make_routine("Cmd No Repo Routine");
+    let agent = AgentCommand {
+        command: "claude".to_string(),
+        args: vec![],
+        setup: None,
+        instructions_file: "CLAUDE.md".to_string(),
+    };
+    let cmd = build_routine_command(&routine, &agent, TriggerSource::Scheduled);
+    assert!(
+        !cmd.contains("git clone") && !cmd.contains("git fetch"),
+        "no declared repositories must emit no clone/fetch statements: {cmd}"
+    );
+}

--- a/src/routines/command_tests.rs
+++ b/src/routines/command_tests.rs
@@ -484,3 +484,6 @@ mod command_trigger_source_tests;
 
 #[path = "command_env_tests.rs"]
 mod command_env_tests;
+
+#[path = "command_repositories_tests.rs"]
+mod command_repositories_tests;

--- a/src/routines/mod_tests.rs
+++ b/src/routines/mod_tests.rs
@@ -73,7 +73,9 @@ fn compose_prompt_lists_repos_and_prompt() {
     let routine = make_routine("x");
     let prompt = compose_prompt(&routine);
     assert!(prompt.contains("# Workbench"));
-    assert!(prompt.contains("https://github.com/octocat/Hello-World (branch master)"));
+    assert!(
+        prompt.contains("- ./Hello-World — https://github.com/octocat/Hello-World (branch master)")
+    );
     assert!(prompt.contains("do the thing"));
 }
 
@@ -85,7 +87,7 @@ fn compose_prompt_repo_without_branch() {
         branch: None,
     }];
     let prompt = compose_prompt(&routine);
-    assert!(prompt.contains("- git@example.com:a/b\n"));
+    assert!(prompt.contains("- ./b — git@example.com:a/b\n"));
 }
 
 #[test]
@@ -95,8 +97,8 @@ fn compose_prompt_without_repositories_omits_clone_header() {
     let prompt = compose_prompt(&routine);
     assert!(prompt.contains("# Workbench"));
     assert!(prompt.contains("You are working in an empty directory.\n"));
-    // No dangling "clone any you need:" header (and no empty bullet list) when there are no repos.
-    assert!(!prompt.contains("clone any you need"));
+    // No dangling "already cloned" header (and no empty bullet list) when there are no repos.
+    assert!(!prompt.contains("already cloned"));
     assert!(!prompt.contains("\n- "));
     assert!(prompt.contains("do the thing"));
 }

--- a/src/routines/model.rs
+++ b/src/routines/model.rs
@@ -13,7 +13,8 @@ use super::command::{agent_command_available, setup_step_available, slugify, tmu
 use super::flags::list_flags;
 use crate::paths::routine_toml_path;
 
-/// A git repository made available to a routine's agent as prompt context (not cloned by moadim).
+/// A git repository the daemon pre-clones (via a persistent local mirror, see
+/// [`crate::paths::repo_cache_dir`]) into the workbench before the agent launches (#466).
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, utoipa::ToSchema)]
 pub struct Repository {
     /// Git remote URL.

--- a/src/routines/service_prompt_preview_tests.rs
+++ b/src/routines/service_prompt_preview_tests.rs
@@ -68,8 +68,9 @@ fn preview_matches_compose_prompt_with_repositories() {
 
     let preview = svc_get_prompt_preview(&store, "with-repos").expect("routine exists");
     assert_eq!(preview, compose_prompt(&routine));
-    assert!(preview.contains("- https://github.com/octocat/Hello-World\n"));
-    assert!(preview.contains("- https://github.com/octocat/Spoon-Knife (branch main)\n"));
+    assert!(preview.contains("- ./Hello-World — https://github.com/octocat/Hello-World\n"));
+    assert!(preview
+        .contains("- ./Spoon-Knife — https://github.com/octocat/Spoon-Knife (branch main)\n"));
 }
 
 #[test]


### PR DESCRIPTION
## Problem

A routine's `repositories` field (`{ repository, branch }`) was only rendered into the prompt preamble as prose — "these repositories are relevant — clone any you need" — and the daemon never acted on it. Every fire pushed the clone onto the agent, with no shared cache and no daemon-side verification:

- A `*/5` routine against a large repo re-cloned from scratch ~288x/day.
- A bad URL, unreachable host, or a `branch` that doesn't exist upstream failed silently *inside* the agent session while the run still counted as "fired".
- The `branch` field was advisory only — never enforced.

## Fix

`build_routine_command` now pre-clones each declared repository into the workbench before the agent launches (`routines::command_repositories::clone_repository_stmts`):

- Each repo is backed by a persistent local mirror under `~/.config/moadim/cache/`, keyed by its exact URL. The first run of a given URL does `git clone --mirror`; every later run — of any routine referencing that same URL — only `git fetch`es it, reusing already-downloaded objects instead of re-cloning from the remote.
- The workbench copy is a fast, local `git clone` from that mirror (no network), checked out at the declared `branch` when set.
- A failure at either step (bad URL, unreachable host, missing branch) aborts the run with the reason recorded in `agent.log`, mirroring the existing `cp prompt.md`/`setup`/`tmux` guards, instead of failing silently inside the agent or not at all.
- A routine with no declared `repositories` is completely unaffected — no clone/fetch statements are emitted (verified by a test).
- `compose_prompt`'s preamble now points the agent at where each repo already lives (`./<name>`) instead of asking it to clone.

Kept intentionally minimal: no new per-routine config flag — declaring `repositories` is itself the opt-in signal, so no schema/API surface changed. `README.md`/`Architecture.md` updated to match the new behavior; `apis/openapi.json` and `schemas/routine.schema.json` regenerated for the updated field description.

## Verification

- `cargo test` — 1179 passed, 0 failed.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` — clean.
- `linecheck --max-lines 500` over `src/**/*.rs` — clean.
- New unit tests cover `repo_dir_name` (URL → directory-name sanitization) and `clone_repository_stmts` (cache-vs-fetch branching, branch checkout, loud-abort-on-failure), plus `build_routine_command` integration tests for the with/without-repositories cases.

Closes #466

---
Opened automatically by the moadim routine: Open issues → fix PRs (owned repos + my orgs).