### PR TITLE
fix: dedupe scheduled triggers by minute

### DIFF
--- a/.changeset/scheduled-trigger-minute-dedupe.md
+++ b/.changeset/scheduled-trigger-minute-dedupe.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Skip duplicate scheduled-trigger requests that target the same routine in the same minute, preventing overlapping multi-schedule cron expressions from launching duplicate workbenches.

--- a/src/routines/service_trigger.rs
+++ b/src/routines/service_trigger.rs
@@ -104,6 +104,23 @@ pub fn svc_trigger_scheduled(store: &RoutineStore, id: &str) -> Result<Routine, 
         }
     }
 
+    let ts = now_secs();
+    if routine
+        .last_scheduled_trigger_at
+        .is_some_and(|last| last / 60 == ts / 60)
+    {
+        let reason = "routine already fired this minute; skipping duplicate scheduled trigger";
+        let slug = slugify(&routine.title);
+        drop(lock);
+        append_skip_log(&slug, ts, reason);
+        return Err(AppError::Locked(reason.into()));
+    }
+    // Same-minute claim (#795): multiple crontab lines can target the same routine when a
+    // multi-schedule routine has overlapping expressions. Claim the current minute while holding the
+    // store mutex so a second scheduled-trigger request observes the in-memory timestamp and no-ops
+    // instead of launching a duplicate workbench. The spawned scheduled command still appends the
+    // durable `scheduled.log` entry for load-after-restart history.
+    routine.last_scheduled_trigger_at = Some(ts);
     let routine = routine.clone();
     drop(lock);
     spawn_routine_command(&routine, TriggerSource::Scheduled);

--- a/src/routines/service_trigger_tests.rs
+++ b/src/routines/service_trigger_tests.rs
@@ -178,6 +178,25 @@ fn svc_trigger_scheduled_missing_routine_not_found() {
 }
 
 #[test]
+fn svc_trigger_scheduled_skips_duplicate_fire_in_same_minute() {
+    let _home = TempHome::set();
+    let store = new_store();
+    let mut routine = make_routine("trig-sched-dedupe-id", "Trig Sched Dedupe ZZZ", 1, 1);
+    routine.last_scheduled_trigger_at = Some(now_secs());
+    store
+        .lock()
+        .unwrap()
+        .insert("trig-sched-dedupe-id".into(), routine);
+
+    let result = svc_trigger_scheduled(&store, "trig-sched-dedupe-id");
+
+    assert!(
+        matches!(result, Err(AppError::Locked(ref msg)) if msg.contains("already fired this minute")),
+        "expected same-minute scheduled fire dedupe, got {result:?}"
+    );
+}
+
+#[test]
 fn svc_trigger_scheduled_spawns_without_recording_manual_trigger() {
     let _home = TempHome::set();
     // The scheduled path must leave `last_manual_trigger_at` untouched (it is for *manual* triggers


### PR DESCRIPTION
## Summary
- claim the current minute in `svc_trigger_scheduled` before spawning so overlapping multi-schedule crontab entries cannot launch duplicate workbenches
- return a locked/no-op response and append a skip log for duplicate scheduled-trigger requests in the same minute
- add a regression test and changeset for #795

## Verification
- `cargo test svc_trigger_scheduled_skips_duplicate_fire_in_same_minute -- --nocapture` (red before implementation, then green)
- `cargo fmt --check`
- `linecheck --max-lines 500 $(find src -name "*.rs")`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\\.rs' --summary-only`\n- `git diff --check`\n\nCloses #795.