### PR TITLE
chore(release): v1.7.5

### DIFF
--- a/.changeset/precache-routine-repos.md
+++ b/.changeset/precache-routine-repos.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-feat(routines): pre-clone/cache declared repositories into the workbench before the agent launches (#466), instead of only printing them as a "clone any you need" prompt preamble. Each declared repository is backed by a persistent local mirror under `~/.config/moadim/cache/`, keyed by its URL — the first run clones the mirror, every later run of any routine referencing the same URL only `git fetch`es it, so repeated fires reuse already-downloaded objects instead of re-cloning from the remote. A clone/fetch failure (bad URL, unreachable host, a `branch` that doesn't exist upstream) now aborts the run with the reason recorded in `agent.log`, the same as the existing prompt-copy/setup/tmux guards, instead of failing silently inside the agent session.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+## [1.7.5] - 2026-07-28
+
+feat(routines): pre-clone/cache declared repositories into the workbench before the agent launches (#466), instead of only printing them as a "clone any you need" prompt preamble. Each declared repository is backed by a persistent local mirror under `~/.config/moadim/cache/`, keyed by its URL — the first run clones the mirror, every later run of any routine referencing the same URL only `git fetch`es it, so repeated fires reuse already-downloaded objects instead of re-cloning from the remote. A clone/fetch failure (bad URL, unreachable host, a `branch` that doesn't exist upstream) now aborts the run with the reason recorded in `agent.log`, the same as the existing prompt-copy/setup/tmux guards, instead of failing silently inside the agent session.
+
 ## [1.7.4] - 2026-07-27
 
 feat(cli): print a one-time hint on a bare `moadim` start ("run `moadim install` to fix that") when the daemon isn't registered as an OS service yet, so it doesn't silently fail to survive a reboot or crash-restart. Non-interactive — no stdin prompt — and fires at most once per install, tracked via `~/.config/moadim/install_prompt.local.marker`.
@@ -4873,7 +4877,8 @@ Enable `clippy::match_same_arms` and merge the two duplicate-body arms it flagge
 - Ship the prebuilt UI in the published crate.
 - Rename the binary to `moadim` and add install docs.
 
-[Unreleased]: https://github.com/moadim-io/daemon/compare/v1.7.4...HEAD
+[Unreleased]: https://github.com/moadim-io/daemon/compare/v1.7.5...HEAD
+[1.7.5]: https://github.com/moadim-io/daemon/compare/v1.7.4...v1.7.5
 [1.7.4]: https://github.com/moadim-io/daemon/compare/v1.7.3...v1.7.4
 [1.7.3]: https://github.com/moadim-io/daemon/compare/v1.7.2...v1.7.3
 [1.7.2]: https://github.com/moadim-io/daemon/compare/v1.7.1...v1.7.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "1.7.4"
+version = "1.7.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moadim"
-version = "1.7.4"
+version = "1.7.5"
 edition = "2021"
 # Floor set by the transitive proc-macro build dependency `darling 0.23`
 # (pulled in via `rmcp-macros` <- `rmcp`), which itself declares

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "1.7.4"
+    "version": "1.7.5"
   },
   "servers": [
     {

--- a/docs/moadim.1
+++ b/docs/moadim.1
@@ -1,7 +1,7 @@
 .\" Man page for moadim.
 .\" Mirrors the built-in `moadim --help` output (src/cli/mod.rs::print_help).
 .\" View with:  man ./docs/moadim.1   or install into share/man/man1/.
-.TH MOADIM 1 "2026-07-27" "moadim 1.7.4" "Moadim Manual"
+.TH MOADIM 1 "2026-07-28" "moadim 1.7.5" "Moadim Manual"
 .SH NAME
 moadim \- routine scheduler with an MCP/REST API and a web control panel
 .SH SYNOPSIS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moadim",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "scripts": {


### PR DESCRIPTION
## Summary
Manual fallback release — no `changeset-release.yml` bot PR was open and no prior release PR from this routine existed, but a pending changeset (`precache-routine-repos.md`, patch) was ready to ship.

- Rolls the pending changeset into `v1.7.5`, promoting it to a dated CHANGELOG section
- Bumps `Cargo.toml`/`package.json` to `1.7.5`, syncs `Cargo.lock` and `apis/openapi.json`
- Updates `docs/moadim.1`'s `.TH` version/date line

## Test plan
- [x] `cargo check` passes, `Cargo.lock` synced
- [x] Pre-push hook (full test suite + coverage gate) passed on push
- [ ] CI green on this PR

---
🤖 Opened by the **Nightly release cutter (moadim daemon)** routine.