### PR TITLE
test(cli): assert status/cleanup/stop --json emit a single line

### DIFF
--- a/.changeset/cli-json-single-line-regression-guard.md
+++ b/.changeset/cli-json-single-line-regression-guard.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Add regression coverage for single-line JSON CLI output.

--- a/src/cli/actual_keys_tests.rs
+++ b/src/cli/actual_keys_tests.rs
@@ -51,6 +51,31 @@ fn readme_stop_json_shape_matches_actual_keys() {
     );
 }
 
+// README's "Scripting" section sells `--json` output as safe to pipe straight into `jq` without
+// buffering (e.g. `moadim status --json | jq -r .pid`); a formatter that ever emitted pretty-printed
+// (multi-line) JSON would silently break that documented pipeline. `serde_json::json!(...).to_string()`
+// always emits compact JSON, but these guard the promise directly at the formatter boundary rather
+// than relying on that being true forever.
+#[test]
+fn status_json_is_a_single_line() {
+    let health = HealthInfo {
+        uptime_secs: 42,
+        version: "0.1.0".to_string(),
+        crontab_sync: None,
+    };
+    assert!(!status_json(true, Some(7), Some(&health)).contains('\n'));
+}
+
+#[test]
+fn cleanup_json_is_a_single_line() {
+    assert!(!cleanup_json(3, 12345, true).contains('\n'));
+}
+
+#[test]
+fn stop_json_is_a_single_line() {
+    assert!(!stop_json(true, Some(7)).contains('\n'));
+}
+
 #[test]
 fn print_help_and_version_emit_without_panicking() {
     print_help();


### PR DESCRIPTION
## Summary
- Adds `status_json_is_a_single_line` / `cleanup_json_is_a_single_line` / `stop_json_is_a_single_line` to `src/cli/actual_keys_tests.rs`, asserting each formatter's output contains no `\n`.

## Context
#345's acceptance criteria had three parts: documented key sets match actual keys, documented exit codes hold, and output is a single line of valid JSON. The first two were already covered by `readme_*_json_shape_matches_actual_keys` and the `stop_reports_not_running_when_no_server`/`stop_signals_running_server` (+ status/cleanup equivalents) tests already in this file. This PR closes the remaining gap — nothing pinned the "single line" half of the README's `| jq -r .pid`-style pipeline promise, so a formatter that started pretty-printing would have broken it silently. `cargo test`/`cargo clippy`/`cargo fmt --check` all pass; these tests already run in CI via `test.yml`'s `cargo test` step, so no separate CI wiring is needed.

Closes #345

---
Opened on behalf of the moadim routine **"Open issues → fix PRs (owned repos + my orgs)"**.