### PR TITLE
fix: write compiled cron to schedule.compailed.cron

### DIFF
--- a/.changeset/schedule-compailed-cron.md
+++ b/.changeset/schedule-compailed-cron.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Write cron-union output to `schedule.compailed.cron` instead of the legacy hidden `.compailed.cron` sidecar.

--- a/src/cli/spawn_tests.rs
+++ b/src/cli/spawn_tests.rs
@@ -128,8 +128,12 @@ fn pid_file_write_read_clear_roundtrip() {
         "gitignore must cover *.local.*"
     );
     assert!(
-        content.contains(".compailed.cron"),
+        content.contains("schedule.compailed.cron"),
         "gitignore must cover cron-union output"
+    );
+    assert!(
+        content.contains(".compailed.cron"),
+        "gitignore must keep covering legacy cron-union output"
     );
     // Manually remove one pattern; a second write must restore it without
     // duplicating the patterns already present.
@@ -141,8 +145,12 @@ fn pid_file_write_read_clear_roundtrip() {
         "missing pattern must be re-added"
     );
     assert!(
-        content.contains(".compailed.cron"),
+        content.contains("schedule.compailed.cron"),
         "missing cron-union pattern must be re-added"
+    );
+    assert!(
+        content.contains(".compailed.cron"),
+        "missing legacy cron-union pattern must be re-added"
     );
     assert_eq!(
         content.matches("*.pid").count(),

--- a/src/cli/system.rs
+++ b/src/cli/system.rs
@@ -91,7 +91,7 @@ Each subdirectory here is one routine (a prompt + schedule + agent, run on a cro
 
 - `<id>/routine.toml` — the agent, repositories, machine targeting, and metadata.
 - `<id>/schedule.cron` — the human-authored cron schedule(s).
-- `<id>/.compailed.cron` — gitignored cron-union output used for OS crontab sync.
+- `<id>/schedule.compailed.cron` — gitignored cron-union output used for OS crontab sync.
 - `<id>/prompts/prompt.pure.md` — the prompt you wrote.
 - `<id>/prompts/prompt.compiled.local.md` — the composed prompt (repositories preamble +
   pure prompt) copied into each run's workbench. Gitignored (`.local.` matches the
@@ -141,8 +141,9 @@ fn ensure_readme(path: &std::path::Path, content: &str) {
 /// they also cover every routine directory (per-routine `.gitignore` files are no longer
 /// generated): `*.local.*` catches the machine-local sidecars (`state.local.toml`,
 /// `routine.local.toml`, `prompt.compiled.local.md`), `*.log` the trigger logs, `*.compiled.*`
-/// the legacy `prompts/prompt.compiled.md`, `.compailed.cron` the cron-union output, and `run.sh`
-/// the obsolete per-routine launch script.
+/// the legacy `prompts/prompt.compiled.md`, `schedule.compailed.cron` the cron-union output,
+/// `.compailed.cron` the legacy cron-union output name, and `run.sh` the obsolete per-routine
+/// launch script.
 ///
 /// Reads the existing file (if any), appends any missing patterns, and writes back only when
 /// something changed. Preserves user-added entries. Best-effort: failure is not fatal.
@@ -152,6 +153,7 @@ fn ensure_config_gitignore() {
         "*.log",
         "*.local.*",
         "*.compiled.*",
+        "schedule.compailed.cron",
         ".compailed.cron",
         "run.sh",
     ];

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -95,13 +95,13 @@ pub fn routine_cron_path(id: &str) -> PathBuf {
     routine_dir(id).join("schedule.cron")
 }
 
-/// Returns the path to `{routines_dir}/{id}/.compailed.cron`, the gitignored cron-union output.
+/// Returns the path to `{routines_dir}/{id}/schedule.compailed.cron`, the gitignored cron-union output.
 ///
-/// The filename intentionally preserves the current sidecar spelling. `schedule.cron` stays the
-/// human-authored source; this derived file is rewritten by crontab sync and ignored by git.
+/// `schedule.cron` stays the human-authored source; this derived file is rewritten by crontab
+/// sync and ignored by git.
 #[must_use]
 pub fn routine_compailed_cron_path(id: &str) -> PathBuf {
-    routine_dir(id).join(".compailed.cron")
+    routine_dir(id).join("schedule.compailed.cron")
 }
 
 /// Returns the path to `{routines_dir}/{id}/prompts/`.

--- a/src/sync/routines.rs
+++ b/src/sync/routines.rs
@@ -133,10 +133,14 @@ fn write_compailed_cron_sidecar(routine: &Routine, schedules: &[String]) {
     let slug = slugify(&routine.title);
     let dir = crate::paths::routine_dir(&slug);
     let path = crate::paths::routine_compailed_cron_path(&slug);
+    let legacy_path = dir.join(".compailed.cron");
     let mut text = schedules.join("\n");
     text.push('\n');
     let _ = crate::utils::fs_perms::create_private_dir_all(&dir);
     let _ = std::fs::write(&path, text);
+    if legacy_path != path && legacy_path.exists() {
+        let _ = std::fs::remove_file(legacy_path);
+    }
 }
 
 /// Build the full routines block from the enabled managed routines in `store`.

--- a/src/sync/routines_sync_multi_cron_tests.rs
+++ b/src/sync/routines_sync_multi_cron_tests.rs
@@ -51,6 +51,7 @@ fn build_block_reads_multiple_crons_from_schedule_sidecar_and_unions_redundant_e
         "# human-edited extra fires\n*/10 * * * *\n*/20 * * * *\n5 9 * * 1-5\n",
     )
     .unwrap();
+    std::fs::write(routine_dir.join(".compailed.cron"), "stale compiled cron\n").unwrap();
 
     let store = new_store();
     store.lock().unwrap().insert(
@@ -74,6 +75,10 @@ fn build_block_reads_multiple_crons_from_schedule_sidecar_and_unions_redundant_e
     assert_eq!(
         std::fs::read_to_string(crate::paths::routine_compailed_cron_path(&slug)).unwrap(),
         "*/10 * * * *\n5 9 * * 1-5\n"
+    );
+    assert!(
+        !routine_dir.join(".compailed.cron").exists(),
+        "legacy hidden cron-union sidecar should be removed"
     );
     assert_eq!(
         std::fs::read_to_string(routine_dir.join("schedule.cron")).unwrap(),


### PR DESCRIPTION
## Summary
- rename the derived cron-union sidecar path from `.compailed.cron` to `schedule.compailed.cron`
- keep `.compailed.cron` gitignored as a legacy name and remove stale legacy files on sync
- update config README/gitignore tests and multi-cron sync coverage

## Verification
- cargo fmt --check
- cargo test build_block_reads_multiple_crons_from_schedule_sidecar_and_unions_redundant_entries
- cargo test build_block_skips_invalid_multi_cron_entries_and_falls_back_if_none_valid
- cargo test pid_file_write_read_clear_roundtrip
- cargo clippy --all-targets --all-features -- -D warnings

Note: cargo build scripts emitted existing warning: `moadim@1.7.6: pnpm build exited with non-zero status`; Rust tests/clippy still passed.