### PR TITLE
chore(release): v3.2.4

### DIFF
--- a/.changeset/cli-json-single-line-regression-guard.md
+++ b/.changeset/cli-json-single-line-regression-guard.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-Add regression coverage for single-line JSON CLI output.

--- a/.changeset/routine-disabled-json.md
+++ b/.changeset/routine-disabled-json.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-Store routine disabled state in a tracked `disabled.json` marker while keeping legacy `enabled = false` routine TOML files loadable.

--- a/.changeset/routine-disabled-reason.md
+++ b/.changeset/routine-disabled-reason.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-Support optional user-provided disabled reasons in `disabled.json` across CLI, API, and MCP disable surfaces.

--- a/.changeset/routine-failure-notification-hooks.md
+++ b/.changeset/routine-failure-notification-hooks.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-Add configurable routine failure notification hooks with global and per-routine command/webhook targets.

--- a/.changeset/routine-object-fixtures.md
+++ b/.changeset/routine-object-fixtures.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-Centralize routine test fixture construction so activation metadata changes do not require repeated struct-literal updates across storage tests.

--- a/.changeset/ui-run-detail-page.md
+++ b/.changeset/ui-run-detail-page.md
@@ -1,5 +1,0 @@
----
-"client": patch
----
-
-Add a deep-linkable Run Detail page (`/runs/:routineId/:workbench`): run metadata, the full log, and Prev/Next navigation between a routine's runs. Linked from the fleet Runs page and each routine's history table, and works standalone from a bookmarked or shared URL.

--- a/.changeset/ui-runs-page.md
+++ b/.changeset/ui-runs-page.md
@@ -1,5 +1,0 @@
----
-"client": patch
----
-
-Add a fleet-wide Runs page to the web UI: search, filter by status and time range, and browse run history across every routine instead of only the last 8 shown on Overview.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,24 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+## [3.2.4] - 2026-08-09
+
 Store routine disable intent in a tracked `disabled.json` marker with basic audit metadata while keeping legacy `enabled = false` TOML configs loadable.
 - Support optional user-provided disabled reasons in `disabled.json` across CLI/API/MCP disable surfaces.
+
+Add regression coverage for single-line JSON CLI output.
+
+Store routine disabled state in a tracked `disabled.json` marker while keeping legacy `enabled = false` routine TOML files loadable.
+
+Support optional user-provided disabled reasons in `disabled.json` across CLI, API, and MCP disable surfaces.
+
+Add configurable routine failure notification hooks with global and per-routine command/webhook targets.
+
+Centralize routine test fixture construction so activation metadata changes do not require repeated struct-literal updates across storage tests.
+
+Add a deep-linkable Run Detail page (`/runs/:routineId/:workbench`): run metadata, the full log, and Prev/Next navigation between a routine's runs. Linked from the fleet Runs page and each routine's history table, and works standalone from a bookmarked or shared URL.
+
+Add a fleet-wide Runs page to the web UI: search, filter by status and time range, and browse run history across every routine instead of only the last 8 shown on Overview.
 
 ## [3.2.3] - 2026-08-01
 
@@ -5027,7 +5043,8 @@ Enable `clippy::match_same_arms` and merge the two duplicate-body arms it flagge
 - Ship the prebuilt UI in the published crate.
 - Rename the binary to `moadim` and add install docs.
 
-[Unreleased]: https://github.com/moadim-io/daemon/compare/v3.2.3...HEAD
+[Unreleased]: https://github.com/moadim-io/daemon/compare/v3.2.4...HEAD
+[3.2.4]: https://github.com/moadim-io/daemon/compare/v3.2.3...v3.2.4
 [3.2.3]: https://github.com/moadim-io/daemon/compare/v3.2.2...v3.2.3
 [3.2.2]: https://github.com/moadim-io/daemon/compare/v3.2.1...v3.2.2
 [3.2.1]: https://github.com/moadim-io/daemon/compare/v3.2.0...v3.2.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "3.2.3"
+version = "3.2.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moadim"
-version = "3.2.3"
+version = "3.2.4"
 edition = "2021"
 # Floor set by the transitive proc-macro build dependency `darling 0.23`
 # (pulled in via `rmcp-macros` <- `rmcp`), which itself declares

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "3.2.3"
+    "version": "3.2.4"
   },
   "servers": [
     {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/moadim.1
+++ b/docs/moadim.1
@@ -1,7 +1,7 @@
 .\" Man page for moadim.
 .\" Mirrors the built-in `moadim --help` output (src/cli/mod.rs::print_help).
 .\" View with:  man ./docs/moadim.1   or install into share/man/man1/.
-.TH MOADIM 1 "2026-07-31" "moadim 3.2.3" "Moadim Manual"
+.TH MOADIM 1 "2026-08-09" "moadim 3.2.4" "Moadim Manual"
 .SH NAME
 moadim \- routine scheduler with an MCP/REST API and a web control panel
 .SH SYNOPSIS

--- a/npm/moadim/package.json
+++ b/npm/moadim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moadim",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Moadim daemon CLI binary distributed through npm platform packages",
   "license": "MIT",
   "repository": {
@@ -24,9 +24,9 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@moadim/daemon-darwin-arm64": "3.2.3",
-    "@moadim/daemon-darwin-x64": "3.2.3",
-    "@moadim/daemon-linux-x64-gnu": "3.2.3"
+    "@moadim/daemon-darwin-arm64": "3.2.4",
+    "@moadim/daemon-darwin-x64": "3.2.4",
+    "@moadim/daemon-linux-x64-gnu": "3.2.4"
   },
   "publishConfig": {
     "access": "public",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moadim",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "scripts": {


### PR DESCRIPTION
## Summary
- Manual fallback release cut: no `changeset-release.yml` bot PR was open (org disables Actions from opening PRs, per CONTRIBUTING.md/#849), and `cut-release.yml`'s push-straight-to-main flow is outside this routine's scope, so this follows the documented manual fallback path instead.
- Rolls 7 pending changesets (5 `moadim` patch, 2 `client` patch) into a new `## [3.2.4] - 2026-08-09` CHANGELOG.md section.
- Bumps `package.json`, `client/package.json`, `npm/moadim/package.json`, `Cargo.toml`/`Cargo.lock`, and `apis/openapi.json` to 3.2.4 via `pnpm version-packages` (`scripts/release/version-and-sync.mjs`).
- Fixes `docs/moadim.1`'s `.TH` line to the new version and today's date.

## Test plan
- [x] `pnpm version-packages` ran clean (bumped versions, rolled changesets, regenerated `apis/openapi.json`)
- [x] `cargo check` passes, `Cargo.lock` in sync
- [x] `CHANGELOG.md` topmost dated heading (3.2.4) matches `Cargo.toml` version (auto-release.yml gate)
- [x] No stray `prebuilt.html` diff
- [ ] CI (test/lint gates mirroring the pre-push hook)

---
Opened automatically by the **Nightly release cutter (moadim daemon)** routine.