### PR TITLE
fix: surface crontab sync failures in health

### DIFF
--- a/.changeset/crontab-sync-health.md
+++ b/.changeset/crontab-sync-health.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Surface the most recent managed-routine crontab sync failure in the health response so macOS crontab/TCC write timeouts are visible instead of leaving users with a healthy daemon and stale OS schedules.

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -1267,6 +1267,35 @@
           }
         }
       },
+      "CrontabSyncHealth": {
+        "type": "object",
+        "description": "OS scheduler synchronization state surfaced by health endpoints.",
+        "required": [
+          "ok"
+        ],
+        "properties": {
+          "last_error": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Last sync error, when the most recent attempt failed."
+          },
+          "last_error_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Unix timestamp of the last sync failure, when known.",
+            "minimum": 0
+          },
+          "ok": {
+            "type": "boolean",
+            "description": "Whether the most recent OS crontab sync attempt completed successfully."
+          }
+        }
+      },
       "DependencyHealth": {
         "type": "object",
         "description": "External-binary dependencies the daemon relies on at runtime, and whether each is resolvable on\nthe daemon's `PATH`. Surfaced in [`HealthResponse`] so the UI/CLI can flag a missing dependency\ninstead of having routine runs silently no-op.",
@@ -1401,6 +1430,7 @@
           "running",
           "machine",
           "dependencies",
+          "crontab_sync",
           "version",
           "git_sha",
           "build_date"
@@ -1409,6 +1439,10 @@
           "build_date": {
             "type": "string",
             "description": "Committer date (`YYYY-MM-DD`) of the build commit, or `\"unknown\"` outside a git checkout."
+          },
+          "crontab_sync": {
+            "$ref": "#/components/schemas/CrontabSyncHealth",
+            "description": "Whether the managed routine block was last synced into the OS crontab successfully."
           },
           "dependencies": {
             "$ref": "#/components/schemas/DependencyHealth",

--- a/src/routes/health/http_tests.rs
+++ b/src/routes/health/http_tests.rs
@@ -42,6 +42,10 @@ async fn build_app_serves_health() {
         json["dependencies"]["python3"].is_boolean(),
         "health payload should carry a boolean dependencies.python3 flag, got: {json}"
     );
+    assert!(
+        json["crontab_sync"]["ok"].is_boolean(),
+        "health payload should carry crontab_sync.ok, got: {json}"
+    );
     assert_eq!(json["version"], env!("CARGO_PKG_VERSION"));
     // The resolved machine name is surfaced so clients can identify which daemon answered.
     assert!(

--- a/src/routes/health/logic.rs
+++ b/src/routes/health/logic.rs
@@ -5,6 +5,17 @@ use crate::routines;
 use crate::utils::time::now_secs;
 use serde::Serialize;
 
+/// OS scheduler synchronization state surfaced by health endpoints.
+#[derive(Serialize, utoipa::ToSchema)]
+pub struct CrontabSyncHealth {
+    /// Whether the most recent OS crontab sync attempt completed successfully.
+    pub ok: bool,
+    /// Last sync error, when the most recent attempt failed.
+    pub last_error: Option<String>,
+    /// Unix timestamp of the last sync failure, when known.
+    pub last_error_at: Option<u64>,
+}
+
 /// External-binary dependencies the daemon relies on at runtime, and whether each is resolvable on
 /// the daemon's `PATH`. Surfaced in [`HealthResponse`] so the UI/CLI can flag a missing dependency
 /// instead of having routine runs silently no-op.
@@ -31,6 +42,8 @@ pub struct HealthResponse {
     pub machine: String,
     /// Presence of required external binaries on the daemon's `PATH`.
     pub dependencies: DependencyHealth,
+    /// Whether the managed routine block was last synced into the OS crontab successfully.
+    pub crontab_sync: CrontabSyncHealth,
     /// Daemon version (from `CARGO_PKG_VERSION`).
     pub version: String,
     /// Short git commit SHA the daemon was built from, or `"unknown"` outside a git checkout.
@@ -56,6 +69,14 @@ pub fn build(uptime_start: u64) -> HealthResponse {
         dependencies: DependencyHealth {
             tmux: routines::tmux_available(),
             python3: routines::agent_command_available("python3"),
+        },
+        crontab_sync: {
+            let status = crate::sync::crontab_sync_status();
+            CrontabSyncHealth {
+                ok: status.ok,
+                last_error: status.last_error,
+                last_error_at: status.last_error_at,
+            }
         },
         version: crate::build_info::VERSION.to_string(),
         git_sha: crate::build_info::GIT_SHA.to_string(),

--- a/src/routes/health/logic_tests.rs
+++ b/src/routes/health/logic_tests.rs
@@ -4,6 +4,7 @@
 )]
 
 use super::build;
+use crate::sync::{record_crontab_sync_failure, reset_crontab_sync_status_for_tests, SyncError};
 use crate::utils::time::now_secs;
 
 #[test]
@@ -28,4 +29,32 @@ fn build_carries_version_and_machine() {
     assert_eq!(response.git_sha, crate::build_info::GIT_SHA);
     assert_eq!(response.build_date, crate::build_info::BUILD_DATE);
     assert!(!response.machine.is_empty());
+}
+
+#[test]
+fn build_surfaces_last_crontab_sync_failure() {
+    reset_crontab_sync_status_for_tests();
+    record_crontab_sync_failure(&SyncError::CrontabCommand(
+        "crontab - timed out".to_string(),
+    ));
+
+    let response = build(now_secs());
+
+    assert!(!response.crontab_sync.ok);
+    assert_eq!(
+        response.crontab_sync.last_error.as_deref(),
+        Some("crontab: crontab - timed out")
+    );
+    assert!(response.crontab_sync.last_error_at.is_some());
+    reset_crontab_sync_status_for_tests();
+}
+
+#[test]
+fn build_reports_healthy_crontab_sync_after_reset() {
+    reset_crontab_sync_status_for_tests();
+    let response = build(now_secs());
+
+    assert!(response.crontab_sync.ok);
+    assert_eq!(response.crontab_sync.last_error, None);
+    assert_eq!(response.crontab_sync.last_error_at, None);
 }

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -15,8 +15,63 @@
 
 use std::io::Write;
 use std::process::{Child, Command, ExitStatus, Stdio};
+use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
+
+use crate::utils::lock::LockRecover;
+use crate::utils::time::now_secs;
+
+/// Snapshot of the most recent OS crontab sync result.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CrontabSyncStatus {
+    /// Whether the most recent sync attempt completed successfully.
+    pub ok: bool,
+    /// Last sync error, when the most recent attempt failed.
+    pub last_error: Option<String>,
+    /// Unix timestamp of the last sync failure, when known.
+    pub last_error_at: Option<u64>,
+}
+
+impl Default for CrontabSyncStatus {
+    fn default() -> Self {
+        Self {
+            ok: true,
+            last_error: None,
+            last_error_at: None,
+        }
+    }
+}
+
+/// Process-local health state for OS crontab sync.
+fn crontab_sync_state() -> &'static Mutex<CrontabSyncStatus> {
+    static STATE: OnceLock<Mutex<CrontabSyncStatus>> = OnceLock::new();
+    STATE.get_or_init(|| Mutex::new(CrontabSyncStatus::default()))
+}
+
+/// Return the last recorded OS crontab sync status.
+pub(crate) fn crontab_sync_status() -> CrontabSyncStatus {
+    crontab_sync_state().lock_recover().clone()
+}
+
+/// Mark the OS crontab sync state healthy after a successful sync attempt.
+pub(crate) fn record_crontab_sync_success() {
+    *crontab_sync_state().lock_recover() = CrontabSyncStatus::default();
+}
+
+/// Mark the OS crontab sync state unhealthy after a failed sync attempt.
+pub(crate) fn record_crontab_sync_failure(err: &SyncError) {
+    *crontab_sync_state().lock_recover() = CrontabSyncStatus {
+        ok: false,
+        last_error: Some(err.to_string()),
+        last_error_at: Some(now_secs()),
+    };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_crontab_sync_status_for_tests() {
+    record_crontab_sync_success();
+}
 
 /// Environment override for the `crontab -` install timeout, in seconds.
 const CRONTAB_WRITE_TIMEOUT_ENV: &str = "MOADIM_CRONTAB_WRITE_TIMEOUT_SECS";

--- a/src/sync/routines.rs
+++ b/src/sync/routines.rs
@@ -265,11 +265,16 @@ pub(crate) const ROUTINE_LINE_MARKER: &str = "# moadim-routine:";
 pub fn sync_routines_to_crontab(store: &RoutineStore) -> Result<(), SyncError> {
     let on_multi_thread_runtime = tokio::runtime::Handle::try_current()
         .is_ok_and(|handle| handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread);
-    if on_multi_thread_runtime {
+    let result = if on_multi_thread_runtime {
         tokio::task::block_in_place(|| sync_routines_to_crontab_blocking(store))
     } else {
         sync_routines_to_crontab_blocking(store)
+    };
+    match &result {
+        Ok(()) => crate::sync::record_crontab_sync_success(),
+        Err(err) => crate::sync::record_crontab_sync_failure(err),
     }
+    result
 }
 
 /// Blocking body of [`sync_routines_to_crontab`], split out so the wrapper can choose whether to
@@ -295,6 +300,10 @@ fn sync_routines_to_crontab_blocking(store: &RoutineStore) -> Result<(), SyncErr
 #[cfg(test)]
 #[path = "routines_sync_tests.rs"]
 mod routines_sync_tests;
+
+#[cfg(test)]
+#[path = "routines_sync_status_tests.rs"]
+mod routines_sync_status_tests;
 
 #[cfg(test)]
 #[path = "routines_sync_multi_cron_tests.rs"]

--- a/src/sync/routines_sync_status_tests.rs
+++ b/src/sync/routines_sync_status_tests.rs
@@ -1,0 +1,138 @@
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and fixtures do not need doc comments"
+)]
+
+use super::*;
+use crate::routines::{new_store, Routine};
+
+fn make_routine(id: &str, title: &str, agent: &str) -> Routine {
+    Routine {
+        model: None,
+        id: id.to_string(),
+        schedule: "30 9 * * 1-5".to_string(),
+        schedules: vec![],
+        title: title.to_string(),
+        agent: agent.to_string(),
+        prompt: "p".to_string(),
+        goal: None,
+        repositories: vec![],
+        machines: vec![crate::machine::current_machine()],
+        enabled: true,
+        source: "managed".to_string(),
+        created_at: 0,
+        updated_at: 0,
+        last_manual_trigger_at: None,
+        last_scheduled_trigger_at: None,
+        snoozed_until: None,
+        skip_runs: None,
+        power_saving: false,
+        tags: vec![],
+        ttl_secs: None,
+        max_runtime_secs: None,
+        env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
+    }
+}
+
+struct CronShim {
+    base: std::path::PathBuf,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl CronShim {
+    fn write_fails(initial: &str) -> Self {
+        Self::new(initial, true)
+    }
+
+    fn write_succeeds(initial: &str) -> Self {
+        Self::new(initial, false)
+    }
+
+    fn new(initial: &str, fail_write: bool) -> Self {
+        use std::os::unix::fs::PermissionsExt;
+
+        let base = std::env::temp_dir().join(format!("moadim-rcronshim-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&base).unwrap();
+        let store_file = base.join("store");
+        std::fs::write(&store_file, initial).unwrap();
+        let store_display = store_file.to_string_lossy().into_owned();
+        let script_path = base.join("crontab-shim.sh");
+        let write_branch = if fail_write {
+            "cat > /dev/null; echo \"write blocked\" 1>&2; exit 1"
+        } else {
+            "cat > \"$STORE\""
+        };
+        let script = format!(
+            "#!/bin/sh\nSTORE=\"{store_display}\"\nif [ \"$1\" = \"-l\" ]; then\n  cat \"$STORE\"\nelif [ \"$1\" = \"-\" ]; then\n  {write_branch}\nfi\n"
+        );
+        std::fs::write(&script_path, script).unwrap();
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let previous = std::env::var_os("MOADIM_CRONTAB_BIN");
+        // SAFETY: tests run single-threaded (RUST_TEST_THREADS=1); restored on drop.
+        unsafe {
+            std::env::set_var("MOADIM_CRONTAB_BIN", &script_path);
+        }
+        Self { base, previous }
+    }
+}
+
+impl Drop for CronShim {
+    fn drop(&mut self) {
+        // SAFETY: single-threaded test harness; restore the saved value.
+        unsafe {
+            match self.previous.take() {
+                Some(value) => std::env::set_var("MOADIM_CRONTAB_BIN", value),
+                None => std::env::remove_var("MOADIM_CRONTAB_BIN"),
+            }
+        }
+        let _ = std::fs::remove_dir_all(&self.base);
+    }
+}
+
+#[test]
+fn failed_routine_sync_is_reported_in_crontab_sync_status() {
+    crate::sync::reset_crontab_sync_status_for_tests();
+    let agent_name = "test-sync-agent-status-failure";
+    std::fs::create_dir_all(crate::paths::agents_dir()).unwrap();
+    let cfg = crate::paths::agent_toml_path(agent_name);
+    std::fs::write(&cfg, "command = \"claude\"\nargs = []\n").unwrap();
+
+    let shim = CronShim::write_fails("# BEGIN MOADIM-ROUTINES\n# END MOADIM-ROUTINES\n");
+    let store = new_store();
+    store.lock().unwrap().insert(
+        "status-fail".into(),
+        make_routine("status-fail", "Status Failure Sync Routine", agent_name),
+    );
+
+    let err = sync_routines_to_crontab(&store).unwrap_err();
+    let status = crate::sync::crontab_sync_status();
+    assert!(!status.ok);
+    assert!(
+        status
+            .last_error
+            .as_deref()
+            .is_some_and(|message| message.contains(&err.to_string())),
+        "status should include sync error, got: {status:?}"
+    );
+    assert!(status.last_error_at.is_some());
+
+    drop(shim);
+    std::fs::remove_file(&cfg).unwrap();
+}
+
+#[test]
+fn successful_routine_sync_clears_previous_crontab_sync_error() {
+    failed_routine_sync_is_reported_in_crontab_sync_status();
+
+    let shim = CronShim::write_succeeds("# BEGIN MOADIM-ROUTINES\n# END MOADIM-ROUTINES\n");
+    sync_routines_to_crontab(&new_store()).unwrap();
+    let status = crate::sync::crontab_sync_status();
+    assert!(status.ok);
+    assert_eq!(status.last_error, None);
+    assert_eq!(status.last_error_at, None);
+    drop(shim);
+}


### PR DESCRIPTION
## Summary
- record the latest managed-routine OS crontab sync success/failure in process state
- expose `crontab_sync` in `/api/v1/health` / MCP health so macOS `crontab -` TCC timeouts are visible
- add regression tests for failed sync status, health payload, and OpenAPI

## Verification
- `cargo fmt --check`
- `linecheck --max-lines 500 $(find src -name '*.rs')`\n- `cargo clippy --all-targets -- -D warnings`\n- `cargo test`\n- `cargo test committed_spec_is_current`\n- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\\.rs' --summary-only`\n- `git diff --check`\n\nFixes #1456.