### PR TITLE
feat(routines): auto-disable a routine after N consecutive failed runs (circuit breaker)

### DIFF
--- a/.changeset/routine-failure-circuit-breaker.md
+++ b/.changeset/routine-failure-circuit-breaker.md
@@ -1,0 +1,12 @@
+---
+"moadim": minor
+---
+
+### Added
+
+Opt-in failure circuit-breaker for routines (#521): set a routine's new `failure_threshold` to
+auto-disable it (and stop scheduling further runs) after that many consecutive failed-or-unknown
+runs, instead of retrying forever. `consecutive_failures` and `auto_disabled_reason` are tracked
+per routine and surfaced on `GET /routines`; manually re-enabling a routine resets the counter and
+clears the reason. Leaving `failure_threshold` unset (or `0`) keeps today's unlimited-retry
+behavior. UI surfacing is left as a follow-up.

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -1184,6 +1184,15 @@
               "type": "string"
             }
           },
+          "failure_threshold": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Consecutive failed-or-unknown runs after which this routine auto-disables (the failure\ncircuit-breaker, #521). `None` or `0` opts out (the default): unlike `ttl_secs`/\n`max_runtime_secs`, `0` is a meaningful opt-out value here, not rejected.",
+            "minimum": 0
+          },
           "goal": {
             "type": [
               "string",
@@ -1569,6 +1578,19 @@
             "type": "string",
             "description": "Agent registry key (e.g. `\"claude\"`) resolved from `~/.config/moadim/agents/`."
           },
+          "auto_disabled_reason": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable reason this routine was auto-disabled by the failure circuit-breaker, or\n`None` if it has never tripped one (or a user has since manually re-enabled it, which clears\nthis — see `svc_update`). Distinguishes an auto-disable from a user-initiated one: both flip\n[`Routine::enabled`] to `false`, but only the former sets a reason. Daemon-owned runtime\nstate, persisted in `state.local.toml` alongside [`Routine::consecutive_failures`]."
+          },
+          "consecutive_failures": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of scheduled/manual runs that finished failed-or-unknown in a row, most recently\nfirst — reset to `0` the instant any run succeeds. Daemon-owned runtime state: persisted in\nthe gitignored `state.local.toml` sidecar, not `routine.toml`, mirroring\n[`Routine::power_saving`]. Counted by [`crate::routines::cleanup::circuit_breaker`] as each\nrun's outcome becomes durable; see [`Routine::failure_threshold`] and issue #521.",
+            "minimum": 0
+          },
           "created_at": {
             "type": "integer",
             "format": "int64",
@@ -1578,6 +1600,15 @@
           "enabled": {
             "type": "boolean",
             "description": "Whether the routine is active."
+          },
+          "failure_threshold": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Consecutive failed-or-unknown-outcome runs after which this routine auto-disables — the\nopt-in failure circuit-breaker (issue #521). `None` or `0` opts out, preserving today's\nbehavior of retrying forever no matter how many times in a row a routine has failed; this is\nthe default so existing routines are unaffected. A \"failed\" run here is any [`RunStatus`]\nother than `Success`, including `Unknown` (session gone with no exit code — e.g. force-killed\nby the max-runtime watchdog): a routine that only ever hangs and gets killed is exactly the\nresource-wasting loop this breaker exists to stop. Tracked config, written to `routine.toml`\nlike [`Routine::ttl_secs`]/[`Routine::max_runtime_secs`]; unlike those two, `0` is a valid,\nmeaningful value here (opt-out) rather than a rejected one. See\n[`crate::routines::cleanup::circuit_breaker`] for where it's enforced.",
+            "minimum": 0
           },
           "goal": {
             "type": [
@@ -1952,6 +1983,15 @@
             "propertyNames": {
               "type": "string"
             }
+          },
+          "failure_threshold": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "New failure-circuit-breaker threshold, or `None` to keep the existing value. `Some(0)`\nexplicitly opts back out (#521); unlike `ttl_secs`/`max_runtime_secs`, `0` is accepted here.",
+            "minimum": 0
           },
           "goal": {
             "type": [

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -319,3 +319,7 @@ fn cmd_list() -> i32 {
 #[cfg(test)]
 #[path = "mod_tests.rs"]
 mod machine_tests;
+
+#[cfg(test)]
+#[path = "mod_concurrency_tests.rs"]
+mod machine_concurrency_tests;

--- a/src/machine/mod_concurrency_tests.rs
+++ b/src/machine/mod_concurrency_tests.rs
@@ -1,0 +1,145 @@
+//! `max_concurrent_runs_override` persistence tests (issue #1155), split out of `mod_tests.rs` to
+//! keep that file under the repo's line-count gate.
+
+use super::*;
+
+/// Save an env var's prior value and restore it on drop, so a test's override never leaks. Tests in
+/// this crate run single-threaded per binary (`RUST_TEST_THREADS=1`), so the global mutation is safe.
+struct EnvGuard {
+    name: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvGuard {
+    /// Set `name` to `value`, remembering the prior value for restoration.
+    fn set(name: &'static str, value: &str) -> Self {
+        let previous = std::env::var_os(name);
+        // SAFETY: single-threaded test execution.
+        unsafe { std::env::set_var(name, value) }
+        Self { name, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: single-threaded test execution.
+        unsafe {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.name, value),
+                None => std::env::remove_var(self.name),
+            }
+        }
+    }
+}
+
+/// Create a unique tempdir to use as `MOADIM_HOME_OVERRIDE` for a test.
+fn temp_home(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("moadim-machine-{tag}-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).expect("create temp home");
+    dir
+}
+
+#[test]
+fn max_concurrent_runs_override_absent_is_none() {
+    let home = temp_home("cap-absent");
+    let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", home.to_str().unwrap());
+    assert_eq!(max_concurrent_runs_override(), None);
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+#[test]
+fn set_max_concurrent_runs_override_then_read_roundtrips() {
+    let home = temp_home("cap-roundtrip");
+    let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", home.to_str().unwrap());
+    set_max_concurrent_runs_override(Some(7)).expect("write cap override");
+    assert_eq!(max_concurrent_runs_override(), Some(7));
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+#[test]
+fn set_max_concurrent_runs_override_none_clears_it() {
+    let home = temp_home("cap-clear");
+    let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", home.to_str().unwrap());
+    set_max_concurrent_runs_override(Some(3)).expect("write cap override");
+    set_max_concurrent_runs_override(None).expect("clear cap override");
+    assert_eq!(max_concurrent_runs_override(), None);
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+#[test]
+fn set_machine_preserves_existing_concurrency_override() {
+    let home = temp_home("cap-preserve-on-name-set");
+    let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", home.to_str().unwrap());
+    set_max_concurrent_runs_override(Some(5)).expect("write cap override");
+    set_machine("my-box").expect("write machine name");
+    // Setting the name must not clobber the previously-persisted cap override.
+    assert_eq!(max_concurrent_runs_override(), Some(5));
+    assert_eq!(read_machine_file(), Some("my-box".to_string()));
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+#[test]
+fn set_max_concurrent_runs_override_preserves_existing_machine_name() {
+    let home = temp_home("cap-preserve-name");
+    let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", home.to_str().unwrap());
+    set_machine("my-box").expect("write machine name");
+    set_max_concurrent_runs_override(Some(5)).expect("write cap override");
+    // Setting the cap override must not clobber the previously-persisted machine name.
+    assert_eq!(read_machine_file(), Some("my-box".to_string()));
+    assert_eq!(max_concurrent_runs_override(), Some(5));
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+#[test]
+fn concurrent_set_machine_and_set_cap_override_do_not_clobber_each_other() {
+    // Regression test for the machine.local.toml read-modify-write race: two threads racing
+    // `set_machine` and `set_max_concurrent_runs_override` each read the whole file, mutate one
+    // field, and write the whole struct back. Without `machine_toml_lock()` serializing that
+    // span, both threads can read the same (empty) snapshot before either writes, and whichever
+    // write lands second silently drops the other thread's field. A `Barrier` forces both
+    // threads to start their read-modify-write span at (as close to) the same instant, so an
+    // unsynchronized version of this test flakes/fails; with the lock in place, both fields
+    // always survive regardless of which thread wins the race.
+    let home = temp_home("concurrent-rmw");
+    // Set once on the parent thread before either child spawns; both children only read it
+    // (via `machine_config_path()`), so there is no concurrent env-var mutation to race on.
+    let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", home.to_str().unwrap());
+
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let b1 = std::sync::Arc::clone(&barrier);
+    let t1 = std::thread::spawn(move || {
+        b1.wait();
+        set_machine("racer-box").expect("set_machine");
+    });
+    let b2 = std::sync::Arc::clone(&barrier);
+    let t2 = std::thread::spawn(move || {
+        b2.wait();
+        set_max_concurrent_runs_override(Some(9)).expect("set_max_concurrent_runs_override");
+    });
+    t1.join().unwrap();
+    t2.join().unwrap();
+
+    assert_eq!(
+        read_machine_file(),
+        Some("racer-box".to_string()),
+        "concurrent cap-override write must not drop the machine name"
+    );
+    assert_eq!(
+        max_concurrent_runs_override(),
+        Some(9),
+        "concurrent machine-name write must not drop the cap override"
+    );
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+#[test]
+fn set_max_concurrent_runs_override_returns_err_on_write_failure() {
+    let home = temp_home("cap-write-fail");
+    let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", home.to_str().unwrap());
+    // Block the write by placing a regular file where the config dir should be.
+    let config_dir = home.join(".config").join("moadim");
+    std::fs::create_dir_all(config_dir.parent().unwrap()).unwrap();
+    std::fs::write(&config_dir, b"").unwrap(); // file, not a dir
+    assert!(set_max_concurrent_runs_override(Some(1)).is_err());
+    let _ = std::fs::remove_dir_all(&home);
+}

--- a/src/machine/mod_tests.rs
+++ b/src/machine/mod_tests.rs
@@ -304,6 +304,9 @@ fn referenced_machines_unions_routines() {
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     };
     crate::routine_storage::write_routine(&routine).expect("write routine");
 
@@ -377,6 +380,9 @@ fn run_list_with_referenced_machine() {
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     };
     crate::routine_storage::write_routine(&routine).expect("write routine");
     assert_eq!(run(&["list".to_string()]), 0);
@@ -389,109 +395,5 @@ fn cmd_set_error_returns_one() {
     assert_eq!(cmd_set("   "), 1);
 }
 
-// ─── max_concurrent_runs_override persistence (issue #1155) ───────────────
-
-#[test]
-fn max_concurrent_runs_override_absent_is_none() {
-    let home = temp_home("cap-absent");
-    let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", home.to_str().unwrap());
-    assert_eq!(max_concurrent_runs_override(), None);
-    let _ = std::fs::remove_dir_all(&home);
-}
-
-#[test]
-fn set_max_concurrent_runs_override_then_read_roundtrips() {
-    let home = temp_home("cap-roundtrip");
-    let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", home.to_str().unwrap());
-    set_max_concurrent_runs_override(Some(7)).expect("write cap override");
-    assert_eq!(max_concurrent_runs_override(), Some(7));
-    let _ = std::fs::remove_dir_all(&home);
-}
-
-#[test]
-fn set_max_concurrent_runs_override_none_clears_it() {
-    let home = temp_home("cap-clear");
-    let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", home.to_str().unwrap());
-    set_max_concurrent_runs_override(Some(3)).expect("write cap override");
-    set_max_concurrent_runs_override(None).expect("clear cap override");
-    assert_eq!(max_concurrent_runs_override(), None);
-    let _ = std::fs::remove_dir_all(&home);
-}
-
-#[test]
-fn set_machine_preserves_existing_concurrency_override() {
-    let home = temp_home("cap-preserve-on-name-set");
-    let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", home.to_str().unwrap());
-    set_max_concurrent_runs_override(Some(5)).expect("write cap override");
-    set_machine("my-box").expect("write machine name");
-    // Setting the name must not clobber the previously-persisted cap override.
-    assert_eq!(max_concurrent_runs_override(), Some(5));
-    assert_eq!(read_machine_file(), Some("my-box".to_string()));
-    let _ = std::fs::remove_dir_all(&home);
-}
-
-#[test]
-fn set_max_concurrent_runs_override_preserves_existing_machine_name() {
-    let home = temp_home("cap-preserve-name");
-    let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", home.to_str().unwrap());
-    set_machine("my-box").expect("write machine name");
-    set_max_concurrent_runs_override(Some(5)).expect("write cap override");
-    // Setting the cap override must not clobber the previously-persisted machine name.
-    assert_eq!(read_machine_file(), Some("my-box".to_string()));
-    assert_eq!(max_concurrent_runs_override(), Some(5));
-    let _ = std::fs::remove_dir_all(&home);
-}
-
-#[test]
-fn concurrent_set_machine_and_set_cap_override_do_not_clobber_each_other() {
-    // Regression test for the machine.local.toml read-modify-write race: two threads racing
-    // `set_machine` and `set_max_concurrent_runs_override` each read the whole file, mutate one
-    // field, and write the whole struct back. Without `machine_toml_lock()` serializing that
-    // span, both threads can read the same (empty) snapshot before either writes, and whichever
-    // write lands second silently drops the other thread's field. A `Barrier` forces both
-    // threads to start their read-modify-write span at (as close to) the same instant, so an
-    // unsynchronized version of this test flakes/fails; with the lock in place, both fields
-    // always survive regardless of which thread wins the race.
-    let home = temp_home("concurrent-rmw");
-    // Set once on the parent thread before either child spawns; both children only read it
-    // (via `machine_config_path()`), so there is no concurrent env-var mutation to race on.
-    let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", home.to_str().unwrap());
-
-    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
-    let b1 = std::sync::Arc::clone(&barrier);
-    let t1 = std::thread::spawn(move || {
-        b1.wait();
-        set_machine("racer-box").expect("set_machine");
-    });
-    let b2 = std::sync::Arc::clone(&barrier);
-    let t2 = std::thread::spawn(move || {
-        b2.wait();
-        set_max_concurrent_runs_override(Some(9)).expect("set_max_concurrent_runs_override");
-    });
-    t1.join().unwrap();
-    t2.join().unwrap();
-
-    assert_eq!(
-        read_machine_file(),
-        Some("racer-box".to_string()),
-        "concurrent cap-override write must not drop the machine name"
-    );
-    assert_eq!(
-        max_concurrent_runs_override(),
-        Some(9),
-        "concurrent machine-name write must not drop the cap override"
-    );
-    let _ = std::fs::remove_dir_all(&home);
-}
-
-#[test]
-fn set_max_concurrent_runs_override_returns_err_on_write_failure() {
-    let home = temp_home("cap-write-fail");
-    let _home = EnvGuard::set("MOADIM_HOME_OVERRIDE", home.to_str().unwrap());
-    // Block the write by placing a regular file where the config dir should be.
-    let config_dir = home.join(".config").join("moadim");
-    std::fs::create_dir_all(config_dir.parent().unwrap()).unwrap();
-    std::fs::write(&config_dir, b"").unwrap(); // file, not a dir
-    assert!(set_max_concurrent_runs_override(Some(1)).is_err());
-    let _ = std::fs::remove_dir_all(&home);
-}
+// `max_concurrent_runs_override` persistence tests (issue #1155) live in
+// `mod_concurrency_tests.rs` (split out to keep this file under the line cap).

--- a/src/routes/create_flag/mcp_tests.rs
+++ b/src/routes/create_flag/mcp_tests.rs
@@ -32,6 +32,7 @@ fn make_create_routine_req() -> crate::routines::CreateRoutineRequest {
         max_runtime_secs: None,
         tags: vec![],
         env: std::collections::HashMap::new(),
+        failure_threshold: None,
     }
 }
 

--- a/src/routes/create_routine/logic_tests.rs
+++ b/src/routes/create_routine/logic_tests.rs
@@ -20,6 +20,7 @@ fn make_req() -> CreateRoutineRequest {
         max_runtime_secs: None,
         tags: vec![],
         env: std::collections::HashMap::new(),
+        failure_threshold: None,
     }
 }
 

--- a/src/routes/create_routine/mcp_tests.rs
+++ b/src/routes/create_routine/mcp_tests.rs
@@ -29,6 +29,7 @@ fn make_create_routine_req() -> crate::routines::CreateRoutineRequest {
         max_runtime_secs: None,
         tags: vec![],
         env: std::collections::HashMap::new(),
+        failure_threshold: None,
     }
 }
 

--- a/src/routes/http_listener_tests.rs
+++ b/src/routes/http_listener_tests.rs
@@ -207,6 +207,9 @@ async fn router_serves_routines_ical_feed() {
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     })
     .unwrap();
     let resp = build_app(crate::routines::new_store())
@@ -262,6 +265,9 @@ async fn router_serves_per_routine_ical_feed_via_query() {
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     };
     crate::routine_storage::write_routine(&mk("a", "Routine A")).unwrap();
     crate::routine_storage::write_routine(&mk("b", "Routine B")).unwrap();

--- a/src/routes/http_tests.rs
+++ b/src/routes/http_tests.rs
@@ -270,6 +270,9 @@ async fn build_app_serves_machines() {
             ttl_secs: None,
             max_runtime_secs: None,
             env: std::collections::HashMap::new(),
+            auto_disabled_reason: None,
+            consecutive_failures: 0,
+            failure_threshold: None,
         },
     );
     let resp = build_app(routines)

--- a/src/routes/list_routine_runs/mcp_tests.rs
+++ b/src/routes/list_routine_runs/mcp_tests.rs
@@ -53,6 +53,7 @@ fn make_create_routine_req() -> crate::routines::CreateRoutineRequest {
         max_runtime_secs: None,
         tags: vec![],
         env: std::collections::HashMap::new(),
+        failure_threshold: None,
     }
 }
 

--- a/src/routes/mcp_parity_tests.rs
+++ b/src/routes/mcp_parity_tests.rs
@@ -63,6 +63,7 @@ fn make_create_routine_req() -> crate::routines::CreateRoutineRequest {
         max_runtime_secs: None,
         tags: vec![],
         env: std::collections::HashMap::new(),
+        failure_threshold: None,
     }
 }
 

--- a/src/routes/mcp_prompt_preview_tests.rs
+++ b/src/routes/mcp_prompt_preview_tests.rs
@@ -85,6 +85,7 @@ fn preview_routine_prompt_success_contains_prompt() {
             max_runtime_secs: None,
             tags: vec![],
             env: std::collections::HashMap::new(),
+            failure_threshold: None,
         }))
         .unwrap();
     assert!(!create_result.is_error.unwrap_or(false));

--- a/src/routes/mcp_tests.rs
+++ b/src/routes/mcp_tests.rs
@@ -78,6 +78,7 @@ fn make_create_routine_req() -> crate::routines::CreateRoutineRequest {
         max_runtime_secs: None,
         tags: vec![],
         env: std::collections::HashMap::new(),
+        failure_threshold: None,
     }
 }
 
@@ -132,6 +133,7 @@ fn create_get_update_trigger_delete_routine_success() {
             max_runtime_secs: None,
             tags: None,
             env: None,
+            failure_threshold: None,
         }))
         .unwrap();
     assert!(!result.is_error.unwrap_or(false));

--- a/src/routes/mcp_types.rs
+++ b/src/routes/mcp_types.rs
@@ -112,6 +112,9 @@ pub(super) struct UpdateRoutineInput {
     /// New max runtime (seconds) for a single run before the watchdog kills it, or `None` to keep
     /// the existing value. Must be greater than zero when set; `0` is rejected (#233).
     pub(super) max_runtime_secs: Option<u64>,
+    /// New failure-circuit-breaker threshold, or `None` to keep the existing value. `Some(0)`
+    /// explicitly opts back out (#521); unlike `ttl_secs`/`max_runtime_secs`, `0` is accepted here.
+    pub(super) failure_threshold: Option<u32>,
     /// New tags list, or `None` to keep the existing value.
     pub(super) tags: Option<Vec<String>>,
     /// New tracked `[env]` map (replaces the whole map), or `None` to keep the existing value.

--- a/src/routes/resolve_flag/mcp_tests.rs
+++ b/src/routes/resolve_flag/mcp_tests.rs
@@ -32,6 +32,7 @@ fn make_create_routine_req() -> crate::routines::CreateRoutineRequest {
         max_runtime_secs: None,
         tags: vec![],
         env: std::collections::HashMap::new(),
+        failure_threshold: None,
     }
 }
 

--- a/src/routes/trigger_routine/mcp_tests.rs
+++ b/src/routes/trigger_routine/mcp_tests.rs
@@ -53,6 +53,7 @@ fn make_create_routine_req() -> crate::routines::CreateRoutineRequest {
         max_runtime_secs: None,
         tags: vec![],
         env: std::collections::HashMap::new(),
+        failure_threshold: None,
     }
 }
 

--- a/src/routes/update_routine/logic_tests.rs
+++ b/src/routes/update_routine/logic_tests.rs
@@ -20,6 +20,7 @@ fn make_update_req() -> UpdateRoutineRequest {
         max_runtime_secs: None,
         tags: None,
         env: None,
+        failure_threshold: None,
     }
 }
 

--- a/src/routes/update_routine/mcp.rs
+++ b/src/routes/update_routine/mcp.rs
@@ -29,6 +29,7 @@ impl MoadimMcp {
             enabled: input.enabled,
             ttl_secs: input.ttl_secs,
             max_runtime_secs: input.max_runtime_secs,
+            failure_threshold: input.failure_threshold,
             tags: input.tags,
             env: input.env,
         };

--- a/src/routes/update_routine/mcp_tests.rs
+++ b/src/routes/update_routine/mcp_tests.rs
@@ -35,6 +35,7 @@ fn update_routine_tool_not_found_is_error() {
             max_runtime_secs: None,
             tags: None,
             env: None,
+            failure_threshold: None,
         }))
         .unwrap();
     assert!(result.is_error.unwrap_or(false));

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -6,10 +6,6 @@ use crate::utils::lock::LockRecover;
 // in this file since `load_store`/`load_store_from_dir` moved to `routine_storage_load`.
 use crate::paths::routines_dir;
 use std::collections::HashMap;
-// Only referenced by the `#[cfg(test)]` sibling test modules via `use super::*;` (they build a
-// `RoutineStore` map by hand); not used directly in this file's own (non-test) code.
-#[cfg(test)]
-use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Serialize};
 
@@ -76,6 +72,11 @@ struct RoutineToml {
     /// the daemon default.
     #[serde(default)]
     max_runtime_secs: Option<u64>,
+    /// Consecutive failed-or-unknown runs after which the daemon auto-disables this routine
+    /// (the failure circuit-breaker); `None`/`0` opts out. See
+    /// [`crate::routines::Routine::failure_threshold`] (#521).
+    #[serde(default)]
+    failure_threshold: Option<u32>,
     /// Free-form labels for the routine; absent means no tags.
     #[serde(default)]
     tags: Vec<String>,
@@ -130,6 +131,14 @@ struct RuntimeState {
     /// [`crate::routines::Routine::power_saving`].
     #[serde(default)]
     power_saving: bool,
+    /// Count of consecutive failed-or-unknown runs. See
+    /// [`crate::routines::Routine::consecutive_failures`].
+    #[serde(default)]
+    consecutive_failures: u32,
+    /// Why the failure circuit-breaker last auto-disabled this routine, or `None`. See
+    /// [`crate::routines::Routine::auto_disabled_reason`].
+    #[serde(default)]
+    auto_disabled_reason: Option<String>,
 }
 
 /// Parse a routine TOML file at `path`, returning `None` on any error.
@@ -255,6 +264,7 @@ pub fn write_routine(routine: &Routine) -> std::io::Result<()> {
         last_manual_trigger_at: None,
         ttl_secs: routine.ttl_secs,
         max_runtime_secs: routine.max_runtime_secs,
+        failure_threshold: routine.failure_threshold,
         tags: routine.tags.clone(),
         env: routine.env.clone(),
     };
@@ -283,7 +293,12 @@ pub fn write_routine(routine: &Routine) -> std::io::Result<()> {
 /// when all are `None`, so the on-disk state always mirrors the in-memory routine.
 fn write_runtime_state(slug: &str, routine: &Routine) -> std::io::Result<()> {
     let path = routine_state_path(slug);
-    if routine.snoozed_until.is_none() && routine.skip_runs.is_none() && !routine.power_saving {
+    if routine.snoozed_until.is_none()
+        && routine.skip_runs.is_none()
+        && !routine.power_saving
+        && routine.consecutive_failures == 0
+        && routine.auto_disabled_reason.is_none()
+    {
         if path.exists() {
             std::fs::remove_file(&path)?;
         }
@@ -296,6 +311,8 @@ fn write_runtime_state(slug: &str, routine: &Routine) -> std::io::Result<()> {
         snoozed_until: routine.snoozed_until,
         skip_runs: routine.skip_runs,
         power_saving: routine.power_saving,
+        consecutive_failures: routine.consecutive_failures,
+        auto_disabled_reason: routine.auto_disabled_reason.clone(),
     };
     let text = toml::to_string_pretty(&state).map_err(std::io::Error::other)?;
     atomic_write(&path, text.as_bytes())?;
@@ -400,6 +417,10 @@ pub(crate) use routine_storage_migrations::{
 #[cfg(test)]
 #[path = "routine_storage_tests.rs"]
 mod routine_storage_tests;
+
+#[cfg(test)]
+#[path = "routine_storage_repersist_tests.rs"]
+mod routine_storage_repersist_tests;
 
 #[cfg(test)]
 #[path = "routine_storage_more_tests.rs"]

--- a/src/routine_storage_env_tests.rs
+++ b/src/routine_storage_env_tests.rs
@@ -56,6 +56,9 @@ fn make_routine(id: &str, title: &str) -> Routine {
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 

--- a/src/routine_storage_gitignore_tests.rs
+++ b/src/routine_storage_gitignore_tests.rs
@@ -56,6 +56,9 @@ fn make_routine(id: &str, title: &str) -> Routine {
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 

--- a/src/routine_storage_load.rs
+++ b/src/routine_storage_load.rs
@@ -101,8 +101,11 @@ fn load_routine_from_base(base: &std::path::Path, dir_name: &str) -> Option<Rout
         snoozed_until: runtime_state.snoozed_until,
         skip_runs: runtime_state.skip_runs,
         power_saving: runtime_state.power_saving,
+        consecutive_failures: runtime_state.consecutive_failures,
+        auto_disabled_reason: runtime_state.auto_disabled_reason,
         ttl_secs: toml.ttl_secs,
         max_runtime_secs: toml.max_runtime_secs,
+        failure_threshold: toml.failure_threshold,
         tags: toml.tags,
         env: toml.env,
     })

--- a/src/routine_storage_migration_tests.rs
+++ b/src/routine_storage_migration_tests.rs
@@ -30,6 +30,9 @@ fn make_routine(id: &str, title: &str) -> Routine {
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 

--- a/src/routine_storage_prompt_sidecar_tests.rs
+++ b/src/routine_storage_prompt_sidecar_tests.rs
@@ -56,6 +56,9 @@ fn make_routine(id: &str, title: &str) -> Routine {
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 

--- a/src/routine_storage_repersist_tests.rs
+++ b/src/routine_storage_repersist_tests.rs
@@ -1,3 +1,6 @@
+//! `repersist_routines` tests, split out of `routine_storage_tests.rs` to keep that file under
+//! the repo's line-count gate.
+
 #![allow(
     clippy::missing_docs_in_private_items,
     reason = "test helpers and fixtures do not need doc comments"
@@ -5,13 +8,11 @@
 
 use super::*;
 use crate::routines::{slugify, Repository, Routine};
-
-fn scratch_dir(tag: &str) -> std::path::PathBuf {
-    std::env::temp_dir().join(format!("moadim-rs-{tag}-{}", uuid::Uuid::new_v4()))
-}
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 fn with_override_home(body: impl FnOnce(&std::path::Path)) {
-    let home = scratch_dir("override-home-more");
+    let home = std::env::temp_dir().join(format!("moadim-rs-repersist-{}", uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&home).unwrap();
     let previous = std::env::var_os("MOADIM_HOME_OVERRIDE");
     // SAFETY: tests in this crate run single-threaded per binary.
@@ -63,29 +64,30 @@ fn make_routine(id: &str, title: &str) -> Routine {
 }
 
 #[test]
-fn write_routine_leaves_no_tmp_residue() {
+fn repersist_routines_recreates_missing_prompt_sidecar() {
     with_override_home(|_home| {
-        let id = "rs-no-residue-id";
-        let title = "Rs No Residue Routine";
+        let id = "rs-repersist-id";
+        let title = "Rs Repersist Routine";
         let slug = slugify(title);
         write_routine(&make_routine(id, title)).unwrap();
-        let residue = std::fs::read_dir(crate::paths::routine_dir(&slug))
-            .unwrap()
-            .filter_map(Result::ok)
-            .filter(|entry| entry.file_name().to_string_lossy().contains(".tmp"))
-            .count();
-        assert_eq!(residue, 0, "atomic_write must leave no .tmp files behind");
-    });
-}
+        // Simulate the sync-only state: prompt.compiled.local.md and schedule.cron are gone.
+        std::fs::remove_file(crate::paths::routine_compiled_prompt_path(&slug)).unwrap();
+        std::fs::remove_file(crate::paths::routine_cron_path(&slug)).unwrap();
+        assert!(!crate::paths::routine_compiled_prompt_path(&slug).exists());
+        assert!(!crate::paths::routine_cron_path(&slug).exists());
 
-#[test]
-fn write_routine_errors_when_schedule_cron_is_a_directory() {
-    with_override_home(|_home| {
-        let title = "Rs Cron Dir Failure";
-        let slug = slugify(title);
-        std::fs::create_dir_all(crate::paths::routine_cron_path(&slug)).unwrap();
+        let mut map = HashMap::new();
+        map.insert(id.to_string(), make_routine(id, title));
+        let store = Arc::new(Mutex::new(map));
+        repersist_routines(&store);
 
-        let err = write_routine(&make_routine("rs-cron-dir-failure", title)).unwrap_err();
-        assert!(err.to_string().contains("directory") || err.to_string().contains("exists"));
+        assert!(
+            crate::paths::routine_compiled_prompt_path(&slug).exists(),
+            "repersist should recreate the prompt sidecar"
+        );
+        assert!(
+            crate::paths::routine_cron_path(&slug).exists(),
+            "repersist should recreate the cron sidecar"
+        );
     });
 }

--- a/src/routine_storage_sidecar_state_tests.rs
+++ b/src/routine_storage_sidecar_state_tests.rs
@@ -53,6 +53,9 @@ fn make_routine(id: &str, title: &str) -> Routine {
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 

--- a/src/routine_storage_slug_collision_tests.rs
+++ b/src/routine_storage_slug_collision_tests.rs
@@ -56,6 +56,9 @@ fn make_routine(id: &str, title: &str) -> Routine {
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 

--- a/src/routine_storage_snooze_tests.rs
+++ b/src/routine_storage_snooze_tests.rs
@@ -32,6 +32,9 @@ fn make_routine(id: &str, title: &str) -> Routine {
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 

--- a/src/routine_storage_tests.rs
+++ b/src/routine_storage_tests.rs
@@ -56,6 +56,9 @@ fn make_routine(id: &str, title: &str) -> Routine {
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 
@@ -466,35 +469,7 @@ fn migrate_routine_dirs_moves_legacy_uuid_dir_to_slug() {
     });
 }
 
-#[test]
-fn repersist_routines_recreates_missing_prompt_sidecar() {
-    with_override_home(|_home| {
-        let id = "rs-repersist-id";
-        let title = "Rs Repersist Routine";
-        let slug = slugify(title);
-        write_routine(&make_routine(id, title)).unwrap();
-        // Simulate the sync-only state: prompt.compiled.local.md and schedule.cron are gone.
-        std::fs::remove_file(crate::paths::routine_compiled_prompt_path(&slug)).unwrap();
-        std::fs::remove_file(crate::paths::routine_cron_path(&slug)).unwrap();
-        assert!(!crate::paths::routine_compiled_prompt_path(&slug).exists());
-        assert!(!crate::paths::routine_cron_path(&slug).exists());
-
-        let mut map = HashMap::new();
-        map.insert(id.to_string(), make_routine(id, title));
-        let store = Arc::new(Mutex::new(map));
-        repersist_routines(&store);
-
-        assert!(
-            crate::paths::routine_compiled_prompt_path(&slug).exists(),
-            "repersist should recreate the prompt sidecar"
-        );
-        assert!(
-            crate::paths::routine_cron_path(&slug).exists(),
-            "repersist should recreate the cron sidecar"
-        );
-    });
-}
-
-// Gitignore-reconciliation tests live in `routine_storage_gitignore_tests.rs`, and `[env]`
-// table / `routine.local.toml` sidecar tests live in `routine_storage_env_tests.rs` (both split
-// out to keep this file under the line cap).
+// Gitignore-reconciliation tests live in `routine_storage_gitignore_tests.rs`, `[env]`
+// table / `routine.local.toml` sidecar tests live in `routine_storage_env_tests.rs`, and
+// `repersist_routines` tests live in `routine_storage_repersist_tests.rs` (all split out to keep
+// this file under the line cap).

--- a/src/routine_storage_walk_tests.rs
+++ b/src/routine_storage_walk_tests.rs
@@ -54,6 +54,9 @@ fn make_routine(id: &str, title: &str) -> Routine {
         max_runtime_secs: None,
         tags: vec![],
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 

--- a/src/routines/cleanup/circuit_breaker.rs
+++ b/src/routines/cleanup/circuit_breaker.rs
@@ -1,0 +1,96 @@
+//! The failure circuit-breaker (issue #521): a routine that fails every scheduled fire otherwise
+//! keeps spawning a fresh agent session forever — on a `*/5` cron that is ~288 doomed sessions/day,
+//! burning CPU, disk, and API spend with no automatic backstop. This module tracks each routine's
+//! [`Routine::consecutive_failures`] and, once it reaches the routine's opt-in
+//! [`Routine::failure_threshold`], auto-disables it through the same `enabled = false` path a user
+//! flipping the toggle off would use — so the very next crontab sync removes it, and no further
+//! sessions spawn.
+//!
+//! # Hook point: the TTL-reap `persist` closure, not `svc_list_runs`
+//!
+//! A run's outcome becomes knowable in two places: the on-demand [`super::super::service_runs`]
+//! listing (`svc_list_runs`/`run_summary`), computed fresh on every `GET .../runs` call straight
+//! from the workbench's `exit_code` file and tmux liveness; and the periodic TTL-reap sweep
+//! ([`super::cleanup_expired_workbenches`]'s `persist` closure), which already durably records the
+//! same outcome into `runs.log` right before the workbench is removed (see
+//! [`super::super::run_history`]).
+//!
+//! `svc_list_runs` looks tempting for responsiveness — it observes a finished run immediately, not
+//! after a TTL — but it is *pull-based*: it only ever runs when an API client happens to call it, so
+//! a routine nobody is watching would never trip the breaker at all. The reap sweep, by contrast, is
+//! a background task the daemon already drives on its own (every [`super::CLEANUP_INTERVAL`], 5
+//! minutes) independent of anyone polling the API, which is what "auto-disables itself" requires.
+//! It also comes with [`super::super::run_history::has_persisted_run`] already guarding against
+//! recording (and so double-counting) the same finished run twice — reusing it here needs no new
+//! dedup bookkeeping.
+//!
+//! The tradeoff is that this hook only fires once a workbench's *retention* has elapsed, not the
+//! instant its session exits. In the worst case that sounds like it could be a long delay, but
+//! retention is `min(MAX_TTL_SECS, cron interval)` ([`super::ttl`]) — capped at the routine's own
+//! firing interval — so for exactly the high-frequency routines this feature is meant to protect
+//! (e.g. the `*/5` example in #521) the delay before a finished run is counted is bounded by
+//! [`super::CLEANUP_INTERVAL`] (a handful of minutes), not by the retention window itself. That is
+//! responsive enough to stop the bleed within a few extra fires — a world away from "forever" — at
+//! the cost of no new per-workbench marker files or a second background sweep.
+
+use crate::routine_storage::write_routine;
+use crate::routines::model::{RoutineStore, RunStatus};
+use crate::utils::lock::LockRecover;
+
+/// Update routine `id`'s consecutive-failure streak for a run that just durably finished with
+/// `status`, auto-disabling it once/if [`Routine::failure_threshold`](
+/// crate::routines::model::Routine::failure_threshold) is reached.
+///
+/// `status` is never [`RunStatus::Running`] here (the caller only invokes this for a workbench
+/// already confirmed finished — see this module's doc comment). [`RunStatus::Success`] resets the
+/// streak to `0`; anything else (`Failed` or `Unknown`) increments it — `Unknown` counts too because
+/// it covers a session that vanished with no exit code, including one the max-runtime watchdog just
+/// force-killed for hanging, which is exactly the kind of never-succeeds loop this breaker exists to
+/// stop. A missing `id` (routine deleted between the workbench's creation and this sweep) is a no-op.
+///
+/// Persists the routine unconditionally (mirroring how [`super::super::run_history`] persists every
+/// outcome), but only re-syncs the crontab when this call is the one that actually flips `enabled`
+/// to `false` — every other call (the common case: a success, or a failure short of the threshold)
+/// changes nothing the crontab cares about, so it skips that round trip.
+pub(super) fn record_run_outcome(store: &RoutineStore, id: &str, status: RunStatus) {
+    let mut just_disabled = false;
+    let routine = {
+        let mut lock = store.lock_recover();
+        let Some(routine) = lock.get_mut(id) else {
+            return;
+        };
+        if status == RunStatus::Success {
+            routine.consecutive_failures = 0;
+        } else {
+            routine.consecutive_failures = routine.consecutive_failures.saturating_add(1);
+            // `None`/`Some(0)` opts out, preserving today's retry-forever behavior (#521).
+            if let Some(threshold) = routine.failure_threshold.filter(|&threshold| threshold > 0) {
+                if routine.enabled && routine.consecutive_failures >= threshold {
+                    routine.enabled = false;
+                    routine.auto_disabled_reason = Some(format!(
+                        "auto-disabled after {threshold} consecutive failed run(s); \
+                         re-enable to reset and try again"
+                    ));
+                    just_disabled = true;
+                }
+            }
+        }
+        routine.clone()
+    };
+    if let Err(err) = write_routine(&routine) {
+        log::warn!("circuit breaker: failed to persist routine {id:?}: {err}");
+    }
+    if just_disabled {
+        log::warn!(
+            "circuit breaker: auto-disabled routine {id:?} after {} consecutive failed run(s)",
+            routine.consecutive_failures
+        );
+        if let Err(err) = crate::sync::routines::sync_routines_to_crontab(store) {
+            log::warn!("circuit breaker: crontab sync after auto-disable failed: {err}");
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "circuit_breaker_tests.rs"]
+mod circuit_breaker_tests;

--- a/src/routines/cleanup/circuit_breaker_tests.rs
+++ b/src/routines/cleanup/circuit_breaker_tests.rs
@@ -1,0 +1,305 @@
+//! Tests for the failure circuit-breaker's `record_run_outcome` (#521): increment-on-fail,
+//! reset-on-success, trip-at-threshold, and the opt-out paths (`None`/`Some(0)` threshold).
+
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and fixtures do not need doc comments"
+)]
+
+use super::*;
+use crate::routines::model::new_store;
+
+struct TempHome(std::path::PathBuf);
+
+impl TempHome {
+    fn set() -> Self {
+        let dir = std::env::temp_dir().join(format!("moadim-cbtest-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).expect("create temp home");
+        // SAFETY: tests in this crate run single-threaded (RUST_TEST_THREADS=1).
+        unsafe {
+            std::env::set_var("MOADIM_HOME_OVERRIDE", &dir);
+        }
+        Self(dir)
+    }
+}
+
+impl Drop for TempHome {
+    fn drop(&mut self) {
+        // SAFETY: single-threaded test execution.
+        unsafe {
+            std::env::remove_var("MOADIM_HOME_OVERRIDE");
+        }
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn make_routine(
+    id: &str,
+    title: &str,
+    failure_threshold: Option<u32>,
+) -> crate::routines::model::Routine {
+    crate::routines::model::Routine {
+        model: None,
+        id: id.to_string(),
+        schedule: "@daily".to_string(),
+        title: title.to_string(),
+        agent: "claude".to_string(),
+        prompt: "do the thing".to_string(),
+        goal: None,
+        repositories: vec![],
+        machines: vec![crate::machine::current_machine()],
+        enabled: true,
+        source: "managed".to_string(),
+        created_at: 1,
+        updated_at: 1,
+        last_manual_trigger_at: None,
+        last_scheduled_trigger_at: None,
+        snoozed_until: None,
+        skip_runs: None,
+        power_saving: false,
+        consecutive_failures: 0,
+        auto_disabled_reason: None,
+        tags: vec![],
+        ttl_secs: None,
+        max_runtime_secs: None,
+        failure_threshold,
+        env: std::collections::HashMap::new(),
+    }
+}
+
+#[test]
+fn record_run_outcome_increments_on_failure() {
+    let _home = TempHome::set();
+    let store = new_store();
+    store
+        .lock()
+        .unwrap()
+        .insert("r1".into(), make_routine("r1", "Breaker Fail", Some(5)));
+
+    record_run_outcome(&store, "r1", crate::routines::model::RunStatus::Failed);
+
+    let lock = store.lock().unwrap();
+    let routine = lock.get("r1").unwrap();
+    assert_eq!(routine.consecutive_failures, 1);
+    assert!(routine.enabled);
+    assert!(routine.auto_disabled_reason.is_none());
+}
+
+#[test]
+fn record_run_outcome_counts_unknown_as_failure() {
+    // `Unknown` (session gone, no exit code — e.g. force-killed for hanging) counts toward the
+    // streak too: a routine that only ever hangs is exactly the loop this breaker exists to stop.
+    let _home = TempHome::set();
+    let store = new_store();
+    store
+        .lock()
+        .unwrap()
+        .insert("r1".into(), make_routine("r1", "Breaker Unknown", Some(5)));
+
+    record_run_outcome(&store, "r1", crate::routines::model::RunStatus::Unknown);
+
+    assert_eq!(
+        store
+            .lock()
+            .unwrap()
+            .get("r1")
+            .unwrap()
+            .consecutive_failures,
+        1
+    );
+}
+
+#[test]
+fn record_run_outcome_resets_on_success() {
+    let _home = TempHome::set();
+    let store = new_store();
+    let mut routine = make_routine("r1", "Breaker Reset", Some(5));
+    routine.consecutive_failures = 3;
+    store.lock().unwrap().insert("r1".into(), routine);
+
+    record_run_outcome(&store, "r1", crate::routines::model::RunStatus::Success);
+
+    assert_eq!(
+        store
+            .lock()
+            .unwrap()
+            .get("r1")
+            .unwrap()
+            .consecutive_failures,
+        0
+    );
+}
+
+#[test]
+fn record_run_outcome_trips_at_threshold() {
+    let _home = TempHome::set();
+    let store = new_store();
+    let mut routine = make_routine("r1", "Breaker Trip", Some(3));
+    routine.consecutive_failures = 2;
+    store.lock().unwrap().insert("r1".into(), routine);
+
+    record_run_outcome(&store, "r1", crate::routines::model::RunStatus::Failed);
+
+    let lock = store.lock().unwrap();
+    let routine = lock.get("r1").unwrap();
+    assert_eq!(routine.consecutive_failures, 3);
+    assert!(
+        !routine.enabled,
+        "must auto-disable on crossing the threshold"
+    );
+    assert!(
+        routine
+            .auto_disabled_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains('3')),
+        "auto_disabled_reason should name the threshold that tripped: {:?}",
+        routine.auto_disabled_reason
+    );
+}
+
+#[test]
+fn record_run_outcome_does_not_retrip_or_overwrite_reason_once_disabled() {
+    // Once a routine is already auto-disabled, further failures keep incrementing the streak (an
+    // operator inspecting it later can see how bad it got) but must not re-run the disable branch
+    // or clobber the original reason with a new one every sweep.
+    let _home = TempHome::set();
+    let store = new_store();
+    let mut routine = make_routine("r1", "Breaker Already Tripped", Some(2));
+    routine.consecutive_failures = 2;
+    routine.enabled = false;
+    routine.auto_disabled_reason = Some("auto-disabled after 2 consecutive failed run(s)".into());
+    store.lock().unwrap().insert("r1".into(), routine);
+
+    record_run_outcome(&store, "r1", crate::routines::model::RunStatus::Failed);
+
+    let lock = store.lock().unwrap();
+    let routine = lock.get("r1").unwrap();
+    assert_eq!(routine.consecutive_failures, 3);
+    assert!(!routine.enabled);
+}
+
+#[test]
+fn record_run_outcome_opts_out_when_threshold_none() {
+    let _home = TempHome::set();
+    let store = new_store();
+    let mut routine = make_routine("r1", "Breaker Opt Out None", None);
+    routine.consecutive_failures = 99;
+    store.lock().unwrap().insert("r1".into(), routine);
+
+    record_run_outcome(&store, "r1", crate::routines::model::RunStatus::Failed);
+
+    let lock = store.lock().unwrap();
+    let routine = lock.get("r1").unwrap();
+    assert_eq!(routine.consecutive_failures, 100);
+    assert!(routine.enabled, "None threshold must never auto-disable");
+}
+
+#[test]
+fn record_run_outcome_opts_out_when_threshold_zero() {
+    let _home = TempHome::set();
+    let store = new_store();
+    let mut routine = make_routine("r1", "Breaker Opt Out Zero", Some(0));
+    routine.consecutive_failures = 99;
+    store.lock().unwrap().insert("r1".into(), routine);
+
+    record_run_outcome(&store, "r1", crate::routines::model::RunStatus::Failed);
+
+    let lock = store.lock().unwrap();
+    let routine = lock.get("r1").unwrap();
+    assert_eq!(routine.consecutive_failures, 100);
+    assert!(routine.enabled, "Some(0) threshold must never auto-disable");
+}
+
+#[test]
+fn record_run_outcome_logs_a_warning_when_persisting_fails() {
+    // Reuse the on-disk slug-collision guard (#188) in `write_routine` as a reliable, filesystem-
+    // permission-free way to make the persist step fail: a `routine.toml` already on disk for this
+    // slug under a *different* id makes `write_routine` refuse to overwrite it.
+    let _home = TempHome::set();
+    let store = new_store();
+    let title = "Breaker Persist Conflict";
+    write_routine(&make_routine("other-id", title, Some(5))).expect("seed conflicting routine");
+    store
+        .lock()
+        .unwrap()
+        .insert("r1".into(), make_routine("r1", title, Some(5)));
+
+    // Must not panic even though the persist step fails; the in-memory counter still updates.
+    record_run_outcome(&store, "r1", crate::routines::model::RunStatus::Failed);
+
+    assert_eq!(
+        store
+            .lock()
+            .unwrap()
+            .get("r1")
+            .unwrap()
+            .consecutive_failures,
+        1
+    );
+}
+
+/// A minimal `crontab` shim wired in via `MOADIM_CRONTAB_BIN` that always succeeds, mirroring the
+/// pattern in `sync::routines_sync_tests::CronShim` — used here only to exercise the successful
+/// crontab-resync path after an auto-disable, since test builds otherwise never touch a real
+/// `crontab` (see `crate::sync::crontab_bin`'s doc comment).
+struct OkCronShim {
+    script: std::path::PathBuf,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl OkCronShim {
+    fn install() -> Self {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!("moadim-cbtest-cron-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let script = dir.join("crontab-ok.sh");
+        std::fs::write(&script, "#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let previous = std::env::var_os("MOADIM_CRONTAB_BIN");
+        // SAFETY: tests in this crate run single-threaded (RUST_TEST_THREADS=1).
+        unsafe {
+            std::env::set_var("MOADIM_CRONTAB_BIN", &script);
+        }
+        Self { script, previous }
+    }
+}
+
+impl Drop for OkCronShim {
+    fn drop(&mut self) {
+        // SAFETY: single-threaded test execution.
+        unsafe {
+            match self.previous.take() {
+                Some(value) => std::env::set_var("MOADIM_CRONTAB_BIN", value),
+                None => std::env::remove_var("MOADIM_CRONTAB_BIN"),
+            }
+        }
+        let _ = std::fs::remove_dir_all(self.script.parent().unwrap());
+    }
+}
+
+#[test]
+fn record_run_outcome_resyncs_crontab_successfully_on_auto_disable() {
+    let _home = TempHome::set();
+    let _cron = OkCronShim::install();
+    let store = new_store();
+    let mut routine = make_routine("r1", "Breaker Trip Cron Ok", Some(1));
+    routine.consecutive_failures = 0;
+    store.lock().unwrap().insert("r1".into(), routine);
+
+    record_run_outcome(&store, "r1", crate::routines::model::RunStatus::Failed);
+
+    assert!(!store.lock().unwrap().get("r1").unwrap().enabled);
+}
+
+#[test]
+fn record_run_outcome_missing_routine_is_a_no_op() {
+    let _home = TempHome::set();
+    let store = new_store();
+    // No routine inserted at all; must return without panicking.
+    record_run_outcome(
+        &store,
+        "does-not-exist",
+        crate::routines::model::RunStatus::Failed,
+    );
+    assert!(store.lock().unwrap().is_empty());
+}

--- a/src/routines/cleanup/cleanup_run_history_tests.rs
+++ b/src/routines/cleanup/cleanup_run_history_tests.rs
@@ -33,6 +33,9 @@ fn make_routine(id: &str, title: &str) -> super::super::model::Routine {
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 

--- a/src/routines/cleanup/cleanup_watchdog_tests.rs
+++ b/src/routines/cleanup/cleanup_watchdog_tests.rs
@@ -310,6 +310,9 @@ fn routine_with(schedule: &str, ttl_secs: Option<u64>) -> super::super::model::R
         ttl_secs,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 

--- a/src/routines/cleanup/mod.rs
+++ b/src/routines/cleanup/mod.rs
@@ -27,6 +27,7 @@ use crate::utils::time::now_secs;
 use super::model::{RoutineStore, RunStatus};
 use super::run_history::{append_persisted_run, has_persisted_run, read_exit_code, PersistedRun};
 
+mod circuit_breaker;
 mod counters;
 mod disk_cap;
 mod log_cap;
@@ -362,6 +363,10 @@ pub fn cleanup_expired_workbenches(store: &RoutineStore) -> ReapStats {
                     exit_code,
                 },
             );
+            // Feed the same, already-deduplicated outcome into the failure circuit-breaker (#521);
+            // see `circuit_breaker`'s doc comment for why this hook point (not `svc_list_runs`) was
+            // chosen.
+            circuit_breaker::record_run_outcome(store, routine_id, status);
         };
     let ttl_stats = reap_dir(
         &workbenches_dir(),

--- a/src/routines/cleanup/snapshot_tests.rs
+++ b/src/routines/cleanup/snapshot_tests.rs
@@ -33,6 +33,9 @@ fn routine_with(title: &str, schedule: &str, ttl_secs: Option<u64>) -> Routine {
         ttl_secs,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 

--- a/src/routines/command_tests.rs
+++ b/src/routines/command_tests.rs
@@ -31,6 +31,9 @@ fn make_routine(title: &str) -> Routine {
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 

--- a/src/routines/defaults/mod.rs
+++ b/src/routines/defaults/mod.rs
@@ -86,8 +86,11 @@ fn materialize(spec: &DefaultRoutine, now: u64) -> Routine {
         snoozed_until: None,
         skip_runs: None,
         power_saving: false,
+        consecutive_failures: 0,
+        auto_disabled_reason: None,
         ttl_secs: None,
         max_runtime_secs: None,
+        failure_threshold: None,
         tags: Vec::new(),
         env: std::collections::HashMap::new(),
     }
@@ -150,8 +153,15 @@ fn reconcile(spec: &DefaultRoutine, cur: &Routine, now: u64) -> Option<Routine> 
         skip_runs: cur.skip_runs,
         // Power saving is daemon/policy-owned, not spec-derived: carry it over like snooze state.
         power_saving: cur.power_saving,
+        // Circuit-breaker runtime state is daemon-owned but not spec-derived either: carry it over
+        // like power saving, so a reconcile doesn't silently clear an in-progress failure streak or
+        // an auto-disable reason.
+        consecutive_failures: cur.consecutive_failures,
+        auto_disabled_reason: cur.auto_disabled_reason.clone(),
         ttl_secs: cur.ttl_secs,
         max_runtime_secs: cur.max_runtime_secs,
+        // The circuit-breaker threshold is user-owned, like `tags`: never overridden by the spec.
+        failure_threshold: cur.failure_threshold,
         // Tags are user-owned, like `enabled`: never overridden by the spec.
         tags: cur.tags.clone(),
         // Env vars are user-owned, like `tags`: never overridden by the spec.

--- a/src/routines/ical.rs
+++ b/src/routines/ical.rs
@@ -401,3 +401,7 @@ pub fn svc_ical_routine(store: &RoutineStore, dir: &std::path::Path, id: &str) -
 #[cfg(test)]
 #[path = "ical_tests.rs"]
 mod ical_tests;
+
+#[cfg(test)]
+#[path = "ical_offset_tests.rs"]
+mod ical_offset_tests;

--- a/src/routines/ical_offset_tests.rs
+++ b/src/routines/ical_offset_tests.rs
@@ -1,0 +1,34 @@
+//! `format_utc_offset` tests, split out of `ical_tests.rs` to keep that file under the repo's
+//! line-count gate.
+
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and fixtures do not need doc comments"
+)]
+
+use super::*;
+
+#[test]
+fn utc_offset_formats_per_rfc5545() {
+    assert_eq!(
+        format_utc_offset(chrono::FixedOffset::east_opt(0).unwrap()),
+        "+0000"
+    );
+    assert_eq!(
+        format_utc_offset(chrono::FixedOffset::east_opt(3 * 3600).unwrap()),
+        "+0300"
+    );
+    assert_eq!(
+        format_utc_offset(chrono::FixedOffset::west_opt(5 * 3600).unwrap()),
+        "-0500"
+    );
+    assert_eq!(
+        format_utc_offset(chrono::FixedOffset::east_opt(5 * 3600 + 30 * 60).unwrap()),
+        "+0530"
+    );
+    // A non-zero seconds component (some pre-1900 zones) appends a third HH:MM:SS group.
+    assert_eq!(
+        format_utc_offset(chrono::FixedOffset::east_opt(3 * 3600 + 25).unwrap()),
+        "+030025"
+    );
+}

--- a/src/routines/ical_tests.rs
+++ b/src/routines/ical_tests.rs
@@ -31,6 +31,9 @@ fn routine_with(id: &str, schedule: &str, enabled: bool) -> Routine {
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 
@@ -472,27 +475,5 @@ fn truncation_marker_also_uses_tzid_dtstart_when_host_zone_known() {
     assert_eq!(count(&ics, "DTSTART;TZID=America/New_York:"), 3);
 }
 
-#[test]
-fn utc_offset_formats_per_rfc5545() {
-    assert_eq!(
-        format_utc_offset(chrono::FixedOffset::east_opt(0).unwrap()),
-        "+0000"
-    );
-    assert_eq!(
-        format_utc_offset(chrono::FixedOffset::east_opt(3 * 3600).unwrap()),
-        "+0300"
-    );
-    assert_eq!(
-        format_utc_offset(chrono::FixedOffset::west_opt(5 * 3600).unwrap()),
-        "-0500"
-    );
-    assert_eq!(
-        format_utc_offset(chrono::FixedOffset::east_opt(5 * 3600 + 30 * 60).unwrap()),
-        "+0530"
-    );
-    // A non-zero seconds component (some pre-1900 zones) appends a third HH:MM:SS group.
-    assert_eq!(
-        format_utc_offset(chrono::FixedOffset::east_opt(3 * 3600 + 25).unwrap()),
-        "+030025"
-    );
-}
+// `format_utc_offset` tests live in `ical_offset_tests.rs` (split out to keep this file under the
+// line cap).

--- a/src/routines/mod_agents_reload_tests.rs
+++ b/src/routines/mod_agents_reload_tests.rs
@@ -34,6 +34,9 @@ fn make_routine(id: &str) -> Routine {
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 

--- a/src/routines/mod_agents_tests.rs
+++ b/src/routines/mod_agents_tests.rs
@@ -32,6 +32,9 @@ fn make_routine(id: &str) -> Routine {
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 
@@ -119,6 +122,7 @@ fn svc_create_invalid_cron_rejected() {
         max_runtime_secs: None,
         tags: vec![],
         env: std::collections::HashMap::new(),
+        failure_threshold: None,
     };
     assert!(svc_create(&store, req).is_err());
 }
@@ -142,6 +146,7 @@ fn svc_create_update_delete_lifecycle() {
             max_runtime_secs: None,
             tags: vec![],
             env: std::collections::HashMap::new(),
+            failure_threshold: None,
         },
     )
     .unwrap();
@@ -170,6 +175,7 @@ fn svc_create_update_delete_lifecycle() {
             max_runtime_secs: None,
             tags: None,
             env: None,
+            failure_threshold: None,
         },
     )
     .unwrap();
@@ -199,6 +205,7 @@ fn svc_update_not_found() {
         max_runtime_secs: None,
         tags: None,
         env: None,
+        failure_threshold: None,
     };
     assert!(svc_update(&new_store(), "missing", req).is_err());
 }
@@ -224,6 +231,7 @@ fn svc_update_invalid_cron_rejected() {
         max_runtime_secs: None,
         tags: None,
         env: None,
+        failure_threshold: None,
     };
     assert!(svc_update(&store, "id", req).is_err());
 }

--- a/src/routines/mod_tests.rs
+++ b/src/routines/mod_tests.rs
@@ -32,6 +32,9 @@ fn make_routine(id: &str) -> Routine {
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 

--- a/src/routines/model.rs
+++ b/src/routines/model.rs
@@ -170,6 +170,20 @@ pub struct Routine {
     /// gitignored `state.local.toml` sidecar, not the version-controlled `routine.toml`.
     #[serde(default)]
     pub power_saving: bool,
+    /// Number of scheduled/manual runs that finished failed-or-unknown in a row, most recently
+    /// first — reset to `0` the instant any run succeeds. Daemon-owned runtime state: persisted in
+    /// the gitignored `state.local.toml` sidecar, not `routine.toml`, mirroring
+    /// [`Routine::power_saving`]. Counted by [`crate::routines::cleanup::circuit_breaker`] as each
+    /// run's outcome becomes durable; see [`Routine::failure_threshold`] and issue #521.
+    #[serde(default)]
+    pub consecutive_failures: u32,
+    /// Human-readable reason this routine was auto-disabled by the failure circuit-breaker, or
+    /// `None` if it has never tripped one (or a user has since manually re-enabled it, which clears
+    /// this — see `svc_update`). Distinguishes an auto-disable from a user-initiated one: both flip
+    /// [`Routine::enabled`] to `false`, but only the former sets a reason. Daemon-owned runtime
+    /// state, persisted in `state.local.toml` alongside [`Routine::consecutive_failures`].
+    #[serde(default)]
+    pub auto_disabled_reason: Option<String>,
     /// How long (seconds) a finished run's workbench is retained before auto-cleanup removes it.
     /// Caps the cron-derived retention (`min(MAX_TTL_SECS, cron interval)`) lower; it can only
     /// shorten, never extend it. `None` uses the cron-derived value. Sessions still running are
@@ -185,6 +199,18 @@ pub struct Routine {
     /// zero when set; `0` is rejected by `svc_create`/`svc_update` (#233).
     #[serde(default)]
     pub max_runtime_secs: Option<u64>,
+    /// Consecutive failed-or-unknown-outcome runs after which this routine auto-disables — the
+    /// opt-in failure circuit-breaker (issue #521). `None` or `0` opts out, preserving today's
+    /// behavior of retrying forever no matter how many times in a row a routine has failed; this is
+    /// the default so existing routines are unaffected. A "failed" run here is any [`RunStatus`]
+    /// other than `Success`, including `Unknown` (session gone with no exit code — e.g. force-killed
+    /// by the max-runtime watchdog): a routine that only ever hangs and gets killed is exactly the
+    /// resource-wasting loop this breaker exists to stop. Tracked config, written to `routine.toml`
+    /// like [`Routine::ttl_secs`]/[`Routine::max_runtime_secs`]; unlike those two, `0` is a valid,
+    /// meaningful value here (opt-out) rather than a rejected one. See
+    /// [`crate::routines::cleanup::circuit_breaker`] for where it's enforced.
+    #[serde(default)]
+    pub failure_threshold: Option<u32>,
     /// Free-form labels for grouping and filtering routines (e.g. `"triage"`, `"nightly"`).
     /// Defaults to empty; each entry is trimmed and must be non-blank.
     #[serde(default)]

--- a/src/routines/model_requests.rs
+++ b/src/routines/model_requests.rs
@@ -45,6 +45,11 @@ pub struct CreateRoutineRequest {
     /// than zero when set; `0` is rejected (#233).
     #[serde(default)]
     pub max_runtime_secs: Option<u64>,
+    /// Consecutive failed-or-unknown runs after which this routine auto-disables (the failure
+    /// circuit-breaker, #521). `None` or `0` opts out (the default): unlike `ttl_secs`/
+    /// `max_runtime_secs`, `0` is a meaningful opt-out value here, not rejected.
+    #[serde(default)]
+    pub failure_threshold: Option<u32>,
     /// Free-form labels for the routine (defaults to empty). Each entry is trimmed
     /// and must be non-blank.
     #[serde(default)]
@@ -87,6 +92,9 @@ pub struct UpdateRoutineRequest {
     /// New max runtime (seconds) for a single run, or `None` to keep the existing value. Must be
     /// greater than zero when set; `0` is rejected (#233).
     pub max_runtime_secs: Option<u64>,
+    /// New failure-circuit-breaker threshold, or `None` to keep the existing value. `Some(0)`
+    /// explicitly opts back out (#521); unlike `ttl_secs`/`max_runtime_secs`, `0` is accepted here.
+    pub failure_threshold: Option<u32>,
     /// New tags list, or `None` to keep the existing value.
     pub tags: Option<Vec<String>>,
     /// New tracked `[env]` map, or `None` to keep the existing value. Replaces the whole map (not

--- a/src/routines/model_tests.rs
+++ b/src/routines/model_tests.rs
@@ -78,6 +78,9 @@ fn make_routine(agent: &str) -> Routine {
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 
@@ -318,6 +321,9 @@ fn from_routine_populates_derived_fields() {
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     };
     let resp = RoutineResponse::from_routine(routine);
     assert!(resp.schedule_description.is_some());
@@ -397,6 +403,9 @@ fn from_routine_counts_open_flags() {
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     };
     let slug = slugify(&routine.title);
     crate::routines::flags::create_flag(

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -194,8 +194,13 @@ pub fn svc_create(
         // Power saving is system-driven, never settable via create/update — see
         // `svc_set_power_saving`.
         power_saving: false,
+        // A brand-new routine has no run history yet; the circuit-breaker state (like
+        // `power_saving`) starts clean regardless of `failure_threshold`.
+        consecutive_failures: 0,
+        auto_disabled_reason: None,
         ttl_secs: req.ttl_secs,
         max_runtime_secs: req.max_runtime_secs,
+        failure_threshold: req.failure_threshold,
         tags,
         env: req.env,
     };

--- a/src/routines/service_ceiling_tests.rs
+++ b/src/routines/service_ceiling_tests.rs
@@ -63,6 +63,9 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 
@@ -91,6 +94,7 @@ fn valid_create_request() -> CreateRoutineRequest {
         max_runtime_secs: None,
         tags: vec![],
         env: std::collections::HashMap::new(),
+        failure_threshold: None,
     }
 }
 
@@ -110,6 +114,7 @@ fn empty_update_request() -> UpdateRoutineRequest {
         max_runtime_secs: None,
         tags: None,
         env: None,
+        failure_threshold: None,
     }
 }
 

--- a/src/routines/service_coverage_tests.rs
+++ b/src/routines/service_coverage_tests.rs
@@ -57,6 +57,9 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 
@@ -87,6 +90,7 @@ fn valid_create_request() -> CreateRoutineRequest {
         max_runtime_secs: None,
         tags: vec![],
         env: std::collections::HashMap::new(),
+        failure_threshold: None,
     }
 }
 
@@ -105,6 +109,7 @@ fn empty_update_request() -> UpdateRoutineRequest {
         max_runtime_secs: None,
         tags: None,
         env: None,
+        failure_threshold: None,
     }
 }
 

--- a/src/routines/service_field_validation_create_tests.rs
+++ b/src/routines/service_field_validation_create_tests.rs
@@ -55,6 +55,9 @@ pub(super) fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 
@@ -74,6 +77,7 @@ pub(super) fn create_req_with_title(title: &str) -> CreateRoutineRequest {
         max_runtime_secs: None,
         tags: vec![],
         env: std::collections::HashMap::new(),
+        failure_threshold: None,
     }
 }
 
@@ -129,6 +133,7 @@ fn svc_create_rejects_unknown_agent() {
             max_runtime_secs: None,
             tags: vec![],
             env: std::collections::HashMap::new(),
+            failure_threshold: None,
         },
     );
     assert!(matches!(result, Err(AppError::BadRequest(_))));
@@ -160,6 +165,7 @@ fn svc_create_accepts_builtin_agent() {
             max_runtime_secs: None,
             tags: vec![],
             env: std::collections::HashMap::new(),
+            failure_threshold: None,
         },
     )
     .unwrap();
@@ -195,6 +201,7 @@ fn svc_create_rejects_blank_repository_url() {
                 max_runtime_secs: None,
                 tags: vec![],
                 env: std::collections::HashMap::new(),
+                failure_threshold: None,
             },
         );
         assert!(matches!(result, Err(AppError::BadRequest(_))));
@@ -228,6 +235,7 @@ fn svc_create_rejects_blank_repository_branch() {
             max_runtime_secs: None,
             tags: vec![],
             env: std::collections::HashMap::new(),
+            failure_threshold: None,
         },
     );
     assert!(matches!(result, Err(AppError::BadRequest(_))));
@@ -261,6 +269,7 @@ fn svc_create_trims_repository_entries() {
             max_runtime_secs: None,
             tags: vec![],
             env: std::collections::HashMap::new(),
+            failure_threshold: None,
         },
     )
     .unwrap();

--- a/src/routines/service_field_validation_update_tests.rs
+++ b/src/routines/service_field_validation_update_tests.rs
@@ -41,6 +41,7 @@ fn svc_update_rejects_blank_and_punctuation_titles() {
                 max_runtime_secs: None,
                 tags: None,
                 env: None,
+                failure_threshold: None,
             },
         );
         assert!(
@@ -82,6 +83,7 @@ fn svc_update_rejects_unknown_agent() {
             max_runtime_secs: None,
             tags: None,
             env: None,
+            failure_threshold: None,
         },
     );
     assert!(matches!(result, Err(AppError::BadRequest(_))));
@@ -123,6 +125,7 @@ fn svc_update_rejects_blank_repository_url() {
             max_runtime_secs: None,
             tags: None,
             env: None,
+            failure_threshold: None,
         },
     );
     assert!(matches!(result, Err(AppError::BadRequest(_))));
@@ -169,6 +172,7 @@ fn svc_update_rejects_invalid_env_key() {
                 "not-valid".to_string(),
                 "x".to_string(),
             )])),
+            failure_threshold: None,
         },
     );
     assert!(matches!(result, Err(AppError::BadRequest(_))));

--- a/src/routines/service_flag_tests.rs
+++ b/src/routines/service_flag_tests.rs
@@ -51,6 +51,7 @@ fn create_req_with_title(title: &str) -> CreateRoutineRequest {
         max_runtime_secs: None,
         tags: vec![],
         env: std::collections::HashMap::new(),
+        failure_threshold: None,
     }
 }
 

--- a/src/routines/service_list_tests.rs
+++ b/src/routines/service_list_tests.rs
@@ -67,6 +67,9 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 

--- a/src/routines/service_logs_tests.rs
+++ b/src/routines/service_logs_tests.rs
@@ -55,6 +55,9 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 

--- a/src/routines/service_model_tests.rs
+++ b/src/routines/service_model_tests.rs
@@ -32,6 +32,9 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 
@@ -50,6 +53,7 @@ fn valid_create_request() -> CreateRoutineRequest {
         max_runtime_secs: None,
         tags: vec![],
         env: std::collections::HashMap::new(),
+        failure_threshold: None,
     }
 }
 
@@ -68,6 +72,7 @@ fn create_req_with_title(title: &str) -> CreateRoutineRequest {
         max_runtime_secs: None,
         tags: vec![],
         env: std::collections::HashMap::new(),
+        failure_threshold: None,
     }
 }
 
@@ -87,6 +92,7 @@ fn empty_update_request() -> UpdateRoutineRequest {
         max_runtime_secs: None,
         tags: None,
         env: None,
+        failure_threshold: None,
     }
 }
 

--- a/src/routines/service_overlap_guard_tests.rs
+++ b/src/routines/service_overlap_guard_tests.rs
@@ -55,6 +55,9 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 

--- a/src/routines/service_power_saving_tests.rs
+++ b/src/routines/service_power_saving_tests.rs
@@ -55,6 +55,9 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 

--- a/src/routines/service_prompt_preview_tests.rs
+++ b/src/routines/service_prompt_preview_tests.rs
@@ -30,6 +30,9 @@ fn make_routine(id: &str, repositories: Vec<Repository>) -> Routine {
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 

--- a/src/routines/service_prompt_tests.rs
+++ b/src/routines/service_prompt_tests.rs
@@ -31,6 +31,9 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 
@@ -55,6 +58,7 @@ fn svc_create_rejects_empty_prompt() {
             ttl_secs: None,
             max_runtime_secs: None,
             env: std::collections::HashMap::new(),
+            failure_threshold: None,
         },
     );
     assert!(matches!(result, Err(AppError::BadRequest(_))));
@@ -82,6 +86,7 @@ fn svc_create_rejects_whitespace_prompt() {
             ttl_secs: None,
             max_runtime_secs: None,
             env: std::collections::HashMap::new(),
+            failure_threshold: None,
         },
     );
     assert!(matches!(result, Err(AppError::BadRequest(_))));
@@ -119,6 +124,7 @@ fn svc_update_rejects_clearing_prompt_to_empty() {
             ttl_secs: None,
             max_runtime_secs: None,
             env: None,
+            failure_threshold: None,
         },
     );
     assert!(matches!(result, Err(AppError::BadRequest(_))));

--- a/src/routines/service_rename_machine_tests.rs
+++ b/src/routines/service_rename_machine_tests.rs
@@ -56,6 +56,9 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 

--- a/src/routines/service_runs_tests.rs
+++ b/src/routines/service_runs_tests.rs
@@ -76,6 +76,9 @@ fn make_routine(id: &str, title: &str) -> Routine {
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 

--- a/src/routines/service_slug_tests.rs
+++ b/src/routines/service_slug_tests.rs
@@ -62,6 +62,9 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 
@@ -90,6 +93,7 @@ fn valid_create_request() -> CreateRoutineRequest {
         max_runtime_secs: None,
         tags: vec![],
         env: std::collections::HashMap::new(),
+        failure_threshold: None,
     }
 }
 
@@ -109,6 +113,7 @@ fn empty_update_request() -> UpdateRoutineRequest {
         max_runtime_secs: None,
         tags: None,
         env: None,
+        failure_threshold: None,
     }
 }
 
@@ -160,6 +165,7 @@ fn svc_create_rejects_duplicate_slug() {
                 max_runtime_secs: None,
                 tags: vec![],
                 env: std::collections::HashMap::new(),
+                failure_threshold: None,
             },
         )
         .unwrap();
@@ -181,6 +187,7 @@ fn svc_create_rejects_duplicate_slug() {
                 max_runtime_secs: None,
                 tags: vec![],
                 env: std::collections::HashMap::new(),
+                failure_threshold: None,
             },
         );
         assert!(matches!(conflict, Err(AppError::Conflict(_))));
@@ -238,6 +245,7 @@ fn svc_create_rejects_malformed_agent_config() {
             max_runtime_secs: None,
             tags: vec![],
             env: std::collections::HashMap::new(),
+            failure_threshold: None,
         },
     );
     match result {
@@ -273,6 +281,7 @@ fn svc_create_rejects_unreadable_agent_config() {
             ttl_secs: None,
             max_runtime_secs: None,
             env: std::collections::HashMap::new(),
+            failure_threshold: None,
         },
     );
     match result {
@@ -315,6 +324,7 @@ fn svc_update_rejects_malformed_agent_config() {
             max_runtime_secs: None,
             tags: None,
             env: None,
+            failure_threshold: None,
         },
     );
     match result {
@@ -363,6 +373,7 @@ fn svc_update_rejects_renaming_into_existing_slug() {
                 max_runtime_secs: None,
                 tags: None,
                 env: None,
+                failure_threshold: None,
             },
         );
         assert!(matches!(conflict, Err(AppError::Conflict(_))));

--- a/src/routines/service_snooze_tests.rs
+++ b/src/routines/service_snooze_tests.rs
@@ -56,6 +56,9 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 

--- a/src/routines/service_sync_tests.rs
+++ b/src/routines/service_sync_tests.rs
@@ -56,6 +56,9 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 
@@ -100,6 +103,7 @@ fn svc_create_warns_when_crontab_sync_fails() {
                 max_runtime_secs: None,
                 tags: vec![],
                 env: std::collections::HashMap::new(),
+                failure_threshold: None,
             },
         )
         .unwrap();
@@ -129,6 +133,7 @@ fn svc_create_rejects_goal_over_five_lines() {
             max_runtime_secs: None,
             tags: vec![],
             env: std::collections::HashMap::new(),
+            failure_threshold: None,
         },
     );
     match result {
@@ -160,6 +165,7 @@ fn svc_create_trims_and_persists_goal() {
                 max_runtime_secs: None,
                 tags: vec![],
                 env: std::collections::HashMap::new(),
+                failure_threshold: None,
             },
         )
         .unwrap();
@@ -207,6 +213,7 @@ fn svc_update_clears_goal_with_empty_string() {
                 max_runtime_secs: None,
                 tags: None,
                 env: None,
+                failure_threshold: None,
             },
         )
         .unwrap();
@@ -241,6 +248,7 @@ fn svc_update_warns_when_crontab_sync_fails() {
                 max_runtime_secs: None,
                 tags: None,
                 env: None,
+                failure_threshold: None,
             },
         )
         .unwrap();

--- a/src/routines/service_tests.rs
+++ b/src/routines/service_tests.rs
@@ -63,6 +63,9 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 
@@ -91,6 +94,7 @@ fn valid_create_request() -> CreateRoutineRequest {
         max_runtime_secs: None,
         tags: vec![],
         env: std::collections::HashMap::new(),
+        failure_threshold: None,
     }
 }
 
@@ -110,6 +114,7 @@ fn empty_update_request() -> UpdateRoutineRequest {
         max_runtime_secs: None,
         tags: None,
         env: None,
+        failure_threshold: None,
     }
 }
 

--- a/src/routines/service_trigger_tests.rs
+++ b/src/routines/service_trigger_tests.rs
@@ -56,6 +56,9 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 
@@ -323,6 +326,7 @@ fn svc_create_syncs_crontab_on_success() {
                 max_runtime_secs: None,
                 tags: vec![],
                 env: std::collections::HashMap::new(),
+                failure_threshold: None,
             },
         )
         .unwrap();
@@ -359,6 +363,7 @@ fn svc_update_syncs_crontab_on_success() {
                 max_runtime_secs: None,
                 tags: None,
                 env: None,
+                failure_threshold: None,
             },
         )
         .unwrap();

--- a/src/routines/service_update.rs
+++ b/src/routines/service_update.rs
@@ -129,11 +129,25 @@ pub fn svc_update(
     if let Some(enabled) = req.enabled {
         routine.enabled = enabled;
     }
+    // Manually re-enabling clears the failure circuit-breaker's state (#521): an operator flipping
+    // a routine back on is a deliberate "give it another chance" signal, so it starts that chance
+    // with a clean slate rather than tripping again after just one more failure because the old
+    // count (or an even-older auto-disable reason) survived the toggle. Unconditional on
+    // `enabled == Some(true)` rather than only on a false->true transition — sending `enabled: true`
+    // while already enabled is the same "I want this healthy" signal and should have the same
+    // effect, not a silent no-op that leaves a stale reason behind.
+    if req.enabled == Some(true) {
+        routine.consecutive_failures = 0;
+        routine.auto_disabled_reason = None;
+    }
     if let Some(ttl) = req.ttl_secs {
         routine.ttl_secs = Some(ttl);
     }
     if let Some(max_runtime) = req.max_runtime_secs {
         routine.max_runtime_secs = Some(max_runtime);
+    }
+    if let Some(threshold) = req.failure_threshold {
+        routine.failure_threshold = Some(threshold);
     }
     if let Some(tags) = tags {
         routine.tags = tags;

--- a/src/routines/service_update_apply_tests.rs
+++ b/src/routines/service_update_apply_tests.rs
@@ -55,6 +55,9 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 
@@ -73,6 +76,7 @@ fn empty_update_request() -> UpdateRoutineRequest {
         max_runtime_secs: None,
         tags: None,
         env: None,
+        failure_threshold: None,
     }
 }
 
@@ -124,6 +128,7 @@ fn svc_update_sets_ttl_secs() {
                 max_runtime_secs: None,
                 tags: None,
                 env: None,
+                failure_threshold: None,
             },
         )
         .unwrap();
@@ -164,6 +169,7 @@ fn svc_update_sets_max_runtime_secs() {
                 max_runtime_secs: Some(1234),
                 tags: None,
                 env: None,
+                failure_threshold: None,
             },
         )
         .unwrap();
@@ -202,6 +208,88 @@ fn svc_update_sets_env() {
                 .map(String::as_str),
             Some("gpt-x")
         );
+    });
+}
+
+#[test]
+fn svc_update_sets_failure_threshold() {
+    let _home = TempHome::set();
+    // Covers the `req.failure_threshold` apply branch in `svc_update`.
+    let title = "Svc Update Failure Threshold ZZZ";
+    let store = new_store();
+    let routine = make_routine("threshold-id", title, 1, 1);
+    crate::routine_storage::write_routine(&routine).unwrap();
+    store.lock().unwrap().insert("threshold-id".into(), routine);
+
+    with_empty_path(|| {
+        let updated = svc_update(
+            &store,
+            "threshold-id",
+            UpdateRoutineRequest {
+                failure_threshold: Some(5),
+                ..empty_update_request()
+            },
+        )
+        .unwrap();
+        assert_eq!(updated.routine.failure_threshold, Some(5));
+    });
+}
+
+#[test]
+fn svc_update_re_enabling_resets_circuit_breaker_state() {
+    let _home = TempHome::set();
+    // Covers the `req.enabled == Some(true)` reset branch in `svc_update` (#521): a manual
+    // re-enable must clear both the failure streak and the auto-disable reason, not just flip
+    // `enabled` back on.
+    let title = "Svc Update Reenable Resets Breaker ZZZ";
+    let store = new_store();
+    let mut routine = make_routine("reenable-id", title, 1, 1);
+    routine.enabled = false;
+    routine.consecutive_failures = 4;
+    routine.auto_disabled_reason = Some("auto-disabled after 4 consecutive failed run(s)".into());
+    crate::routine_storage::write_routine(&routine).unwrap();
+    store.lock().unwrap().insert("reenable-id".into(), routine);
+
+    with_empty_path(|| {
+        let updated = svc_update(
+            &store,
+            "reenable-id",
+            UpdateRoutineRequest {
+                enabled: Some(true),
+                ..empty_update_request()
+            },
+        )
+        .unwrap();
+        assert!(updated.routine.enabled);
+        assert_eq!(updated.routine.consecutive_failures, 0);
+        assert!(updated.routine.auto_disabled_reason.is_none());
+    });
+}
+
+#[test]
+fn svc_update_disabling_does_not_touch_circuit_breaker_state() {
+    let _home = TempHome::set();
+    // The reset only fires for `enabled == Some(true)`; a manual disable (or an update that
+    // doesn't touch `enabled` at all) must leave an in-progress failure streak alone.
+    let title = "Svc Update Disable Keeps Breaker State ZZZ";
+    let store = new_store();
+    let mut routine = make_routine("disable-id", title, 1, 1);
+    routine.consecutive_failures = 2;
+    crate::routine_storage::write_routine(&routine).unwrap();
+    store.lock().unwrap().insert("disable-id".into(), routine);
+
+    with_empty_path(|| {
+        let updated = svc_update(
+            &store,
+            "disable-id",
+            UpdateRoutineRequest {
+                enabled: Some(false),
+                ..empty_update_request()
+            },
+        )
+        .unwrap();
+        assert!(!updated.routine.enabled);
+        assert_eq!(updated.routine.consecutive_failures, 2);
     });
 }
 

--- a/src/routines/service_update_not_found_tests.rs
+++ b/src/routines/service_update_not_found_tests.rs
@@ -56,6 +56,7 @@ fn empty_update_request() -> UpdateRoutineRequest {
         max_runtime_secs: None,
         tags: None,
         env: None,
+        failure_threshold: None,
     }
 }
 

--- a/src/sync/routines_sync_multi_cron_tests.rs
+++ b/src/sync/routines_sync_multi_cron_tests.rs
@@ -30,6 +30,9 @@ fn make_routine(id: &str, title: &str, agent: &str) -> Routine {
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 

--- a/src/sync/routines_sync_tests.rs
+++ b/src/sync/routines_sync_tests.rs
@@ -30,6 +30,9 @@ fn make_routine(id: &str, title: &str, agent: &str) -> Routine {
         ttl_secs: None,
         max_runtime_secs: None,
         env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
     }
 }
 


### PR DESCRIPTION
## What

Adds an opt-in **failure circuit-breaker** for routines: after `N` consecutive
failed (or unknown-outcome) runs, a routine auto-disables — removed from the
crontab on the next sync — instead of spawning a fresh doomed agent session on
every fire forever.

## Why

Closes #521. A routine with a bad/empty prompt, a missing token, or an agent
whose binary/sandbox always blocks the task keeps firing on schedule with no
feedback loop back into the daemon. On a `*/5` cron that's ~288 wasted agent
sessions/day (CPU, disk, API spend, and repeated junk side-effects) with no
automatic backstop — this closes that gap.

## What was implemented

- **`consecutive_failures: u32`** and **`auto_disabled_reason: Option<String>`**
  tracked per routine, persisted in the daemon-owned, gitignored
  `state.local.toml` sidecar (not `routine.toml`) — mirroring how
  `snoozed_until`/`skip_runs`/`power_saving` already work
  (`src/routine_storage.rs`'s `RuntimeState`).
- **`failure_threshold: Option<u32>`**, a new opt-in field on `routine.toml` /
  the `Routine` model. `None` or `0` opts out, preserving today's
  unlimited-retry behavior — no existing routine changes behavior. Unlike
  `ttl_secs`/`max_runtime_secs`, `0` is a *meaningful* value here, not rejected.
- The counter updates in `src/routines/cleanup/circuit_breaker.rs`, hooked into
  the same already-deduplicated `persist` closure the TTL-reap sweep uses to
  write `runs.log` (`cleanup_expired_workbenches`). See that module's doc
  comment for the reasoning: `svc_list_runs` is pull-based (only runs when an
  API client happens to call it, so a routine nobody is watching would never
  trip the breaker), while the reap sweep is a background task the daemon
  already drives every `CLEANUP_INTERVAL` (5 min) on its own. Retention is
  capped at the routine's own cron interval, so in the worst case the
  practical detection delay is bounded by that 5-minute sweep cadence, not by
  the (much longer, and issue-cited) "forever" this feature exists to stop.
  `Unknown` outcomes (session gone, no exit code — e.g. a hung run the
  max-runtime watchdog just force-killed) count as failures too, since that's
  exactly the kind of never-succeeds loop this breaker is meant to catch.
- On crossing the threshold: flips `enabled = false` through the same path a
  manual disable uses, so the routine is removed from the crontab on the very
  next sync, and records a human-readable `auto_disabled_reason` — distinct
  from a user-initiated disable.
- **Manually re-enabling** a routine (`enabled: true` via the existing
  update path) resets `consecutive_failures` to `0` and clears
  `auto_disabled_reason`.
- Surfaced on the API: `consecutive_failures`, `auto_disabled_reason`, and
  `failure_threshold` are all visible on `Routine`/`RoutineResponse`
  (`GET /routines`), so an operator can see the state via API/health without a
  UI change. `apis/openapi.json` is build/test-generated (`openapi_tests.rs`'s
  `committed_spec_is_current`), not hand-edited.
- Validation: `failure_threshold` is a plain `Option<u32>`, so a negative value
  is already rejected at the JSON/type level — no separate `reject_*` helper
  was needed the way `ttl_secs`/`max_runtime_secs` have one, since (unlike
  those) `0` here is a valid, meaningful opt-out rather than a rejected value.
- Tests cover: increment-on-fail, reset-on-success, trip-at-threshold,
  `Unknown`-counts-as-failure, both opt-out paths (`None`/`Some(0)`),
  not-re-tripping-or-clobbering-the-reason once already disabled, the
  persist-failure and crontab-resync-success branches, and (in
  `svc_update`'s tests) setting `failure_threshold` plus re-enable clearing
  the breaker state vs. a plain disable leaving it untouched. Full local gate
  passes: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`,
  `cargo test`, `cargo llvm-cov --fail-under-lines 100
  --ignore-filename-regex 'src/main\.rs'` (100% line coverage), and
  `linecheck --max-lines 500`.

## Out of scope (follow-up)

The React UI (`client/`) is **not** touched — no banner/column surfacing an
auto-disabled routine yet. This lands backend/API-first, matching how other
features in this repo have shipped; a UI follow-up can consume the new
`consecutive_failures`/`auto_disabled_reason`/`failure_threshold` fields
already exposed on `GET /routines`.

## Changeset

`.changeset/routine-failure-circuit-breaker.md` (minor — new feature).

---

_Opened by the moadim routine "Open issues → fix PRs (owned repos + my orgs)"._

Closes #521