### PR TITLE
docs: fix stale <uuid> routine-folder layout in Architecture.md

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -26,10 +26,18 @@ Moadim is a Rust daemon that manages scheduled AI-agent routines and exposes the
                ~/.config/moadim/
                ├── .gitignore                            (generated; covers the whole tree, no per-routine copy)
                └── routines/
-                   ├── <uuid>/routine.toml                  (tracked; [env] = non-secret vars)
-                   ├── <uuid>/routine.local.toml             (gitignored, optional; secret env overrides)
-                   ├── <uuid>/prompts/prompt.pure.md         (tracked)
-                   └── <uuid>/prompts/prompt.compiled.local.md (gitignored)
+                   ├── <slug>/routine.toml                  (tracked; [env] = non-secret vars)
+                   ├── <slug>/routine.local.toml             (gitignored, optional; secret env overrides)
+                   ├── <slug>/prompts/prompt.pure.md         (tracked)
+                   └── <slug>/prompts/prompt.compiled.local.md (gitignored)
+```
+
+Folders are filesystem-derived, not UUID-named (see `routine_storage_location.rs`): a routine keeps
+whatever directory it already lives in — found by scanning `routines/` for a `routine.toml` whose
+`id` matches — and only a brand-new, never-persisted routine falls back to `slugify(title)`. Folders
+can nest arbitrarily (`routines/<folder>/<slug>/...`), and `write_routine` refuses to overwrite a
+directory whose `routine.toml` already holds a *different* routine's `id`, so a slug collision
+between distinct routines errors instead of silently clobbering one of them.
 ```
 
 ---


### PR DESCRIPTION
## Summary
- The storage-tree diagram in Architecture.md's "High-level picture" section still showed `routines/<uuid>/...`, left over from before the UUID→slug folder migration (#58).
- Routine directories are filesystem-derived and slug-named (`routine_storage_location.rs`): a routine keeps whatever directory it already lives in (found by scanning `routines/` for a `routine.toml` whose `id` matches), and only a brand-new, never-persisted routine falls back to `slugify(title)`. Folders can nest, and `write_routine` refuses to overwrite a directory whose `routine.toml` holds a *different* routine's `id`.
- Updated the diagram's `<uuid>` labels to `<slug>` and added a short paragraph documenting the filesystem-derived lookup, nesting, and the collision guard — this also closes the "document folder-naming + collision rule in Architecture.md" acceptance criterion from #188 (the collision guard itself is already implemented; this PR only adds the missing documentation).

Docs-only change (`Architecture.md`), no `src/` or `client/` touched, so no changeset is needed per this repo's changelog gate.

## Test plan
- [x] `typos Architecture.md` — clean
- [x] `lychee --config lychee.toml Architecture.md` — clean (0 links in the new prose)

---
Opened by the moadim routine **"Daemon + Landing auto-improve & auto-merge lint/docs PRs"**.
