### PR TITLE
Write cron-union output to .compailed.cron

### DIFF
--- a/.changeset/compailed-cron-sidecar.md
+++ b/.changeset/compailed-cron-sidecar.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Write cron-union output to gitignored `.compailed.cron` while preserving `schedule.cron` as the pure human-edited source.

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 dist/
 *.profraw
 client/coverage/
+.compailed.cron

--- a/src/cli/spawn_tests.rs
+++ b/src/cli/spawn_tests.rs
@@ -127,6 +127,10 @@ fn pid_file_write_read_clear_roundtrip() {
         content.contains("*.local.*"),
         "gitignore must cover *.local.*"
     );
+    assert!(
+        content.contains(".compailed.cron"),
+        "gitignore must cover cron-union output"
+    );
     // Manually remove one pattern; a second write must restore it without
     // duplicating the patterns already present.
     std::fs::write(&gitignore, "*.pid\n*.log\n").unwrap();
@@ -135,6 +139,10 @@ fn pid_file_write_read_clear_roundtrip() {
     assert!(
         content.contains("*.local.*"),
         "missing pattern must be re-added"
+    );
+    assert!(
+        content.contains(".compailed.cron"),
+        "missing cron-union pattern must be re-added"
     );
     assert_eq!(
         content.matches("*.pid").count(),

--- a/src/cli/system.rs
+++ b/src/cli/system.rs
@@ -90,7 +90,8 @@ const ROUTINES_README: &str = "\
 Each subdirectory here is one routine (a prompt + schedule + agent, run on a cron schedule).
 
 - `<id>/routine.toml` — the agent, repositories, machine targeting, and metadata.
-- `<id>/schedule.cron` — the cron schedule.
+- `<id>/schedule.cron` — the human-authored cron schedule(s).
+- `<id>/.compailed.cron` — gitignored cron-union output used for OS crontab sync.
 - `<id>/prompts/prompt.pure.md` — the prompt you wrote.
 - `<id>/prompts/prompt.compiled.local.md` — the composed prompt (repositories preamble +
   pure prompt) copied into each run's workbench. Gitignored (`.local.` matches the
@@ -140,12 +141,20 @@ fn ensure_readme(path: &std::path::Path, content: &str) {
 /// they also cover every routine directory (per-routine `.gitignore` files are no longer
 /// generated): `*.local.*` catches the machine-local sidecars (`state.local.toml`,
 /// `routine.local.toml`, `prompt.compiled.local.md`), `*.log` the trigger logs, `*.compiled.*`
-/// the legacy `prompts/prompt.compiled.md`, and `run.sh` the obsolete per-routine launch script.
+/// the legacy `prompts/prompt.compiled.md`, `.compailed.cron` the cron-union output, and `run.sh`
+/// the obsolete per-routine launch script.
 ///
 /// Reads the existing file (if any), appends any missing patterns, and writes back only when
 /// something changed. Preserves user-added entries. Best-effort: failure is not fatal.
 fn ensure_config_gitignore() {
-    const REQUIRED: &[&str] = &["*.pid", "*.log", "*.local.*", "*.compiled.*", "run.sh"];
+    const REQUIRED: &[&str] = &[
+        "*.pid",
+        "*.log",
+        "*.local.*",
+        "*.compiled.*",
+        ".compailed.cron",
+        "run.sh",
+    ];
     let gitignore = crate::paths::config_gitignore_path();
     let existing = std::fs::read_to_string(&gitignore).unwrap_or_default();
     let lines: Vec<&str> = existing.lines().collect();

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -95,6 +95,15 @@ pub fn routine_cron_path(id: &str) -> PathBuf {
     routine_dir(id).join("schedule.cron")
 }
 
+/// Returns the path to `{routines_dir}/{id}/.compailed.cron`, the gitignored cron-union output.
+///
+/// The filename intentionally preserves the current sidecar spelling. `schedule.cron` stays the
+/// human-authored source; this derived file is rewritten by crontab sync and ignored by git.
+#[must_use]
+pub fn routine_compailed_cron_path(id: &str) -> PathBuf {
+    routine_dir(id).join(".compailed.cron")
+}
+
 /// Returns the path to `{routines_dir}/{id}/prompts/`.
 #[must_use]
 pub fn routine_prompts_dir(id: &str) -> PathBuf {

--- a/src/sync/routines.rs
+++ b/src/sync/routines.rs
@@ -84,44 +84,59 @@ pub(crate) fn format_routine_line(routine: &Routine) -> String {
     format_routine_line_for_schedule(routine, &routine.schedule)
 }
 
-/// Read the cron sidecar schedules for a routine, falling back to the loaded single schedule.
-fn routine_schedules_for_crontab(routine: &Routine) -> Vec<String> {
+/// Read the pure cron sidecar schedules for a routine, falling back to the loaded single schedule.
+fn pure_schedules_for_crontab(routine: &Routine) -> Vec<String> {
     let slug = slugify(&routine.title);
     let entries = read_routine_crons(&crate::paths::routine_dir(&slug).join("schedule.cron"));
     if entries.is_empty() {
         vec![routine.schedule.clone()]
     } else {
-        let schedules: Vec<String> = entries
-            .iter()
-            .map(|entry| normalize_schedule(entry))
-            .filter(|schedule| match validate_cron(schedule) {
-                Ok(()) => true,
-                Err(err) => {
-                    log::warn!(
-                        "routine sync: invalid schedule.cron entry {:?} for routine {:?}: {}; \
-                         skipping",
-                        schedule,
-                        routine.id,
-                        err
-                    );
-                    false
-                }
-            })
-            .collect();
-        if schedules.is_empty() {
-            return vec![routine.schedule.clone()];
-        }
-        let refs: Vec<&str> = schedules.iter().map(String::as_str).collect();
-        #[allow(
-            clippy::expect_used,
-            reason = "each entry was validated by validate_cron before reaching cron-union"
-        )]
-        cron_union::union(refs)
-            .expect("validated cron schedules compile through cron-union")
-            .iter()
-            .map(ToString::to_string)
-            .collect()
+        entries
     }
+}
+
+/// Compile pure schedules with cron-union, skipping invalid human-edited entries.
+fn compailed_schedules_for_crontab(routine: &Routine, pure_schedules: &[String]) -> Vec<String> {
+    let schedules: Vec<String> = pure_schedules
+        .iter()
+        .map(|entry| normalize_schedule(entry))
+        .filter(|schedule| match validate_cron(schedule) {
+            Ok(()) => true,
+            Err(err) => {
+                log::warn!(
+                    "routine sync: invalid schedule.cron entry {:?} for routine {:?}: {}; skipping",
+                    schedule,
+                    routine.id,
+                    err
+                );
+                false
+            }
+        })
+        .collect();
+    if schedules.is_empty() {
+        return vec![routine.schedule.clone()];
+    }
+    let refs: Vec<&str> = schedules.iter().map(String::as_str).collect();
+    #[allow(
+        clippy::expect_used,
+        reason = "each entry was validated by validate_cron before reaching cron-union"
+    )]
+    cron_union::union(refs)
+        .expect("validated cron schedules compile through cron-union")
+        .iter()
+        .map(ToString::to_string)
+        .collect()
+}
+
+/// Write the gitignored cron-union output sidecar used by the OS crontab.
+fn write_compailed_cron_sidecar(routine: &Routine, schedules: &[String]) {
+    let slug = slugify(&routine.title);
+    let dir = crate::paths::routine_dir(&slug);
+    let path = crate::paths::routine_compailed_cron_path(&slug);
+    let mut text = schedules.join("\n");
+    text.push('\n');
+    let _ = crate::utils::fs_perms::create_private_dir_all(&dir);
+    let _ = std::fs::write(&path, text);
 }
 
 /// Build the full routines block from the enabled managed routines in `store`.
@@ -162,12 +177,15 @@ fn build_block(store: &RoutineStore) -> String {
         .filter_map(|routine| match load_agent_command(&routine.agent) {
             // Validate the agent config at sync time so a broken routine is skipped here rather than
             // failing at fire time; the crontab line itself no longer embeds the agent command.
-            Ok(_) => Some(
-                routine_schedules_for_crontab(routine)
+            Ok(_) => Some({
+                let pure_schedules = pure_schedules_for_crontab(routine);
+                let compailed_schedules = compailed_schedules_for_crontab(routine, &pure_schedules);
+                write_compailed_cron_sidecar(routine, &compailed_schedules);
+                compailed_schedules
                     .iter()
                     .map(|schedule| format_routine_line_for_schedule(routine, schedule))
-                    .collect::<Vec<_>>(),
-            ),
+                    .collect::<Vec<_>>()
+            }),
             Err(err) => {
                 log::warn!(
                     "routine sync: cannot load agent {:?} ({}) for routine {:?}; skipping",

--- a/src/sync/routines_sync_multi_cron_tests.rs
+++ b/src/sync/routines_sync_multi_cron_tests.rs
@@ -68,6 +68,14 @@ fn build_block_reads_multiple_crons_from_schedule_sidecar_and_unions_redundant_e
         !block.contains("*/20 * * * * "),
         "cron-union should remove redundant subset: {block}"
     );
+    assert_eq!(
+        std::fs::read_to_string(crate::paths::routine_compailed_cron_path(&slug)).unwrap(),
+        "*/10 * * * *\n5 9 * * 1-5\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(routine_dir.join("schedule.cron")).unwrap(),
+        "# human-edited extra fires\n*/10 * * * *\n*/20 * * * *\n5 9 * * 1-5\n"
+    );
 
     std::fs::remove_file(&cfg).unwrap();
     let _ = std::fs::remove_dir_all(routine_dir);
@@ -112,6 +120,14 @@ fn build_block_skips_invalid_multi_cron_entries_and_falls_back_if_none_valid() {
     assert!(block.contains("15 10 * * * "), "{block}");
     assert!(!block.contains("not a cron"), "{block}");
     assert!(!block.contains("99 99 99 99 99"), "{block}");
+    assert_eq!(
+        std::fs::read_to_string(crate::paths::routine_compailed_cron_path(&valid_slug)).unwrap(),
+        "5 9 * * 1-5\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(crate::paths::routine_compailed_cron_path(&invalid_slug)).unwrap(),
+        "15 10 * * *\n"
+    );
 
     std::fs::remove_file(&cfg).unwrap();
     let _ = std::fs::remove_dir_all(valid_dir);


### PR DESCRIPTION
## Summary
- keep schedule.cron as the human-authored pure cron source
- write the cron-union result to a derived .compailed.cron sidecar and sync crontab from that compiled output
- gitignore .compailed.cron through the generated config .gitignore and repo .gitignore

## Test plan
- cargo clippy --all-targets -- -D warnings
- cargo test multi_cron --quiet
- cargo test pid_file_write_read_clear_roundtrip --quiet
- cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\.rs' --summary-only
- pre-push hook passed during push