### PR TITLE
test(client): cover nextFireAfterAny/nextFiresAny multi-schedule merge logic

### DIFF
--- a/.changeset/test-schedule-multi-cron-merge.md
+++ b/.changeset/test-schedule-multi-cron-merge.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Add unit tests for `nextFireAfterAny`/`nextFiresAny` (client `src/lib/schedule.ts`), the multi-schedule "next fire" merge logic backing the Routines table row and the Overview page's dead-schedule detection. Both were previously untested (0% coverage on that code path).

--- a/client/src/lib/schedule.test.ts
+++ b/client/src/lib/schedule.test.ts
@@ -6,7 +6,9 @@ import {
   fmtWhen,
   monthStart,
   nextFireAfter,
+  nextFireAfterAny,
   nextFires,
+  nextFiresAny,
   occurrencesPerDay,
 } from "./schedule";
 
@@ -128,6 +130,56 @@ describe("fireTimesOnDay", () => {
 
   it("is empty for an invalid schedule", () => {
     expect(fireTimesOnDay("not a cron", day())).toEqual([]);
+  });
+});
+
+describe("nextFireAfterAny", () => {
+  it("returns the earliest fire across every schedule", () => {
+    const then = nextFireAfterAny(["0 0 * * *", "0 * * * *"], now());
+    expect(then).toEqual(new Date(2026, 5, 21, 13, 0, 0));
+  });
+
+  it("ignores invalid schedules and uses the remaining valid ones", () => {
+    const then = nextFireAfterAny(["not a cron", "0 * * * *"], now());
+    expect(then).toEqual(new Date(2026, 5, 21, 13, 0, 0));
+  });
+
+  it("is undefined when every schedule is invalid", () => {
+    expect(nextFireAfterAny(["not a cron", ""], now())).toBeUndefined();
+  });
+
+  it("is undefined for an empty list", () => {
+    expect(nextFireAfterAny([], now())).toBeUndefined();
+  });
+});
+
+describe("nextFiresAny", () => {
+  it("merges, sorts, and de-duplicates fires across schedules", () => {
+    // "0 */2 * * *" fires 14:00, 16:00, 18:00; "0 * * * *" fires 13:00, 14:00, 15:00 —
+    // the coinciding 14:00 collapses to one entry.
+    const fires = nextFiresAny(["0 */2 * * *", "0 * * * *"], now(), 3);
+    expect(fires).toEqual([
+      new Date(2026, 5, 21, 13, 0, 0),
+      new Date(2026, 5, 21, 14, 0, 0),
+      new Date(2026, 5, 21, 15, 0, 0),
+    ]);
+  });
+
+  it("de-duplicates fires that coincide across schedules", () => {
+    const fires = nextFiresAny(["0 * * * *", "0 * * * *"], now(), 2);
+    expect(fires).toEqual([
+      new Date(2026, 5, 21, 13, 0, 0),
+      new Date(2026, 5, 21, 14, 0, 0),
+    ]);
+  });
+
+  it("ignores invalid schedules", () => {
+    const fires = nextFiresAny(["not a cron", "0 * * * *"], now(), 1);
+    expect(fires).toEqual([new Date(2026, 5, 21, 13, 0, 0)]);
+  });
+
+  it("is empty for an empty list", () => {
+    expect(nextFiresAny([], now(), 5)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds unit tests for `nextFireAfterAny` and `nextFiresAny` in `client/src/lib/schedule.ts`. Both were previously untested (0% line coverage on that code path per `pnpm run test:coverage`).
- These are the multi-schedule "next fire" merge functions backing:
  - `RoutineRow.tsx`'s next-fire display (`nextFireAfterAny`) and the fire-list popover (`nextFiresAny`)
  - `overviewLogic.ts`'s dead-schedule detection on the Overview page (`nextFireAfterAny`)
- Coverage added: earliest-fire selection across schedules, invalid-schedule tolerance (a bad schedule in the list doesn't break the others), merge/sort/de-duplication of coinciding fire times, and empty-list edge cases.

## Test plan
- [x] `pnpm vitest run src/lib/schedule.test.ts` — 34 passed
- [x] `pnpm vitest run` (full client suite) — 487 passed
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean
- [x] `.changeset/test-schedule-multi-cron-merge.md` added (this PR touches `client/`)

---
Opened by the moadim routine **"Daemon + Landing auto-improve & auto-merge lint/docs PRs"**.