### PR TITLE
Use schedule.cron as routine schedule source

### DIFF
--- a/.changeset/schedule-cron-sidecar-source.md
+++ b/.changeset/schedule-cron-sidecar-source.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Use `schedule.cron` as the authoritative routine schedule source instead of `routine.toml`.

--- a/schemas/routine.example.toml
+++ b/schemas/routine.example.toml
@@ -1,6 +1,6 @@
 #:schema ./routine.schema.json
 
-schedule = "30 9 * * 1-5"
+# schedule.cron (next to this file) holds the cron entry.
 title    = "My routine"
 agent    = "claude"
 prompt   = "Describe the task for the agent here."

--- a/schemas/routine.schema.json
+++ b/schemas/routine.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
-  "description": "A scheduled AI-agent task. Normally written and maintained by the daemon (one routine.toml per routine); this schema documents its on-disk shape and powers editor validation. Runtime trigger state lives in a gitignored state.local.toml sidecar, not here.",
+  "description": "A scheduled AI-agent task. Normally written and maintained by the daemon (one routine.toml plus one schedule.cron sidecar per routine); this schema documents routine.toml's on-disk shape and powers editor validation. Runtime trigger state lives in a gitignored state.local.toml sidecar, not here.",
   "properties": {
     "agent": {
       "description": "Agent registry key (e.g. \"claude\") resolved from the agents config directory.",
@@ -61,15 +61,6 @@
       },
       "type": "array"
     },
-    "schedule": {
-      "description": "Cron expression for when the routine runs, evaluated in the host's local system timezone (the OS crontab timezone), not UTC. Also mirrored into the sibling schedule.cron sidecar, which is not functional yet — this field stays authoritative.",
-      "examples": [
-        "@hourly",
-        "@daily",
-        "30 9 * * 1-5"
-      ],
-      "type": "string"
-    },
     "title": {
       "description": "Human name; slugified to name the workbench folder and tmux session.",
       "type": "string"
@@ -86,7 +77,6 @@
     }
   },
   "required": [
-    "schedule",
     "title",
     "agent",
     "prompt"

--- a/src/build/routine_schema.rs
+++ b/src/build/routine_schema.rs
@@ -16,19 +16,15 @@ pub fn generate(manifest_dir: &str) {
     let routine_schema = json!({
         "$schema": "https://json-schema.org/draft-07/schema#",
         "title": "Routine",
-        "description": "A scheduled AI-agent task. Normally written and maintained by the daemon (one routine.toml per routine); this schema documents its on-disk shape and powers editor validation. Runtime trigger state lives in a gitignored state.local.toml sidecar, not here.",
+        "description": "A scheduled AI-agent task. Normally written and maintained by the daemon (one routine.toml plus one schedule.cron sidecar per routine); this schema documents routine.toml's on-disk shape and powers editor validation. Runtime trigger state lives in a gitignored state.local.toml sidecar, not here.",
         "type": "object",
-        "required": ["schedule", "title", "agent", "prompt"],
+        "required": ["title", "agent", "prompt"],
         "properties": {
             "id": {
                 "type": "string",
                 "description": "UUID v4 uniquely identifying the routine, stable across renames. Assigned by the daemon on create."
             },
-            "schedule": {
-                "type": "string",
-                "description": "Cron expression for when the routine runs, evaluated in the host's local system timezone (the OS crontab timezone), not UTC. Also mirrored into the sibling schedule.cron sidecar, which is not functional yet — this field stays authoritative.",
-                "examples": ["@hourly", "@daily", "30 9 * * 1-5"]
-            },
+
             "title": {
                 "type": "string",
                 "description": "Human name; slugified to name the workbench folder and tmux session."
@@ -108,7 +104,7 @@ pub fn generate(manifest_dir: &str) {
     let example_toml = concat!(
         "#:schema ./routine.schema.json\n",
         "\n",
-        "schedule = \"30 9 * * 1-5\"\n",
+        "# schedule.cron (next to this file) holds the cron entry.\n",
         "title    = \"My routine\"\n",
         "agent    = \"claude\"\n",
         "prompt   = \"Describe the task for the agent here.\"\n",

--- a/src/cli/system.rs
+++ b/src/cli/system.rs
@@ -89,9 +89,8 @@ const ROUTINES_README: &str = "\
 
 Each subdirectory here is one routine (a prompt + schedule + agent, run on a cron schedule).
 
-- `<id>/routine.toml` — the schedule, agent, and repositories.
-- `<id>/schedule.cron` — a tracked mirror of the cron entry; not functional yet, the daemon
-  reads `schedule` from `routine.toml`.
+- `<id>/routine.toml` — the agent, repositories, machine targeting, and metadata.
+- `<id>/schedule.cron` — the cron schedule.
 - `<id>/prompts/prompt.pure.md` — the prompt you wrote.
 - `<id>/prompts/prompt.compiled.local.md` — the composed prompt (repositories preamble +
   pure prompt) copied into each run's workbench. Gitignored (`.local.` matches the

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -26,10 +26,7 @@ use crate::utils::atomic::atomic_write;
 struct RoutineToml {
     /// UUID that uniquely identifies this routine (stable across renames).
     id: Option<String>,
-    /// Cron expression. Authoritative: the daemon reads the schedule from here. It is also
-    /// mirrored into the tracked `schedule.cron` sidecar, which is not functional yet.
-    #[serde(default)]
-    schedule: Option<String>,
+
     /// Human name.
     title: Option<String>,
     /// Agent registry key.
@@ -234,7 +231,6 @@ pub fn write_routine(routine: &Routine) -> std::io::Result<()> {
 
     let toml_routine = RoutineToml {
         id: Some(routine.id.clone()),
-        schedule: Some(routine.schedule.clone()),
         title: Some(routine.title.clone()),
         agent: Some(routine.agent.clone()),
         model: routine.model.clone(),
@@ -408,6 +404,10 @@ mod routine_storage_prompt_sidecar_tests;
 #[cfg(test)]
 #[path = "routine_storage_migration_tests.rs"]
 mod routine_storage_migration_tests;
+
+#[cfg(test)]
+#[path = "routine_storage_schedule_cron_migration_tests.rs"]
+mod routine_storage_schedule_cron_migration_tests;
 
 #[cfg(test)]
 #[path = "routine_storage_prompt_file_migration_tests.rs"]

--- a/src/routine_storage_load.rs
+++ b/src/routine_storage_load.rs
@@ -72,12 +72,9 @@ fn load_routine_from_base(base: &std::path::Path, dir_name: &str) -> Option<Rout
     let title = toml.title?;
     let id = toml.id.unwrap_or_else(|| dir_name.to_string());
     let runtime_state = read_runtime_state(base, dir_name);
-    // routine.toml is authoritative (schedule.cron only mirrors it and is not functional yet);
-    // fall back to the cron sidecar so dirs written while the schedule lived only there keep
-    // loading until repersisted.
-    let schedule = toml
-        .schedule
-        .or_else(|| read_routine_cron(&base.join(dir_name).join("schedule.cron")))?;
+    // The tracked cron sidecar is the only schedule source of truth. A legacy routine.toml
+    // `schedule` key is ignored and does not keep a routine loadable without schedule.cron.
+    let schedule = read_routine_cron(&base.join(dir_name).join("schedule.cron"))?;
     // Prefer the log file; fall back to legacy state.local.toml field then routine.toml field for
     // routines that predate the log-file migration.
     let last_manual_trigger_at = read_manual_state(base, dir_name)

--- a/src/routine_storage_migration_tests.rs
+++ b/src/routine_storage_migration_tests.rs
@@ -381,6 +381,7 @@ fn migrate_routine_dirs_from_dir_logs_on_remove_failure() {
             "id = \"{id}\"\nschedule = \"@daily\"\ntitle = \"{title}\"\nagent = \"claude\"\nprompt = \"task\"\nenabled = true\n"
         );
         std::fs::write(legacy_dir.join("routine.toml"), &toml).unwrap();
+        std::fs::write(legacy_dir.join("schedule.cron"), "@daily\n").unwrap();
         std::fs::write(legacy_dir.join("prompt.md"), "legacy").unwrap();
 
         // Read-only legacy dir blocks removing its own children, so remove_dir_all fails.

--- a/src/routine_storage_migrations.rs
+++ b/src/routine_storage_migrations.rs
@@ -8,6 +8,34 @@ use super::{
 };
 use serde::{Deserialize, Serialize};
 
+/// Minimal view of pre-sidecar `routine.toml` files that still carried the cron schedule.
+#[derive(Debug, Deserialize)]
+struct LegacyRoutineSchedule {
+    /// Legacy cron expression, used only to seed `schedule.cron` during directory migration.
+    schedule: Option<String>,
+}
+
+/// Seed a missing `schedule.cron` from a legacy `routine.toml` before loading a legacy directory.
+pub(crate) fn seed_schedule_cron_from_legacy_toml(routine_dir: &std::path::Path) {
+    let cron_path = routine_dir.join("schedule.cron");
+    if cron_path.exists() {
+        return;
+    }
+    let Some(schedule) = std::fs::read_to_string(routine_dir.join("routine.toml"))
+        .ok()
+        .and_then(|text| toml::from_str::<LegacyRoutineSchedule>(&text).ok())
+        .and_then(|legacy| legacy.schedule)
+    else {
+        return;
+    };
+    if let Err(err) = std::fs::write(&cron_path, format!("{}\n", schedule.trim())) {
+        log::warn!(
+            "migrate_routine_dirs: failed to seed {} from legacy routine.toml schedule: {err}",
+            cron_path.display()
+        );
+    }
+}
+
 /// Legacy scheduled-state TOML, superseded by the `scheduled.log` append-only file.
 ///
 /// Only used during startup migration: if `scheduled.local.toml` exists and `scheduled.log` does
@@ -151,6 +179,7 @@ pub(crate) fn migrate_routine_dirs_from_dir(dir: &std::path::Path) {
             continue;
         }
         let dir_name = entry.file_name().to_string_lossy().to_string();
+        seed_schedule_cron_from_legacy_toml(&entry.path());
         let Some(routine) = load_routine_from_dir(&dir_name) else {
             // A dir without a parsable routine.toml (e.g. a sync-created dir holding only run.sh)
             // carries no routine to migrate; the routine it shadows is healed from its own dir.

--- a/src/routine_storage_schedule_cron_migration_tests.rs
+++ b/src/routine_storage_schedule_cron_migration_tests.rs
@@ -1,0 +1,104 @@
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and fixtures do not need doc comments"
+)]
+
+use crate::routine_storage::routine_storage_migrations::seed_schedule_cron_from_legacy_toml;
+
+#[test]
+fn seed_schedule_cron_from_legacy_toml_writes_missing_sidecar() {
+    let base =
+        std::env::temp_dir().join(format!("moadim-rs-seed-schedule-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&base).unwrap();
+    std::fs::write(
+        base.join("routine.toml"),
+        r#"title = "Legacy"
+agent = "claude"
+schedule = "@weekly"
+"#,
+    )
+    .unwrap();
+
+    seed_schedule_cron_from_legacy_toml(&base);
+
+    assert_eq!(
+        std::fs::read_to_string(base.join("schedule.cron")).unwrap(),
+        "@weekly\n"
+    );
+    let _ = std::fs::remove_dir_all(base);
+}
+
+#[test]
+fn seed_schedule_cron_from_legacy_toml_preserves_existing_sidecar() {
+    let base = std::env::temp_dir().join(format!(
+        "moadim-rs-seed-schedule-existing-{}",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&base).unwrap();
+    std::fs::write(base.join("schedule.cron"), "@hourly\n").unwrap();
+    std::fs::write(
+        base.join("routine.toml"),
+        r#"title = "Legacy"
+agent = "claude"
+schedule = "@weekly"
+"#,
+    )
+    .unwrap();
+
+    seed_schedule_cron_from_legacy_toml(&base);
+
+    assert_eq!(
+        std::fs::read_to_string(base.join("schedule.cron")).unwrap(),
+        "@hourly\n"
+    );
+    let _ = std::fs::remove_dir_all(base);
+}
+
+#[test]
+fn seed_schedule_cron_from_legacy_toml_ignores_missing_legacy_schedule() {
+    let base = std::env::temp_dir().join(format!(
+        "moadim-rs-seed-schedule-missing-{}",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&base).unwrap();
+    std::fs::write(
+        base.join("routine.toml"),
+        r#"title = "Legacy"
+agent = "claude"
+"#,
+    )
+    .unwrap();
+
+    seed_schedule_cron_from_legacy_toml(&base);
+
+    assert!(!base.join("schedule.cron").exists());
+    let _ = std::fs::remove_dir_all(base);
+}
+
+#[test]
+#[cfg(unix)]
+fn seed_schedule_cron_from_legacy_toml_logs_write_failure() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let base = std::env::temp_dir().join(format!(
+        "moadim-rs-seed-schedule-write-fail-{}",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&base).unwrap();
+    std::fs::write(
+        base.join("routine.toml"),
+        r#"title = "Legacy"
+agent = "claude"
+schedule = "@weekly"
+"#,
+    )
+    .unwrap();
+    let original_perms = std::fs::metadata(&base).unwrap().permissions();
+    std::fs::set_permissions(&base, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+    seed_schedule_cron_from_legacy_toml(&base);
+
+    std::fs::set_permissions(&base, original_perms).unwrap();
+    assert!(!base.join("schedule.cron").exists());
+    let _ = std::fs::remove_dir_all(base);
+}

--- a/src/routine_storage_snooze_tests.rs
+++ b/src/routine_storage_snooze_tests.rs
@@ -106,16 +106,16 @@ fn load_routine_from_dir_missing_title_returns_none() {
 }
 
 #[test]
-fn load_routine_from_dir_missing_schedule_returns_none() {
-    // Covers L124: `schedule: toml.schedule?,` — a TOML with `title` and `agent` but
-    // no `schedule` field causes `load_routine_from_dir` to return `None`.
+fn load_routine_from_dir_requires_schedule_cron_sidecar() {
+    // A legacy routine.toml `schedule` is no longer a source of truth: the routine should load only
+    // when the tracked schedule.cron sidecar exists.
     with_override_home(|_home| {
-        let slug = "rs-no-schedule-zzz";
+        let slug = "rs-no-schedule-cron-zzz";
         let dir = crate::paths::routine_dir(slug);
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(
             crate::paths::routine_toml_path(slug),
-            "title = \"Rs No Schedule\"\nagent = \"claude\"\n",
+            "title = \"Rs No Schedule Cron\"\nagent = \"claude\"\nschedule = \"@daily\"\n",
         )
         .unwrap();
         assert!(load_routine_from_dir(slug).is_none());
@@ -124,17 +124,18 @@ fn load_routine_from_dir_missing_schedule_returns_none() {
 
 #[test]
 fn load_routine_from_dir_missing_agent_returns_none() {
-    // Covers L126: `agent: toml.agent?,` — a TOML with `title` and `schedule` but no
-    // `agent` field causes `load_routine_from_dir` to return `None`.
+    // Covers `agent: toml.agent?` — a TOML with title and schedule.cron but no `agent` field
+    // causes `load_routine_from_dir` to return `None`.
     with_override_home(|_home| {
         let slug = "rs-no-agent-zzz";
         let dir = crate::paths::routine_dir(slug);
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(
             crate::paths::routine_toml_path(slug),
-            "title = \"Rs No Agent\"\nschedule = \"@daily\"\n",
+            "title = \"Rs No Agent\"\n",
         )
         .unwrap();
+        std::fs::write(crate::paths::routine_cron_path(slug), "@daily\n").unwrap();
         assert!(load_routine_from_dir(slug).is_none());
     });
 }

--- a/src/routine_storage_tests.rs
+++ b/src/routine_storage_tests.rs
@@ -96,8 +96,8 @@ fn write_then_load_round_trips() {
         );
         let toml_text = std::fs::read_to_string(crate::paths::routine_toml_path(&slug)).unwrap();
         assert!(
-            toml_text.contains("schedule = \"@daily\""),
-            "routine.toml must carry the authoritative schedule: {toml_text}"
+            !toml_text.contains("schedule"),
+            "routine.toml must not carry the schedule: {toml_text}"
         );
         assert!(
             !toml_text.contains("prompt"),
@@ -159,9 +159,10 @@ fn load_routine_from_dir_applies_defaults_for_absent_optional_fields() {
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(
             crate::paths::routine_toml_path(slug),
-            "schedule = \"@daily\"\ntitle = \"Rs Defaults Routine\"\nagent = \"claude\"\n",
+            "title = \"Rs Defaults Routine\"\nagent = \"claude\"\n",
         )
         .unwrap();
+        std::fs::write(crate::paths::routine_cron_path(slug), "@daily\n").unwrap();
 
         let loaded = load_routine_from_dir(slug).unwrap();
         assert_eq!(loaded.id, slug, "absent id falls back to the dir name");
@@ -190,9 +191,10 @@ fn load_routine_falls_back_to_legacy_last_triggered_in_routine_toml() {
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(
             crate::paths::routine_toml_path(slug),
-            "schedule = \"@daily\"\ntitle = \"Rs Legacy Trigger\"\nagent = \"claude\"\nlast_triggered_at = 777\n",
+            "title = \"Rs Legacy Trigger\"\nagent = \"claude\"\nlast_triggered_at = 777\n",
         )
         .unwrap();
+        std::fs::write(crate::paths::routine_cron_path(slug), "@daily\n").unwrap();
         // No sidecar exists yet.
         assert!(!crate::paths::routine_state_path(slug).exists());
 
@@ -204,9 +206,9 @@ fn load_routine_falls_back_to_legacy_last_triggered_in_routine_toml() {
 }
 
 #[test]
-fn load_routine_prefers_routine_toml_schedule_over_cron_sidecar() {
-    // routine.toml is the authoritative schedule source; the schedule.cron mirror is not
-    // functional yet, so a diverging sidecar must lose.
+fn load_routine_ignores_legacy_toml_schedule_when_cron_sidecar_exists() {
+    // schedule.cron is the authoritative schedule source; a diverging legacy routine.toml schedule
+    // is ignored.
     with_override_home(|_home| {
         let slug = "rs-toml-schedule-wins-routine";
         let dir = crate::paths::routine_dir(slug);
@@ -218,15 +220,13 @@ fn load_routine_prefers_routine_toml_schedule_over_cron_sidecar() {
         .unwrap();
         std::fs::write(crate::paths::routine_cron_path(slug), "@weekly\n").unwrap();
 
-        assert_eq!(load_routine_from_dir(slug).unwrap().schedule, "@hourly");
+        assert_eq!(load_routine_from_dir(slug).unwrap().schedule, "@weekly");
     });
 }
 
 #[test]
-fn load_routine_falls_back_to_cron_sidecar_when_routine_toml_has_no_schedule() {
-    // Dirs written while the schedule lived only in schedule.cron keep loading until the next
-    // repersist restores the field in routine.toml. Comment lines are skipped when reading the
-    // sidecar.
+fn load_routine_reads_schedule_from_cron_sidecar() {
+    // The schedule lives in schedule.cron. Comment lines are skipped when reading the sidecar.
     with_override_home(|_home| {
         let slug = "rs-cron-fallback-routine";
         let dir = crate::paths::routine_dir(slug);
@@ -281,9 +281,10 @@ fn load_routine_ignores_unparsable_sidecar() {
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(
             crate::paths::routine_toml_path(slug),
-            "schedule = \"@daily\"\ntitle = \"Rs Bad Sidecar\"\nagent = \"claude\"\n",
+            "title = \"Rs Bad Sidecar\"\nagent = \"claude\"\n",
         )
         .unwrap();
+        std::fs::write(crate::paths::routine_cron_path(slug), "@daily\n").unwrap();
         std::fs::write(crate::paths::routine_state_path(slug), "= not valid toml =").unwrap();
 
         assert_eq!(
@@ -325,9 +326,10 @@ fn load_routine_ignores_unparsable_scheduled_log() {
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(
             crate::paths::routine_toml_path(slug),
-            "schedule = \"@daily\"\ntitle = \"Rs Bad Scheduled Sidecar\"\nagent = \"claude\"\n",
+            "title = \"Rs Bad Scheduled Sidecar\"\nagent = \"claude\"\n",
         )
         .unwrap();
+        std::fs::write(crate::paths::routine_cron_path(slug), "@daily\n").unwrap();
         std::fs::write(
             crate::paths::routine_scheduled_log_path(slug),
             "not a timestamp\n",

--- a/src/routines/ical_tests.rs
+++ b/src/routines/ical_tests.rs
@@ -51,16 +51,17 @@ fn scratch_dir() -> std::path::PathBuf {
     dir
 }
 
-/// Write `routine` to `{base}/{routine.id}/routine.toml` so the directory-aware reload loads it
-/// back keyed by the `id` inside the file.
+/// Write `routine` to `{base}/{routine.id}/routine.toml` plus schedule.cron so the
+/// directory-aware reload loads it back keyed by the `id` inside the file.
 fn write_routine_to(base: &std::path::Path, routine: &Routine) {
     let dir = base.join(&routine.id);
     std::fs::create_dir_all(&dir).unwrap();
     let toml = format!(
-        "id = \"{}\"\nschedule = \"{}\"\ntitle = \"{}\"\nagent = \"{}\"\nprompt = \"{}\"\nenabled = {}\ncreated_at = 0\nupdated_at = 0\nmachines = []\ntags = []\n",
-        routine.id, routine.schedule, routine.title, routine.agent, routine.prompt, routine.enabled,
+        "id = \"{}\"\ntitle = \"{}\"\nagent = \"{}\"\nprompt = \"{}\"\nenabled = {}\ncreated_at = 0\nupdated_at = 0\nmachines = []\ntags = []\n",
+        routine.id, routine.title, routine.agent, routine.prompt, routine.enabled,
     );
     std::fs::write(dir.join("routine.toml"), toml).unwrap();
+    std::fs::write(dir.join("schedule.cron"), format!("{}\n", routine.schedule)).unwrap();
 }
 
 #[test]

--- a/src/routines/mod_agents_reload_tests.rs
+++ b/src/routines/mod_agents_reload_tests.rs
@@ -46,8 +46,8 @@ fn scratch_routines_dir() -> std::path::PathBuf {
     dir
 }
 
-/// Write `routine` to `{base}/{routine.id}/routine.toml` so the directory-aware reload in
-/// `svc_list`/`svc_get` loads it back, keyed by the `id` inside the file.
+/// Write `routine` to `{base}/{routine.id}/routine.toml` plus schedule.cron so the
+/// directory-aware reload in `svc_list`/`svc_get` loads it back, keyed by the `id` inside the file.
 ///
 /// The scan keys routines by the `id` field in `routine.toml` (the directory name is only the scan
 /// entry), so using the id as the dir name keeps fixtures with identical titles from colliding the
@@ -58,9 +58,8 @@ fn write_routine_to(base: &std::path::Path, routine: &Routine) {
     let dir = base.join(&routine.id);
     std::fs::create_dir_all(&dir).unwrap();
     let mut toml = format!(
-        "id = \"{}\"\nschedule = \"{}\"\ntitle = \"{}\"\nagent = \"{}\"\nprompt = \"{}\"\nenabled = {}\ncreated_at = {}\nupdated_at = {}\nmachines = {:?}\ntags = {:?}\n",
+        "id = \"{}\"\ntitle = \"{}\"\nagent = \"{}\"\nprompt = \"{}\"\nenabled = {}\ncreated_at = {}\nupdated_at = {}\nmachines = {:?}\ntags = {:?}\n",
         routine.id,
-        routine.schedule,
         routine.title,
         routine.agent,
         routine.prompt,
@@ -78,6 +77,7 @@ fn write_routine_to(base: &std::path::Path, routine: &Routine) {
         }
     }
     std::fs::write(dir.join("routine.toml"), toml).unwrap();
+    std::fs::write(dir.join("schedule.cron"), format!("{}\n", routine.schedule)).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- remove the routine.toml schedule field from the tracked schema/example and storage model
- load schedules only from schedule.cron for normal routine loads
- seed schedule.cron from legacy routine.toml only during legacy directory migration

## Test plan
- cargo test --quiet
- cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs' --summary-only
- pre-push hook (cargo/clippy/tests/coverage/linecheck/client checks/changeset) passed during push