### PR TITLE
fix: preserve launchd working directory

### DIFF
--- a/.changeset/launchd-working-directory.md
+++ b/.changeset/launchd-working-directory.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Install the macOS LaunchAgent with a WorkingDirectory matching the directory where `moadim install` was run so launchd restarts keep the intended server root instead of defaulting to `/`.

--- a/src/service/macos.rs
+++ b/src/service/macos.rs
@@ -74,14 +74,14 @@ fn agent_path(home: &Path) -> String {
 /// Render the launchd property list for the moadim user agent.
 ///
 /// `exe` is the absolute path to the `moadim` binary; `log` is where launchd writes its stdout and
-/// stderr; `home` derives the `PATH` (see [`agent_path`]). The agent runs `moadim --interactive` so
-/// launchd supervises it directly.
+/// stderr; `home` derives the `PATH` (see [`agent_path`]); `working_dir` is the Moadim server root
+/// the daemon should use. The agent runs `moadim --interactive` so launchd supervises it directly.
 ///
 /// `KeepAlive` is a `{ SuccessfulExit = false }` dict (not unconditional `true`): launchd relaunches
 /// the agent only when it exits abnormally, so a crash is still auto-restarted but a clean shutdown
 /// — `moadim stop`, the UI STOP button, `POST /shutdown`, all of which exit `0` — stays stopped
 /// instead of being immediately resurrected by launchd.
-pub(super) fn render_plist(exe: &Path, log: &Path, home: &Path) -> String {
+pub(super) fn render_plist(exe: &Path, log: &Path, home: &Path, working_dir: &Path) -> String {
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -105,6 +105,8 @@ pub(super) fn render_plist(exe: &Path, log: &Path, home: &Path) -> String {
   <string>{log}</string>
   <key>StandardErrorPath</key>
   <string>{log}</string>
+  <key>WorkingDirectory</key>
+  <string>{working_dir}</string>
   <key>EnvironmentVariables</key>
   <dict>
     <key>PATH</key>
@@ -116,19 +118,26 @@ pub(super) fn render_plist(exe: &Path, log: &Path, home: &Path) -> String {
         label = LAUNCHD_LABEL,
         exe = xml_escape(&exe.display().to_string()),
         log = xml_escape(&log.display().to_string()),
+        working_dir = xml_escape(&working_dir.display().to_string()),
         path = xml_escape(&agent_path(home)),
     )
 }
 
 /// Render the plist for `exe`/`log`/`home` and write it (creating parent dirs) to `plist`.
-pub(super) fn write_plist(plist: &Path, exe: &Path, log: &Path, home: &Path) -> anyhow::Result<()> {
+pub(super) fn write_plist(
+    plist: &Path,
+    exe: &Path,
+    log: &Path,
+    home: &Path,
+    working_dir: &Path,
+) -> anyhow::Result<()> {
     if let Some(dir) = plist.parent() {
         std::fs::create_dir_all(dir)?;
     }
     if let Some(dir) = log.parent() {
         std::fs::create_dir_all(dir)?;
     }
-    std::fs::write(plist, render_plist(exe, log, home))?;
+    std::fs::write(plist, render_plist(exe, log, home, working_dir))?;
     Ok(())
 }
 
@@ -165,7 +174,8 @@ pub fn install() -> anyhow::Result<()> {
                   `plist_path_from_home`), so this is a proven invariant, not a real failure path"
     )]
     let home = home.expect("plist_path_from_home errors before this point when home is None");
-    write_plist(&plist, &exe, &log, &home)?;
+    let working_dir = std::env::current_dir()?;
+    write_plist(&plist, &exe, &log, &home, &working_dir)?;
     reload_agent(&plist)?;
     report_installed(&plist, &log);
     request_automation_permission();

--- a/src/service/mod_tests.rs
+++ b/src/service/mod_tests.rs
@@ -13,6 +13,7 @@ fn plist_carries_label_program_args_and_supervision_keys() {
         std::path::Path::new("/opt/moadim/bin/moadim"),
         std::path::Path::new("/Users/u/.config/moadim/daemon.log"),
         std::path::Path::new("/Users/u"),
+        std::path::Path::new("/Users/u/.hermes"),
     );
     assert!(plist.contains("<string>io.moadim.daemon</string>"));
     assert!(plist.contains("<string>/opt/moadim/bin/moadim</string>"));
@@ -27,6 +28,8 @@ fn plist_carries_label_program_args_and_supervision_keys() {
         "KeepAlive must not be unconditional true"
     );
     assert!(plist.contains("/Users/u/.config/moadim/daemon.log"));
+    assert!(plist.contains("<key>WorkingDirectory</key>"));
+    assert!(plist.contains("<string>/Users/u/.hermes</string>"));
     assert!(plist.contains("<key>EnvironmentVariables</key>"));
     assert!(plist.contains("/opt/homebrew/bin:/usr/local/bin:/Users/u/.cargo/bin"));
 }
@@ -38,8 +41,10 @@ fn plist_escapes_xml_metacharacters_in_paths() {
         std::path::Path::new("/tmp/a&b<c>"),
         std::path::Path::new("/tmp/log"),
         std::path::Path::new("/tmp/home"),
+        std::path::Path::new("/tmp/work&root"),
     );
     assert!(plist.contains("/tmp/a&amp;b&lt;c&gt;"));
+    assert!(plist.contains("/tmp/work&amp;root"));
     assert!(!plist.contains("a&b<c>"));
 }
 
@@ -186,7 +191,7 @@ fn write_plist_skips_dir_creation_when_paths_have_no_parent() {
     // path ("") skips create_dir_all for both the plist and the log. The trailing write then fails,
     // which is expected — only the no-parent branches need exercising.
     let no_parent = std::path::Path::new("");
-    assert!(write_plist(no_parent, no_parent, no_parent, no_parent).is_err());
+    assert!(write_plist(no_parent, no_parent, no_parent, no_parent, no_parent).is_err());
 }
 
 #[cfg(target_os = "macos")]
@@ -204,6 +209,7 @@ fn write_plist_errors_when_plist_dir_creation_blocked() {
         &plist,
         std::path::Path::new("/usr/local/bin/moadim"),
         &log,
+        &base,
         &base
     )
     .is_err());
@@ -228,6 +234,7 @@ fn write_plist_errors_when_log_dir_creation_blocked() {
         &plist,
         std::path::Path::new("/usr/local/bin/moadim"),
         &log,
+        &base,
         &base
     )
     .is_err());


### PR DESCRIPTION
## Summary
- write macOS LaunchAgent plists with `WorkingDirectory` set to the directory where `moadim install` is run
- keeps launchd restarts on the intended server root instead of defaulting to `/`
- adds LaunchAgent plist tests and a patch changeset

## Test plan
- targeted LaunchAgent plist tests
- full Rust quality gates including fmt, linecheck, clippy, tests, committed spec, llvm-cov, diff-check

Refs #1456
