### PR TITLE
fix: fall back when cron union rejects valid schedules

### DIFF
--- a/.changeset/cron-union-fallback.md
+++ b/.changeset/cron-union-fallback.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Keep valid cron schedules active when cron-union cannot simplify an expression, falling back to the validated schedule lines instead of panicking during crontab sync.

--- a/src/sync/routines.rs
+++ b/src/sync/routines.rs
@@ -117,15 +117,18 @@ fn compailed_schedules_for_crontab(routine: &Routine, pure_schedules: &[String])
         return vec![routine.schedule.clone()];
     }
     let refs: Vec<&str> = schedules.iter().map(String::as_str).collect();
-    #[allow(
-        clippy::expect_used,
-        reason = "each entry was validated by validate_cron before reaching cron-union"
-    )]
-    cron_union::union(refs)
-        .expect("validated cron schedules compile through cron-union")
-        .iter()
-        .map(ToString::to_string)
-        .collect()
+    match cron_union::union(refs) {
+        Ok(union) => union.iter().map(ToString::to_string).collect(),
+        Err(err) => {
+            log::warn!(
+                "routine sync: cron-union could not compile schedules for routine {:?}: {}; \
+                 using validated schedules without dedupe",
+                routine.id,
+                err
+            );
+            schedules
+        }
+    }
 }
 
 /// Write the gitignored cron-union output sidecar used by the OS crontab.

--- a/src/sync/routines_sync_multi_cron_tests.rs
+++ b/src/sync/routines_sync_multi_cron_tests.rs
@@ -142,3 +142,33 @@ fn build_block_skips_invalid_multi_cron_entries_and_falls_back_if_none_valid() {
     let _ = std::fs::remove_dir_all(valid_dir);
     let _ = std::fs::remove_dir_all(invalid_dir);
 }
+
+#[test]
+fn build_block_keeps_valid_schedules_when_cron_union_cannot_simplify_them() {
+    let agent_name = "test-sync-agent-cron-union-fallback-block";
+    let title = "Cron Union Fallback Routine";
+    let slug = slugify(title);
+    std::fs::create_dir_all(crate::paths::agents_dir()).unwrap();
+    let cfg = crate::paths::agent_toml_path(agent_name);
+    std::fs::write(&cfg, "command = \"claude\"\nargs = []\n").unwrap();
+    let routine_dir = crate::paths::routine_dir(&slug);
+    std::fs::create_dir_all(&routine_dir).unwrap();
+    std::fs::write(routine_dir.join("schedule.cron"), "0 18 * * 0-4\n").unwrap();
+
+    let store = new_store();
+    store.lock().unwrap().insert(
+        "cron-union-fallback".into(),
+        make_routine("cron-union-fallback", title, agent_name),
+    );
+
+    let block = build_block(&store);
+
+    assert!(block.contains("0 18 * * 0-4 "), "{block}");
+    assert_eq!(
+        std::fs::read_to_string(crate::paths::routine_compailed_cron_path(&slug)).unwrap(),
+        "0 18 * * 0-4\n"
+    );
+
+    std::fs::remove_file(&cfg).unwrap();
+    let _ = std::fs::remove_dir_all(routine_dir);
+}


### PR DESCRIPTION
## Summary
- avoid panicking during crontab sync when cron-union rejects a cron expression that croner/OS cron accepts
- keep validated schedules active without dedupe as a fallback
- add a regression test for `0 18 * * 0-4`

## Tests
- cargo fmt --check
- linecheck --max-lines 500 $(find src -name "*.rs")
- cargo test build_block_keeps_valid_schedules_when_cron_union_cannot_simplify_them
- cargo clippy --all-targets -- -D warnings