### PR TITLE
feat(routines): store disabled state in disabled.json

### DIFF
--- a/.changeset/routine-disabled-json.md
+++ b/.changeset/routine-disabled-json.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Store routine disabled state in a tracked `disabled.json` marker while keeping legacy `enabled = false` routine TOML files loadable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+Store routine disable intent in a tracked `disabled.json` marker with basic audit metadata while keeping legacy `enabled = false` TOML configs loadable.
+
 ## [3.2.3] - 2026-08-01
 
 Protect REST/MCP with optional MOADIM_API_TOKEN authentication and send that token from the CLI/UI.

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -108,6 +108,13 @@ pub fn routine_cron_path(id: &str) -> PathBuf {
     routine_dir(id).join("schedule.cron")
 }
 
+/// Returns the path to `{routines_dir}/{id}/disabled.json`, the tracked marker whose presence
+/// disables the routine while carrying basic audit metadata.
+#[must_use]
+pub fn routine_disabled_json_path(id: &str) -> PathBuf {
+    routine_dir(id).join("disabled.json")
+}
+
 /// Returns the path to `{routines_dir}/{id}/schedule.compailed.cron`, the gitignored cron-union output.
 ///
 /// `schedule.cron` stays the human-authored source; this derived file is rewritten by crontab

--- a/src/read_runtime_state.rs
+++ b/src/read_runtime_state.rs
@@ -84,6 +84,9 @@ pub(crate) fn write_routine_to_rel_dir(routine: &Routine, rel_dir: &str) -> std:
     }
     crate::utils::fs_perms::create_private_dir_all(&dir)?;
     crate::utils::fs_perms::create_private_dir_all(&routine_prompts_dir(rel_dir))?;
+    if !routine.enabled {
+        write_disabled_state(rel_dir, false)?;
+    }
 
     // Remove any stale `run.sh` left by an older daemon that generated per-routine launch scripts;
     // the crontab line now invokes the binary directly, so the script is obsolete. Best-effort: a
@@ -100,7 +103,7 @@ pub(crate) fn write_routine_to_rel_dir(routine: &Routine, rel_dir: &str) -> std:
         goal: routine.goal.clone(),
         repositories: routine.repositories.clone(),
         machines: routine.machines.clone(),
-        enabled: Some(routine.enabled),
+        enabled: None,
         power_saving_exempt: routine.power_saving_exempt,
         created_at: Some(routine.created_at),
         updated_at: Some(routine.updated_at),
@@ -133,6 +136,9 @@ pub(crate) fn write_routine_to_rel_dir(routine: &Routine, rel_dir: &str) -> std:
         compose_prompt(routine).as_bytes(),
     )?;
     write_runtime_state(rel_dir, routine)?;
+    if routine.enabled {
+        write_disabled_state(rel_dir, true)?;
+    }
     Ok(())
 }
 

--- a/src/routine_disabled_state.rs
+++ b/src/routine_disabled_state.rs
@@ -1,0 +1,51 @@
+//! Read/write support for the tracked `disabled.json` routine marker.
+
+use chrono::{SecondsFormat, Utc};
+
+use crate::utils::atomic::atomic_write;
+
+/// Resolve enabled state from `disabled.json` first, then legacy `routine.toml`.
+pub(crate) fn read_enabled_state(
+    base: &std::path::Path,
+    dir_name: &str,
+    legacy_enabled: Option<bool>,
+) -> bool {
+    if base.join(dir_name).join("disabled.json").exists() {
+        false
+    } else {
+        legacy_enabled.unwrap_or(true)
+    }
+}
+
+/// Persist the source-of-truth disabled marker for a routine.
+pub(crate) fn write_disabled_state(rel_dir: &str, enabled: bool) -> std::io::Result<()> {
+    let path = crate::paths::routine_disabled_json_path(rel_dir);
+    if enabled {
+        if path.exists() {
+            std::fs::remove_file(path)?;
+        }
+        return Ok(());
+    }
+    let marker = serde_json::json!({
+        "version": 1,
+        "disabled_at": Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+        "disabled_by_machine": crate::machine::current_machine(),
+        "disabled_by_user": current_user(),
+        "source": "daemon",
+    });
+    let text = marker.to_string();
+    atomic_write(&path, text.as_bytes())?;
+    Ok(())
+}
+
+/// Best-effort current OS user for audit metadata.
+fn current_user() -> Option<String> {
+    ["USER", "USERNAME"]
+        .into_iter()
+        .find_map(|key| std::env::var(key).ok())
+        .filter(|value| !value.trim().is_empty())
+}
+
+#[cfg(test)]
+#[path = "routine_disabled_state_tests.rs"]
+mod routine_disabled_state_tests;

--- a/src/routine_disabled_state_tests.rs
+++ b/src/routine_disabled_state_tests.rs
@@ -1,0 +1,59 @@
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and fixtures do not need doc comments"
+)]
+
+use std::sync::Mutex;
+
+use super::current_user;
+
+static ENV_GUARD: Mutex<()> = Mutex::new(());
+
+fn with_user_env(user: Option<&str>, username: Option<&str>, body: impl FnOnce()) {
+    let guard = ENV_GUARD
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let saved_user = std::env::var_os("USER");
+    let saved_username = std::env::var_os("USERNAME");
+    // SAFETY: this test serializes env mutations with ENV_GUARD.
+    unsafe {
+        match user {
+            Some(value) => std::env::set_var("USER", value),
+            None => std::env::remove_var("USER"),
+        }
+        match username {
+            Some(value) => std::env::set_var("USERNAME", value),
+            None => std::env::remove_var("USERNAME"),
+        }
+    }
+    body();
+    // SAFETY: this test serializes env mutations with ENV_GUARD.
+    unsafe {
+        match saved_user {
+            Some(value) => std::env::set_var("USER", value),
+            None => std::env::remove_var("USER"),
+        }
+        match saved_username {
+            Some(value) => std::env::set_var("USERNAME", value),
+            None => std::env::remove_var("USERNAME"),
+        }
+    }
+    drop(guard);
+}
+
+#[test]
+fn current_user_prefers_user_env_when_present() {
+    with_user_env(Some("alice"), Some("bob"), || {
+        assert_eq!(current_user().as_deref(), Some("alice"));
+    });
+}
+
+#[test]
+fn current_user_falls_back_to_username_and_ignores_blank_values() {
+    with_user_env(None, Some("bob"), || {
+        assert_eq!(current_user().as_deref(), Some("bob"));
+    });
+    with_user_env(Some("   "), None, || {
+        assert_eq!(current_user(), None);
+    });
+}

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -10,6 +10,9 @@ use crate::utils::lock::LockRecover;
 #[path = "read_runtime_state.rs"]
 mod read_runtime_state;
 pub(crate) use read_runtime_state::*;
+#[path = "routine_disabled_state.rs"]
+mod routine_disabled_state;
+pub(crate) use routine_disabled_state::*;
 
 // Re-exported (as `super::routines_dir`) for `routine_storage_migrations`; not called directly
 // in this file since `load_store`/`load_store_from_dir` moved to `routine_storage_load`.
@@ -61,6 +64,12 @@ struct RoutineToml {
     #[serde(default)]
     machines: Vec<String>,
     /// Whether the routine is enabled.
+    ///
+    /// **Read-only / legacy.** Disable intent now lives in the tracked `disabled.json` marker:
+    /// marker present means disabled, marker absent means enabled. This field is still parsed so
+    /// older routine.toml files with `enabled = false` continue to load during migration, but it is
+    /// never written back.
+    #[serde(default, skip_serializing)]
     enabled: Option<bool>,
     /// Whether the routine may launch while the host is in system power saving.
     #[serde(default)]

--- a/src/routine_storage_2.rs
+++ b/src/routine_storage_2.rs
@@ -85,3 +85,7 @@ mod routine_storage_env_tests;
 #[cfg(test)]
 #[path = "routine_storage_location_tests.rs"]
 mod routine_storage_location_tests;
+
+#[cfg(test)]
+#[path = "routine_storage_disabled_json_tests.rs"]
+mod routine_storage_disabled_json_tests;

--- a/src/routine_storage_disabled_json_tests.rs
+++ b/src/routine_storage_disabled_json_tests.rs
@@ -1,0 +1,167 @@
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and fixtures do not need doc comments"
+)]
+
+use super::*;
+use crate::routines::{slugify, Repository, Routine};
+
+fn scratch_dir(tag: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!("moadim-disabled-{tag}-{}", uuid::Uuid::new_v4()))
+}
+
+fn with_override_home(body: impl FnOnce(&std::path::Path)) {
+    let home = scratch_dir("override-home");
+    std::fs::create_dir_all(&home).unwrap();
+    let previous = std::env::var_os("MOADIM_HOME_OVERRIDE");
+    // SAFETY: tests in this crate run single-threaded per binary.
+    unsafe {
+        std::env::set_var("MOADIM_HOME_OVERRIDE", &home);
+    }
+    body(&home);
+    // SAFETY: tests in this crate run single-threaded per binary.
+    unsafe {
+        match previous {
+            Some(value) => std::env::set_var("MOADIM_HOME_OVERRIDE", value),
+            None => std::env::remove_var("MOADIM_HOME_OVERRIDE"),
+        }
+    }
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+fn make_routine(id: &str, title: &str, enabled: bool) -> Routine {
+    Routine {
+        model: None,
+        id: id.to_string(),
+        schedule: "@daily".to_string(),
+        schedules: vec![],
+        title: title.to_string(),
+        agent: "claude".to_string(),
+        prompt: "task".to_string(),
+        goal: None,
+        repositories: vec![Repository {
+            repository: "https://example.com/r.git".to_string(),
+            branch: Some("main".to_string()),
+            auto_pull: true,
+        }],
+        machines: vec![crate::machine::current_machine()],
+        enabled,
+        source: "managed".to_string(),
+        created_at: 5,
+        updated_at: 6,
+        last_manual_trigger_at: None,
+        last_scheduled_trigger_at: None,
+        snoozed_until: None,
+        skip_runs: None,
+        power_saving: false,
+        power_saving_exempt: false,
+        tags: vec![],
+        ttl_secs: None,
+        max_runtime_secs: None,
+        env: std::collections::HashMap::new(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
+        notifications: Default::default(),
+    }
+}
+
+#[test]
+fn disabled_routine_writes_disabled_json_instead_of_enabled_toml() {
+    with_override_home(|_home| {
+        let title = "Rs Disabled Json Routine";
+        let slug = slugify(title);
+        write_routine(&make_routine("rs-disabled-json-id", title, false)).unwrap();
+
+        let disabled_text = std::fs::read_to_string(crate::paths::routine_disabled_json_path(&slug))
+            .expect("disabled.json should be written for disabled routines");
+        let disabled: serde_json::Value = serde_json::from_str(&disabled_text).unwrap();
+        assert_eq!(disabled["version"], 1);
+        assert_eq!(disabled["disabled_by_machine"], crate::machine::current_machine());
+        assert_eq!(disabled["source"], "daemon");
+        assert!(disabled["disabled_at"].as_str().is_some());
+        assert!(disabled.get("reason").is_none());
+
+        let toml_text = std::fs::read_to_string(crate::paths::routine_toml_path(&slug)).unwrap();
+        assert!(
+            !toml_text.contains("enabled"),
+            "routine.toml must not carry enabled state"
+        );
+        assert!(!load_routine_from_dir(&slug).unwrap().enabled);
+    });
+}
+
+#[test]
+fn enabling_routine_removes_disabled_json() {
+    with_override_home(|_home| {
+        let title = "Rs Enable Removes Disabled Json";
+        let slug = slugify(title);
+        write_routine(&make_routine("rs-enable-removes-disabled-json-id", title, false)).unwrap();
+        assert!(crate::paths::routine_disabled_json_path(&slug).exists());
+
+        write_routine(&make_routine("rs-enable-removes-disabled-json-id", title, true)).unwrap();
+
+        assert!(!crate::paths::routine_disabled_json_path(&slug).exists());
+        assert!(load_routine_from_dir(&slug).unwrap().enabled);
+    });
+}
+
+#[test]
+fn disabled_json_presence_wins_over_legacy_toml_enabled_true_even_when_invalid() {
+    with_override_home(|_home| {
+        let title = "Rs Disabled Json Wins";
+        let slug = slugify(title);
+        write_routine(&make_routine("rs-disabled-json-wins-id", title, true)).unwrap();
+        std::fs::write(crate::paths::routine_disabled_json_path(&slug), b"not json").unwrap();
+
+        assert!(!load_routine_from_dir(&slug).unwrap().enabled);
+    });
+}
+
+#[test]
+fn legacy_toml_enabled_false_still_loads_as_disabled_without_disabled_json() {
+    with_override_home(|_home| {
+        let title = "Rs Legacy Toml Disabled";
+        let slug = slugify(title);
+        write_routine(&make_routine("rs-legacy-toml-disabled-id", title, true)).unwrap();
+        let toml_path = crate::paths::routine_toml_path(&slug);
+        let toml_text = std::fs::read_to_string(&toml_path).unwrap();
+        std::fs::write(
+            toml_path,
+            toml_text.replace("agent = \"claude\"", "agent = \"claude\"\nenabled = false"),
+        )
+        .unwrap();
+
+        assert!(!load_routine_from_dir(&slug).unwrap().enabled);
+    });
+}
+
+#[test]
+fn write_disabled_state_reports_remove_failure_when_marker_path_is_directory() {
+    with_override_home(|_home| {
+        let slug = "disabled-marker-directory";
+        std::fs::create_dir_all(crate::paths::routine_disabled_json_path(slug)).unwrap();
+
+        let err = write_disabled_state(slug, true).unwrap_err();
+
+        assert!(matches!(
+            err.kind(),
+            std::io::ErrorKind::IsADirectory | std::io::ErrorKind::PermissionDenied
+        ));
+    });
+}
+
+#[test]
+fn write_disabled_state_reports_atomic_write_failure_when_marker_path_is_directory() {
+    with_override_home(|_home| {
+        let slug = "disabled-marker-write-directory";
+        std::fs::create_dir_all(crate::paths::routine_disabled_json_path(slug)).unwrap();
+
+        let err = write_disabled_state(slug, false).unwrap_err();
+
+        assert!(matches!(
+            err.kind(),
+            std::io::ErrorKind::IsADirectory | std::io::ErrorKind::AlreadyExists
+        ));
+    });
+}

--- a/src/routine_storage_load.rs
+++ b/src/routine_storage_load.rs
@@ -11,7 +11,7 @@ use crate::paths::routines_dir;
 use crate::routines::{Routine, RoutineStore};
 use crate::utils::lock::LockRecover;
 
-use super::{read_routine_crons, read_routine_toml, read_runtime_state};
+use super::{read_enabled_state, read_routine_crons, read_routine_toml, read_runtime_state};
 
 #[path = "routine_storage_walk.rs"]
 mod routine_storage_walk;
@@ -94,7 +94,7 @@ fn load_routine_from_base(base: &std::path::Path, dir_name: &str) -> Option<Rout
         goal: toml.goal,
         repositories: toml.repositories,
         machines: toml.machines,
-        enabled: toml.enabled.unwrap_or(true),
+        enabled: read_enabled_state(base, dir_name, toml.enabled),
         power_saving_exempt: toml.power_saving_exempt,
         source: "managed".to_string(),
         created_at: toml.created_at.unwrap_or(0),


### PR DESCRIPTION
## Summary
- store disabled routine state in a tracked `disabled.json` marker instead of writing `enabled` into `routine.toml`
- keep legacy `enabled = false` TOML files loadable, with `disabled.json` presence taking precedence even if its JSON is invalid
- write basic disable audit metadata (`version`, `disabled_at`, `disabled_by_machine`, `disabled_by_user`, `source`) without adding reason support

Closes #1501.

## Verification
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` — 1314 passed
- `cargo llvm-cov --fail-under-lines 100 ...` — TOTAL 100.00%
- `linecheck --max-lines 200 ...`
- `git push` pre-push hook — Rust checks, coverage, line-count, client typecheck/lint/test (507 passed), changeset check

## Notes
- Reason metadata/input is intentionally excluded; that remains stacked on #1502.
