### PR TITLE
fix: prune the unbounded repository mirror cache under {config_dir}/cache/

### DIFF
--- a/.changeset/repo-mirror-cache-cleanup.md
+++ b/.changeset/repo-mirror-cache-cleanup.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+fix(routines): prune the repository mirror cache under `{config_dir}/cache/` — orphaned mirrors (routine deleted or `repositories` URL edited) are now removed on every cleanup sweep, and an optional `MOADIM_MAX_REPO_CACHE_DISK_BYTES` ceiling evicts least-recently-fetched mirrors once the tree exceeds it, mirroring the existing `MOADIM_MAX_WORKBENCH_DISK_BYTES` safety valve. The tree's total size is now also reported via the new `moadim_repo_cache_bytes` metric (closes #1425).

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -328,6 +328,14 @@ pub fn user_prompt_path() -> PathBuf {
 
 // ─── Repository cache ────────────────────────────────────────────────────────
 
+/// Returns the path to `{config_dir}/cache/`, the root of every repository mirror
+/// [`repo_cache_dir`] creates. Used by the cleanup sweep (issue #1425) to walk and prune the whole
+/// tree without each caller re-deriving `config_dir().join("cache")` by hand.
+#[must_use]
+pub fn repo_cache_root_dir() -> PathBuf {
+    config_dir().join("cache")
+}
+
 /// Returns the path to `{config_dir}/cache/<sanitized-url>`, the persistent local mirror clone of
 /// a declared repository (issue #466) — shared across every run, of every routine, that references
 /// the same `url`, so a repository is fetched from the remote at most once per fresh URL rather
@@ -340,9 +348,7 @@ pub fn user_prompt_path() -> PathBuf {
 /// give.
 #[must_use]
 pub fn repo_cache_dir(url: &str) -> PathBuf {
-    config_dir()
-        .join("cache")
-        .join(sanitize_repo_cache_name(url))
+    repo_cache_root_dir().join(sanitize_repo_cache_name(url))
 }
 
 /// Sanitize `url` into a single filesystem-safe path segment for [`repo_cache_dir`].

--- a/src/paths/mod_tests.rs
+++ b/src/paths/mod_tests.rs
@@ -278,3 +278,16 @@ fn claude_json_path_is_dot_claude_json_under_home() {
 fn sanitize_repo_cache_name_empty_url_falls_back_to_repo() {
     assert_eq!(super::sanitize_repo_cache_name(""), "repo");
 }
+
+#[test]
+fn repo_cache_root_dir_ends_with_cache_under_config_dir() {
+    let path = repo_cache_root_dir();
+    assert_eq!(path.file_name().unwrap().to_str().unwrap(), "cache");
+    assert_eq!(path.parent().unwrap(), config_dir());
+}
+
+#[test]
+fn repo_cache_dir_is_child_of_repo_cache_root_dir() {
+    let path = repo_cache_dir("https://example.com/a/b.git");
+    assert_eq!(path.parent().unwrap(), repo_cache_root_dir());
+}

--- a/src/routes/metrics.rs
+++ b/src/routes/metrics.rs
@@ -53,6 +53,10 @@ struct MetricsSnapshot<'input> {
     active_sessions: usize,
     /// Total size in bytes of the workbench tree on disk.
     workbench_bytes: u64,
+    /// Total size in bytes of the repository mirror cache tree (`{config_dir}/cache/`) on disk —
+    /// never pruned before issue #1425, so previously invisible without walking the filesystem
+    /// by hand.
+    repo_cache_bytes: u64,
     /// Every run across every routine, live and historical (see
     /// [`crate::routines::svc_list_all_runs`]).
     runs: &'input [FleetRunSummary],
@@ -78,6 +82,7 @@ pub async fn metrics(State(state): State<AppState>) -> impl IntoResponse {
         machine: machine.as_str(),
         active_sessions: crate::routines::tmux_session_count(crate::routines::TMUX_SESSION_PREFIX),
         workbench_bytes: crate::routines::workbenches_total_bytes(),
+        repo_cache_bytes: crate::routines::repo_cache_total_bytes(),
         runs: &runs,
         cleanup_removed_total,
         cleanup_freed_bytes_total,
@@ -153,6 +158,13 @@ fn render(snapshot: &MetricsSnapshot<'_>) -> String {
     );
     let _ = writeln!(out, "# TYPE moadim_workbench_bytes gauge");
     let _ = writeln!(out, "moadim_workbench_bytes {}", snapshot.workbench_bytes);
+
+    let _ = writeln!(
+        out,
+        "# HELP moadim_repo_cache_bytes Total size in bytes of the repository mirror cache tree ({{config_dir}}/cache/) on disk."
+    );
+    let _ = writeln!(out, "# TYPE moadim_repo_cache_bytes gauge");
+    let _ = writeln!(out, "moadim_repo_cache_bytes {}", snapshot.repo_cache_bytes);
 
     render_runs_total(&mut out, snapshot.runs);
     render_run_duration_histogram(&mut out, snapshot.runs);

--- a/src/routes/metrics_tests.rs
+++ b/src/routes/metrics_tests.rs
@@ -41,6 +41,7 @@ fn empty_snapshot(runs: &[FleetRunSummary]) -> MetricsSnapshot<'_> {
         machine: "test-machine",
         active_sessions: 2,
         workbench_bytes: 1024,
+        repo_cache_bytes: 512,
         runs,
         cleanup_removed_total: 5,
         cleanup_freed_bytes_total: 2048,
@@ -55,6 +56,7 @@ fn render_emits_help_and_type_for_every_gauge_and_counter() {
         "moadim_build_info",
         "moadim_active_sessions",
         "moadim_workbench_bytes",
+        "moadim_repo_cache_bytes",
         "moadim_runs_total",
         "moadim_run_duration_seconds",
         "moadim_cleanup_removed_total",
@@ -75,6 +77,7 @@ fn render_emits_help_and_type_for_every_gauge_and_counter() {
     ));
     assert!(text.contains("moadim_active_sessions 2"));
     assert!(text.contains("moadim_workbench_bytes 1024"));
+    assert!(text.contains("moadim_repo_cache_bytes 512"));
     assert!(text.contains("moadim_cleanup_removed_total 5"));
     assert!(text.contains("moadim_cleanup_freed_bytes_total 2048"));
 }

--- a/src/routines/cleanup/mod.rs
+++ b/src/routines/cleanup/mod.rs
@@ -30,6 +30,7 @@ use super::run_history::{append_persisted_run, has_persisted_run, read_exit_code
 mod counters;
 mod disk_cap;
 mod log_cap;
+mod repo_cache_cap;
 mod runtime;
 mod session;
 mod snapshot;
@@ -38,6 +39,7 @@ mod ttl;
 use session::{note_forced_kill, tmux_kill_session, tmux_session_alive};
 
 pub(crate) use counters::totals as cleanup_sweep_totals;
+pub(crate) use repo_cache_cap::total_bytes as repo_cache_total_bytes;
 pub(crate) use runtime::max_runtime_ceiling_secs;
 pub(crate) use session::tmux_session_alive as run_session_alive;
 pub(crate) use session::tmux_session_count;
@@ -323,7 +325,8 @@ fn reap_dir(
 ///
 /// Returns the count of workbenches removed and the total bytes freed. Safe to call repeatedly; it
 /// only ever touches directories whose run has ended. Also enforces the optional total-disk safety
-/// valve (see [`disk_cap::enforce`]) once the normal TTL reap above has run.
+/// valve (see [`disk_cap::enforce`]) once the normal TTL reap above has run, and sweeps the
+/// repository mirror cache under `{config_dir}/cache/` (see [`repo_cache_cap::sweep`], issue #1425).
 pub fn cleanup_expired_workbenches(store: &RoutineStore) -> ReapStats {
     let ttls = snapshot::snapshot_ttls(store);
     let max_runtimes = snapshot::snapshot_max_runtimes(store);
@@ -376,9 +379,12 @@ pub fn cleanup_expired_workbenches(store: &RoutineStore) -> ReapStats {
         &tmux_session_alive,
         &agent_log_finish_time,
     );
+    // Repository mirror cache (issue #1425): both its safety valves live behind one call — see
+    // [`repo_cache_cap::sweep`].
+    let repo_cache_stats = repo_cache_cap::sweep(store);
     let stats = ReapStats {
-        removed: ttl_stats.removed + cap_stats.removed,
-        freed_bytes: ttl_stats.freed_bytes + cap_stats.freed_bytes,
+        removed: ttl_stats.removed + cap_stats.removed + repo_cache_stats.removed,
+        freed_bytes: ttl_stats.freed_bytes + cap_stats.freed_bytes + repo_cache_stats.freed_bytes,
     };
     // Record this sweep for `moadim_cleanup_removed_total`/`moadim_cleanup_freed_bytes_total`
     // (see `counters`) — both the periodic background task and the on-demand `svc_cleanup` route

--- a/src/routines/cleanup/repo_cache_cap.rs
+++ b/src/routines/cleanup/repo_cache_cap.rs
@@ -1,5 +1,5 @@
 //! Two safety valves for `{config_dir}/cache/`, the persistent local mirror cache
-//! [`crate::routines::command_repositories::clone_repository_stmts`] backs each routine's
+//! [`crate::routines::command::clone_repository_stmts`] backs each routine's
 //! declared `repositories` with (issue #466): nothing ever removed a mirror once cloned, so the
 //! cache grew unbounded as routines were deleted, edited to a new URL, or a URL was a one-off
 //! typo (issue #1425).

--- a/src/routines/cleanup/repo_cache_cap.rs
+++ b/src/routines/cleanup/repo_cache_cap.rs
@@ -1,0 +1,208 @@
+//! Two safety valves for `{config_dir}/cache/`, the persistent local mirror cache
+//! [`crate::routines::command_repositories::clone_repository_stmts`] backs each routine's
+//! declared `repositories` with (issue #466): nothing ever removed a mirror once cloned, so the
+//! cache grew unbounded as routines were deleted, edited to a new URL, or a URL was a one-off
+//! typo (issue #1425).
+//!
+//! Mirrors this module's sibling [`super::disk_cap`] (the workbench-tree size cap): an *orphan*
+//! pass ([`prune_orphaned`]) removes any mirror no currently-stored routine's `repositories`
+//! references anymore, and an optional total-size ceiling ([`MAX_REPO_CACHE_DISK_BYTES_ENV`])
+//! evicts the least-recently-fetched mirrors still in use once the tree exceeds it. Unset or `0`
+//! preserves today's unbounded behavior, the same convention as `MOADIM_MAX_WORKBENCH_DISK_BYTES`.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use super::super::model::RoutineStore;
+use super::{dir_size, ReapStats};
+
+/// Env var naming the total-disk ceiling for `{config_dir}/cache/`, in bytes. Unset, empty, or
+/// unparsable means unbounded (today's behavior) — an additional safety valve layered on top of
+/// [`prune_orphaned`], not a replacement for it.
+pub(super) const MAX_REPO_CACHE_DISK_BYTES_ENV: &str = "MOADIM_MAX_REPO_CACHE_DISK_BYTES";
+
+/// The configured ceiling, or `0` (unbounded) if [`MAX_REPO_CACHE_DISK_BYTES_ENV`] is
+/// unset/unparsable.
+pub(super) fn max_repo_cache_bytes() -> u64 {
+    std::env::var(MAX_REPO_CACHE_DISK_BYTES_ENV)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(0)
+}
+
+/// Best-effort last-fetch time of a mirror, in unix seconds: the mtime of its `FETCH_HEAD` (
+/// written by both the initial `git clone --mirror` and every later `git fetch --prune`, see
+/// `clone_repository_stmts`). Falls back to the mirror directory's own mtime when `FETCH_HEAD` is
+/// missing or unreadable, and to `0` (oldest possible, evicted first) when neither mtime is
+/// readable — mirroring `agent_log_finish_time`'s fallback-to-directory convention in
+/// [`super::agent_log_finish_time`].
+pub(super) fn mirror_last_fetch_time(path: &Path) -> u64 {
+    std::fs::metadata(path.join("FETCH_HEAD"))
+        .or_else(|_err| std::fs::metadata(path))
+        .and_then(|meta| meta.modified())
+        .ok()
+        .and_then(|mtime| mtime.duration_since(std::time::UNIX_EPOCH).ok())
+        .map_or(0, |elapsed| elapsed.as_secs())
+}
+
+/// Remove every directory under `dir` (the `{config_dir}/cache/` tree) whose name is not present
+/// in `referenced` — i.e. orphaned by a routine deletion or a `repositories` URL edit (issue
+/// #1425). `referenced` is a point-in-time snapshot of every currently-stored routine's repo-cache
+/// directory *names* (see [`super::snapshot::snapshot_repo_cache_names`]), taken before this scan,
+/// so a mirror that legitimately still matches a routine is never touched.
+pub(super) fn prune_orphaned(dir: &Path, referenced: &HashSet<String>) -> ReapStats {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return ReapStats::default();
+    };
+    let mut stats = ReapStats::default();
+    for entry in entries.flatten() {
+        if !entry.file_type().is_ok_and(|ft| ft.is_dir()) {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if referenced.contains(&name) {
+            continue;
+        }
+        let size = dir_size(&entry.path());
+        match std::fs::remove_dir_all(entry.path()) {
+            Ok(()) => {
+                stats.removed += 1;
+                stats.freed_bytes += size;
+                log::info!(
+                    "cleanup: removed orphaned repo mirror {name:?} ({size} bytes) — no routine references it"
+                );
+            }
+            Err(err) => {
+                log::warn!("cleanup: failed to remove orphaned repo mirror {name:?}: {err}");
+            }
+        }
+    }
+    stats
+}
+
+/// One repo mirror eligible for cap-forced eviction (mirrors [`super::disk_cap::EvictCandidate`]).
+pub(super) struct EvictCandidate {
+    /// Mirror directory name, for logging.
+    pub name: String,
+    /// Absolute path to the mirror directory.
+    pub path: PathBuf,
+    /// Size in bytes of the mirror tree, as measured by [`super::dir_size`].
+    pub size: u64,
+    /// Best-effort last-fetch time (unix seconds, see [`mirror_last_fetch_time`]),
+    /// least-recently-fetched evicted first.
+    pub last_fetch: u64,
+}
+
+/// Given every mirror still present after [`prune_orphaned`] and the tree's `total_bytes`, pick
+/// the least-recently-fetched subset to remove so the tree drops back under `cap_bytes`. Returns
+/// an empty vec when `cap_bytes` is `0` (unbounded) or the tree is already at or under it.
+///
+/// Pure decision logic — no filesystem access — so it is unit-testable with injected
+/// sizes/timestamps, mirroring [`super::disk_cap::pick_for_eviction`].
+pub(super) fn pick_for_eviction(
+    mut candidates: Vec<EvictCandidate>,
+    cap_bytes: u64,
+    total_bytes: u64,
+) -> Vec<EvictCandidate> {
+    if cap_bytes == 0 || total_bytes <= cap_bytes {
+        return Vec::new();
+    }
+    candidates.sort_by_key(|candidate| candidate.last_fetch);
+    let mut remaining = total_bytes;
+    let mut chosen = Vec::new();
+    for candidate in candidates {
+        if remaining <= cap_bytes {
+            break;
+        }
+        remaining = remaining.saturating_sub(candidate.size);
+        chosen.push(candidate);
+    }
+    chosen
+}
+
+/// Post-orphan-prune safety valve: if `cap_bytes` is nonzero (see [`max_repo_cache_bytes`]) and
+/// the tree under `dir` still exceeds it, evict mirrors least-recently-fetched-first (per
+/// `last_fetch_for`) until back under the cap. Every mirror considered here is still referenced
+/// by some routine — orphans are already gone by the time this runs (see [`prune_orphaned`]) —
+/// but may still be evicted; it is simply re-cloned in full on that routine's next fire. Returns
+/// the count removed and bytes freed by this pass alone. `last_fetch_for` (production:
+/// [`mirror_last_fetch_time`]) is injected so the decision logic is unit-testable without relying
+/// on real filesystem mtimes, mirroring [`super::disk_cap::enforce`]'s injected `finished_at`.
+pub(super) fn enforce(
+    dir: &Path,
+    cap_bytes: u64,
+    last_fetch_for: &dyn Fn(&Path) -> u64,
+) -> ReapStats {
+    if cap_bytes == 0 {
+        return ReapStats::default();
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return ReapStats::default();
+    };
+    let mut total_bytes = 0_u64;
+    let mut candidates = Vec::new();
+    for entry in entries.flatten() {
+        if !entry.file_type().is_ok_and(|ft| ft.is_dir()) {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let size = dir_size(&entry.path());
+        total_bytes += size;
+        candidates.push(EvictCandidate {
+            name,
+            path: entry.path(),
+            size,
+            last_fetch: last_fetch_for(&entry.path()),
+        });
+    }
+    let mut stats = ReapStats::default();
+    for candidate in pick_for_eviction(candidates, cap_bytes, total_bytes) {
+        match std::fs::remove_dir_all(&candidate.path) {
+            Ok(()) => {
+                stats.removed += 1;
+                stats.freed_bytes += candidate.size;
+                log::warn!(
+                    "cleanup: evicted repo mirror {:?} ({} bytes) — over the {} cap",
+                    candidate.name,
+                    candidate.size,
+                    MAX_REPO_CACHE_DISK_BYTES_ENV
+                );
+            }
+            Err(err) => {
+                log::warn!(
+                    "cleanup: failed to evict repo mirror {:?}: {err}",
+                    candidate.name
+                );
+            }
+        }
+    }
+    stats
+}
+
+/// Total size in bytes of the whole `{config_dir}/cache/` tree — the persistent repository mirror
+/// cache never pruned before issue #1425. Backs the `moadim_repo_cache_bytes` metric
+/// (`crate::routes::metrics`), the same way `super::workbenches_total_bytes` backs
+/// `moadim_workbench_bytes`.
+pub(crate) fn total_bytes() -> u64 {
+    dir_size(&crate::paths::repo_cache_root_dir())
+}
+
+/// Run both of this module's safety valves as one step of the periodic cleanup sweep (see
+/// [`super::cleanup_expired_workbenches`]): [`prune_orphaned`] first, then [`enforce`] the
+/// optional size cap on whatever mirrors remain. Snapshots `store` up front (see
+/// [`super::snapshot::snapshot_repo_cache_names`]) so the store lock is released before this
+/// touches disk, matching the TTL/disk-cap snapshots the workbench sweep already takes.
+pub(super) fn sweep(store: &RoutineStore) -> ReapStats {
+    let dir = crate::paths::repo_cache_root_dir();
+    let referenced = super::snapshot::snapshot_repo_cache_names(store);
+    let orphan_stats = prune_orphaned(&dir, &referenced);
+    let cap_stats = enforce(&dir, max_repo_cache_bytes(), &mirror_last_fetch_time);
+    ReapStats {
+        removed: orphan_stats.removed + cap_stats.removed,
+        freed_bytes: orphan_stats.freed_bytes + cap_stats.freed_bytes,
+    }
+}
+
+#[cfg(test)]
+#[path = "repo_cache_cap_tests.rs"]
+mod repo_cache_cap_tests;

--- a/src/routines/cleanup/repo_cache_cap_tests.rs
+++ b/src/routines/cleanup/repo_cache_cap_tests.rs
@@ -1,0 +1,348 @@
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and fixtures do not need doc comments"
+)]
+
+use super::*;
+
+fn candidate(name: &str, size: u64, last_fetch: u64) -> EvictCandidate {
+    EvictCandidate {
+        name: name.to_string(),
+        path: std::path::PathBuf::from(name),
+        size,
+        last_fetch,
+    }
+}
+
+fn touch_mirror(parent: &std::path::Path, name: &str) {
+    std::fs::create_dir_all(parent.join(name)).unwrap();
+}
+
+fn write_bytes(parent: &std::path::Path, name: &str, len: usize) {
+    std::fs::write(parent.join(name).join("HEAD"), vec![b'x'; len]).unwrap();
+}
+
+/// A `last_fetch_for` that reports each mirror's last-fetch time from its directory name
+/// (`"{label}-{ts}"`), isolating cap eviction ordering from real filesystem mtimes — mirroring
+/// `enforce_disk_cap_tests`'s `finish_at_trigger` seam.
+fn last_fetch_from_name(path: &std::path::Path) -> u64 {
+    let name = path.file_name().unwrap().to_string_lossy().into_owned();
+    let (_label, ts) = name.rsplit_once('-').unwrap();
+    ts.parse().unwrap()
+}
+
+#[test]
+fn max_repo_cache_bytes_defaults_to_zero_when_unset() {
+    let prev = std::env::var_os(MAX_REPO_CACHE_DISK_BYTES_ENV);
+    // SAFETY: tests in this crate run single-threaded (RUST_TEST_THREADS=1); restored below.
+    unsafe {
+        std::env::remove_var(MAX_REPO_CACHE_DISK_BYTES_ENV);
+    }
+    assert_eq!(max_repo_cache_bytes(), 0);
+    // SAFETY: single-threaded test execution.
+    unsafe {
+        match prev {
+            Some(value) => std::env::set_var(MAX_REPO_CACHE_DISK_BYTES_ENV, value),
+            None => std::env::remove_var(MAX_REPO_CACHE_DISK_BYTES_ENV),
+        }
+    }
+}
+
+#[test]
+fn max_repo_cache_bytes_parses_a_valid_value() {
+    let prev = std::env::var_os(MAX_REPO_CACHE_DISK_BYTES_ENV);
+    // SAFETY: tests in this crate run single-threaded (RUST_TEST_THREADS=1); restored below.
+    unsafe {
+        std::env::set_var(MAX_REPO_CACHE_DISK_BYTES_ENV, "1234");
+    }
+    assert_eq!(max_repo_cache_bytes(), 1234);
+    // SAFETY: single-threaded test execution.
+    unsafe {
+        match prev {
+            Some(value) => std::env::set_var(MAX_REPO_CACHE_DISK_BYTES_ENV, value),
+            None => std::env::remove_var(MAX_REPO_CACHE_DISK_BYTES_ENV),
+        }
+    }
+}
+
+#[test]
+fn max_repo_cache_bytes_falls_back_to_zero_on_garbage() {
+    let prev = std::env::var_os(MAX_REPO_CACHE_DISK_BYTES_ENV);
+    // SAFETY: tests in this crate run single-threaded (RUST_TEST_THREADS=1); restored below.
+    unsafe {
+        std::env::set_var(MAX_REPO_CACHE_DISK_BYTES_ENV, "not-a-number");
+    }
+    assert_eq!(max_repo_cache_bytes(), 0);
+    // SAFETY: single-threaded test execution.
+    unsafe {
+        match prev {
+            Some(value) => std::env::set_var(MAX_REPO_CACHE_DISK_BYTES_ENV, value),
+            None => std::env::remove_var(MAX_REPO_CACHE_DISK_BYTES_ENV),
+        }
+    }
+}
+
+#[test]
+fn pick_for_eviction_is_noop_when_cap_unset() {
+    let candidates = vec![candidate("a", 100, 1)];
+    assert!(pick_for_eviction(candidates, 0, 100).is_empty());
+}
+
+#[test]
+fn pick_for_eviction_is_noop_when_under_cap() {
+    let candidates = vec![candidate("a", 100, 1)];
+    assert!(pick_for_eviction(candidates, 200, 100).is_empty());
+}
+
+#[test]
+fn pick_for_eviction_evicts_least_recently_fetched_first() {
+    // Total 300 over a 150 cap: the least-recently-fetched (ts 1) must go first; once evicting it
+    // alone (100 bytes) still leaves 200 > 150, the next-oldest (ts 2) also goes, dropping to
+    // 100 <= 150. The most-recently-fetched (ts 3) is never touched.
+    let candidates = vec![
+        candidate("newest", 100, 3),
+        candidate("oldest", 100, 1),
+        candidate("middle", 100, 2),
+    ];
+    let chosen = pick_for_eviction(candidates, 150, 300);
+    let names: Vec<&str> = chosen
+        .iter()
+        .map(|candidate| candidate.name.as_str())
+        .collect();
+    assert_eq!(names, vec!["oldest", "middle"]);
+}
+
+#[test]
+fn pick_for_eviction_stops_as_soon_as_under_cap() {
+    let candidates = vec![candidate("oldest", 200, 1), candidate("newer", 100, 2)];
+    let chosen = pick_for_eviction(candidates, 300, 500);
+    assert_eq!(chosen.len(), 1);
+    assert_eq!(chosen[0].name, "oldest");
+}
+
+#[test]
+fn prune_orphaned_is_noop_for_a_missing_dir() {
+    let missing = std::env::temp_dir().join(format!(
+        "moadim-repo-cache-prune-missing-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let _ = std::fs::remove_dir_all(&missing);
+    let stats = prune_orphaned(&missing, &HashSet::new());
+    assert_eq!(stats, ReapStats::default());
+}
+
+#[test]
+fn prune_orphaned_removes_mirrors_no_routine_references() {
+    let base = std::env::temp_dir().join(format!(
+        "moadim-repo-cache-prune-orphan-{}",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&base).unwrap();
+    touch_mirror(&base, "still-referenced");
+    write_bytes(&base, "still-referenced", 10);
+    touch_mirror(&base, "orphaned");
+    write_bytes(&base, "orphaned", 20);
+
+    let mut referenced = HashSet::new();
+    referenced.insert("still-referenced".to_string());
+    let stats = prune_orphaned(&base, &referenced);
+
+    assert_eq!(stats.removed, 1);
+    assert_eq!(stats.freed_bytes, 20);
+    assert!(base.join("still-referenced").exists());
+    assert!(!base.join("orphaned").exists());
+
+    std::fs::remove_dir_all(&base).unwrap();
+}
+
+#[test]
+fn prune_orphaned_skips_a_stray_file() {
+    let base = std::env::temp_dir().join(format!(
+        "moadim-repo-cache-prune-file-{}",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&base).unwrap();
+    std::fs::write(base.join("stray-file"), b"x").unwrap();
+
+    let stats = prune_orphaned(&base, &HashSet::new());
+    assert_eq!(stats, ReapStats::default());
+    assert!(base.join("stray-file").exists());
+
+    std::fs::remove_dir_all(&base).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn prune_orphaned_counts_zero_when_remove_fails() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    // An orphaned mirror whose removal fails (parent dir is read-only) is not counted, exercising
+    // the `Err` arm of the prune's remove match.
+    let base = std::env::temp_dir().join(format!(
+        "moadim-repo-cache-prune-removefail-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let _ = std::fs::remove_dir_all(&base);
+    std::fs::create_dir_all(&base).unwrap();
+    touch_mirror(&base, "orphaned");
+    write_bytes(&base, "orphaned", 10);
+
+    // Strip write permission from the parent so removing the child directory fails.
+    let mut perms = std::fs::metadata(&base).unwrap().permissions();
+    perms.set_mode(0o555);
+    std::fs::set_permissions(&base, perms).unwrap();
+
+    let stats = prune_orphaned(&base, &HashSet::new());
+    // A read-only parent makes `remove_dir_all` fail for an unprivileged user, so the directory
+    // survives and the Err arm runs (0 removed). Root bypasses the permission check; tolerate
+    // that by only asserting consistency.
+    if base.join("orphaned").exists() {
+        assert_eq!(stats.removed, 0);
+    }
+
+    // Restore permissions so cleanup can proceed.
+    let mut perms = std::fs::metadata(&base).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&base, perms).unwrap();
+    std::fs::remove_dir_all(&base).unwrap();
+}
+
+#[test]
+fn enforce_repo_cache_cap_is_noop_when_unset() {
+    let base = std::env::temp_dir().join(format!(
+        "moadim-repo-cache-enforce-unset-{}",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&base).unwrap();
+    touch_mirror(&base, "mirror-1");
+
+    let stats = enforce(&base, 0, &last_fetch_from_name);
+    assert_eq!(stats, ReapStats::default());
+    assert!(base.join("mirror-1").exists());
+
+    std::fs::remove_dir_all(&base).unwrap();
+}
+
+#[test]
+fn enforce_repo_cache_cap_is_noop_for_a_missing_dir() {
+    let missing = std::env::temp_dir().join(format!(
+        "moadim-repo-cache-enforce-missing-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let _ = std::fs::remove_dir_all(&missing);
+    let stats = enforce(&missing, 100, &last_fetch_from_name);
+    assert_eq!(stats, ReapStats::default());
+}
+
+#[test]
+fn enforce_repo_cache_cap_evicts_least_recently_fetched_mirrors_over_cap() {
+    let base = std::env::temp_dir().join(format!(
+        "moadim-repo-cache-enforce-evict-{}",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&base).unwrap();
+    touch_mirror(&base, "older-1");
+    write_bytes(&base, "older-1", 40);
+    touch_mirror(&base, "newer-2");
+    write_bytes(&base, "newer-2", 40);
+
+    // Total 80 bytes over a 50-byte cap: the least-recently-fetched must be evicted, dropping to
+    // 40 <= 50.
+    let stats = enforce(&base, 50, &last_fetch_from_name);
+
+    assert_eq!(stats.removed, 1);
+    assert_eq!(stats.freed_bytes, 40);
+    assert!(!base.join("older-1").exists());
+    assert!(base.join("newer-2").exists());
+
+    std::fs::remove_dir_all(&base).unwrap();
+}
+
+#[test]
+fn enforce_repo_cache_cap_is_noop_when_under_cap() {
+    let base = std::env::temp_dir().join(format!(
+        "moadim-repo-cache-enforce-under-{}",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&base).unwrap();
+    touch_mirror(&base, "mirror-1");
+    write_bytes(&base, "mirror-1", 10);
+
+    let stats = enforce(&base, 1000, &last_fetch_from_name);
+    assert_eq!(stats, ReapStats::default());
+    assert!(base.join("mirror-1").exists());
+
+    std::fs::remove_dir_all(&base).unwrap();
+}
+
+#[test]
+fn enforce_repo_cache_cap_skips_a_stray_file() {
+    let base = std::env::temp_dir().join(format!(
+        "moadim-repo-cache-enforce-skip-{}",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&base).unwrap();
+    std::fs::write(base.join("stray-file"), vec![b'x'; 100]).unwrap();
+
+    // The stray file is not a directory, so it is skipped entirely — never counted toward
+    // `total_bytes` nor considered for eviction, even far over cap.
+    let stats = enforce(&base, 1, &last_fetch_from_name);
+    assert_eq!(stats, ReapStats::default());
+    assert!(base.join("stray-file").exists());
+
+    std::fs::remove_dir_all(&base).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn enforce_repo_cache_cap_counts_zero_when_remove_fails() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    // An over-cap mirror whose removal fails (parent dir is read-only) is not counted, exercising
+    // the `Err` arm of the eviction remove match.
+    let base = std::env::temp_dir().join(format!(
+        "moadim-repo-cache-enforce-removefail-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let _ = std::fs::remove_dir_all(&base);
+    std::fs::create_dir_all(&base).unwrap();
+    touch_mirror(&base, "older-1");
+    write_bytes(&base, "older-1", 100);
+
+    // Strip write permission from the parent so removing the child directory fails.
+    let mut perms = std::fs::metadata(&base).unwrap().permissions();
+    perms.set_mode(0o555);
+    std::fs::set_permissions(&base, perms).unwrap();
+
+    let stats = enforce(&base, 10, &last_fetch_from_name);
+    // A read-only parent makes `remove_dir_all` fail for an unprivileged user, so the directory
+    // survives and the Err arm runs (0 removed). Root bypasses the permission check; tolerate
+    // that by only asserting consistency.
+    if base.join("older-1").exists() {
+        assert_eq!(stats.removed, 0);
+    }
+
+    // Restore permissions so cleanup can proceed.
+    let mut perms = std::fs::metadata(&base).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&base, perms).unwrap();
+    std::fs::remove_dir_all(&base).unwrap();
+}
+
+#[test]
+fn mirror_last_fetch_time_falls_back_to_directory_mtime_when_fetch_head_missing() {
+    let base = std::env::temp_dir().join(format!(
+        "moadim-repo-cache-fetch-time-{}",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&base).unwrap();
+
+    // No `FETCH_HEAD` file exists, so the fallback to the directory's own mtime must not panic
+    // and must yield a plausible (nonzero, roughly "now") unix timestamp.
+    let now = crate::utils::time::now_secs();
+    let fetched = mirror_last_fetch_time(&base);
+    assert!(fetched > 0);
+    assert!(fetched <= now + 5);
+
+    std::fs::remove_dir_all(&base).unwrap();
+}

--- a/src/routines/cleanup/snapshot.rs
+++ b/src/routines/cleanup/snapshot.rs
@@ -2,7 +2,7 @@
 //! drive a cleanup sweep without holding the store lock across filesystem and tmux work.
 
 use crate::utils::lock::LockRecover;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use super::super::command::slugify;
 use super::super::model::RoutineStore;
@@ -52,6 +52,26 @@ pub fn snapshot_routine_ids(store: &RoutineStore) -> HashMap<String, String> {
     let lock = store.lock_recover();
     lock.values()
         .map(|routine| (slugify(&routine.title), routine.id.clone()))
+        .collect()
+}
+
+/// Snapshot the set of repo-cache directory *names* (see [`crate::paths::repo_cache_dir`]) every
+/// currently-stored routine's `repositories` still references.
+///
+/// Backs the orphaned-mirror sweep ([`super::repo_cache_cap::prune_orphaned`], issue #1425): a
+/// mirror whose name is absent from this snapshot was cloned for a repository no routine declares
+/// anymore (the routine was deleted, or edited to a different URL) and is safe to remove. Taken up
+/// front for the same reason as [`snapshot_ttls`] — the store lock must not be held across the
+/// sweep's filesystem work.
+pub fn snapshot_repo_cache_names(store: &RoutineStore) -> HashSet<String> {
+    let lock = store.lock_recover();
+    lock.values()
+        .flat_map(|routine| &routine.repositories)
+        .filter_map(|repo| {
+            crate::paths::repo_cache_dir(&repo.repository)
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+        })
         .collect()
 }
 

--- a/src/routines/cleanup/snapshot_tests.rs
+++ b/src/routines/cleanup/snapshot_tests.rs
@@ -4,7 +4,7 @@
 )]
 
 use super::super::super::command::slugify;
-use super::super::super::model::{new_store, Routine};
+use super::super::super::model::{new_store, Repository, Routine};
 use super::super::runtime::MAX_RUNTIME_SECS;
 use super::super::ttl::MAX_TTL_SECS;
 use super::*;
@@ -98,4 +98,35 @@ fn max_runtime_for_returns_snapshot_value_when_present() {
 fn max_runtime_for_falls_back_to_cap_for_orphan_slug() {
     let snapshot: HashMap<String, u64> = HashMap::new();
     assert_eq!(max_runtime_for(&snapshot, "orphan"), MAX_RUNTIME_SECS);
+}
+
+#[test]
+fn snapshot_repo_cache_names_maps_every_referenced_repository() {
+    let store = new_store();
+    let repo = Repository {
+        repository: "https://example.com/a/b.git".into(),
+        branch: None,
+    };
+    store.lock().unwrap().insert(
+        "id".into(),
+        Routine {
+            repositories: vec![repo.clone()],
+            ..routine_with("My Routine", "*/10 * * * *", None)
+        },
+    );
+
+    let snapshot = snapshot_repo_cache_names(&store);
+    let expected = crate::paths::repo_cache_dir(&repo.repository)
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
+    let mut want = std::collections::HashSet::new();
+    want.insert(expected);
+    assert_eq!(snapshot, want);
+}
+
+#[test]
+fn snapshot_repo_cache_names_empty_store_is_empty() {
+    assert!(snapshot_repo_cache_names(&new_store()).is_empty());
 }

--- a/src/routines/command_repositories.rs
+++ b/src/routines/command_repositories.rs
@@ -68,8 +68,7 @@ pub(crate) fn clone_repository_stmts(repositories: &[Repository]) -> Vec<String>
             };
             format!(
                 r#"mkdir -p {cache_parent} && {{ if [ -d {cache} ]; then git -C {cache} fetch --prune --quiet origin; else git clone --mirror --quiet {url} {cache}; fi; }} || {{ echo "moadim: failed to sync cached repository {url}; aborting launch" | tee -a "$WB/agent.log" >&2; exit 1; }}; git clone --local --quiet{branch_arg} {cache} "$WB/{dir_name}" || {{ echo "moadim: failed to materialize repository {url}{branch_desc}; aborting launch" | tee -a "$WB/agent.log" >&2; exit 1; }}"#,
-                cache_parent =
-                    shell_quote(&crate::paths::config_dir().join("cache").to_string_lossy()),
+                cache_parent = shell_quote(&crate::paths::repo_cache_root_dir().to_string_lossy()),
             )
         })
         .collect()


### PR DESCRIPTION
## Summary

`clone_repository_stmts` (`src/routines/command_repositories.rs`, #466) backs each routine's declared `repositories` with a persistent local mirror clone under `{config_dir}/cache/<sanitized-url>`, but nothing ever removed one: the existing `disk_cap` safety valve only bounds `~/.moadim/workbenches/`, and no other cleanup pass touched the repo mirror cache. A mirror survived a routine deletion, a `repositories` URL edit, or a one-off typo forever, growing the cache tree unbounded with no visibility.

This PR adds a second safety-valve module, `src/routines/cleanup/repo_cache_cap.rs`, that mirrors the existing `disk_cap.rs` (workbench-tree cap) pattern closely:

- **Orphan pruning** (`prune_orphaned`): removes every mirror directory under `{config_dir}/cache/` whose name is not in the point-in-time snapshot of every currently-stored routine's `repositories` (`snapshot::snapshot_repo_cache_names`, new in `cleanup/snapshot.rs`).
- **Optional size cap** (`enforce`): if `MOADIM_MAX_REPO_CACHE_DISK_BYTES` is set, evicts least-recently-fetched mirrors (by `FETCH_HEAD` mtime, falling back to the mirror directory's own mtime) until back under the cap — unset/`0` preserves today's unbounded behavior, matching the existing `MOADIM_MAX_WORKBENCH_DISK_BYTES` convention.
- Both steps are wired into the existing periodic `cleanup_expired_workbenches` sweep (and therefore also the on-demand `POST /routines/cleanup` route) via `repo_cache_cap::sweep`, so no new interval or task was added.
- `GET /api/v1/metrics` now also reports `moadim_repo_cache_bytes` (total size of the `{config_dir}/cache/` tree), the same way it already reports `moadim_workbench_bytes`.
- `src/paths/mod.rs` gained `repo_cache_root_dir()` (`{config_dir}/cache/`), reused by both the cleanup sweep and the existing `repo_cache_dir`/`command_repositories.rs` call sites that used to hand-build that path.

Tests mirror the sibling `disk_cap_tests.rs`/`enforce_disk_cap_tests.rs` style: pure decision-logic tests for `pick_for_eviction` and env-var parsing, plus filesystem-level tests for `prune_orphaned`/`enforce` (including permission-failure and stray-file/missing-dir edge cases), plus new `snapshot_repo_cache_names` and `repo_cache_root_dir`/`repo_cache_bytes` metric tests.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets` (repo enforces `deny(warnings)` + a strict clippy lint set)
- [x] `cargo test` — full suite (1202 tests) passes
- [x] `cargo llvm-cov` — new code paths fully covered

Closes #1425.

---
This PR was generated by the moadim routine "Open issues → fix PRs (owned repos + my orgs)".