### PR TITLE
fix(cli): accept -f/--foreground aliases on restart's foreground flag

### DIFF
--- a/.changeset/restart-foreground-flag-aliases.md
+++ b/.changeset/restart-foreground-flag-aliases.md
@@ -1,0 +1,10 @@
+---
+"moadim": patch
+---
+
+### Fixed
+
+`moadim restart -f`/`--foreground` now relaunches attached to the terminal
+instead of silently falling back to a detached restart — `-f`/`--foreground`
+are now accepted as aliases of `-i`/`--interactive` on `restart`, matching
+`start`'s existing behavior.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -47,7 +47,7 @@ pub enum Command {
         /// hint block. Ignored under `json`, which always prints its single object.
         quiet: bool,
         /// Start the fresh instance in the foreground, attached to the terminal, instead of
-        /// detached in the background (mirrors `moadim -i`).
+        /// detached in the background (mirrors `moadim -i`/`-f`).
         interactive: bool,
     },
     /// Ask a running background server to stop. `json` requests machine-readable output.
@@ -181,10 +181,12 @@ fn wants_quiet(rest: &[String]) -> bool {
     rest.iter().any(|arg| arg == "--quiet" || arg == "-q")
 }
 
-/// Whether a `--interactive`/`-i` flag appears among a command's trailing arguments, requesting
-/// that `restart` bring the fresh instance up in the foreground instead of detached.
+/// Whether a `--interactive`/`-i` flag (or its `--foreground`/`-f` alias, matching the top-level
+/// start flags) appears among a command's trailing arguments, requesting that `restart` bring the
+/// fresh instance up in the foreground instead of detached.
 fn wants_interactive(rest: &[String]) -> bool {
-    rest.iter().any(|arg| arg == "--interactive" || arg == "-i")
+    rest.iter()
+        .any(|arg| arg == "--interactive" || arg == "-i" || arg == "--foreground" || arg == "-f")
 }
 
 /// Default poll timeout for a bare `--wait` (no explicit seconds) on `status`.
@@ -223,7 +225,9 @@ pub fn help_text() -> String {
          \n\
          COMMANDS:\n\
          \x20   restart [--json] [-q] [-i] stop a running server (if any) and start a fresh one\n\
-         \x20                          (-q/--quiet: rotation line only; -i/--interactive: foreground)\n\
+         \x20                          (-q/--quiet: rotation line only; -i/--interactive: run the\n\
+         \x20                          fresh instance in the foreground, attached to the terminal\n\
+         \x20                          (Ctrl-C to stop); aliases: -f, --foreground)\n\
          \x20   stop [--json] [-q]     stop a running background server (-q/--quiet: no stdout)\n\
          \x20   status [--json] [--wait[=SECS]] show whether a server is running (--wait: poll until\n\
          \x20                          reachable or SECS elapse, default 30, instead of checking once)\n\

--- a/src/cli/restart_tests.rs
+++ b/src/cli/restart_tests.rs
@@ -7,7 +7,9 @@ use super::*;
 
 #[test]
 fn restart_command_interactive_flag() {
-    for flag in ["-i", "--interactive"] {
+    // `-f`/`--foreground` are accepted as aliases of `-i`/`--interactive`, matching the
+    // top-level start flags (issue #308).
+    for flag in ["-i", "--interactive", "-f", "--foreground"] {
         assert_eq!(
             parse(argv(&["restart", flag])),
             Command::Restart {


### PR DESCRIPTION
## Summary

Closes #308.

Most of `moadim restart -i`/`--interactive` (foreground restart) was already implemented: `Command::Restart` already carried an `interactive: bool` field, `main.rs` already branched on it to relaunch attached to the terminal instead of detached, and `--help` already documented `-i`/`--interactive` under `restart`.

The gap was that the flag parser (`wants_interactive` in `src/cli/mod.rs`) only recognized `-i`/`--interactive` and not the `-f`/`--foreground` aliases that plain `moadim start` accepts for the same foreground mode. So `moadim restart -f` / `moadim restart --foreground` silently fell through to a **detached** restart instead of foreground — an inconsistency with the acceptance criteria in #308, which calls for `-f`/`--foreground` to work identically to `-i`/`--interactive` on `restart`, matching `start`.

## Changes

- `wants_interactive` now also matches `--foreground`/`-f`.
- `--help`'s `restart` line is expanded to spell out the foreground behavior and list the `-f`/`--foreground` aliases, mirroring the wording already used for the top-level start flag.
- Extended the existing `restart_command_interactive_flag` test in `src/cli/restart_tests.rs` to cover all four accepted forms (`-i`, `--interactive`, `-f`, `--foreground`) parsing to `Command::Restart { interactive: true, .. }`.
- Plain `moadim restart` (no flag) is unchanged: still parses to `interactive: false` (detached relaunch) — covered by the pre-existing `restart_command` test.

## Test plan

- [x] `cargo build`
- [x] `cargo test` (1229 passed, 0 failed)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (clean)

---

This PR was opened on behalf of the moadim routine "Open issues → fix PRs (owned repos + my orgs)".