### PR TITLE
chore(release): version packages

### DIFF
--- a/.changeset/crontab-sync-retry.md
+++ b/.changeset/crontab-sync-retry.md
@@ -1,6 +1,0 @@
----
-"client": patch
-"moadim": patch
----
-
-Add a manual crontab sync retry endpoint and surface it from Settings system health.

--- a/.changeset/crontab-sync-status-recovery.md
+++ b/.changeset/crontab-sync-status-recovery.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-Add crontab sync staleness and macOS recovery guidance to `moadim status` output.

--- a/.changeset/npm-binary-packages.md
+++ b/.changeset/npm-binary-packages.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-Add npm binary distribution package scaffolding with platform optional packages, Rust/npm version lockstep checks, and parallel npm package CI/release jobs.

--- a/.changeset/routine-filesystem-tree.md
+++ b/.changeset/routine-filesystem-tree.md
@@ -1,5 +1,0 @@
----
-"client": patch
----
-
-Add a filesystem tree view for routines that groups by folder metadata and keeps routine actions available from each file node.

--- a/.changeset/routine-repository-auto-pull.md
+++ b/.changeset/routine-repository-auto-pull.md
@@ -1,6 +1,0 @@
----
-"moadim": patch
-"client": patch
----
-
-Allow routine repositories to opt out of the default pre-run auto-pull/materialization flow.

--- a/.changeset/settings-crontab-recovery.md
+++ b/.changeset/settings-crontab-recovery.md
@@ -1,5 +1,0 @@
----
-"client": patch
----
-
-Show crontab sync recovery guidance in Settings system health.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+## [3.2.2] - 2026-07-31
+
+Add a manual crontab sync retry endpoint and surface it from Settings system health.
+
+Add crontab sync staleness and macOS recovery guidance to `moadim status` output.
+
+Add npm binary distribution package scaffolding with platform optional packages, Rust/npm version lockstep checks, and parallel npm package CI/release jobs.
+
+Add a filesystem tree view for routines that groups by folder metadata and keeps routine actions available from each file node.
+
+Allow routine repositories to opt out of the default pre-run auto-pull/materialization flow.
+
+Show crontab sync recovery guidance in Settings system health.
+
 ## [3.2.1] - 2026-07-31
 
 Surface failed OS crontab sync status as a global header warning so stale schedule installs are visible in the UI.
@@ -4998,7 +5012,8 @@ Enable `clippy::match_same_arms` and merge the two duplicate-body arms it flagge
 - Ship the prebuilt UI in the published crate.
 - Rename the binary to `moadim` and add install docs.
 
-[Unreleased]: https://github.com/moadim-io/daemon/compare/v3.2.1...HEAD
+[Unreleased]: https://github.com/moadim-io/daemon/compare/v3.2.2...HEAD
+[3.2.2]: https://github.com/moadim-io/daemon/compare/v3.2.1...v3.2.2
 [3.2.1]: https://github.com/moadim-io/daemon/compare/v3.2.0...v3.2.1
 [3.2.0]: https://github.com/moadim-io/daemon/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/moadim-io/daemon/compare/v3.0.0...v3.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moadim"
-version = "3.2.1"
+version = "3.2.2"
 edition = "2021"
 # Floor set by the transitive proc-macro build dependency `darling 0.23`
 # (pulled in via `rmcp-macros` <- `rmcp`), which itself declares

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "3.2.1"
+    "version": "3.2.2"
   },
   "servers": [
     {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/moadim.1
+++ b/docs/moadim.1
@@ -1,7 +1,7 @@
 .\" Man page for moadim.
 .\" Mirrors the built-in `moadim --help` output (src/cli/mod.rs::print_help).
 .\" View with:  man ./docs/moadim.1   or install into share/man/man1/.
-.TH MOADIM 1 "2026-07-31" "moadim 3.2.1" "Moadim Manual"
+.TH MOADIM 1 "2026-07-31" "moadim 3.2.2" "Moadim Manual"
 .SH NAME
 moadim \- routine scheduler with an MCP/REST API and a web control panel
 .SH SYNOPSIS

--- a/npm/moadim/package.json
+++ b/npm/moadim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moadim",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Moadim daemon CLI binary distributed through npm platform packages",
   "license": "MIT",
   "repository": {
@@ -24,9 +24,9 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@moadim/daemon-darwin-arm64": "3.2.1",
-    "@moadim/daemon-darwin-x64": "3.2.1",
-    "@moadim/daemon-linux-x64-gnu": "3.2.1"
+    "@moadim/daemon-darwin-arm64": "3.2.2",
+    "@moadim/daemon-darwin-x64": "3.2.2",
+    "@moadim/daemon-linux-x64-gnu": "3.2.2"
   },
   "publishConfig": {
     "access": "public",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moadim",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "scripts": {


### PR DESCRIPTION
Release moadim v3.2.2.

Generated by cut-release.yml run 30671653792 after merging feature PR #1490.

Includes:
- consumes pending changesets
- updates Cargo/client/npm package versions
- updates CHANGELOG and generated release metadata
