### PR TITLE
feat: add routine move CLI

### DIFF
--- a/.changeset/routine-move-cli.md
+++ b/.changeset/routine-move-cli.md
@@ -1,0 +1,5 @@
+---
+"moadim": minor
+---
+
+Add a `moadim routines move` CLI command for moving routines between filesystem-derived folders and slugs through the explicit move API.

--- a/README.md
+++ b/README.md
@@ -501,6 +501,8 @@ moadim routines list
 moadim routines get <id>
 moadim routines update <id> --title "Renamed" --ttl-secs 3600
 moadim routines replace <id> --schedule "0 8 * * *" --title "Daily" --agent claude --prompt "..."
+moadim routines move <id-or-slug> --folder maintenance   # preserve current slug
+moadim routines move <id-or-slug> --folder team/ops --slug nightly-triage
 moadim routines trigger <id>
 moadim routines logs <id>
 moadim routines ical          # iCalendar feed of upcoming fire times

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -213,6 +213,17 @@ enum RoutineCmd {
         /// UUID of the routine to delete.
         id: String,
     },
+    /// Move a routine to another filesystem folder and/or slug.
+    Move {
+        /// Routine id, slug, or relative path to move.
+        id: String,
+        /// New parent folder relative to `routines/`; omit or pass blank for the root.
+        #[arg(long)]
+        folder: Option<String>,
+        /// New routine directory name inside the folder. Omit to preserve the current slug.
+        #[arg(long)]
+        slug: Option<String>,
+    },
     /// Manually trigger a routine outside its schedule.
     Trigger {
         /// UUID of the routine to trigger.
@@ -376,62 +387,12 @@ fn dispatch_routine(cmd: RoutineCmd) -> i32 {
             Err(code) => code,
         },
         RoutineCmd::Delete { id } => request("DELETE", &routine_path(&id), None),
+        RoutineCmd::Move { id, folder, slug } => move_routine(&id, folder, slug),
         RoutineCmd::Trigger { id } => {
             request("POST", &format!("{}/trigger", routine_path(&id)), None)
         }
         RoutineCmd::Logs { id } => request("GET", &format!("{}/logs", routine_path(&id)), None),
         RoutineCmd::Ical => request("GET", "/api/v1/routines.ics", None),
-    }
-}
-
-/// Flip a single routine's `enabled` flag via `PATCH /routines/{routine}`, the same partial-update
-/// path the web UI's toggle uses. `routine` is forwarded as an id or slug and resolved server-side,
-/// consistent with the other routine subcommands. Prints the resulting state — a human status line,
-/// or a `{"routine","enabled"}` object under `--json` — and maps the HTTP result to an exit code
-/// exactly like [`request`]: `0` on a 2xx (so re-enabling an already-enabled routine is an
-/// idempotent no-op rather than an error), `1` on any other status (e.g. an unknown routine's 404),
-/// and [`crate::cli::EXIT_NOT_RUNNING`] when no server is reachable.
-fn set_routine_enabled(routine: &str, enabled: bool, json: bool) -> i32 {
-    let body = serde_json::json!({ "enabled": enabled }).to_string();
-    match crate::cli::http_request_json("PATCH", &routine_path(routine), Some(&body)) {
-        Ok((status, resp)) if (200..300).contains(&status) => {
-            report_enabled(routine, enabled, &resp, json);
-            0
-        }
-        Ok((status, resp)) => {
-            eprintln!("error: server returned HTTP {status}");
-            if !resp.is_empty() {
-                eprintln!("{resp}");
-            }
-            1
-        }
-        Err(_) => {
-            eprintln!("moadim is not running");
-            crate::cli::EXIT_NOT_RUNNING
-        }
-    }
-}
-
-/// Report the outcome of an enable/disable. Prefers the server's echoed `id`/`enabled` so the
-/// printed state reflects what actually persisted (covering the idempotent no-op), falling back to
-/// the addressed `routine` and the `requested` flag when the response is not the expected object.
-fn report_enabled(routine: &str, requested: bool, resp: &str, json: bool) {
-    let parsed = serde_json::from_str::<Value>(resp).ok();
-    let id = parsed
-        .as_ref()
-        .and_then(|value| value.get("id"))
-        .and_then(Value::as_str)
-        .unwrap_or(routine);
-    let state = parsed
-        .as_ref()
-        .and_then(|value| value.get("enabled"))
-        .and_then(Value::as_bool)
-        .unwrap_or(requested);
-    if json {
-        println!("{}", serde_json::json!({ "routine": id, "enabled": state }));
-    } else {
-        let word = if state { "enabled" } else { "disabled" };
-        println!("routine {id} is now {word}");
     }
 }
 
@@ -485,6 +446,10 @@ fn routine_body(
 #[path = "commands_http.rs"]
 mod commands_http;
 use commands_http::{insert_json_opt, insert_opt, request, tags_value, to_body};
+
+#[path = "commands_routine_actions.rs"]
+mod commands_routine_actions;
+use commands_routine_actions::{move_routine, set_routine_enabled};
 
 #[cfg(test)]
 #[path = "commands_tests.rs"]

--- a/src/commands_routine_actions.rs
+++ b/src/commands_routine_actions.rs
@@ -1,0 +1,149 @@
+//! Higher-level routine data-plane actions that need response parsing before printing.
+
+use serde_json::{Map, Value};
+
+use super::{routine_path, to_body};
+
+/// Flip a single routine's `enabled` flag via `PATCH /routines/{routine}`.
+pub(super) fn set_routine_enabled(routine: &str, enabled: bool, json: bool) -> i32 {
+    let body = serde_json::json!({ "enabled": enabled }).to_string();
+    match crate::cli::http_request_json("PATCH", &routine_path(routine), Some(&body)) {
+        Ok((status, resp)) if (200..300).contains(&status) => {
+            report_enabled(routine, enabled, &resp, json);
+            0
+        }
+        Ok((status, resp)) => report_http_error(status, &resp),
+        Err(_) => not_running(),
+    }
+}
+
+/// Move a routine directory through the explicit `POST /routines/{id}/move` API.
+pub(super) fn move_routine(routine: &str, folder: Option<String>, slug: Option<String>) -> i32 {
+    let (id, current_slug) = match resolve_routine(routine) {
+        Ok(found) => found,
+        Err(code) => return code,
+    };
+    let Some(slug) = slug.or(current_slug) else {
+        return 1;
+    };
+    let mut map = Map::new();
+    map.insert("slug".to_string(), Value::String(slug));
+    if let Some(folder) = folder {
+        map.insert("folder".to_string(), Value::String(folder));
+    }
+    match crate::cli::http_request_json(
+        "POST",
+        &format!("{}/move", routine_path(&id)),
+        Some(&to_body(map)),
+    ) {
+        Ok((status, resp)) if (200..300).contains(&status) => {
+            print_move_result(&resp);
+            0
+        }
+        Ok((status, resp)) => report_http_error(status, &resp),
+        Err(_) => not_running(),
+    }
+}
+
+/// Resolve an id/slug/relative path to the routine id and current slug.
+fn resolve_routine(routine: &str) -> Result<(String, Option<String>), i32> {
+    if let Ok((status, resp)) = crate::cli::http_request_json("GET", &routine_path(routine), None) {
+        if (200..300).contains(&status) {
+            return Ok(parse_routine_identity(&resp).unwrap_or_else(|| (routine.to_string(), None)));
+        }
+    } else {
+        return Err(not_running());
+    }
+    let resp = match crate::cli::http_request_json("GET", "/api/v1/routines", None) {
+        Ok((status, resp)) if (200..300).contains(&status) => resp,
+        Ok((status, resp)) => {
+            return Err(report_http_error(status, &resp));
+        }
+        Err(_) => return Err(not_running()),
+    };
+    let Ok(value) = serde_json::from_str::<Value>(&resp) else {
+        eprintln!("error: could not parse routines list from server");
+        return Err(1);
+    };
+    value
+        .as_array()
+        .and_then(|items| {
+            items.iter().find_map(|item| {
+                let id = item.get("id")?.as_str()?;
+                let slug = item.get("slug").and_then(Value::as_str);
+                let rel_path = item.get("rel_path").and_then(Value::as_str);
+                (routine == id || Some(routine) == slug || Some(routine) == rel_path)
+                    .then(|| (id.to_string(), slug.map(ToString::to_string)))
+            })
+        })
+        .ok_or_else(|| {
+            eprintln!("error: no routine with id, slug, or path {routine}");
+            1
+        })
+}
+
+/// Parse a single routine response into the id plus current filesystem slug.
+fn parse_routine_identity(resp: &str) -> Option<(String, Option<String>)> {
+    let value = serde_json::from_str::<Value>(resp).ok()?;
+    let id = value.get("id")?.as_str()?.to_string();
+    let slug = value
+        .get("slug")
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
+    Some((id, slug))
+}
+
+/// Report the outcome of an enable/disable request.
+fn report_enabled(routine: &str, requested: bool, resp: &str, json: bool) {
+    let parsed = serde_json::from_str::<Value>(resp).ok();
+    let id = parsed
+        .as_ref()
+        .and_then(|value| value.get("id"))
+        .and_then(Value::as_str)
+        .unwrap_or(routine);
+    let state = parsed
+        .as_ref()
+        .and_then(|value| value.get("enabled"))
+        .and_then(Value::as_bool)
+        .unwrap_or(requested);
+    if json {
+        println!("{}", serde_json::json!({ "routine": id, "enabled": state }));
+    } else {
+        let word = if state { "enabled" } else { "disabled" };
+        println!("routine {id} is now {word}");
+    }
+}
+
+/// Print a compact success line that exposes the filesystem-derived destination.
+fn print_move_result(resp: &str) {
+    let parsed = serde_json::from_str::<Value>(resp).ok();
+    let Some(value) = parsed.as_ref() else {
+        println!("{resp}");
+        return;
+    };
+    let id = value.get("id").and_then(Value::as_str).unwrap_or("routine");
+    let rel_path = value
+        .get("rel_path")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    println!("moved routine {id} to {rel_path}");
+}
+
+/// Print a server-side error body and return the generic failure exit code.
+fn report_http_error(status: u16, resp: &str) -> i32 {
+    eprintln!("error: server returned HTTP {status}");
+    if !resp.is_empty() {
+        eprintln!("{resp}");
+    }
+    1
+}
+
+/// Print the standard liveness failure message and return the not-running exit code.
+fn not_running() -> i32 {
+    eprintln!("moadim is not running");
+    crate::cli::EXIT_NOT_RUNNING
+}
+
+#[cfg(test)]
+#[path = "commands_routine_actions_tests.rs"]
+mod commands_routine_actions_tests;

--- a/src/commands_routine_actions_tests.rs
+++ b/src/commands_routine_actions_tests.rs
@@ -1,0 +1,156 @@
+//! Coverage tests for routine CLI actions that parse server responses.
+
+use super::*;
+use std::io::{Read as _, Write as _};
+use std::net::TcpListener;
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+const BIND_ENV: &str = "MOADIM_BIND_ADDR";
+
+struct EnvGuard(Option<std::ffi::OsString>);
+
+impl EnvGuard {
+    fn set(value: &str) -> Self {
+        let previous = std::env::var_os(BIND_ENV);
+        // SAFETY: tests run single-threaded in this crate.
+        unsafe { std::env::set_var(BIND_ENV, value) };
+        Self(previous)
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: tests run single-threaded in this crate.
+        unsafe {
+            match self.0.take() {
+                Some(value) => std::env::set_var(BIND_ENV, value),
+                None => std::env::remove_var(BIND_ENV),
+            }
+        }
+    }
+}
+
+struct SequenceServer {
+    addr: String,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl SequenceServer {
+    fn start(responses: Vec<(u16, &'static str)>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let addr = listener.local_addr().expect("local addr").to_string();
+        listener.set_nonblocking(true).expect("set nonblocking");
+        let responses = Arc::new(Mutex::new(responses.into_iter()));
+        let loop_responses = Arc::clone(&responses);
+        let handle = std::thread::spawn(move || loop {
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    let mut buf = [0_u8; 2048];
+                    let _ = stream.read(&mut buf);
+                    let Some((status, body)) = loop_responses.lock().unwrap().next() else {
+                        break;
+                    };
+                    let response = format!(
+                            "HTTP/1.1 {status} OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                            body.len()
+                        );
+                    let _ = stream.write_all(response.as_bytes());
+                }
+                Err(ref err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                    if loop_responses.lock().unwrap().as_slice().is_empty() {
+                        break;
+                    }
+                    std::thread::sleep(Duration::from_millis(2));
+                }
+                Err(_) => break,
+            }
+        });
+        Self {
+            addr,
+            handle: Some(handle),
+        }
+    }
+}
+
+impl Drop for SequenceServer {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+#[test]
+fn move_resolves_slug_through_list_before_posting() {
+    let server = SequenceServer::start(vec![
+        (404, "{}"),
+        (
+            200,
+            "[{\"id\":\"rid\",\"slug\":\"daily\",\"rel_path\":\"ops/daily\"}]",
+        ),
+        (200, "{\"id\":\"rid\",\"rel_path\":\"maintenance/daily\"}"),
+    ]);
+    let _addr = EnvGuard::set(&server.addr);
+    assert_eq!(move_routine("daily", Some("maintenance".into()), None), 0);
+}
+
+#[test]
+fn move_reports_resolution_failures() {
+    let _addr = EnvGuard::set("127.0.0.1:1");
+    assert_eq!(
+        move_routine("missing", Some("ops".into()), None),
+        crate::cli::EXIT_NOT_RUNNING
+    );
+
+    let missing = SequenceServer::start(vec![(404, "{}"), (200, "[]")]);
+    let _addr = EnvGuard::set(&missing.addr);
+    assert_eq!(move_routine("missing", Some("ops".into()), None), 1);
+
+    let list_error = SequenceServer::start(vec![(404, "{}"), (500, "boom")]);
+    let _addr = EnvGuard::set(&list_error.addr);
+    assert_eq!(move_routine("missing", Some("ops".into()), None), 1);
+
+    let list_down = SequenceServer::start(vec![(404, "{}")]);
+    let _addr = EnvGuard::set(&list_down.addr);
+    assert_eq!(
+        move_routine("missing", Some("ops".into()), None),
+        crate::cli::EXIT_NOT_RUNNING
+    );
+
+    let invalid = SequenceServer::start(vec![(404, "{}"), (200, "not json")]);
+    let _addr = EnvGuard::set(&invalid.addr);
+    assert_eq!(move_routine("missing", Some("ops".into()), None), 1);
+}
+
+#[test]
+fn move_reports_post_failures_and_plain_success() {
+    let conflict = SequenceServer::start(vec![
+        (200, "{\"id\":\"rid\",\"slug\":\"daily\"}"),
+        (409, "{\"error\":\"exists\"}"),
+    ]);
+    let _addr = EnvGuard::set(&conflict.addr);
+    assert_eq!(move_routine("rid", Some("ops".into()), None), 1);
+
+    let plain = SequenceServer::start(vec![(200, "{\"id\":\"rid\"}"), (200, "moved")]);
+    let _addr = EnvGuard::set(&plain.addr);
+    assert_eq!(
+        move_routine("rid", Some("ops".into()), Some("daily".into())),
+        0
+    );
+}
+
+#[test]
+fn move_surfaces_liveness_and_missing_slug_failures() {
+    let get_only = SequenceServer::start(vec![(200, "{\"id\":\"rid\",\"slug\":\"daily\"}")]);
+    let _addr = EnvGuard::set(&get_only.addr);
+    assert_eq!(
+        move_routine("rid", Some("ops".into()), None),
+        crate::cli::EXIT_NOT_RUNNING
+    );
+
+    let no_slug = SequenceServer::start(vec![(200, "{\"ok\":true}")]);
+    let _addr = EnvGuard::set(&no_slug.addr);
+    assert_eq!(move_routine("rid", Some("ops".into()), None), 1);
+}

--- a/src/commands_tests.rs
+++ b/src/commands_tests.rs
@@ -259,6 +259,15 @@ fn every_subcommand_succeeds_against_a_2xx_server() {
             "p",
         ],
         &["routines", "delete", "rid"],
+        &[
+            "routines",
+            "move",
+            "rid",
+            "--folder",
+            "maintenance",
+            "--slug",
+            "nightly",
+        ],
         &["routines", "trigger", "rid"],
         &["routines", "logs", "rid"],
         &["routines", "ical"],
@@ -278,6 +287,19 @@ fn logs_print_raw_when_body_is_not_json() {
     let server = FakeServer::start(200, "plain log line\nsecond line");
     let _addr = EnvGuard::set(BIND_ENV, &server.addr);
     assert_eq!(run(argv(&["routines", "logs", "abc"])), 0);
+}
+
+#[test]
+fn move_preserves_current_slug_when_slug_is_omitted() {
+    let server = FakeServer::start(
+        200,
+        "{\"id\":\"rid\",\"slug\":\"daily\",\"rel_path\":\"maintenance/daily\"}",
+    );
+    let _addr = EnvGuard::set(BIND_ENV, &server.addr);
+    assert_eq!(
+        run(argv(&["routine", "move", "rid", "--folder", "maintenance"])),
+        0
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `moadim routines move <id-or-slug> --folder <folder> [--slug <slug>]`
- resolve slug/rel_path inputs through the routines list before calling the explicit move API
- document the CLI and add a changeset

## Verification
- CLI smoke against a temp daemon: create routine, move via CLI, verify `folder=ops`, `slug=cli-move-smoke-renamed`, `rel_path=ops/cli-move-smoke-renamed`
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (`1250 passed`)
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main\\.rs'` (line coverage `100.00%`)
- `linecheck --max-lines 500 $(find src -name '*.rs')`
- `pnpm --filter client typecheck`
- `pnpm --filter client lint`
- `pnpm --filter client test` (`468 passed`)
- pre-push hook passed
