### PR TITLE
feat: add npm binary distribution packages

### DIFF
--- a/.changeset/npm-binary-packages.md
+++ b/.changeset/npm-binary-packages.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Add npm binary distribution package scaffolding with platform optional packages, Rust/npm version lockstep checks, and parallel npm package CI/release jobs.

--- a/.github/workflows/npm-packages.yml
+++ b/.github/workflows/npm-packages.yml
@@ -1,0 +1,186 @@
+name: npm packages
+
+on:
+  pull_request:
+    paths:
+      - "npm/**"
+      - "scripts/release/*npm*.mjs"
+      - "scripts/release/version-and-sync.mjs"
+      - ".github/workflows/npm-packages.yml"
+      - "Cargo.toml"
+      - "package.json"
+  push:
+    branches: [main]
+    paths:
+      - "npm/**"
+      - "scripts/release/*npm*.mjs"
+      - "scripts/release/version-and-sync.mjs"
+      - ".github/workflows/npm-packages.yml"
+      - "Cargo.toml"
+      - "package.json"
+  workflow_call:
+    inputs:
+      tag:
+        description: Release tag, e.g. v3.2.0
+        required: false
+        type: string
+      publish:
+        description: Publish npm packages after validation
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: npm-packages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: npm package metadata
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+
+      - name: Verify package versions and pack contents
+        run: node scripts/release/verify-npm-packages.mjs
+
+      - name: Unit-test npm wrapper
+        run: node --test npm/moadim/test/*.test.mjs
+
+  build:
+    name: build npm binary (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            package_dir: daemon-linux-x64-gnu
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            package_dir: daemon-darwin-arm64
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            package_dir: daemon-darwin-x64
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+
+      - name: Build binary
+        run: cargo build --release --locked --target ${{ matrix.target }}
+
+      - name: Smoke binary version
+        run: ./target/${{ matrix.target }}/release/moadim --version
+
+      - name: Stage binary into npm package
+        run: node scripts/release/stage-npm-binaries.mjs ${{ matrix.target }} target/${{ matrix.target }}/release/moadim
+
+      - name: Pack staged platform package
+        run: npm pack --json --dry-run
+        working-directory: npm/${{ matrix.package_dir }}
+
+      - uses: actions/upload-artifact@2848b2cda0e5190984587ec6bb1f36730ca78d50 # v4.6.2
+        with:
+          name: npm-${{ matrix.package_dir }}
+          path: npm/${{ matrix.package_dir }}/bin/moadim
+          if-no-files-found: error
+
+  pack-root:
+    name: npm root pack smoke
+    needs: [validate, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          pattern: npm-*
+          path: /tmp/moadim-npm-binaries
+
+      - name: Generate npm platform package metadata
+        run: node scripts/release/generate-npm-packages.mjs
+
+      - name: Restore staged binaries
+        run: |
+          set -euo pipefail
+          cp /tmp/moadim-npm-binaries/npm-daemon-linux-x64-gnu/moadim npm/daemon-linux-x64-gnu/bin/moadim
+          cp /tmp/moadim-npm-binaries/npm-daemon-darwin-arm64/moadim npm/daemon-darwin-arm64/bin/moadim
+          cp /tmp/moadim-npm-binaries/npm-daemon-darwin-x64/moadim npm/daemon-darwin-x64/bin/moadim
+          chmod +x npm/daemon-*/bin/moadim
+
+      - name: Verify staged npm packages include binaries
+        run: node scripts/release/verify-npm-packages.mjs
+        env:
+          MOADIM_REQUIRE_NPM_BINARIES: "1"
+
+      - name: Pack all npm packages
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/moadim-npm-packs
+          for pkg in npm/*; do
+            [ -d "$pkg" ] || continue
+            (cd "$pkg" && npm pack --pack-destination /tmp/moadim-npm-packs)
+          done
+          ls -1 /tmp/moadim-npm-packs
+
+  publish-platforms:
+    name: publish npm platform packages
+    if: inputs.publish == true
+    needs: [pack-root]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - daemon-darwin-arm64
+          - daemon-darwin-x64
+          - daemon-linux-x64-gnu
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Generate npm platform package metadata
+        run: node scripts/release/generate-npm-packages.mjs
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: npm-${{ matrix.package }}
+          path: npm/${{ matrix.package }}/bin
+      - name: Restore executable bit
+        run: chmod +x npm/${{ matrix.package }}/bin/moadim
+      - name: Verify staged platform package includes binary
+        run: node scripts/release/verify-npm-packages.mjs
+        env:
+          MOADIM_REQUIRE_NPM_BINARIES: "1"
+          MOADIM_REQUIRED_NPM_PACKAGE: ${{ matrix.package }}
+      - name: Publish ${{ matrix.package }}
+        run: npm publish --provenance --access public
+        working-directory: npm/${{ matrix.package }}
+
+  publish-root:
+    name: publish npm root package
+    if: inputs.publish == true
+    needs: [publish-platforms]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish moadim
+        run: npm publish --provenance --access public
+        working-directory: npm/moadim

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write # required for npm provenance in the called npm-packages workflow
 
 jobs:
   # Gate for the manual `push: tags` escape hatch only — see #260. Skipped
@@ -96,6 +97,14 @@ jobs:
           tag_name: ${{ env.TAG }}
           name: ${{ env.TAG }}
           body_path: release-notes.md
+
+  npm-packages:
+    name: Build and publish npm packages
+    needs: release
+    uses: ./.github/workflows/npm-packages.yml
+    with:
+      tag: ${{ needs.release.outputs.tag }}
+      publish: true
 
   # Cross-compiled binary archives attached to the release created above, so `cargo binstall
   # moadim` and users without a Rust toolchain have a prebuilt executable to download instead of

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ client/coverage/
 .compailed.cron
 client/test-results/
 client/playwright-report/
+npm/daemon-*/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,7 +182,9 @@ Changeset files accumulate silently on `main` as PRs land (each one required
 by the `unreleased-entry` check above) until someone decides it's time to
 ship: trigger [`cut-release.yml`](.github/workflows/cut-release.yml) —
 `gh workflow run cut-release.yml`, or "Run workflow" on the Actions tab. It
-bumps `package.json`, syncs that version into `Cargo.toml`/`Cargo.lock`
+bumps `package.json`, syncs that version into `Cargo.toml`/`Cargo.lock` and
+`npm/moadim/package.json`, using [`npm/packages.json`](npm/packages.json) as
+the source manifest for generated platform-package metadata
 ([`scripts/release/version-and-sync.mjs`](scripts/release/version-and-sync.mjs)),
 rolls the pending changesets into a new dated `CHANGELOG.md` section, verifies
 the result through the same lint/test gates a PR would get, and pushes it
@@ -198,10 +200,11 @@ To cut one manually instead (e.g. a hotfix, or the workflow is unavailable):
 
 Either way, on landing on `main`, [`auto-release.yml`](.github/workflows/auto-release.yml)
 detects the new version, pushes the `vx.y.z` tag, then publishes to crates.io
-([`publish.yml`](.github/workflows/publish.yml)) and cuts the GitHub Release
-([`release.yml`](.github/workflows/release.yml)). No manual tag push. The tag
-must not already exist, and `Cargo.toml`'s version must match the topmost
-changelog heading. Pushing a `v*` tag by hand still works as a fallback.
+([`publish.yml`](.github/workflows/publish.yml)), cuts the GitHub Release
+([`release.yml`](.github/workflows/release.yml)), and publishes the npm binary
+packages via [`npm-packages.yml`](.github/workflows/npm-packages.yml). No manual
+tag push. The tag must not already exist, and `Cargo.toml`'s version must match
+the topmost changelog heading. Pushing a `v*` tag by hand still works as a fallback.
 
 `publish.yml` authenticates to crates.io via [Trusted Publishing](https://crates.io/docs/trusted-publishing)
 (OIDC) — no `CARGO_REGISTRY_TOKEN` secret involved.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ and Linux x86_64. Install one with [`cargo binstall`](https://github.com/cargo-b
 cargo binstall moadim
 ```
 
+Node/npm users can install the same prebuilt binaries through npm. The npm
+package is a thin wrapper over per-platform optional binary packages; it does
+not run `cargo install` during installation, and every npm package version is
+kept in lockstep with the Rust crate version:
+
+```sh
+npm install -g moadim
+moadim --version
+```
+
 ...or download the archive for your platform directly from the
 [Releases page](https://github.com/moadim-io/daemon/releases).
 

--- a/npm/moadim/LICENSE
+++ b/npm/moadim/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Moadim
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/moadim/README.md
+++ b/npm/moadim/README.md
@@ -1,0 +1,15 @@
+# moadim
+
+npm distribution package for the `moadim` daemon CLI.
+
+This package does not compile Moadim during install. It resolves the matching
+prebuilt platform package from optional dependencies and runs that binary:
+
+```sh
+npm install -g moadim
+moadim --version
+```
+
+If installation omitted optional dependencies (`npm install --omit=optional`) or
+the current platform is unsupported, the wrapper prints a clear error and points
+to GitHub Releases for direct downloads.

--- a/npm/moadim/bin/moadim.js
+++ b/npm/moadim/bin/moadim.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+const { spawnSync } = require('node:child_process');
+const { resolveBinary, missingBinaryMessage } = require('../lib/platform.cjs');
+
+const resolved = resolveBinary();
+if (!resolved.ok) {
+  console.error(missingBinaryMessage(resolved));
+  process.exit(1);
+}
+
+const child = spawnSync(resolved.path, process.argv.slice(2), {
+  stdio: 'inherit',
+  windowsHide: false,
+});
+
+if (child.error) {
+  console.error(`Failed to run ${resolved.path}: ${child.error.message}`);
+  process.exit(1);
+}
+
+if (child.signal) {
+  process.kill(process.pid, child.signal);
+}
+
+process.exit(child.status ?? 1);

--- a/npm/moadim/lib/platform.cjs
+++ b/npm/moadim/lib/platform.cjs
@@ -1,0 +1,61 @@
+const { existsSync } = require('node:fs');
+const { join } = require('node:path');
+const { arch, platform, report } = require('node:process');
+
+const PACKAGES = Object.freeze({
+  darwin: {
+    arm64: { packageName: '@moadim/daemon-darwin-arm64', binary: 'moadim' },
+    x64: { packageName: '@moadim/daemon-darwin-x64', binary: 'moadim' },
+  },
+  linux: {
+    x64: {
+      gnu: { packageName: '@moadim/daemon-linux-x64-gnu', binary: 'moadim' },
+    },
+  },
+});
+
+function linuxLibc() {
+  if (process.env.MOADIM_NPM_LIBC) {
+    return process.env.MOADIM_NPM_LIBC;
+  }
+  try {
+    return report?.getReport?.().header?.glibcVersionRuntime ? 'gnu' : 'musl';
+  } catch {
+    return 'gnu';
+  }
+}
+
+function packageFor(currentPlatform = platform, currentArch = arch) {
+  const byArch = PACKAGES[currentPlatform]?.[currentArch];
+  if (!byArch) {
+    return null;
+  }
+  return currentPlatform === 'linux' ? byArch[linuxLibc()] ?? null : byArch;
+}
+
+function resolveBinary() {
+  const selected = packageFor();
+  if (!selected) {
+    return { ok: false, reason: 'unsupported-platform', platform, arch, libc: platform === 'linux' ? linuxLibc() : undefined };
+  }
+
+  const localBinary = join(__dirname, '..', '..', selected.packageName.split('/').pop(), 'bin', selected.binary);
+  if (existsSync(localBinary)) {
+    return { ok: true, path: localBinary, packageName: selected.packageName };
+  }
+
+  try {
+    return { ok: true, path: require.resolve(`${selected.packageName}/bin/${selected.binary}`), packageName: selected.packageName };
+  } catch (error) {
+    return { ok: false, reason: 'missing-optional-dependency', packageName: selected.packageName, error };
+  }
+}
+
+function missingBinaryMessage(result) {
+  if (result.reason === 'unsupported-platform') {
+    return `Moadim does not publish an npm binary for ${result.platform}/${result.arch}${result.libc ? `/${result.libc}` : ''}. Download a release archive from https://github.com/moadim-io/daemon/releases instead.`;
+  }
+  return `Could not find ${result.packageName}, the optional npm package that contains the Moadim binary for this platform. Reinstall without --omit=optional, or download a release archive from https://github.com/moadim-io/daemon/releases.`;
+}
+
+module.exports = { PACKAGES, linuxLibc, packageFor, resolveBinary, missingBinaryMessage };

--- a/npm/moadim/package.json
+++ b/npm/moadim/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "moadim",
+  "version": "3.2.1",
+  "description": "Moadim daemon CLI binary distributed through npm platform packages",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/moadim-io/daemon.git"
+  },
+  "homepage": "https://moadim.io",
+  "bugs": {
+    "url": "https://github.com/moadim-io/daemon/issues"
+  },
+  "bin": {
+    "moadim": "bin/moadim.js"
+  },
+  "files": [
+    "bin",
+    "lib",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "optionalDependencies": {
+    "@moadim/daemon-darwin-arm64": "3.2.1",
+    "@moadim/daemon-darwin-x64": "3.2.1",
+    "@moadim/daemon-linux-x64-gnu": "3.2.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/npm/moadim/test/platform.test.mjs
+++ b/npm/moadim/test/platform.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { test } from 'node:test';
+
+const require = createRequire(import.meta.url);
+const { missingBinaryMessage, packageFor } = require('../lib/platform.cjs');
+
+test('selects macOS packages by architecture', () => {
+  assert.equal(packageFor('darwin', 'arm64').packageName, '@moadim/daemon-darwin-arm64');
+  assert.equal(packageFor('darwin', 'x64').packageName, '@moadim/daemon-darwin-x64');
+});
+
+test('selects Linux glibc package and rejects unsupported musl', () => {
+  process.env.MOADIM_NPM_LIBC = 'gnu';
+  assert.equal(packageFor('linux', 'x64').packageName, '@moadim/daemon-linux-x64-gnu');
+  process.env.MOADIM_NPM_LIBC = 'musl';
+  assert.equal(packageFor('linux', 'x64'), null);
+  delete process.env.MOADIM_NPM_LIBC;
+});
+
+test('returns null for unsupported platforms', () => {
+  assert.equal(packageFor('win32', 'x64'), null);
+});
+
+test('missing optional dependency error explains omit optional', () => {
+  const message = missingBinaryMessage({ reason: 'missing-optional-dependency', packageName: '@moadim/daemon-linux-x64-gnu' });
+  assert.match(message, /--omit=optional/);
+  assert.match(message, /GitHub Releases|release archive/);
+});

--- a/npm/packages.json
+++ b/npm/packages.json
@@ -1,0 +1,31 @@
+{
+  "root": {
+    "name": "moadim",
+    "packageDir": "moadim",
+    "bin": "moadim"
+  },
+  "platforms": [
+    {
+      "target": "aarch64-apple-darwin",
+      "packageDir": "daemon-darwin-arm64",
+      "name": "@moadim/daemon-darwin-arm64",
+      "os": "darwin",
+      "cpu": "arm64"
+    },
+    {
+      "target": "x86_64-apple-darwin",
+      "packageDir": "daemon-darwin-x64",
+      "name": "@moadim/daemon-darwin-x64",
+      "os": "darwin",
+      "cpu": "x64"
+    },
+    {
+      "target": "x86_64-unknown-linux-gnu",
+      "packageDir": "daemon-linux-x64-gnu",
+      "name": "@moadim/daemon-linux-x64-gnu",
+      "os": "linux",
+      "cpu": "x64",
+      "libc": "glibc"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "packageManager": "pnpm@10.33.2",
   "scripts": {
     "changeset": "changeset",
-    "version-packages": "node scripts/release/version-and-sync.mjs"
+    "version-packages": "node scripts/release/version-and-sync.mjs",
+    "generate:npm-packages": "node scripts/release/generate-npm-packages.mjs",
+    "verify:npm-packages": "node scripts/release/verify-npm-packages.mjs && node --test npm/moadim/test/*.test.mjs"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.1",

--- a/scripts/release/generate-npm-packages.mjs
+++ b/scripts/release/generate-npm-packages.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+import { mkdirSync, readFileSync, writeFileSync, copyFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const NPM_DIR = path.join(ROOT, 'npm');
+const MANIFEST_PATH = path.join(NPM_DIR, 'packages.json');
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, 'utf8'));
+}
+
+function readCargoField(field) {
+  const cargoToml = readFileSync(path.join(ROOT, 'Cargo.toml'), 'utf8');
+  const match = cargoToml.match(new RegExp(`^${field} = "([^"]+)"`, 'm'));
+  return match?.[1];
+}
+
+function writeJson(file, value) {
+  writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function syncLicense(destinationDir) {
+  copyFileSync(path.join(ROOT, 'LICENSE'), path.join(destinationDir, 'LICENSE'));
+}
+
+function platformPackageJson(platform, version) {
+  const pkg = {
+    name: platform.name,
+    version,
+    description: `Prebuilt Moadim binary for ${platform.os} ${platform.cpu}${platform.libc ? ` ${platform.libc}` : ''}`,
+    homepage: readCargoField('homepage'),
+    license: readCargoField('license'),
+    repository: {
+      type: 'git',
+      url: `${readCargoField('repository')}.git`,
+    },
+    os: [platform.os],
+    cpu: [platform.cpu],
+    files: ['bin/moadim', 'README.md', 'LICENSE'],
+    publishConfig: {
+      access: 'public',
+      provenance: true,
+    },
+  };
+  if (platform.libc) pkg.libc = [platform.libc];
+  return pkg;
+}
+
+function platformReadme(platform) {
+  return `# ${platform.name}\n\nPrebuilt Moadim binary for ${platform.os} ${platform.cpu}${platform.libc ? ` ${platform.libc}` : ''}.\n`;
+}
+
+export function manifest() {
+  return readJson(MANIFEST_PATH);
+}
+
+export function cargoVersion() {
+  const version = readCargoField('version');
+  if (!version) throw new Error('Cargo.toml is missing a package version');
+  return version;
+}
+
+export function platformDir(platform) {
+  return path.join(NPM_DIR, platform.packageDir);
+}
+
+export function generatePlatformPackages() {
+  const version = cargoVersion();
+  const { platforms } = manifest();
+  for (const platform of platforms) {
+    const dir = platformDir(platform);
+    mkdirSync(path.join(dir, 'bin'), { recursive: true });
+    writeJson(path.join(dir, 'package.json'), platformPackageJson(platform, version));
+    writeFileSync(path.join(dir, 'README.md'), platformReadme(platform));
+    syncLicense(dir);
+    const placeholder = path.join(dir, 'bin', '.gitkeep');
+    if (!existsSync(path.join(dir, 'bin', 'moadim'))) {
+      writeFileSync(placeholder, '');
+    }
+  }
+  console.log(`Generated ${platforms.length} npm platform package(s) for ${version}.`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  generatePlatformPackages();
+}

--- a/scripts/release/stage-npm-binaries.mjs
+++ b/scripts/release/stage-npm-binaries.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import { copyFileSync, chmodSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { generatePlatformPackages, manifest } from './generate-npm-packages.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function usage() {
+  console.error('usage: node scripts/release/stage-npm-binaries.mjs <target-triple> <path-to-moadim-binary>');
+  process.exit(2);
+}
+
+const [target, binaryPath] = process.argv.slice(2);
+if (!target || !binaryPath) usage();
+
+generatePlatformPackages();
+
+const platform = manifest().platforms.find((candidate) => candidate.target === target);
+if (!platform) {
+  throw new Error(`No npm platform package is configured for target ${target}`);
+}
+
+const destinationDir = path.join(ROOT, 'npm', platform.packageDir, 'bin');
+const destination = path.join(destinationDir, process.platform === 'win32' ? 'moadim.exe' : 'moadim');
+mkdirSync(destinationDir, { recursive: true });
+copyFileSync(path.resolve(binaryPath), destination);
+chmodSync(destination, 0o755);
+console.log(`Staged ${target} binary into ${path.relative(ROOT, destination)}`);

--- a/scripts/release/verify-npm-packages.mjs
+++ b/scripts/release/verify-npm-packages.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { cargoVersion, generatePlatformPackages, manifest, platformDir } from './generate-npm-packages.mjs';
+
+const require = createRequire(import.meta.url);
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const ROOT_PACKAGE = path.join(ROOT, 'npm', 'moadim', 'package.json');
+const NPM_WORKFLOW = path.join(ROOT, '.github', 'workflows', 'npm-packages.yml');
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, 'utf8'));
+}
+
+function packageDirs() {
+  const { root, platforms } = manifest();
+  return [
+    path.join(ROOT, 'npm', root.packageDir),
+    ...platforms.map((platform) => platformDir(platform)),
+  ];
+}
+
+function verifyVersions(version) {
+  const workspacePackage = readJson(path.join(ROOT, 'package.json'));
+  if (workspacePackage.version !== version) {
+    throw new Error(`root package.json version ${workspacePackage.version} != Cargo.toml ${version}`);
+  }
+
+  const { platforms } = manifest();
+  const rootPackage = readJson(ROOT_PACKAGE);
+  if (rootPackage.version !== version) {
+    throw new Error(`npm/moadim version ${rootPackage.version} != Cargo.toml ${version}`);
+  }
+
+  const expectedOptional = Object.fromEntries(platforms.map((platform) => [platform.name, version]));
+  const actualOptional = rootPackage.optionalDependencies ?? {};
+  if (JSON.stringify(actualOptional) !== JSON.stringify(expectedOptional)) {
+    throw new Error(`npm/moadim optionalDependencies do not match npm/packages.json for ${version}`);
+  }
+
+  for (const platform of platforms) {
+    const pkg = readJson(path.join(platformDir(platform), 'package.json'));
+    if (pkg.name !== platform.name) {
+      throw new Error(`${platform.packageDir} package name ${pkg.name} != manifest ${platform.name}`);
+    }
+    if (pkg.version !== version) {
+      throw new Error(`${platform.packageDir} version ${pkg.version} != Cargo.toml ${version}`);
+    }
+    if (pkg.os?.[0] !== platform.os || pkg.cpu?.[0] !== platform.cpu) {
+      throw new Error(`${platform.packageDir} os/cpu do not match npm/packages.json`);
+    }
+    if ((pkg.libc?.[0] ?? undefined) !== platform.libc) {
+      throw new Error(`${platform.packageDir} libc does not match npm/packages.json`);
+    }
+  }
+}
+
+function wrapperLibc(platform) {
+  if (platform.os !== 'linux') return undefined;
+  if (platform.libc === 'glibc') return 'gnu';
+  return platform.libc;
+}
+
+function verifyWrapperManifestSync() {
+  const { PACKAGES, packageFor } = require(path.join(ROOT, 'npm', 'moadim', 'lib', 'platform.cjs'));
+  const { platforms } = manifest();
+  const expectedNames = new Set(platforms.map((platform) => platform.name));
+  const actualNames = new Set();
+
+  for (const byArch of Object.values(PACKAGES)) {
+    for (const entry of Object.values(byArch)) {
+      const candidates = entry.packageName ? [entry] : Object.values(entry);
+      for (const candidate of candidates) {
+        actualNames.add(candidate.packageName);
+      }
+    }
+  }
+
+  for (const expectedName of expectedNames) {
+    if (!actualNames.has(expectedName)) {
+      throw new Error(`npm wrapper does not declare ${expectedName} from npm/packages.json`);
+    }
+  }
+  for (const actualName of actualNames) {
+    if (!expectedNames.has(actualName)) {
+      throw new Error(`npm wrapper declares ${actualName}, but npm/packages.json does not`);
+    }
+  }
+
+  const previousLibc = process.env.MOADIM_NPM_LIBC;
+  try {
+    for (const platform of platforms) {
+      if (platform.os === 'linux') {
+        process.env.MOADIM_NPM_LIBC = wrapperLibc(platform);
+      } else {
+        delete process.env.MOADIM_NPM_LIBC;
+      }
+      const selected = packageFor(platform.os, platform.cpu);
+      if (selected?.packageName !== platform.name) {
+        throw new Error(`npm wrapper selects ${selected?.packageName ?? 'nothing'} for ${platform.os}/${platform.cpu}, expected ${platform.name}`);
+      }
+    }
+  } finally {
+    if (previousLibc === undefined) {
+      delete process.env.MOADIM_NPM_LIBC;
+    } else {
+      process.env.MOADIM_NPM_LIBC = previousLibc;
+    }
+  }
+}
+
+function verifyWorkflowManifestSync() {
+  const workflow = readFileSync(NPM_WORKFLOW, 'utf8');
+  const { platforms } = manifest();
+  for (const platform of platforms) {
+    if (!workflow.includes(`target: ${platform.target}`)) {
+      throw new Error(`npm workflow matrix is missing target ${platform.target} from npm/packages.json`);
+    }
+    if (!workflow.includes(`package_dir: ${platform.packageDir}`)) {
+      throw new Error(`npm workflow build matrix is missing ${platform.packageDir} from npm/packages.json`);
+    }
+    if (!workflow.includes(`- ${platform.packageDir}`)) {
+      throw new Error(`npm workflow publish matrix is missing ${platform.packageDir} from npm/packages.json`);
+    }
+  }
+}
+
+function verifyPackContents() {
+  const requirePlatformBinaries = process.env.MOADIM_REQUIRE_NPM_BINARIES === '1';
+  const { root, platforms } = manifest();
+  const requiredPackageDir = process.env.MOADIM_REQUIRED_NPM_PACKAGE;
+  if (requiredPackageDir && !platforms.some((platform) => platform.packageDir === requiredPackageDir)) {
+    throw new Error(`${requiredPackageDir} is not declared in npm/packages.json`);
+  }
+  const platformDirs = new Set(platforms.map((platform) => platformDir(platform)));
+  const requiredPlatformDirs = new Set(
+    requirePlatformBinaries
+      ? platforms
+          .filter((platform) => !requiredPackageDir || platform.packageDir === requiredPackageDir)
+          .map((platform) => platformDir(platform))
+      : [],
+  );
+
+  for (const dir of packageDirs()) {
+    const output = execFileSync('npm', ['pack', '--json', '--dry-run'], { cwd: dir, encoding: 'utf8' });
+    const [{ files }] = JSON.parse(output);
+    const names = files.map((file) => file.path).sort();
+    if (!names.includes('package.json')) throw new Error(`${dir} pack is missing package.json`);
+    if (requirePlatformBinaries && requiredPlatformDirs.has(dir) && !names.includes('bin/moadim')) {
+      throw new Error(`${dir} pack is missing staged bin/moadim`);
+    }
+    if (!platformDirs.has(dir) && path.basename(dir) !== root.packageDir) {
+      throw new Error(`${dir} is not declared in npm/packages.json`);
+    }
+    for (const forbidden of ['Cargo.toml', '.env', 'node_modules/', 'target/']) {
+      if (names.some((name) => name === forbidden || name.startsWith(forbidden))) {
+        throw new Error(`${dir} pack includes forbidden path ${forbidden}`);
+      }
+    }
+  }
+}
+
+function main() {
+  generatePlatformPackages();
+  const version = cargoVersion();
+  verifyVersions(version);
+  verifyWrapperManifestSync();
+  verifyWorkflowManifestSync();
+  verifyPackContents();
+  const binaryMode = process.env.MOADIM_REQUIRE_NPM_BINARIES === '1' ? ' with staged platform binaries' : '';
+  console.log(`npm package versions and pack contents${binaryMode} match Cargo.toml ${version}.`);
+}
+
+main();

--- a/scripts/release/version-and-sync.mjs
+++ b/scripts/release/version-and-sync.mjs
@@ -21,6 +21,9 @@ const CHANGELOG_PATH = path.join(ROOT, "CHANGELOG.md");
 const PACKAGE_JSON_PATH = path.join(ROOT, "package.json");
 const CARGO_TOML_PATH = path.join(ROOT, "Cargo.toml");
 const MAN_PAGE_PATH = path.join(ROOT, "docs", "moadim.1");
+const NPM_DIR = path.join(ROOT, "npm");
+const NPM_MANIFEST_PATH = path.join(NPM_DIR, "packages.json");
+const NPM_ROOT_PACKAGE_PATH = path.join(NPM_DIR, "moadim", "package.json");
 const REPO_URL = "https://github.com/moadim-io/daemon";
 
 function readPendingChangesets() {
@@ -64,6 +67,24 @@ function bumpManPage(version) {
     throw new Error(`Could not find a .TH header line in ${MAN_PAGE_PATH}`);
   }
   writeFileSync(MAN_PAGE_PATH, next);
+}
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, "utf8"));
+}
+
+function writeJson(file, value) {
+  writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function syncNpmPackages(version) {
+  const manifest = readJson(NPM_MANIFEST_PATH);
+  const rootPackage = readJson(NPM_ROOT_PACKAGE_PATH);
+  rootPackage.version = version;
+  rootPackage.optionalDependencies = Object.fromEntries(
+    manifest.platforms.map((platform) => [platform.name, version]),
+  );
+  writeJson(NPM_ROOT_PACKAGE_PATH, rootPackage);
 }
 
 function todayIso() {
@@ -145,6 +166,7 @@ function main() {
   updateChangelog(version, combinedBody);
   bumpCargoToml(version);
   bumpManPage(version);
+  syncNpmPackages(version);
 
   execSync("cargo check -q", { cwd: ROOT, stdio: "inherit" });
 
@@ -163,7 +185,7 @@ function main() {
     );
   }
 
-  console.log(`Synced Cargo.toml, Cargo.lock, CHANGELOG.md, docs/moadim.1, and apis/openapi.json to ${version}.`);
+  console.log(`Synced Cargo.toml, Cargo.lock, CHANGELOG.md, docs/moadim.1, apis/openapi.json, and npm root package metadata to ${version}.`);
 }
 
 main();


### PR DESCRIPTION
## Summary

- replace the old npm bootstrapper direction with npm binary distribution packages
- add `npm/moadim` as the thin user-facing wrapper and platform packages for current release targets:
  - `@moadim/daemon-darwin-arm64`
  - `@moadim/daemon-darwin-x64`
  - `@moadim/daemon-linux-x64-gnu`
- add version lockstep validation so root package.json, Cargo.toml, npm package versions, and optional dependency pins stay identical
- add parallel npm package CI/release workflow: metadata validation + matrix binary builds, then platform package publish before root publish
- update release docs and version sync so npm packages follow the Rust release version

## Verification

- `pnpm verify:npm-packages`
- `make readme-check`
- `cargo fmt`
- `linecheck --max-lines 200 $(find src -name '*.rs')`
- `cargo check --all-targets`
- local packed install smoke with a fake current-platform binary: `./node_modules/.bin/moadim --version` -> `moadim 3.2.0`
- `.githooks/pre-push` passed after rebasing onto current `origin/main`:
  - cargo test: 1262 passed
  - cargo llvm-cov: 100% line coverage
  - client vitest: 493 passed
  - client typecheck/lint passed

## Notes

This intentionally does not run `cargo install` from npm install scripts. It follows the Rollup/esbuild/Biome-style optional platform package architecture and keeps the final publish ordering serialized only where needed: platform packages first, root package last.
