### PR TITLE
chore: update cron-union to 1.0.3

### DIFF
--- a/.changeset/cron-union-1-0-3.md
+++ b/.changeset/cron-union-1-0-3.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Update cron-union to 1.0.3 so compiled routine cron generation natively accepts POSIX zero-based day-of-week ranges.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "cron-union"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89812a1a051e3c64649c1205e51632862ff2590cec7982eef4a8010ac35f11c8"
+checksum = "d8233515fff8251a210abcaa18257f97c9998e5c595fe0dfb55a1f3e4d3b4b43"
 dependencies = [
  "cron",
 ]

--- a/src/sync/routines_sync_multi_cron_tests.rs
+++ b/src/sync/routines_sync_multi_cron_tests.rs
@@ -172,3 +172,33 @@ fn build_block_keeps_valid_schedules_when_cron_union_cannot_simplify_them() {
     std::fs::remove_file(&cfg).unwrap();
     let _ = std::fs::remove_dir_all(routine_dir);
 }
+
+#[test]
+fn build_block_falls_back_for_croner_valid_schedules_unsupported_by_cron_union() {
+    let agent_name = "test-sync-agent-croner-only-fallback-block";
+    let title = "Croner Only Fallback Routine";
+    let slug = slugify(title);
+    std::fs::create_dir_all(crate::paths::agents_dir()).unwrap();
+    let cfg = crate::paths::agent_toml_path(agent_name);
+    std::fs::write(&cfg, "command = \"claude\"\nargs = []\n").unwrap();
+    let routine_dir = crate::paths::routine_dir(&slug);
+    std::fs::create_dir_all(&routine_dir).unwrap();
+    std::fs::write(routine_dir.join("schedule.cron"), "0 18 L * *\n").unwrap();
+
+    let store = new_store();
+    store.lock().unwrap().insert(
+        "croner-only-fallback".into(),
+        make_routine("croner-only-fallback", title, agent_name),
+    );
+
+    let block = build_block(&store);
+
+    assert!(block.contains("0 18 L * * "), "{block}");
+    assert_eq!(
+        std::fs::read_to_string(crate::paths::routine_compailed_cron_path(&slug)).unwrap(),
+        "0 18 L * *\n"
+    );
+
+    std::fs::remove_file(&cfg).unwrap();
+    let _ = std::fs::remove_dir_all(routine_dir);
+}


### PR DESCRIPTION
## Summary
- update Cargo.lock to cron-union 1.0.3, which accepts POSIX zero-based day-of-week ranges like `0-4`
- keep the daemon-side fallback as defense-in-depth if future cron-union parsing differs from daemon validation

## Tests
- cargo test build_block_reads_multiple_crons_from_schedule_sidecar_and_unions_redundant_entries
- cargo test build_block_keeps_valid_schedules_when_cron_union_cannot_simplify_them
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings