### PR TITLE
ci: attach prebuilt binary archives to GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,8 @@ jobs:
     # make this job skip too.
     if: always() && (needs.lint.result == 'success' || needs.lint.result == 'skipped') && (needs.test.result == 'success' || needs.test.result == 'skipped')
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ env.TAG }}
     env:
       TAG: ${{ inputs.tag || github.ref_name }}
     steps:
@@ -94,3 +96,57 @@ jobs:
           tag_name: ${{ env.TAG }}
           name: ${{ env.TAG }}
           body_path: release-notes.md
+
+  # Cross-compiled binary archives attached to the release created above, so `cargo binstall
+  # moadim` and users without a Rust toolchain have a prebuilt executable to download instead of
+  # `cargo install`'s from-source compile (#329). `cargo build --release` alone already embeds the
+  # UI: build.rs falls back to the committed prebuilt.html verbatim whenever pnpm isn't installed
+  # (see prebuilt.yml's header comment), which is exactly this job's case, so no extra UI-build
+  # step is needed here.
+  #
+  # Unix-only, matching the daemon itself (see #187's tmux/crontab dependency). Linux aarch64 is a
+  # nice-to-have per #329 and left for later — the three targets below cover the common case.
+  build-binaries:
+    name: Build binary (${{ matrix.target }})
+    needs: release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: macos-latest
+            target: x86_64-apple-darwin
+    env:
+      TAG: ${{ needs.release.outputs.tag }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+
+      - name: Build
+        run: cargo build --release --locked --target ${{ matrix.target }}
+
+      - name: Package archive and checksum
+        id: package
+        run: |
+          VERSION=${TAG#v}
+          ARCHIVE="moadim-${VERSION}-${{ matrix.target }}.tar.gz"
+          tar -czf "$ARCHIVE" -C "target/${{ matrix.target }}/release" moadim
+          shasum -a 256 "$ARCHIVE" > "$ARCHIVE.sha256"
+          echo "archive=$ARCHIVE" >> "$GITHUB_OUTPUT"
+
+      - name: Attach to release
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          tag_name: ${{ env.TAG }}
+          files: |
+            ${{ steps.package.outputs.archive }}
+            ${{ steps.package.outputs.archive }}.sha256

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,13 @@ homepage = "https://moadim.io"
 keywords = ["scheduler", "mcp", "automation", "rest"]
 categories = ["command-line-utilities", "web-programming::http-server"]
 
+# Lets `cargo binstall moadim` fetch the prebuilt archive release.yml's `build-binaries` job
+# attaches to each `v*` tag's GitHub Release instead of compiling from source (#329).
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/moadim-{ version }-{ target }.tar.gz"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
+
 [dependencies]
 anyhow = "1"
 axum = "0.8"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ release (from the crate's `Cargo.lock`) instead of re-resolving every dependency
 to the newest semver-compatible version at install time — so a bad or breaking
 transitive bump can't fail an otherwise-unchanged install.
 
+Prefer a prebuilt binary over compiling from source? Each release publishes
+binary archives (with a SHA256 checksum) for macOS (Apple Silicon and Intel)
+and Linux x86_64. Install one with [`cargo binstall`](https://github.com/cargo-bins/cargo-binstall)
+(no Rust toolchain compile required):
+
+```sh
+cargo binstall moadim
+```
+
+...or download the archive for your platform directly from the
+[Releases page](https://github.com/moadim-io/daemon/releases).
+
 If `moadim` is not found after install, add Cargo's bin directory to your PATH:
 
 ```sh


### PR DESCRIPTION
## Summary

`cargo install moadim` is currently the only documented install path, which requires a full Rust toolchain to compile from source. `release.yml` already cuts a GitHub Release on every `v*` tag, but it attaches only changelog notes — no binaries — so there's no toolchain-light way to install.

## Fix

- Adds a `build-binaries` job to `release.yml` that cross-compiles `moadim` for macOS (Apple Silicon + Intel) and Linux x86_64 after the release is created, packages each as `moadim-<version>-<target>.tar.gz`, generates a SHA256 checksum, and attaches both to the release.
- Declares `[package.metadata.binstall]` in `Cargo.toml` so `cargo binstall moadim` resolves those assets without a source compile.
- Documents both the binary-download and `cargo binstall` install paths in the README alongside the existing `cargo install` line.

`cargo build --release` alone already embeds the UI — `build.rs` falls back to the committed `prebuilt.html` verbatim whenever `pnpm` isn't installed (see `prebuilt.yml`'s header comment), which is exactly this job's case, so no extra UI-build step was needed.

Validated: `actionlint` passes on the updated workflow, `cargo check` still succeeds after the `Cargo.toml` edit.

## Scope note

Linux `aarch64` is called out in the issue itself as a "nice-to-have" — left for a follow-up. The three targets here (macOS arm64/x86_64, Linux x86_64) cover the common case.

Closes #329

---
_Opened automatically by the moadim routine "Open issues → fix PRs (owned repos + my orgs)"._
