### PR TITLE
chore(lint): enable clippy::checked_conversions lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -542,3 +542,13 @@ struct_excessive_bools = "deny"
 # the routine's existing `schedule: String` field. The rest of the codebase is already clean, so
 # `deny` locks that in.
 assigning_clones = "deny"
+# Reject manual bounds-checking before a numeric `as` cast (e.g. checking a value fits `u32`'s
+# range, then casting) in favour of `TryFrom`/`TryInto`. This codebase already denies
+# `cast_lossless`, `cast_sign_loss`, `cast_possible_wrap`, and `cast_precision_loss` to keep every
+# numeric cast honest about the invariants it relies on; a hand-rolled range check before an `as`
+# cast is the same problem those lints guard against, just written out manually — easy to get the
+# boundary condition wrong (off-by-one, wrong comparison operator, forgetting a bound), and the
+# compiler can't verify it for you. `TryFrom`/`TryInto` express the same check as a single call the
+# compiler validates, with the failure path made explicit via `Result`. The codebase is already
+# clean, so `deny` locks that in.
+checked_conversions = "deny"


### PR DESCRIPTION
## Summary
- Adds `checked_conversions = "deny"` to `[lints.clippy]` in `Cargo.toml`, matching this repo's existing pattern of one documented, reasoned entry per lint.
- `cargo clippy --all-targets` reports zero violations, so this is a zero-noise addition — no code changes needed.

Closes #1521

---
Opened on behalf of the moadim routine **"Open issues → fix PRs (owned repos + my orgs)"**.