### PR TITLE
perf(routines): dedupe redundant routine_rel_dir tree walks in RoutineResponse

### DIFF
--- a/.changeset/dedupe-routine-rel-dir-lookups.md
+++ b/.changeset/dedupe-routine-rel-dir-lookups.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+`RoutineResponse::from_routine` (built for every routine on each `GET /routines` poll) called `routine_rel_dir` three times per routine — once directly and once each inside `routine_slug`/`routine_folder` — and every call re-walked the whole `routines/` tree. It now computes the relative directory once and derives the slug/folder from it with pure string ops (`slug_from_rel_dir`/`folder_from_rel_dir`), cutting the list endpoint's filesystem walks by 3x with no behavior change.

--- a/src/routine_storage_2.rs
+++ b/src/routine_storage_2.rs
@@ -9,7 +9,9 @@ pub(crate) use routine_storage_load::reload_store_from_dir;
 
 #[path = "routine_storage_location.rs"]
 mod routine_storage_location;
-pub(crate) use routine_storage_location::{routine_folder, routine_rel_dir, routine_slug};
+pub(crate) use routine_storage_location::{
+    folder_from_rel_dir, routine_rel_dir, routine_slug, slug_from_rel_dir,
+};
 
 #[path = "routine_storage_migrations.rs"]
 mod routine_storage_migrations;

--- a/src/routine_storage_location.rs
+++ b/src/routine_storage_location.rs
@@ -67,13 +67,25 @@ pub(crate) fn routine_rel_dir(routine: &Routine) -> String {
 
 /// Return the last path segment of a routine's filesystem location.
 pub(crate) fn routine_slug(routine: &Routine) -> String {
-    let rel_dir = routine_rel_dir(routine);
+    slug_from_rel_dir(&routine_rel_dir(routine))
+}
+
+/// Return the last path segment of an already-computed [`routine_rel_dir`] value.
+///
+/// Pure string derivation — no filesystem access. Prefer this over [`routine_slug`] when a
+/// `rel_dir` has already been computed for the same routine, so callers that need both the
+/// directory and its slug (or folder) don't each trigger their own recursive tree walk.
+pub(crate) fn slug_from_rel_dir(rel_dir: &str) -> String {
     rel_dir.rsplit('/').next().unwrap_or("").to_string()
 }
 
-/// Return the parent folder of a routine's filesystem location, relative to `routines/`.
-pub(crate) fn routine_folder(routine: &Routine) -> Option<String> {
-    std::path::Path::new(&routine_rel_dir(routine))
+/// Return the parent folder of an already-computed [`routine_rel_dir`] value, relative to
+/// `routines/`.
+///
+/// Pure string derivation — no filesystem access. See [`slug_from_rel_dir`] for why this exists
+/// as a companion for callers that already computed a relative directory.
+pub(crate) fn folder_from_rel_dir(rel_dir: &str) -> Option<String> {
+    std::path::Path::new(rel_dir)
         .parent()
         .filter(|parent| !parent.as_os_str().is_empty())
         .map(rel_string)

--- a/src/routine_storage_location_tests.rs
+++ b/src/routine_storage_location_tests.rs
@@ -66,6 +66,21 @@ fn write_routine_preserves_existing_filesystem_location_after_title_change() {
 }
 
 #[test]
+fn slug_from_rel_dir_returns_last_segment() {
+    assert_eq!(slug_from_rel_dir("guidde/prs/review-nudge"), "review-nudge");
+    assert_eq!(slug_from_rel_dir("top-level-slug"), "top-level-slug");
+}
+
+#[test]
+fn folder_from_rel_dir_returns_parent_or_none_at_top_level() {
+    assert_eq!(
+        folder_from_rel_dir("guidde/prs/review-nudge"),
+        Some("guidde/prs".to_string())
+    );
+    assert_eq!(folder_from_rel_dir("top-level-slug"), None);
+}
+
+#[test]
 fn routine_response_derives_folder_slug_and_paths_from_disk_location() {
     with_override_home(|| {
         let id = "location-response-id";

--- a/src/routines/next_run_at.rs
+++ b/src/routines/next_run_at.rs
@@ -38,8 +38,8 @@ impl RoutineResponse {
     /// Build a response from `routine`, deriving registration status and schedule description.
     pub fn from_routine(routine: Routine) -> Self {
         let rel_path = crate::routine_storage::routine_rel_dir(&routine);
-        let slug = crate::routine_storage::routine_slug(&routine);
-        let folder = crate::routine_storage::routine_folder(&routine);
+        let slug = crate::routine_storage::slug_from_rel_dir(&rel_path);
+        let folder = crate::routine_storage::folder_from_rel_dir(&rel_path);
         // An agent counts as registered only if its config both exists *and* parses: a
         // present-but-malformed config is silently dropped at crontab-sync time, so reporting it as
         // registered would paint a never-firing routine as healthy. See issue #301.


### PR DESCRIPTION
## Why

`RoutineResponse::from_routine` builds one response per routine on every `GET /routines` call (`src/routines/model.rs`), and that endpoint is polled by the client on an interval (Routines/Overview/Machines/Heatmap pages). It called `routine_rel_dir` three times per routine — once directly for `rel_path`, then again inside `routine_slug` and `routine_folder` — and every `routine_rel_dir` call re-walks the entire `routines/` directory tree, reading and TOML-parsing each `routine.toml` until it finds the matching id. Listing N routines did roughly 3x the necessary filesystem+parse work.

## What

- Add pure, filesystem-free `slug_from_rel_dir`/`folder_from_rel_dir` helpers to `routine_storage_location.rs` that derive the slug/folder from an already-computed `rel_dir` string.
- `RoutineResponse::from_routine` now computes `rel_dir` once and derives `slug`/`folder` from it, instead of each doing its own tree walk.
- `routine_folder` (routine → tree walk → folder) had no other callers, so it's removed in favor of the new pure helper; `routine_slug` is kept since `service.rs`/`service_move.rs`/`command.rs`/`service_trigger.rs` still call it directly on a single routine (not in the hot list-endpoint path).
- Added unit tests for the new pure helpers; the existing `routine_response_derives_folder_slug_and_paths_from_disk_location` test already covers the modified `from_routine` path end-to-end.

No behavior or API change — `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and the full `cargo test` suite (1252 tests) all pass locally.

---
Opened automatically by the moadim routine **"Daemon + Landing auto-improve & auto-merge lint/docs PRs"**.