### PR TITLE
chore(release): version packages to 3.2.0

### DIFF
--- a/.changeset/routine-move-cli.md
+++ b/.changeset/routine-move-cli.md
@@ -1,5 +1,0 @@
----
-"moadim": minor
----
-
-Add a `moadim routines move` CLI command for moving routines between filesystem-derived folders and slugs through the explicit move API.

--- a/.changeset/routines-shareable-view-links.md
+++ b/.changeset/routines-shareable-view-links.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-Mirror the Routines page's filter/sort/group-by state into the URL and add a "COPY LINK" action, so an operator can share a link to a specific filtered/sorted view instead of walking a teammate through reproducing it by hand.

--- a/.changeset/ui-e2e-dark-screenshot.md
+++ b/.changeset/ui-e2e-dark-screenshot.md
@@ -1,6 +1,0 @@
----
-"client": patch
-"moadim": patch
----
-
-Add a mocked dark-mode UI E2E screenshot baseline for visual PR review.

--- a/.changeset/ui-e2e-screenshots.md
+++ b/.changeset/ui-e2e-screenshots.md
@@ -1,6 +1,0 @@
----
-"moadim": patch
-"client": patch
----
-
-Add mocked Playwright UI E2E screenshot coverage for PR visual review.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+## [3.2.0] - 2026-07-31
+
+Add a `moadim routines move` CLI command for moving routines between filesystem-derived folders and slugs through the explicit move API.
+
+Mirror the Routines page's filter/sort/group-by state into the URL and add a "COPY LINK" action, so an operator can share a link to a specific filtered/sorted view instead of walking a teammate through reproducing it by hand.
+
+Add a mocked dark-mode UI E2E screenshot baseline for visual PR review.
+
+Add mocked Playwright UI E2E screenshot coverage for PR visual review.
+
 ## [3.1.0] - 2026-07-30
 
 Surface the most recent managed-routine crontab sync failure in the health response so macOS crontab/TCC write timeouts are visible instead of leaving users with a healthy daemon and stale OS schedules.
@@ -4954,7 +4964,8 @@ Enable `clippy::match_same_arms` and merge the two duplicate-body arms it flagge
 - Ship the prebuilt UI in the published crate.
 - Rename the binary to `moadim` and add install docs.
 
-[Unreleased]: https://github.com/moadim-io/daemon/compare/v3.1.0...HEAD
+[Unreleased]: https://github.com/moadim-io/daemon/compare/v3.2.0...HEAD
+[3.2.0]: https://github.com/moadim-io/daemon/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/moadim-io/daemon/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/moadim-io/daemon/compare/v1.7.6...v3.0.0
 [1.7.6]: https://github.com/moadim-io/daemon/compare/v1.7.5...v1.7.6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moadim"
-version = "3.1.0"
+version = "3.2.0"
 edition = "2021"
 # Floor set by the transitive proc-macro build dependency `darling 0.23`
 # (pulled in via `rmcp-macros` <- `rmcp`), which itself declares

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "3.1.0"
+    "version": "3.2.0"
   },
   "servers": [
     {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/moadim.1
+++ b/docs/moadim.1
@@ -1,7 +1,7 @@
 .\" Man page for moadim.
 .\" Mirrors the built-in `moadim --help` output (src/cli/mod.rs::print_help).
 .\" View with:  man ./docs/moadim.1   or install into share/man/man1/.
-.TH MOADIM 1 "2026-07-30" "moadim 3.1.0" "Moadim Manual"
+.TH MOADIM 1 "2026-07-31" "moadim 3.2.0" "Moadim Manual"
 .SH NAME
 moadim \- routine scheduler with an MCP/REST API and a web control panel
 .SH SYNOPSIS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moadim",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "scripts": {


### PR DESCRIPTION
## Summary
- Manual fallback release cut — no open `changeset-release.yml` bot PR was found, so this rolls the pending changesets into a version bump directly (per CONTRIBUTING.md's "manual fallback" release path).
- Bumps `package.json`/`client/package.json`/`Cargo.toml`/`Cargo.lock` to **3.2.0** (minor, driven by the `moadim: minor` changeset) via `pnpm version-packages`.
- Rolls 4 pending `.changeset/*.md` entries into a new `## [3.2.0] - 2026-07-31` CHANGELOG section: routine move CLI, Routines page shareable view links, and two UI E2E screenshot baselines.
- Regenerates `apis/openapi.json` and updates `docs/moadim.1`'s `.TH` version/date line to match.

## Test plan
- [x] `pnpm version-packages` ran clean
- [x] `cargo check` passed (synced `Cargo.lock`)
- [x] Pre-push hook (full test suite + coverage gate) passed on push
- [ ] CI green on this PR

---
🤖 Originating routine: **Nightly release cutter (moadim daemon)**