### PR TITLE
fix(ci): gate crates.io publish on a matching CHANGELOG.md section

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,6 +127,14 @@ jobs:
             exit 1
           fi
 
+      - name: Verify CHANGELOG.md has a section for this version
+        run: |
+          VERSION=${TAG#v}
+          if ! grep -qE "^## \[$VERSION\]" CHANGELOG.md; then
+            echo "No '## [$VERSION]' section in CHANGELOG.md — roll '[Unreleased]' over before tagging (see #274)." >&2
+            exit 1
+          fi
+
       - name: Authenticate with crates.io (Trusted Publishing)
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: auth


### PR DESCRIPTION
## Summary

A manual `v*` tag push runs `publish.yml` directly. That workflow only verifies the tag matches `Cargo.toml`'s version — it never checks `CHANGELOG.md`. `release.yml` *does* require a `## [<version>]` section and fails without one, but the two workflows don't gate each other. So a tag with an un-rolled `[Unreleased]` changelog can pass `publish.yml` (irreversible `cargo publish`) and only then fail `release.yml` — shipping a crate version with no matching changelog section and no GitHub Release.

The automated release path (`auto-release.yml`) already checks the changelog heading before tagging at all, so this gap is specific to the manual tag-push escape hatch.

## Change

Add a guard step to `publish.yml`, mirroring the existing "verify tag matches Cargo.toml version" step, right before the crates.io auth/publish steps: fail the job if `CHANGELOG.md` has no `## [<version>]` heading for the tagged version.

## Test plan

- `actionlint .github/workflows/publish.yml` (with shellcheck, matching this repo's own `actionlint.yml` CI gate) — clean.
- Manually traced both trigger paths: `workflow_call` from `auto-release.yml` (already changelog-gated upstream, so this step is a no-op there) and the direct `push: tags` escape hatch (previously ungated — now fails fast before `cargo publish` runs).

Closes #274

---
Opened by the "Open issues → fix PRs (owned repos + my orgs)" routine of moadim.