### PR TITLE
Retry on_failure_webhook on transient curl failures

### DIFF
--- a/src/routines/failure_notify.rs
+++ b/src/routines/failure_notify.rs
@@ -158,9 +158,36 @@ fn dispatch_webhook(webhook: &str, payload: &FailurePayload<'_>) {
     std::thread::spawn(move || post_webhook(&curl_bin, &webhook, &body));
 }
 
-#[allow(clippy::expect_used, reason = "spawned curl child should wait")]
+/// Bounded retry count for a dropped webhook delivery: the failure notification
+/// is the one delivery that matters most, but retries must stay bounded so a
+/// dead endpoint can't pile up threads across successive routine failures.
+const WEBHOOK_MAX_ATTEMPTS: u32 = 3;
+/// Backoff before the first retry; doubles after each subsequent failure.
+const WEBHOOK_RETRY_BACKOFF: std::time::Duration = std::time::Duration::from_millis(100);
+
 fn post_webhook(curl_bin: &str, webhook: &str, body: &[u8]) {
-    let mut child = match std::process::Command::new(curl_bin)
+    let mut backoff = WEBHOOK_RETRY_BACKOFF;
+    for attempt in 1..=WEBHOOK_MAX_ATTEMPTS {
+        match post_webhook_once(curl_bin, webhook, body) {
+            Ok(()) => return,
+            Err(err) => {
+                if attempt == WEBHOOK_MAX_ATTEMPTS {
+                    log::warn!(
+                        "failure notification webhook failed after {WEBHOOK_MAX_ATTEMPTS} attempts: {err}"
+                    );
+                    return;
+                }
+                std::thread::sleep(backoff);
+                backoff *= 2;
+            }
+        }
+    }
+}
+
+/// Runs a single `curl` attempt, returning the failure reason on error.
+#[allow(clippy::expect_used, reason = "spawned curl child should wait")]
+fn post_webhook_once(curl_bin: &str, webhook: &str, body: &[u8]) -> Result<(), String> {
+    let mut child = std::process::Command::new(curl_bin)
         .arg("-fsS")
         .arg("--max-time")
         .arg("10")
@@ -175,21 +202,13 @@ fn post_webhook(curl_bin: &str, webhook: &str, body: &[u8]) {
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped())
         .spawn()
-    {
-        Ok(child) => child,
-        Err(err) => {
-            log::warn!("failure notification webhook: failed to spawn curl: {err}");
-            return;
-        }
-    };
+        .map_err(|err| format!("failed to spawn curl: {err}"))?;
     let _ = child.stdin.take().map(|mut stdin| stdin.write_all(body));
     let out = child.wait_with_output().expect("curl child exits");
-    if !out.status.success() {
-        log::warn!(
-            "failure notification webhook failed: {}",
-            String::from_utf8_lossy(&out.stderr).trim()
-        );
+    if out.status.success() {
+        return Ok(());
     }
+    Err(String::from_utf8_lossy(&out.stderr).trim().to_string())
 }
 
 #[cfg(test)]

--- a/src/routines/failure_notify_dispatch_tests.rs
+++ b/src/routines/failure_notify_dispatch_tests.rs
@@ -6,7 +6,7 @@
 
 use super::super::{
     dispatch_command, dispatch_webhook, exit_reason, notify_finished_run, post_webhook,
-    FailureNotificationConfig, RunStatus, CURL_BIN_ENV,
+    FailureNotificationConfig, RunStatus, CURL_BIN_ENV, WEBHOOK_MAX_ATTEMPTS,
 };
 use super::{temp_dir, EnvGuard};
 
@@ -15,6 +15,28 @@ fn curl_shim(dir: &std::path::Path, code: i32) -> std::path::PathBuf {
     std::fs::write(
         &path,
         format!("#!/bin/sh\nfor arg do target=\"$arg\"; done\ncat > \"$target\"\nprintf err >&2\nexit {code}\n"),
+    )
+    .unwrap();
+    std::process::Command::new("chmod")
+        .arg("+x")
+        .arg(&path)
+        .status()
+        .unwrap();
+    path
+}
+
+/// A `curl` shim that fails on its first `fail_count` invocations (writing
+/// nothing) then succeeds and writes `stdin` to the final positional arg.
+/// Tracks the number of invocations in `dir/attempts.count`.
+fn flaky_curl_shim(dir: &std::path::Path, fail_count: u32) -> std::path::PathBuf {
+    let path = dir.join("curl-flaky.sh");
+    let counter = dir.join("attempts.count");
+    std::fs::write(
+        &path,
+        format!(
+            "#!/bin/sh\nn=$(cat {counter} 2>/dev/null || echo 0)\nn=$((n+1))\necho \"$n\" > {counter}\nfor arg do target=\"$arg\"; done\nif [ \"$n\" -le {fail_count} ]; then\n  printf err >&2\n  exit 1\nfi\ncat > \"$target\"\nexit 0\n",
+            counter = counter.display(),
+        ),
     )
     .unwrap();
     std::process::Command::new("chmod")
@@ -112,6 +134,54 @@ fn command_hook_uses_default_shell_when_env_is_absent() {
             std::env::set_var("MOADIM_SH_BIN", value);
         }
     }
+}
+
+#[test]
+fn post_webhook_retries_and_delivers_after_transient_failures() {
+    let dir = temp_dir("webhook-retry-success");
+    let sink = dir.join("sink.json");
+    // Fails on every attempt but the last, so delivery only succeeds because
+    // of the retry loop.
+    let shim = flaky_curl_shim(&dir, WEBHOOK_MAX_ATTEMPTS - 1);
+
+    post_webhook(
+        &shim.to_string_lossy(),
+        &sink.to_string_lossy(),
+        b"{\"ok\":true}",
+    );
+
+    assert_eq!(
+        std::fs::read_to_string(&sink).unwrap(),
+        "{\"ok\":true}",
+        "final attempt should have delivered the payload"
+    );
+    let attempts: u32 = std::fs::read_to_string(dir.join("attempts.count"))
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+    assert_eq!(attempts, WEBHOOK_MAX_ATTEMPTS);
+}
+
+#[test]
+fn post_webhook_gives_up_and_logs_after_exhausting_retries() {
+    let dir = temp_dir("webhook-retry-exhausted");
+    let sink = dir.join("sink.json");
+    // Always fails: even the last attempt is a failure.
+    let shim = flaky_curl_shim(&dir, WEBHOOK_MAX_ATTEMPTS + 5);
+
+    post_webhook(&shim.to_string_lossy(), &sink.to_string_lossy(), b"{}");
+
+    assert!(!sink.exists(), "payload should never have been delivered");
+    let attempts: u32 = std::fs::read_to_string(dir.join("attempts.count"))
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+    assert_eq!(
+        attempts, WEBHOOK_MAX_ATTEMPTS,
+        "should stop retrying at the bounded attempt limit"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`post_webhook` (`src/routines/failure_notify.rs`) was fire-and-forget: a single transient `curl` failure (DNS blip, receiving endpoint briefly 5xx-ing, momentary network drop) silently dropped the one notification that matters most — the routine has already failed, so a dropped webhook means the failure goes unnoticed until someone checks the UI.

This adds a bounded retry loop around the curl invocation:

- Up to 3 attempts, with short exponential backoff (100ms, then 200ms) between retries.
- The retry count is fixed and small, so a dead webhook endpoint can't pile up threads across successive routine failures — same as before, just with (bounded) extra attempts.
- Final failure after all attempts is still logged via `log::warn!`, matching prior behavior rather than swallowing errors silently.
- `on_failure_command` is untouched — it's a local process, not subject to the same network flakiness this issue is about.

## Test plan

- Added `post_webhook_retries_and_delivers_after_transient_failures` and `post_webhook_gives_up_and_logs_after_exhausting_retries` in `src/routines/failure_notify_dispatch_tests.rs`, using a fake `curl` shim (mirroring the existing `MOADIM_NOTIFICATION_CURL_BIN` pattern) that fails N times before succeeding (or always fails), asserting on both delivery and attempt count.
- `cargo fmt --check` passes.
- `cargo clippy --all-targets -- -D warnings` passes.
- `cargo test` passes (1325 passed, 0 failed), including all `failure_notify` tests.

Closes #1530

This PR was opened automatically by the moadim routine 'Open issues → fix PRs (owned repos + my orgs)'.