### PR TITLE
refactor(tests): centralize routine fixtures

### DIFF
--- a/.changeset/routine-object-fixtures.md
+++ b/.changeset/routine-object-fixtures.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Centralize routine test fixture construction so activation metadata changes do not require repeated struct-literal updates across storage tests.

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,8 @@ mod service;
 mod sync;
 /// Host power-state detector for conservative routine launch throttling.
 mod system_power;
+#[cfg(test)]
+mod test_fixtures;
 /// Shared utility functions.
 mod utils;
 

--- a/src/routine_storage_disabled_json_tests.rs
+++ b/src/routine_storage_disabled_json_tests.rs
@@ -4,7 +4,7 @@
 )]
 
 use super::*;
-use crate::routines::{slugify, Repository, Routine};
+use crate::routines::{slugify, Routine};
 
 fn scratch_dir(tag: &str) -> std::path::PathBuf {
     std::env::temp_dir().join(format!("moadim-disabled-{tag}-{}", uuid::Uuid::new_v4()))
@@ -30,41 +30,9 @@ fn with_override_home(body: impl FnOnce(&std::path::Path)) {
 }
 
 fn make_routine(id: &str, title: &str, enabled: bool) -> Routine {
-    Routine {
-        model: None,
-        id: id.to_string(),
-        schedule: "@daily".to_string(),
-        schedules: vec![],
-        title: title.to_string(),
-        agent: "claude".to_string(),
-        prompt: "task".to_string(),
-        goal: None,
-        repositories: vec![Repository {
-            repository: "https://example.com/r.git".to_string(),
-            branch: Some("main".to_string()),
-            auto_pull: true,
-        }],
-        machines: vec![crate::machine::current_machine()],
-        enabled,
-        disabled_reason: None,
-        source: "managed".to_string(),
-        created_at: 5,
-        updated_at: 6,
-        last_manual_trigger_at: None,
-        last_scheduled_trigger_at: None,
-        snoozed_until: None,
-        skip_runs: None,
-        power_saving: false,
-        power_saving_exempt: false,
-        tags: vec![],
-        ttl_secs: None,
-        max_runtime_secs: None,
-        env: std::collections::HashMap::new(),
-        auto_disabled_reason: None,
-        consecutive_failures: 0,
-        failure_threshold: None,
-        notifications: Default::default(),
-    }
+    crate::test_fixtures::routine_fixture(id, title)
+        .enabled(enabled)
+        .build()
 }
 
 #[test]

--- a/src/routine_storage_disabled_reason_tests.rs
+++ b/src/routine_storage_disabled_reason_tests.rs
@@ -4,7 +4,7 @@
 )]
 
 use super::*;
-use crate::routines::{slugify, Repository, Routine};
+use crate::routines::{slugify, Routine};
 
 fn scratch_dir(tag: &str) -> std::path::PathBuf {
     std::env::temp_dir().join(format!("moadim-disabled-reason-{tag}-{}", uuid::Uuid::new_v4()))
@@ -30,41 +30,9 @@ fn with_override_home(body: impl FnOnce(&std::path::Path)) {
 }
 
 fn make_routine(id: &str, title: &str, enabled: bool) -> Routine {
-    Routine {
-        model: None,
-        id: id.to_string(),
-        schedule: "@daily".to_string(),
-        schedules: vec![],
-        title: title.to_string(),
-        agent: "claude".to_string(),
-        prompt: "task".to_string(),
-        goal: None,
-        repositories: vec![Repository {
-            repository: "https://example.com/r.git".to_string(),
-            branch: Some("main".to_string()),
-            auto_pull: true,
-        }],
-        machines: vec![crate::machine::current_machine()],
-        enabled,
-        disabled_reason: None,
-        source: "managed".to_string(),
-        created_at: 5,
-        updated_at: 6,
-        last_manual_trigger_at: None,
-        last_scheduled_trigger_at: None,
-        snoozed_until: None,
-        skip_runs: None,
-        power_saving: false,
-        power_saving_exempt: false,
-        tags: vec![],
-        ttl_secs: None,
-        max_runtime_secs: None,
-        env: std::collections::HashMap::new(),
-        auto_disabled_reason: None,
-        consecutive_failures: 0,
-        failure_threshold: None,
-        notifications: Default::default(),
-    }
+    crate::test_fixtures::routine_fixture(id, title)
+        .enabled(enabled)
+        .build()
 }
 
 #[test]
@@ -72,8 +40,10 @@ fn disabled_routine_writes_optional_reason_to_disabled_json() {
     with_override_home(|_home| {
         let title = "Rs Disabled Json Reason";
         let slug = slugify(title);
-        let mut routine = make_routine("rs-disabled-json-reason-id", title, false);
-        routine.disabled_reason = Some("Temporarily noisy".to_string());
+        let routine = crate::test_fixtures::routine_fixture("rs-disabled-json-reason-id", title)
+            .enabled(false)
+            .disabled_reason("Temporarily noisy")
+            .build();
 
         write_routine(&routine).unwrap();
 

--- a/src/routine_storage_gitignore_tests.rs
+++ b/src/routine_storage_gitignore_tests.rs
@@ -4,7 +4,7 @@
 )]
 
 use super::*;
-use crate::routines::{slugify, Repository, Routine};
+use crate::routines::{slugify, Routine};
 
 fn scratch_dir(tag: &str) -> std::path::PathBuf {
     std::env::temp_dir().join(format!("moadim-rs-{tag}-{}", uuid::Uuid::new_v4()))
@@ -30,41 +30,7 @@ fn with_override_home(body: impl FnOnce(&std::path::Path)) {
 }
 
 fn make_routine(id: &str, title: &str) -> Routine {
-    Routine {
-        model: None,
-        id: id.to_string(),
-        schedule: "@daily".to_string(),
-        schedules: vec![],
-        title: title.to_string(),
-        agent: "claude".to_string(),
-        prompt: "task".to_string(),
-        goal: None,
-        repositories: vec![Repository {
-            repository: "https://example.com/r.git".to_string(),
-            branch: Some("main".to_string()),
-            auto_pull: true,
-        }],
-        machines: vec![crate::machine::current_machine()],
-        enabled: true,
-        disabled_reason: None,
-        source: "managed".to_string(),
-        created_at: 5,
-        updated_at: 6,
-        last_manual_trigger_at: None,
-        last_scheduled_trigger_at: None,
-        snoozed_until: None,
-        skip_runs: None,
-        power_saving: false,
-        power_saving_exempt: false,
-        tags: vec![],
-        ttl_secs: None,
-        max_runtime_secs: None,
-        env: std::collections::HashMap::new(),
-        auto_disabled_reason: None,
-        consecutive_failures: 0,
-        failure_threshold: None,
-        notifications: Default::default(),
-    }
+    crate::test_fixtures::routine_fixture(id, title).build()
 }
 
 #[test]

--- a/src/routine_storage_migration_tests.rs
+++ b/src/routine_storage_migration_tests.rs
@@ -7,37 +7,13 @@ use super::*;
 use crate::routines::{slugify, Routine};
 
 fn make_routine(id: &str, title: &str) -> Routine {
-    Routine {
-        model: None,
-        id: id.to_string(),
-        schedule: "@daily".to_string(),
-        schedules: vec![],
-        title: title.to_string(),
-        agent: "claude".to_string(),
-        prompt: "do the thing".to_string(),
-        goal: None,
-        repositories: vec![],
-        machines: vec![],
-        enabled: true,
-        disabled_reason: None,
-        source: "managed".to_string(),
-        created_at: 0,
-        updated_at: 0,
-        last_manual_trigger_at: None,
-        last_scheduled_trigger_at: None,
-        snoozed_until: None,
-        skip_runs: None,
-        power_saving: false,
-        power_saving_exempt: false,
-        tags: vec![],
-        ttl_secs: None,
-        max_runtime_secs: None,
-        env: std::collections::HashMap::new(),
-        auto_disabled_reason: None,
-        consecutive_failures: 0,
-        failure_threshold: None,
-        notifications: Default::default(),
-    }
+    let mut routine = crate::test_fixtures::routine_fixture(id, title)
+        .no_repositories()
+        .prompt("do the thing")
+        .times(0, 0)
+        .build();
+    routine.machines = vec![];
+    routine
 }
 
 /// A unique, not-yet-created scratch directory under the system temp dir.

--- a/src/routine_storage_prompt_sidecar_tests.rs
+++ b/src/routine_storage_prompt_sidecar_tests.rs
@@ -4,7 +4,7 @@
 )]
 
 use super::*;
-use crate::routines::{slugify, Repository, Routine};
+use crate::routines::{slugify, Routine};
 
 fn scratch_dir(tag: &str) -> std::path::PathBuf {
     std::env::temp_dir().join(format!("moadim-rs-{tag}-{}", uuid::Uuid::new_v4()))
@@ -30,41 +30,7 @@ fn with_override_home(body: impl FnOnce(&std::path::Path)) {
 }
 
 fn make_routine(id: &str, title: &str) -> Routine {
-    Routine {
-        model: None,
-        id: id.to_string(),
-        schedule: "@daily".to_string(),
-        schedules: vec![],
-        title: title.to_string(),
-        agent: "claude".to_string(),
-        prompt: "task".to_string(),
-        goal: None,
-        repositories: vec![Repository {
-            repository: "https://example.com/r.git".to_string(),
-            branch: Some("main".to_string()),
-            auto_pull: true,
-        }],
-        machines: vec![crate::machine::current_machine()],
-        enabled: true,
-        disabled_reason: None,
-        source: "managed".to_string(),
-        created_at: 5,
-        updated_at: 6,
-        last_manual_trigger_at: None,
-        last_scheduled_trigger_at: None,
-        snoozed_until: None,
-        skip_runs: None,
-        power_saving: false,
-        power_saving_exempt: false,
-        tags: vec![],
-        ttl_secs: None,
-        max_runtime_secs: None,
-        env: std::collections::HashMap::new(),
-        auto_disabled_reason: None,
-        consecutive_failures: 0,
-        failure_threshold: None,
-        notifications: Default::default(),
-    }
+    crate::test_fixtures::routine_fixture(id, title).build()
 }
 
 #[test]

--- a/src/routine_storage_repersist_tests.rs
+++ b/src/routine_storage_repersist_tests.rs
@@ -7,7 +7,7 @@
 )]
 
 use super::*;
-use crate::routines::{slugify, Repository, Routine};
+use crate::routines::{slugify, Routine};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -31,41 +31,7 @@ fn with_override_home(body: impl FnOnce(&std::path::Path)) {
 }
 
 fn make_routine(id: &str, title: &str) -> Routine {
-    Routine {
-        model: None,
-        id: id.to_string(),
-        schedule: "@daily".to_string(),
-        schedules: vec![],
-        title: title.to_string(),
-        agent: "claude".to_string(),
-        prompt: "task".to_string(),
-        goal: None,
-        repositories: vec![Repository {
-            repository: "https://example.com/r.git".to_string(),
-            branch: Some("main".to_string()),
-            auto_pull: true,
-        }],
-        machines: vec![crate::machine::current_machine()],
-        enabled: true,
-        disabled_reason: None,
-        source: "managed".to_string(),
-        created_at: 5,
-        updated_at: 6,
-        last_manual_trigger_at: None,
-        last_scheduled_trigger_at: None,
-        snoozed_until: None,
-        skip_runs: None,
-        power_saving: false,
-        power_saving_exempt: false,
-        tags: vec![],
-        ttl_secs: None,
-        max_runtime_secs: None,
-        env: std::collections::HashMap::new(),
-        auto_disabled_reason: None,
-        consecutive_failures: 0,
-        failure_threshold: None,
-        notifications: Default::default(),
-    }
+    crate::test_fixtures::routine_fixture(id, title).build()
 }
 
 #[test]

--- a/src/routine_storage_slug_collision_tests.rs
+++ b/src/routine_storage_slug_collision_tests.rs
@@ -4,7 +4,7 @@
 )]
 
 use super::*;
-use crate::routines::{slugify, Repository, Routine};
+use crate::routines::{slugify, Routine};
 
 fn scratch_dir(tag: &str) -> std::path::PathBuf {
     std::env::temp_dir().join(format!("moadim-rs-{tag}-{}", uuid::Uuid::new_v4()))
@@ -30,41 +30,7 @@ fn with_override_home(body: impl FnOnce(&std::path::Path)) {
 }
 
 fn make_routine(id: &str, title: &str) -> Routine {
-    Routine {
-        model: None,
-        id: id.to_string(),
-        schedule: "@daily".to_string(),
-        schedules: vec![],
-        title: title.to_string(),
-        agent: "claude".to_string(),
-        prompt: "task".to_string(),
-        goal: None,
-        repositories: vec![Repository {
-            repository: "https://example.com/r.git".to_string(),
-            branch: Some("main".to_string()),
-            auto_pull: true,
-        }],
-        machines: vec![crate::machine::current_machine()],
-        enabled: true,
-        disabled_reason: None,
-        source: "managed".to_string(),
-        created_at: 5,
-        updated_at: 6,
-        last_manual_trigger_at: None,
-        last_scheduled_trigger_at: None,
-        snoozed_until: None,
-        skip_runs: None,
-        power_saving: false,
-        power_saving_exempt: false,
-        tags: vec![],
-        ttl_secs: None,
-        max_runtime_secs: None,
-        env: std::collections::HashMap::new(),
-        auto_disabled_reason: None,
-        consecutive_failures: 0,
-        failure_threshold: None,
-        notifications: Default::default(),
-    }
+    crate::test_fixtures::routine_fixture(id, title).build()
 }
 
 #[test]

--- a/src/routine_storage_tests.rs
+++ b/src/routine_storage_tests.rs
@@ -4,7 +4,7 @@
 )]
 
 use super::*;
-use crate::routines::{slugify, Repository, Routine};
+use crate::routines::{slugify, Routine};
 
 fn scratch_dir(tag: &str) -> std::path::PathBuf {
     std::env::temp_dir().join(format!("moadim-rs-{tag}-{}", uuid::Uuid::new_v4()))
@@ -30,41 +30,7 @@ fn with_override_home(body: impl FnOnce(&std::path::Path)) {
 }
 
 fn make_routine(id: &str, title: &str) -> Routine {
-    Routine {
-        model: None,
-        id: id.to_string(),
-        schedule: "@daily".to_string(),
-        schedules: vec![],
-        title: title.to_string(),
-        agent: "claude".to_string(),
-        prompt: "task".to_string(),
-        goal: None,
-        repositories: vec![Repository {
-            repository: "https://example.com/r.git".to_string(),
-            branch: Some("main".to_string()),
-            auto_pull: true,
-        }],
-        machines: vec![crate::machine::current_machine()],
-        enabled: true,
-        disabled_reason: None,
-        source: "managed".to_string(),
-        created_at: 5,
-        updated_at: 6,
-        last_manual_trigger_at: None,
-        last_scheduled_trigger_at: None,
-        snoozed_until: None,
-        skip_runs: None,
-        power_saving: false,
-        power_saving_exempt: false,
-        tags: vec![],
-        ttl_secs: None,
-        max_runtime_secs: None,
-        env: std::collections::HashMap::new(),
-        auto_disabled_reason: None,
-        consecutive_failures: 0,
-        failure_threshold: None,
-        notifications: Default::default(),
-    }
+    crate::test_fixtures::routine_fixture(id, title).build()
 }
 
 #[test]

--- a/src/routine_storage_walk_tests.rs
+++ b/src/routine_storage_walk_tests.rs
@@ -31,37 +31,10 @@ fn with_home(body: &dyn Fn()) {
 }
 
 fn make_routine(id: &str, title: &str) -> Routine {
-    Routine {
-        model: None,
-        id: id.to_string(),
-        schedule: "@daily".to_string(),
-        schedules: vec![],
-        title: title.to_string(),
-        agent: "claude".to_string(),
-        prompt: "task".to_string(),
-        goal: None,
-        repositories: vec![],
-        machines: vec![crate::machine::current_machine()],
-        enabled: true,
-        disabled_reason: None,
-        source: "managed".to_string(),
-        created_at: 1,
-        updated_at: 2,
-        last_manual_trigger_at: None,
-        last_scheduled_trigger_at: None,
-        snoozed_until: None,
-        skip_runs: None,
-        power_saving: false,
-        power_saving_exempt: false,
-        ttl_secs: None,
-        max_runtime_secs: None,
-        tags: vec![],
-        env: std::collections::HashMap::new(),
-        auto_disabled_reason: None,
-        consecutive_failures: 0,
-        failure_threshold: None,
-        notifications: Default::default(),
-    }
+    crate::test_fixtures::routine_fixture(id, title)
+        .no_repositories()
+        .times(1, 2)
+        .build()
 }
 
 #[test]

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -1,0 +1,96 @@
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test fixtures intentionally trade docs for compact call sites"
+)]
+
+use crate::routines::{Repository, Routine};
+
+pub(crate) fn routine_fixture(id: &str, title: &str) -> RoutineFixture {
+    RoutineFixture {
+        id: id.to_string(),
+        title: title.to_string(),
+        prompt: "task".to_string(),
+        repositories: vec![Repository {
+            repository: "https://example.com/r.git".to_string(),
+            branch: Some("main".to_string()),
+            auto_pull: true,
+        }],
+        enabled: true,
+        disabled_reason: None,
+        created_at: 5,
+        updated_at: 6,
+    }
+}
+
+pub(crate) struct RoutineFixture {
+    id: String,
+    title: String,
+    prompt: String,
+    repositories: Vec<Repository>,
+    enabled: bool,
+    disabled_reason: Option<String>,
+    created_at: u64,
+    updated_at: u64,
+}
+
+impl RoutineFixture {
+    pub(crate) fn prompt(mut self, prompt: &str) -> Self {
+        self.prompt = prompt.to_string();
+        self
+    }
+
+    pub(crate) fn no_repositories(mut self) -> Self {
+        self.repositories = vec![];
+        self
+    }
+
+    pub(crate) fn enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
+    }
+
+    pub(crate) fn disabled_reason(mut self, reason: &str) -> Self {
+        self.disabled_reason = Some(reason.to_string());
+        self
+    }
+
+    pub(crate) fn times(mut self, created_at: u64, updated_at: u64) -> Self {
+        self.created_at = created_at;
+        self.updated_at = updated_at;
+        self
+    }
+
+    pub(crate) fn build(self) -> Routine {
+        Routine {
+            model: None,
+            id: self.id,
+            schedule: "@daily".to_string(),
+            schedules: vec![],
+            title: self.title,
+            agent: "claude".to_string(),
+            prompt: self.prompt,
+            goal: None,
+            repositories: self.repositories,
+            machines: vec![crate::machine::current_machine()],
+            enabled: self.enabled,
+            disabled_reason: self.disabled_reason,
+            source: "managed".to_string(),
+            created_at: self.created_at,
+            updated_at: self.updated_at,
+            last_manual_trigger_at: None,
+            last_scheduled_trigger_at: None,
+            snoozed_until: None,
+            skip_runs: None,
+            power_saving: false,
+            power_saving_exempt: false,
+            tags: vec![],
+            ttl_secs: None,
+            max_runtime_secs: None,
+            env: std::collections::HashMap::new(),
+            auto_disabled_reason: None,
+            consecutive_failures: 0,
+            failure_threshold: None,
+            notifications: Default::default(),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add a central `test_fixtures::routine_fixture` builder for routine test objects
- replace repeated storage-test `Routine { ... enabled, disabled_reason, ... }` literals with the shared fixture
- keep per-test overrides local through builder methods for enabled state, reason, repositories, prompt, and timestamps

## Why

The disabled-state work made object construction noisy because every new routine field had to be repeated across many tests. This keeps the object shape in one place so future metadata changes do not require broad fixture churn.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo llvm-cov --fail-under-lines 100 --ignore-filename-regex ...`
- `linecheck --max-lines 200 $(find src -name '*.rs')`
- pre-push hook passed, including client typecheck/lint/vitest and changeset check
