### PR TITLE
fix: ignore repo cache in config gitignore

### DIFF
--- a/.changeset/silent-turtles-notice.md
+++ b/.changeset/silent-turtles-notice.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Include the daemon's repo mirror cache in the generated config .gitignore so cached clones don't show up as untracked files.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ install -Dm644 docs/moadim.1 "$HOME/.local/share/man/man1/moadim.1"
 │           └── prompt.compiled.local.md  # gitignored — derived, rendered prompt
 ├── agents/                    # registered coding agents referenced by routines
 │   └── claude.toml
-├── .gitignore                 # generated — excludes *.compiled.*, *.local.*, *.log, … for the whole tree
+├── .gitignore                 # generated — excludes *.compiled.*, *.local.*, *.log, cache/, … for the whole tree
 └── user_prompt.md             # optional — appended to every routine's prompt (see ## Routines)
 
 ~/.moadim/                     # runtime tree, separate from the config dir above

--- a/src/cli/ensure_config_gitignore.rs
+++ b/src/cli/ensure_config_gitignore.rs
@@ -1,4 +1,3 @@
-
 /// Ensure the config dir `.gitignore` contains all required patterns on every start.
 ///
 /// This is the single `.gitignore` for the whole config tree — its patterns apply recursively, so
@@ -6,8 +5,8 @@
 /// generated): `*.local.*` catches the machine-local sidecars (`state.local.toml`,
 /// `routine.local.toml`, `prompt.compiled.local.md`), `*.log` the trigger logs, `*.compiled.*`
 /// the legacy `prompts/prompt.compiled.md`, `schedule.compailed.cron` the cron-union output,
-/// `.compailed.cron` the legacy cron-union output name, and `run.sh` the obsolete per-routine
-/// launch script.
+/// `.compailed.cron` the legacy cron-union output name, `run.sh` the obsolete per-routine launch
+/// script, and `cache/` the persistent repository mirror cache.
 ///
 /// Reads the existing file (if any), appends any missing patterns, and writes back only when
 /// something changed. Preserves user-added entries. Best-effort: failure is not fatal.
@@ -20,6 +19,7 @@ fn ensure_config_gitignore() {
         "schedule.compailed.cron",
         ".compailed.cron",
         "run.sh",
+        "cache/",
     ];
     let gitignore = crate::paths::config_gitignore_path();
     let existing = std::fs::read_to_string(&gitignore).unwrap_or_default();

--- a/src/cli/pid_file_write_read_clear_roundtrip_tests.rs
+++ b/src/cli/pid_file_write_read_clear_roundtrip_tests.rs
@@ -17,6 +17,10 @@ fn pid_file_write_read_clear_roundtrip() {
         "gitignore must cover cron-union output"
     );
     assert!(
+        content.contains("cache/"),
+        "gitignore must cover repo cache"
+    );
+    assert!(
         content.contains(".compailed.cron"),
         "gitignore must keep covering legacy cron-union output"
     );
@@ -32,6 +36,10 @@ fn pid_file_write_read_clear_roundtrip() {
     assert!(
         content.contains("schedule.compailed.cron"),
         "missing cron-union pattern must be re-added"
+    );
+    assert!(
+        content.contains("cache/"),
+        "missing repo cache pattern must be re-added"
     );
     assert!(
         content.contains(".compailed.cron"),

--- a/src/cli/system.rs
+++ b/src/cli/system.rs
@@ -85,6 +85,7 @@ routines and agents across machines.
 - `agents/` — the agent registry referenced by routines; see its own `README.md`.
 - `machine.local.toml` — this machine's identity, used to match a routine's `machines`
   targeting list. Gitignored: it's per-machine, not shared.
+- `cache/` — persistent local git mirror cache for declared repositories. Gitignored.
 - `moadim.pid`, `daemon.log` — daemon-managed runtime files. Gitignored.
 - `.gitignore` — seeded and kept up to date by the daemon; append your own patterns freely.
 


### PR DESCRIPTION
Add the persistent repository mirror cache to the generated config .gitignore.

What changed:
- seed cache/ in the generated config .gitignore
- document the cache entry in the config README text and top-level README
- add a regression test that verifies write_pid_file seeds and restores the cache ignore pattern

Verification:
- cargo test pid_file_write_read_clear_roundtrip -- --nocapture