### PR TITLE
chore: enable clippy::struct_excessive_bools, scope-allow it on RoutineResponse

### DIFF
--- a/.changeset/enable-struct-excessive-bools-lint.md
+++ b/.changeset/enable-struct-excessive-bools-lint.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Enable `clippy::struct_excessive_bools`, scope-allowed on `RoutineResponse`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -520,3 +520,10 @@ stable_sort_primitive = "deny"
 # scoping the lock/read to just the data actually needed) makes the hold time match what's
 # written. The codebase is already clean, so `deny` locks that in.
 significant_drop_in_scrutinee = "deny"
+# Reject a struct with more than 3 `bool` fields. Past that count, a call site constructing or
+# reading the struct positionally (or a `Default`-then-mutate sequence) can no longer tell which
+# `true`/`false` means what without cross-checking field names against their declarations, and `n`
+# independent bools imply `2^n` possible states, most of which were never meant to be reachable
+# together. A state machine or a two-variant enum usually expresses the real, restricted set of
+# valid combinations far more precisely than a pile of loose flags.
+struct_excessive_bools = "deny"

--- a/src/routines/model.rs
+++ b/src/routines/model.rs
@@ -206,6 +206,13 @@ pub struct Routine {
 
 /// A [`Routine`] enriched with derived, non-persisted fields for API responses.
 #[derive(Debug, Clone, Serialize, JsonSchema, utoipa::ToSchema)]
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "agent_registered/agent_command_available/agent_setup_available/is_running are \
+              independent, already-documented probes, not combinatorial state, and this is a \
+              #[serde(flatten)] HTTP response DTO — collapsing them into an enum would break the \
+              JSON shape existing API clients parse"
+)]
 pub struct RoutineResponse {
     /// The underlying routine.
     #[serde(flatten)]


### PR DESCRIPTION
## Summary
- Adds `clippy::struct_excessive_bools = "deny"` to `[lints.clippy]` in `Cargo.toml`, matching the repo's pattern of machine-enforcing error-handling/API-shape conventions.
- The only violation (`cargo clippy --all-targets -- -W clippy::struct_excessive_bools`) is `routines::model::RoutineResponse`: a `#[serde(flatten)]` HTTP response DTO with four independent, already-documented bool probes (`agent_registered`, `agent_command_available`, `agent_setup_available`, `is_running`). Collapsing them into an enum would change the JSON shape existing API clients parse, so per the issue's own recommendation this gets a reasoned, scoped `#[allow(..., reason = "...")]` — matching the existing `mem_forget`/`zombie_processes` allow style in this repo — rather than a redesign.

Closes #1401

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (1209 passed)

---
Opened by the moadim routine **"Open issues → fix PRs (owned repos + my orgs)"**.