### PR TITLE
chore(release): v1.7.6

### DIFF
--- a/.changeset/client-responsive-mobile-shell.md
+++ b/.changeset/client-responsive-mobile-shell.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-feat(client): add a responsive breakpoint to the app shell so the header, nav, page padding, and touch targets adapt on narrow (mobile/tablet) viewports instead of overflowing.

--- a/.changeset/coverage-empty-sanitize-branch.md
+++ b/.changeset/coverage-empty-sanitize-branch.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-fix(paths): add missing test coverage for the empty-sanitize fallback branch in `sanitize_repo_cache_name`, closing the crate-wide 100% line coverage gap left by #1417.

--- a/.changeset/hermes-agent-oneshot-default.md
+++ b/.changeset/hermes-agent-oneshot-default.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-fix: update the built-in Hermes agent config to launch Hermes in one-shot mode with the composed prompt, replacing the unsupported `hermes exec` default.

--- a/.changeset/multi-cron-sidecar.md
+++ b/.changeset/multi-cron-sidecar.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-Allow manually edited `schedule.cron` sidecars to carry multiple cron entries and dedupe redundant entries with cron-union when syncing crontab.

--- a/.changeset/npm-group-bump-8b828eb283.md
+++ b/.changeset/npm-group-bump-8b828eb283.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-chore(deps): bump the npm group with 3 updates

--- a/.changeset/repo-mirror-cache-cleanup.md
+++ b/.changeset/repo-mirror-cache-cleanup.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-fix(routines): prune the repository mirror cache under `{config_dir}/cache/` — orphaned mirrors (routine deleted or `repositories` URL edited) are now removed on every cleanup sweep, and an optional `MOADIM_MAX_REPO_CACHE_DISK_BYTES` ceiling evicts least-recently-fetched mirrors once the tree exceeds it, mirroring the existing `MOADIM_MAX_WORKBENCH_DISK_BYTES` safety valve. The tree's total size is now also reported via the new `moadim_repo_cache_bytes` metric (closes #1425).

--- a/.changeset/routine-folder-groups-collapse.md
+++ b/.changeset/routine-folder-groups-collapse.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-feat(client): add a "Folder" group-by to the Routines table (grouping by the `/`-nested path already supported in titles), and make every group-by mode collapsible with a per-group health rollup chip and persisted collapse state, plus a COLLAPSE ALL / EXPAND ALL pair (#1420).

--- a/.changeset/schedule-cron-sidecar-source.md
+++ b/.changeset/schedule-cron-sidecar-source.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-Use `schedule.cron` as the authoritative routine schedule source instead of `routine.toml`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+## [1.7.6] - 2026-07-29
+
+feat(client): add a responsive breakpoint to the app shell so the header, nav, page padding, and touch targets adapt on narrow (mobile/tablet) viewports instead of overflowing.
+
+fix(paths): add missing test coverage for the empty-sanitize fallback branch in `sanitize_repo_cache_name`, closing the crate-wide 100% line coverage gap left by #1417.
+
+fix: update the built-in Hermes agent config to launch Hermes in one-shot mode with the composed prompt, replacing the unsupported `hermes exec` default.
+
+Allow manually edited `schedule.cron` sidecars to carry multiple cron entries and dedupe redundant entries with cron-union when syncing crontab.
+
+chore(deps): bump the npm group with 3 updates
+
+fix(routines): prune the repository mirror cache under `{config_dir}/cache/` — orphaned mirrors (routine deleted or `repositories` URL edited) are now removed on every cleanup sweep, and an optional `MOADIM_MAX_REPO_CACHE_DISK_BYTES` ceiling evicts least-recently-fetched mirrors once the tree exceeds it, mirroring the existing `MOADIM_MAX_WORKBENCH_DISK_BYTES` safety valve. The tree's total size is now also reported via the new `moadim_repo_cache_bytes` metric (closes #1425).
+
+feat(client): add a "Folder" group-by to the Routines table (grouping by the `/`-nested path already supported in titles), and make every group-by mode collapsible with a per-group health rollup chip and persisted collapse state, plus a COLLAPSE ALL / EXPAND ALL pair (#1420).
+
+Use `schedule.cron` as the authoritative routine schedule source instead of `routine.toml`.
+
 ## [1.7.5] - 2026-07-28
 
 feat(routines): pre-clone/cache declared repositories into the workbench before the agent launches (#466), instead of only printing them as a "clone any you need" prompt preamble. Each declared repository is backed by a persistent local mirror under `~/.config/moadim/cache/`, keyed by its URL — the first run clones the mirror, every later run of any routine referencing the same URL only `git fetch`es it, so repeated fires reuse already-downloaded objects instead of re-cloning from the remote. A clone/fetch failure (bad URL, unreachable host, a `branch` that doesn't exist upstream) now aborts the run with the reason recorded in `agent.log`, the same as the existing prompt-copy/setup/tmux guards, instead of failing silently inside the agent session.
@@ -4877,7 +4895,8 @@ Enable `clippy::match_same_arms` and merge the two duplicate-body arms it flagge
 - Ship the prebuilt UI in the published crate.
 - Rename the binary to `moadim` and add install docs.
 
-[Unreleased]: https://github.com/moadim-io/daemon/compare/v1.7.5...HEAD
+[Unreleased]: https://github.com/moadim-io/daemon/compare/v1.7.6...HEAD
+[1.7.6]: https://github.com/moadim-io/daemon/compare/v1.7.5...v1.7.6
 [1.7.5]: https://github.com/moadim-io/daemon/compare/v1.7.4...v1.7.5
 [1.7.4]: https://github.com/moadim-io/daemon/compare/v1.7.3...v1.7.4
 [1.7.3]: https://github.com/moadim-io/daemon/compare/v1.7.2...v1.7.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "1.7.5"
+version = "1.7.6"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moadim"
-version = "1.7.5"
+version = "1.7.6"
 edition = "2021"
 # Floor set by the transitive proc-macro build dependency `darling 0.23`
 # (pulled in via `rmcp-macros` <- `rmcp`), which itself declares

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "1.7.5"
+    "version": "1.7.6"
   },
   "servers": [
     {

--- a/docs/moadim.1
+++ b/docs/moadim.1
@@ -1,7 +1,7 @@
 .\" Man page for moadim.
 .\" Mirrors the built-in `moadim --help` output (src/cli/mod.rs::print_help).
 .\" View with:  man ./docs/moadim.1   or install into share/man/man1/.
-.TH MOADIM 1 "2026-07-28" "moadim 1.7.5" "Moadim Manual"
+.TH MOADIM 1 "2026-07-29" "moadim 1.7.6" "Moadim Manual"
 .SH NAME
 moadim \- routine scheduler with an MCP/REST API and a web control panel
 .SH SYNOPSIS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moadim",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "scripts": {


### PR DESCRIPTION
## Summary
- Manual fallback release: no `changeset-release.yml` bot PR was open and none from a prior run of this routine existed, so this cuts the release directly per CONTRIBUTING.md's manual fallback path.
- Rolls up 8 pending changesets (all patch-level) into a new `## [1.7.6] - 2026-07-29` CHANGELOG section.
- Bumps `package.json`, `Cargo.toml`/`Cargo.lock`, `apis/openapi.json`, and `docs/moadim.1`'s `.TH` version+date to 1.7.6.

## Test plan
- [x] `pnpm version-packages` (bump + changelog roll-up)
- [x] `cargo check` (Cargo.lock sync)
- [x] Full `.githooks/pre-push` suite run manually: cargo fmt/clippy/test, 100% line coverage, linecheck, client typecheck/lint/test — all green

---
Automated by moadim routine: **Nightly release cutter (moadim daemon)**.