### PR TITLE
fix: run Hermes default agent in one-shot mode

### DIFF
--- a/.changeset/hermes-agent-oneshot-default.md
+++ b/.changeset/hermes-agent-oneshot-default.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+fix: update the built-in Hermes agent config to launch Hermes in one-shot mode with the composed prompt, replacing the unsupported `hermes exec` default.

--- a/src/routines/agents/agents_tests.rs
+++ b/src/routines/agents/agents_tests.rs
@@ -50,6 +50,21 @@ fn codex_default_config_enables_sandbox_network_access() {
 }
 
 #[test]
+fn hermes_default_config_uses_oneshot_prompt_argument() {
+    let cmd: AgentCommand =
+        toml::from_str(super::hermes::CONFIG).expect("hermes default config must be valid TOML");
+    assert_eq!(cmd.command, "hermes");
+    assert_eq!(
+        cmd.args,
+        vec![
+            "-z".to_string(),
+            "{prompt}".to_string(),
+            "--ignore-rules".to_string()
+        ]
+    );
+}
+
+#[test]
 fn load_agent_command_parses_a_valid_config() {
     // Happy path: a well-formed config resolves to an `AgentCommand` (Ok), unchanged from before.
     let agent_name = "load-agent-valid-zzz";

--- a/src/routines/agents/hermes/setup.rs
+++ b/src/routines/agents/hermes/setup.rs
@@ -5,9 +5,9 @@ pub const NAME: &str = "hermes";
 
 /// Default `hermes.toml` contents, written on startup when the file is absent.
 ///
-/// Runs `hermes exec` headless with the composed prompt file passed as an argument
-/// (`{prompt_file}`), mirroring the Codex default. Users can override the file under
-/// `~/.config/moadim/agents/hermes.toml` if their Hermes CLI expects a different invocation.
+/// Runs Hermes headless in one-shot mode with the composed prompt passed as an argument
+/// (`{prompt}`). Users can override the file under `~/.config/moadim/agents/hermes.toml`
+/// if their Hermes CLI expects a different invocation.
 pub const CONFIG: &str = r#"command = "hermes"
-args = ["exec", "{prompt_file}"]
+args = ["-z", "{prompt}", "--ignore-rules"]
 "#;

--- a/src/routines/mod_tests.rs
+++ b/src/routines/mod_tests.rs
@@ -403,11 +403,18 @@ fn ensure_default_agents_writes_parsable_configs() {
     assert_eq!(codex.command, "codex");
     assert!(codex.args.contains(&"{prompt_file}".to_string()));
 
-    // hermes default parses and passes the prompt file as an argument
+    // hermes default parses and passes the prompt as a one-shot argument
     let hermes: AgentCommand =
         toml::from_str(&std::fs::read_to_string(dir.join("hermes.toml")).unwrap()).unwrap();
     assert_eq!(hermes.command, "hermes");
-    assert!(hermes.args.contains(&"{prompt_file}".to_string()));
+    assert_eq!(
+        hermes.args,
+        vec![
+            "-z".to_string(),
+            "{prompt}".to_string(),
+            "--ignore-rules".to_string()
+        ]
+    );
 
     // pi default parses and runs print mode against the composed prompt file
     let pi: AgentCommand =


### PR DESCRIPTION
## What changed
Updates the built-in Hermes agent config seeded by the daemon from the unsupported `hermes exec {prompt_file}` invocation to Hermes' supported one-shot mode:

```toml
command = "hermes"
args = ["-z", "{prompt}", "--ignore-rules"]
```

This keeps the fix as a small default `hermes.toml` config change, using Moadim's existing `{prompt}` placeholder rather than adding wrappers or new launch logic. It also updates/extends the existing default-agent tests and adds a patch changeset.

## Why
The current default launches `hermes exec`, but the Hermes CLI does not expose an `exec` subcommand. Hermes-backed routines fail before receiving the prompt.

Moadim already supports `{prompt}` for CLIs that take the prompt as a positional argument; daemon source expands it to `"$(cat prompt.md)"` in the workbench cwd before tmux launches the agent.

## Verification
- `cargo fmt -- --check`
- `cargo test hermes_default_config_uses_oneshot_prompt_argument` — 1 passed
- `cargo test ensure_default_agents_writes_parsable_configs` — 1 passed
- `cargo test command_placeholder` — 4 passed
- `cargo test routines::agents::agents_tests` — 24 passed
- `git diff --check`

I also validated the installed Hermes CLI locally with `hermes -z ... --ignore-rules`, and simulated Moadim's substituted workbench command: `sh -c 'hermes -z "$(cat prompt.md)" --ignore-rules'`.

Note: Cargo emitted the existing build-script warning `moadim@1.7.5: pnpm build exited with non-zero status`, but the targeted Rust tests completed successfully. Local `pnpm exec changeset status --since=origin/main` could not run because this temp clone did not have the workspace's JS dependencies installed (`Command "changeset" not found`); CI runs that after setup.
