### PR TITLE
docs: fix validation findings

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -23,12 +23,13 @@ Moadim is a Rust daemon that manages scheduled AI-agent routines and exposes the
                 └──────────────┬──────────────────────────┘
                                │ read+write on every mutation
                                ▼
-               ~/.config/moadim/routines/
-               ├── <uuid>/routine.toml                  (tracked; [env] = non-secret vars)
-               ├── <uuid>/routine.local.toml             (gitignored, optional; secret env overrides)
-               ├── <uuid>/prompts/prompt.pure.md         (tracked)
-               ├── <uuid>/prompts/prompt.compiled.local.md (gitignored)
-               └── <uuid>/.gitignore                    (generated)
+               ~/.config/moadim/
+               ├── .gitignore                            (generated; covers the whole tree, no per-routine copy)
+               └── routines/
+                   ├── <uuid>/routine.toml                  (tracked; [env] = non-secret vars)
+                   ├── <uuid>/routine.local.toml             (gitignored, optional; secret env overrides)
+                   ├── <uuid>/prompts/prompt.pure.md         (tracked)
+                   └── <uuid>/prompts/prompt.compiled.local.md (gitignored)
 ```
 
 ---


### PR DESCRIPTION
Architecture.md:26-31 — the directory diagram showed a generated `<uuid>/.gitignore` inside each routine directory, but PRs #1384/#1385 dropped per-routine `.gitignore` generation in favor of a single generated `.gitignore` at the config-dir root (`~/.config/moadim/.gitignore`), covering the whole tree. README.md's own directory-layout diagram was already updated to match; Architecture.md's diagram was not. Fixed the diagram to show the root-level `.gitignore` instead of a per-routine one.

---
Opened by the moadim routine: Weekly docs validation + fix PRs for repos I worked on.