### PR TITLE
fix: add coverage for empty-sanitize branch in sanitize_repo_cache_name

### DIFF
--- a/.changeset/coverage-empty-sanitize-branch.md
+++ b/.changeset/coverage-empty-sanitize-branch.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+fix(paths): add missing test coverage for the empty-sanitize fallback branch in `sanitize_repo_cache_name`, closing the crate-wide 100% line coverage gap left by #1417.

--- a/src/paths/mod_tests.rs
+++ b/src/paths/mod_tests.rs
@@ -273,3 +273,8 @@ fn claude_json_path_is_dot_claude_json_under_home() {
 
     assert_eq!(path, Some(std::path::PathBuf::from("/home/u/.claude.json")));
 }
+
+#[test]
+fn sanitize_repo_cache_name_empty_url_falls_back_to_repo() {
+    assert_eq!(super::sanitize_repo_cache_name(""), "repo");
+}


### PR DESCRIPTION
_Opened automatically by the moadim routine **Open issues → fix PRs (owned repos + my orgs)**._

## What

`sanitize_repo_cache_name` in `src/paths/mod.rs` (added by #1417) has a fallback branch — returning `"repo"` when the sanitized URL is empty — that no test exercised. That left one line uncovered, which fails the `cargo llvm-cov --fail-under-lines 100` gate in `test.yml` for every PR.

## Fix

Added a single unit test in `src/paths/mod_tests.rs`, matching the file's existing style, that calls `sanitize_repo_cache_name("")` and asserts it returns `"repo"` (the sanitizer maps every character 1:1, replacing disallowed ones with `_` rather than stripping them, so an empty result only occurs for an empty input URL).

## Verification

- `cargo test` — 1180 passed, 0 failed
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs'` — now exits 0; `paths/mod.rs` is 153/153 lines covered (100%), crate-wide Lines column is 100%
- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean

Closes #1422