### PR TITLE
fix(routines): key flag operations by on-disk rel_dir, not title slug

### DIFF
--- a/.changeset/fix-flags-dir-key.md
+++ b/.changeset/fix-flags-dir-key.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Fix flags being written to and read from a phantom title-slug directory for routines that live in a folder or have been renamed/moved, by keying all flag operations (create, list, resolve) and `flag_count` on the routine's actual on-disk relative directory instead of `slugify(title)`.

--- a/src/routines/next_run_at.rs
+++ b/src/routines/next_run_at.rs
@@ -67,7 +67,10 @@ impl RoutineResponse {
             .iter()
             .filter_map(|schedule| describe_schedule(schedule, timezone.as_deref()))
             .collect();
-        let flag_count = list_flags(&slug).len();
+        // Keyed by `rel_path` (the routine's actual on-disk directory), not the bare `slug`: for a
+        // routine inside a folder those differ, and the flags/ dir lives under the full rel_path
+        // (see #1514).
+        let flag_count = list_flags(&rel_path).len();
         let next_run_at = next_run_at(&schedules, routine.enabled);
         let missed_scheduled_run_at = missed_scheduled_run_at(&routine, &schedules);
         let is_running = tmux_session_prefix_alive(&tmux_session_prefix(&slug));

--- a/src/routines/service_trigger_flags.rs
+++ b/src/routines/service_trigger_flags.rs
@@ -1,8 +1,7 @@
 //! Flag CRUD for routines: raise, list, and resolve flags raised against a routine.
 
 use crate::error::AppError;
-use crate::routine_storage::write_routine;
-use crate::routines::command::slugify;
+use crate::routine_storage::{routine_rel_dir, write_routine};
 use crate::routines::flags::{self, Flag, FlagScope};
 use crate::routines::model::{Routine, RoutineStore};
 use crate::utils::lock::LockRecover;
@@ -29,15 +28,21 @@ fn parse_flag_scope(scope: &str) -> Result<FlagScope, AppError> {
     }
 }
 
-/// Look up a routine by `id` and derive its slug, `NotFound` if it does not exist.
-fn routine_and_slug(store: &RoutineStore, id: &str) -> Result<(Routine, String), AppError> {
+/// Look up a routine by `id` and derive its on-disk relative directory, `NotFound` if it does not
+/// exist.
+///
+/// Flags must be keyed by [`routine_rel_dir`] — the routine's actual filesystem location — rather
+/// than `slugify(&routine.title)`: the two diverge for any routine that lives in a folder or has
+/// been renamed/moved since its flags directory was first created, silently stranding flags in a
+/// phantom directory nothing else reads (see #1514).
+fn routine_and_rel_dir(store: &RoutineStore, id: &str) -> Result<(Routine, String), AppError> {
     let routine = store
         .lock_recover()
         .get(id)
         .cloned()
         .ok_or(AppError::NotFound)?;
-    let slug = slugify(&routine.title);
-    Ok((routine, slug))
+    let rel_dir = routine_rel_dir(&routine);
+    Ok((routine, rel_dir))
 }
 
 /// Raise a new flag against routine `id`. `flag_type` and `description` must be non-blank;
@@ -54,17 +59,17 @@ pub fn svc_create_flag(
     validate_flag_field("type", flag_type)?;
     validate_flag_field("description", description)?;
     let scope = parse_flag_scope(scope)?;
-    let (routine, slug) = routine_and_slug(store, id)?;
-    let flag =
-        flags::create_flag(&slug, flag_type, description, scope).map_err(|_| AppError::Internal)?;
+    let (routine, rel_dir) = routine_and_rel_dir(store, id)?;
+    let flag = flags::create_flag(&rel_dir, flag_type, description, scope)
+        .map_err(|_| AppError::Internal)?;
     write_routine(&routine).map_err(|_| AppError::Internal)?;
     Ok(flag)
 }
 
 /// List every open flag raised against routine `id`, oldest first.
 pub fn svc_list_flags(store: &RoutineStore, id: &str) -> Result<Vec<Flag>, AppError> {
-    let (_, slug) = routine_and_slug(store, id)?;
-    Ok(flags::list_flags(&slug))
+    let (_, rel_dir) = routine_and_rel_dir(store, id)?;
+    Ok(flags::list_flags(&rel_dir))
 }
 
 /// Resolve (delete) the flag named `filename` under routine `id`.
@@ -73,8 +78,8 @@ pub fn svc_list_flags(store: &RoutineStore, id: &str) -> Result<Vec<Flag>, AppEr
 /// Refreshes `prompts/prompt.compiled.local.md` afterward so a resolved flag stops appearing in the next
 /// run's prompt.
 pub fn svc_resolve_flag(store: &RoutineStore, id: &str, filename: &str) -> Result<(), AppError> {
-    let (routine, slug) = routine_and_slug(store, id)?;
-    let resolved = flags::resolve_flag(&slug, filename).map_err(|_| AppError::Internal)?;
+    let (routine, rel_dir) = routine_and_rel_dir(store, id)?;
+    let resolved = flags::resolve_flag(&rel_dir, filename).map_err(|_| AppError::Internal)?;
     if !resolved {
         return Err(AppError::NotFound);
     }

--- a/src/routines/svc_flag_folder_rel_dir_tests.rs
+++ b/src/routines/svc_flag_folder_rel_dir_tests.rs
@@ -1,0 +1,48 @@
+#![allow(
+    clippy::wildcard_imports,
+    clippy::too_many_arguments,
+    clippy::needless_pass_by_value,
+    dead_code,
+    reason = "split-out module preserves existing code while keeping files under the linecheck limit"
+)]
+use super::*;
+
+/// Regression for #1514: flags must be keyed by the routine's actual on-disk directory
+/// (`routine_rel_dir`), not `slugify(&routine.title)`. Before the fix, a routine moved into a
+/// folder had its flags silently written to (and read from) a phantom top-level
+/// `routines/{slug}/flags/` dir that `compose_prompt` never looked at, so raised flags never
+/// reached the agent and never left `svc_list_flags`/`flag_count` even after being resolved.
+#[test]
+fn svc_create_flag_visible_after_move_to_folder() {
+    let _home = TempHome::set();
+    let store = new_store();
+    let created = svc_create(&store, create_req_with_title("Svc Flag Folder ZZZ")).unwrap();
+    let id = created.routine.id;
+
+    svc_move(
+        &store,
+        &id,
+        MoveRoutineRequest {
+            folder: Some("ops".into()),
+            slug: "svc-flag-folder-zzz".into(),
+        },
+    )
+    .unwrap();
+
+    let flag = svc_create_flag(&store, &id, "bug", "stuck in the wrong dir", "general").unwrap();
+
+    // Landed under the routine's real (foldered) directory, not a phantom title-slug dir.
+    assert!(crate::paths::routine_flags_dir("ops/svc-flag-folder-zzz")
+        .join(&flag.filename)
+        .exists());
+
+    let flags = svc_list_flags(&store, &id).unwrap();
+    assert_eq!(flags.len(), 1);
+    assert_eq!(flags[0].filename, flag.filename);
+
+    let routine = store.lock_recover().get(&id).cloned().unwrap();
+    assert_eq!(RoutineResponse::from_routine(routine).flag_count, 1);
+
+    svc_resolve_flag(&store, &id, &flag.filename).unwrap();
+    assert!(svc_list_flags(&store, &id).unwrap().is_empty());
+}

--- a/src/routines/svc_list_flags_not_found_tests.rs
+++ b/src/routines/svc_list_flags_not_found_tests.rs
@@ -70,3 +70,12 @@ fn svc_resolve_flag_deletes_and_refreshes_prompt() {
 )]
 #[path = "svc_resolve_flag_returns_internal_on_resolve_flag_failure_tests.rs"]
 mod svc_resolve_flag_returns_internal_on_resolve_flag_failure_tests;
+
+// ─── flags keyed by on-disk rel_dir, not title slug (issue #1514) ─────────
+
+#[allow(
+    clippy::missing_docs_in_private_items,
+    reason = "split-out module keeps the file under the linecheck limit"
+)]
+#[path = "svc_flag_folder_rel_dir_tests.rs"]
+mod svc_flag_folder_rel_dir_tests;


### PR DESCRIPTION
## Problem

The flags feature (#856) used **three different keys** to locate a routine's `flags/` directory, agreeing only for a top-level routine whose directory slug still matches its current title:

- `svc_create_flag` / `svc_list_flags` / `svc_resolve_flag` derived the key from the routine's *title* (`slugify(&routine.title)`), so flags landed in `routines/{title-slug}/flags/`.
- `RoutineResponse::from_routine`'s `flag_count` used only the *last path segment* of the routine's real rel_dir, dropping any folder prefix.
- `compose_prompt` (the one place that actually surfaces open flags to the agent) already read from the routine's *real on-disk relative directory* via `routine_rel_dir` — the only one of the four call sites the other three should have matched.

`routine_rel_dir` is deliberately filesystem-owned and decoupled from the title, so these keys diverge in normal use: a routine in a folder (`routines/ops/nightly/`) had flags written to a phantom top-level `routines/nightly/flags/`; a renamed routine kept writing new flags to a phantom directory named after the new title. The agent's `# Open flags` prompt section never saw them, `flag_count`/`svc_list_flags` kept showing them as "open" forever, and any resolve silently no-op'd.

## Fix

Route every flag call site through the same `routine_rel_dir` helper `compose_prompt` already used, instead of `slugify(title)` or a bare last-segment slug:

- `service_trigger_flags.rs`: `routine_and_slug` → `routine_and_rel_dir`, keyed by `routine_rel_dir(&routine)`.
- `next_run_at.rs`: `RoutineResponse::from_routine`'s `flag_count` now reads `list_flags(&rel_path)` (the full rel_dir already computed a few lines above) instead of `list_flags(&slug)`.

## Tests

Added `svc_create_flag_visible_after_move_to_folder` (`src/routines/svc_flag_folder_rel_dir_tests.rs`), which moves a routine into a folder via `svc_move`, raises a flag, and asserts it lands under the routine's real foldered directory, appears in `svc_list_flags` and `RoutineResponse::from_routine(..).flag_count`, and disappears after `svc_resolve_flag`.

## Checks

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 1324 passed, 0 failed
- `linecheck --max-lines 200` — clean
- `cargo llvm-cov --fail-under-lines 100 ...` — 99.99%, but the single uncovered line is in `dispatch_routine.rs`, unrelated to this change; reproduced identically on `main` before this patch (verified via `git stash`), so it's a pre-existing gap, not a regression introduced here.
- Added a changeset (`.changeset/fix-flags-dir-key.md`).

Closes #1514

🤖 Opened automatically by the moadim routine "Open issues → fix PRs (owned repos + my orgs)".