### PR TITLE
fix(routines): stop leaking per-routine env secrets via process argv

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -201,7 +201,14 @@ failure (bad URL, unreachable host, missing `branch`) aborts the run and is reco
 the same as a failed prompt copy or `setup` step.
 
 The spawned script runs under a *login* shell (`sh -lc`) so the user's `~/.profile` is sourced and
-the agent inherits their environment (`GH_TOKEN`, API keys, …). Everything after the workbench
+the agent inherits their environment (`GH_TOKEN`, API keys, …). A routine's own `[env]` values
+(`routine.toml`, overlaid with the untracked `routine.local.toml` secrets sidecar) reach the agent
+the same way, but never as a literal in that `sh -lc` command string: `spawn_routine_command` sets
+them on the spawned process's own environment (`Command::envs`, `/proc/<pid>/environ`, owner-only)
+under private carrier names, and the command string only contains an `export KEY="$carrier"`
+indirection naming the variable, not its value — the command string becomes this process's argv,
+which is world-readable via `ps`/`/proc/<pid>/cmdline` for as long as the launcher shell runs (#1515).
+Everything after the workbench
 `mkdir` is redirected into `$WB/launch.log`, so a failure in the prompt copy, the agent's `setup`
 step, or the `tmux` launch itself is captured next to the run's other artifacts instead of being
 lost. `agent.log` remains the agent's own output (via `pipe-pane`); `launch.log` is the wrapper's

--- a/src/routines/command_env_tests.rs
+++ b/src/routines/command_env_tests.rs
@@ -52,15 +52,49 @@ fn test_agent() -> AgentCommand {
 
 #[test]
 fn build_routine_command_exports_tracked_env_vars() {
-    // `routine.toml`'s `[env]` table (loaded into `Routine::env`) is emitted as `export KEY=value`
-    // statements, shell-quoted.
+    // `routine.toml`'s `[env]` table (loaded into `Routine::env`) is emitted as an
+    // `export KEY="$carrier"` indirection statement (#1515) — the value itself travels on the
+    // spawned process's own environment via `routine_env_carrier_vars`, not inlined here.
     with_home_override(|_| {
         let mut routine = make_routine("Cmd Env Tracked Routine");
         routine.env = HashMap::from([("MY_VAR".to_string(), "hello world".to_string())]);
         let cmd = build_routine_command(&routine, &test_agent(), TriggerSource::Scheduled);
         assert!(
-            cmd.contains(&format!("export MY_VAR={}", shell_quote("hello world"))),
-            "expected tracked env var exported in: {cmd}"
+            cmd.contains(r#"export MY_VAR="$MOADIM_ROUTINE_ENV__MY_VAR""#),
+            "expected tracked env var's indirection export in: {cmd}"
+        );
+        assert_eq!(
+            routine_env_carrier_vars(&routine).get("MOADIM_ROUTINE_ENV__MY_VAR"),
+            Some(&"hello world".to_string())
+        );
+    });
+}
+
+#[test]
+fn build_routine_command_never_inlines_a_secret_value() {
+    // Issue #1515's regression test: whatever the command string contains, a configured secret's
+    // *value* must never be one of the substrings — that string becomes this process's argv,
+    // world-readable via `ps`/`/proc/<pid>/cmdline` for as long as the launcher shell runs.
+    const SENTINEL: &str = "sk-live-sentinel-1515-do-not-leak";
+    with_home_override(|_| {
+        let mut routine = make_routine("Cmd Env Secret Not Inlined Routine");
+        let slug = slugify(&routine.title);
+        write_local_env(&slug, &[("SECRET_TOKEN", SENTINEL)]);
+        routine.env = HashMap::new();
+
+        let cmd = build_routine_command(&routine, &test_agent(), TriggerSource::Scheduled);
+        assert!(
+            !cmd.contains(SENTINEL),
+            "secret value must never be inlined into the command string, in: {cmd}"
+        );
+        assert!(
+            cmd.contains(r#"export SECRET_TOKEN="$MOADIM_ROUTINE_ENV__SECRET_TOKEN""#),
+            "expected the indirection export by real name in: {cmd}"
+        );
+        assert_eq!(
+            routine_env_carrier_vars(&routine).get("MOADIM_ROUTINE_ENV__SECRET_TOKEN"),
+            Some(&SENTINEL.to_string()),
+            "the value must still reach the spawned process, just via the carrier env var"
         );
     });
 }
@@ -86,7 +120,9 @@ fn build_routine_command_env_exports_precede_ts_and_follow_path() {
 #[test]
 fn build_routine_command_local_toml_overrides_tracked_env_for_the_same_key() {
     // routine.local.toml (untracked, gitignored) layers on top of routine.toml's [env] table; its
-    // keys win on conflict (#408 acceptance criteria).
+    // keys win on conflict (#408 acceptance criteria). Values now travel via
+    // `routine_env_carrier_vars`, not the command string (#1515), so the precedence check moves
+    // there.
     with_home_override(|_| {
         let mut routine = make_routine("Cmd Env Override Routine");
         let slug = slugify(&routine.title);
@@ -95,15 +131,13 @@ fn build_routine_command_local_toml_overrides_tracked_env_for_the_same_key() {
 
         let cmd = build_routine_command(&routine, &test_agent(), TriggerSource::Scheduled);
         assert!(
-            cmd.contains(&format!(
-                "export SHARED_KEY={}",
-                shell_quote("secret-value")
-            )),
-            "expected routine.local.toml's value to win in: {cmd}"
+            cmd.contains(r#"export SHARED_KEY="$MOADIM_ROUTINE_ENV__SHARED_KEY""#),
+            "expected the indirection export by real name in: {cmd}"
         );
-        assert!(
-            !cmd.contains("tracked-value"),
-            "the overridden tracked value must not appear in: {cmd}"
+        assert_eq!(
+            routine_env_carrier_vars(&routine).get("MOADIM_ROUTINE_ENV__SHARED_KEY"),
+            Some(&"secret-value".to_string()),
+            "expected routine.local.toml's value to win"
         );
     });
 }
@@ -118,8 +152,23 @@ fn build_routine_command_merges_local_and_tracked_env_for_distinct_keys() {
         write_local_env(&slug, &[("LOCAL_ONLY", "b")]);
 
         let cmd = build_routine_command(&routine, &test_agent(), TriggerSource::Scheduled);
-        assert!(cmd.contains("export TRACKED_ONLY='a'"), "in: {cmd}");
-        assert!(cmd.contains("export LOCAL_ONLY='b'"), "in: {cmd}");
+        assert!(
+            cmd.contains(r#"export TRACKED_ONLY="$MOADIM_ROUTINE_ENV__TRACKED_ONLY""#),
+            "in: {cmd}"
+        );
+        assert!(
+            cmd.contains(r#"export LOCAL_ONLY="$MOADIM_ROUTINE_ENV__LOCAL_ONLY""#),
+            "in: {cmd}"
+        );
+        let carriers = routine_env_carrier_vars(&routine);
+        assert_eq!(
+            carriers.get("MOADIM_ROUTINE_ENV__TRACKED_ONLY"),
+            Some(&"a".to_string())
+        );
+        assert_eq!(
+            carriers.get("MOADIM_ROUTINE_ENV__LOCAL_ONLY"),
+            Some(&"b".to_string())
+        );
     });
 }
 
@@ -140,8 +189,12 @@ fn build_routine_command_skips_invalid_env_key_from_local_toml() {
             "invalid key must be dropped, not exported, in: {cmd}"
         );
         assert!(
-            cmd.contains("export VALID_KEY='ok'"),
+            cmd.contains(r#"export VALID_KEY="$MOADIM_ROUTINE_ENV__VALID_KEY""#),
             "the valid sibling entry must still be exported in: {cmd}"
+        );
+        assert_eq!(
+            routine_env_carrier_vars(&routine).get("MOADIM_ROUTINE_ENV__VALID_KEY"),
+            Some(&"ok".to_string())
         );
     });
 }

--- a/src/routines/service_trigger.rs
+++ b/src/routines/service_trigger.rs
@@ -12,8 +12,8 @@ use crate::routines::cleanup::{
     tmux_session_prefix_alive,
 };
 use crate::routines::command::{
-    build_routine_command, inline_prompt_overflow, tmux_session_prefix, TriggerSource,
-    TMUX_SESSION_PREFIX,
+    build_routine_command, inline_prompt_overflow, routine_env_carrier_vars, tmux_session_prefix,
+    TriggerSource, TMUX_SESSION_PREFIX,
 };
 use crate::routines::model::{CleanupResponse, Routine, RoutineStore};
 use crate::routines::{max_concurrent_runs, MAX_CONCURRENT_RUNS_ENV};

--- a/src/routines/slugify.rs
+++ b/src/routines/slugify.rs
@@ -83,14 +83,14 @@ pub(crate) fn is_valid_env_key(key: &str) -> bool {
 /// the tracked `routine.toml` `[env]` table, overlaid with the untracked `routine.local.toml`
 /// sidecar (secrets) — whose keys win on conflict (#408).
 ///
-/// A `BTreeMap` merge keeps the emitted statements in a deterministic, sorted-by-key order (stable
-/// test assertions, stable output for anyone reading `launch.log`). Every entry — from either
-/// source — is re-checked with [`is_valid_env_key`] and scanned for newlines: `routine.toml` was
-/// already validated at create/update time (`service_validate::validate_env`), but
-/// `routine.local.toml` is a file a human edits directly on disk and never passes through that
-/// check, so a malformed entry there is dropped (with a warning) rather than corrupting the
-/// single-line, `;`-joined launch command.
-pub(crate) fn env_export_stmts(routine: &Routine) -> Vec<String> {
+/// A `BTreeMap` merge keeps the merged set in a deterministic, sorted-by-key order (stable test
+/// assertions, stable output for anyone reading `launch.log`). Every entry — from either source —
+/// is re-checked with [`is_valid_env_key`] and scanned for newlines: `routine.toml` was already
+/// validated at create/update time (`service_validate::validate_env`), but `routine.local.toml` is
+/// a file a human edits directly on disk and never passes through that check, so a malformed entry
+/// there is dropped (with a warning) rather than corrupting the single-line, `;`-joined launch
+/// command.
+fn merged_env_vars(routine: &Routine) -> BTreeMap<String, String> {
     let rel_dir = crate::routine_storage::routine_rel_dir(routine);
     let local_env = read_local_env(&rel_dir);
     let mut merged: BTreeMap<String, String> = BTreeMap::new();
@@ -106,8 +106,46 @@ pub(crate) fn env_export_stmts(routine: &Routine) -> Vec<String> {
         }
     }
     merged
+}
+
+/// The process-environment carrier name [`routine_env_carrier_vars`] sets `key`'s value under, so
+/// [`env_export_stmts`]'s indirection line can read it back without the value ever appearing in
+/// the composed command string (#1515). Prefixed so it cannot collide with a routine's own `[env]`
+/// key of the same name; [`is_valid_env_key`] already restricts `key` to a shell identifier, so
+/// the prefixed result is always a valid one too.
+fn carrier_env_var(key: &str) -> String {
+    format!("MOADIM_ROUTINE_ENV__{key}")
+}
+
+/// Build the `export KEY="$MOADIM_ROUTINE_ENV__KEY"` indirection statements for `routine`'s
+/// resolved environment (see [`merged_env_vars`]).
+///
+/// The statement names each variable but never embeds its *value*: the value instead travels
+/// privately on the spawned process's own environment (`Command::envs`, set by
+/// [`routine_env_carrier_vars`] in `spawn_routine_command`), which the kernel keeps in
+/// `/proc/<pid>/environ` (owner-only, `0400`) rather than in the world-readable `ps`/
+/// `/proc/<pid>/cmdline` argv this statement is inlined into (#1515). Immediately `unset`ting the
+/// carrier after copying it to the real name limits how long the redundant copy lives in the
+/// process environment. Placed after `sh -l`'s profile sourcing (see `build_routine_command`), so
+/// a routine env var still overrides a same-named profile-inherited one, exactly as before.
+pub(crate) fn env_export_stmts(routine: &Routine) -> Vec<String> {
+    merged_env_vars(routine)
+        .into_keys()
+        .map(|key| {
+            let carrier = carrier_env_var(&key);
+            format!("export {key}=\"${carrier}\"; unset {carrier}")
+        })
+        .collect()
+}
+
+/// The carrier environment variables (name -> value, see [`carrier_env_var`]) that must be set on
+/// the spawned launcher process's own environment (via `Command::envs` in
+/// `spawn_routine_command`) so the indirection statements [`env_export_stmts`] embeds in the
+/// command string can resolve them without ever inlining a value into that string (#1515).
+pub(crate) fn routine_env_carrier_vars(routine: &Routine) -> BTreeMap<String, String> {
+    merged_env_vars(routine)
         .into_iter()
-        .map(|(key, value)| format!("export {key}={}", shell_quote(&value)))
+        .map(|(key, value)| (carrier_env_var(&key), value))
         .collect()
 }
 

--- a/src/routines/spawn_routine_command.rs
+++ b/src/routines/spawn_routine_command.rs
@@ -93,6 +93,13 @@ pub(crate) fn spawn_routine_command(routine: &Routine, source: TriggerSource) {
             // environment whether fired by cron or on demand.
             let mut command = std::process::Command::new(sh_bin());
             command.arg("-lc").arg(&cmd);
+            // Carry the routine's `[env]` values on the spawned process's own environment rather
+            // than inlining them into `cmd` above: `cmd` becomes this process's argv, which is
+            // world-readable via `ps`/`/proc/<pid>/cmdline` for as long as the launcher shell runs
+            // (mkdir, repo clone, agent setup, tmux launch), while `Command::envs` values land in
+            // `/proc/<pid>/environ` (owner-only, `0400`) instead (#1515). `cmd`'s own
+            // `export KEY="$carrier"` indirection lines read these back under their real names.
+            command.envs(routine_env_carrier_vars(routine));
             // Reap the child in the background so the short-lived launcher shell does not
             // linger as a zombie for the daemon's lifetime (the trigger stays non-blocking).
             crate::utils::process::spawn_and_reap(command, "routine command");


### PR DESCRIPTION
## Summary
`routine.toml [env]` and the secrets-oriented `routine.local.toml` overlay were interpolated as plaintext `export KEY='value'` statements into the single-line launch command (`command_builder.rs`), which `spawn_routine_command` then passed as one argv argument to `sh -lc`. Process arguments are world-readable via `ps`/`/proc/<pid>/cmdline` on multi-user hosts for as long as that wrapper shell runs (mkdir, repo pre-clone, agent `setup`, tmux launch) — every scheduled fire re-exposed every configured secret in plaintext. This affects both the manual-trigger and scheduled-cron paths, since the crontab line only invokes `moadim schedule trigger <id>`, which funnels into the same `spawn_routine_command`.

## Fix
Implements option 1 from the issue's proposed direction:
- `slugify.rs`: `env_export_stmts` now emits `export KEY="$MOADIM_ROUTINE_ENV__KEY"; unset MOADIM_ROUTINE_ENV__KEY` indirection statements — the variable *name* appears in the command string, never its value. A new `routine_env_carrier_vars` returns the `{carrier_name: value}` map for the caller to set on the spawned process's own environment.
- `spawn_routine_command.rs`: `command.envs(routine_env_carrier_vars(routine))` sets those carrier vars on the spawned `sh -lc` process directly, so the kernel keeps the values in `/proc/<pid>/environ` (owner-only, `0400`) instead of argv.
- Precedence is unchanged: the indirection line still runs after `sh -l` sources `~/.profile`, so a routine env var still overrides a same-named profile-inherited one.
- `command_env_tests.rs`: existing precedence/merge/invalid-key tests updated to check `routine_env_carrier_vars` instead of literal values in the command string, plus a new regression test (`build_routine_command_never_inlines_a_secret_value`) asserting a sentinel secret value never appears in the composed command.
- `Architecture.md` updated to document the new carrier-variable mechanism.

## Testing
- `cargo test` — 1321 passed, 0 failed
- `cargo clippy --all-targets` — clean
- `cargo fmt --check` — clean

Closes #1515

---
Opened on behalf of the moadim routine **"Open issues → fix PRs (owned repos + my orgs)"**.