### PR TITLE
chore(lint): enable clippy::assigning_clones

### DIFF
--- a/.changeset/enable-clippy-assigning-clones.md
+++ b/.changeset/enable-clippy-assigning-clones.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Enable `clippy::assigning_clones` and fix the one violation it surfaced: `svc_update` now uses `clone_from` instead of assigning a fresh `.clone()` onto the routine's existing `schedule` field.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -534,3 +534,11 @@ significant_drop_in_scrutinee = "deny"
 # together. A state machine or a two-variant enum usually expresses the real, restricted set of
 # valid combinations far more precisely than a pile of loose flags.
 struct_excessive_bools = "deny"
+# Reject `x = y.clone()` in favour of `x.clone_from(&y)` where `x` is already initialized.
+# `Clone::clone_from` lets a type reuse `x`'s existing allocation instead of allocating a fresh one
+# and dropping the old value, so the plain-assignment form does unnecessary allocate/drop work for
+# any type that overrides it (most collection and `String`-like types). Fixed the one violation
+# this surfaced: `routines::service_update::svc_update` assigning a freshly validated schedule onto
+# the routine's existing `schedule: String` field. The rest of the codebase is already clean, so
+# `deny` locks that in.
+assigning_clones = "deny"

--- a/src/routines/service_update.rs
+++ b/src/routines/service_update.rs
@@ -110,7 +110,7 @@ pub fn svc_update(
         .get_mut(id)
         .expect("id existence checked above, and the lock has been held continuously since");
     if let Some(schedules) = requested_schedules {
-        routine.schedule = schedules[0].clone();
+        routine.schedule.clone_from(&schedules[0]);
         routine.schedules = schedules;
     }
     if let Some(title) = req.title {


### PR DESCRIPTION
## Summary
- Enables `clippy::assigning_clones` (pedantic) in `[lints.clippy]`, denying `x = y.clone()` assignments where `x.clone_from(&y)` would reuse `x`'s existing allocation instead of allocating a fresh value and dropping the old one.
- Fixes the one violation this surfaced: `routines::service_update::svc_update` assigned `schedules[0].clone()` onto the routine's existing `schedule: String` field. Rewritten as `routine.schedule.clone_from(&schedules[0])`, which runs before `schedules` is moved into `routine.schedules` on the next line, so no reordering was needed.
- Checked HEAD against the repo's own pre-push gate first (`.githooks/pre-push`: fmt, clippy, tests, 100% line coverage, linecheck, client typecheck/lint/test, changeset check) — all currently pass on `main`, so this PR instead adds one more of the pedantic lints the repo has been progressively enabling (following the pattern of `struct_excessive_bools`, `significant_drop_in_scrutinee`, `stable_sort_primitive`, etc., without duplicating any of those).

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean (with the new lint enabled)
- [x] `cargo test` — 1250 passed, 0 failed
- [x] `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex 'src/main.rs'` — 100% line coverage maintained
- [x] `bash .githooks/pre-push` (full local hook, including client typecheck/lint/test and the changeset gate) — passes end to end

---
Opened by the moadim routine: Daemon + Landing auto-improve & auto-merge lint/docs PRs.