### PR TITLE
CLI: add global routine lock parity (lock/unlock/lock-status)

### DIFF
--- a/docs/moadim.1
+++ b/docs/moadim.1
@@ -122,6 +122,18 @@ Turn a routine off (set enabled=false) by id or slug.
 .TP
 .B agents
 List available agent keys.
+.TP
+.BR "lock " [ \-\-scope " " shared | local ]
+Create a lock sentinel, halting all routine scheduling and triggers without touching any
+individual routine's enabled state. Scope defaults to
+.BR shared .
+.TP
+.BR "unlock " [ \-\-scope " " shared | local | all ]
+Remove lock sentinel(s), restoring prior scheduling. Scope defaults to
+.BR all .
+.TP
+.B lock-status
+Show the current global lock status (whether the shared and/or local sentinel is present).
 .SH OPTIONS
 .TP
 .B \-\-json

--- a/src/cli/completions.rs
+++ b/src/cli/completions.rs
@@ -86,14 +86,18 @@ pub(super) fn build_cli() -> ClapCommand {
                         .required(true),
                 ),
         )
-        // Data-plane subcommands (`routines`, `agents`, `enable`, `disable`, `schedule`) are a
-        // separate clap parser already (`crate::commands::DataCli`); listing their bare names
-        // here (with no further flag detail) is enough for top-level tab-completion to find them.
+        // Data-plane subcommands (`routines`, `agents`, `enable`, `disable`, `schedule`, `lock`,
+        // `unlock`, `lock-status`) are a separate clap parser already
+        // (`crate::commands::DataCli`); listing their bare names here (with no further flag
+        // detail) is enough for top-level tab-completion to find them.
         .subcommand(ClapCommand::new("routines").visible_alias("routine"))
         .subcommand(ClapCommand::new("schedule").visible_alias("sched"))
         .subcommand(ClapCommand::new("enable").arg(Arg::new("routine")))
         .subcommand(ClapCommand::new("disable").arg(Arg::new("routine")))
         .subcommand(ClapCommand::new("agents"))
+        .subcommand(ClapCommand::new("lock").arg(Arg::new("scope").long("scope")))
+        .subcommand(ClapCommand::new("unlock").arg(Arg::new("scope").long("scope")))
+        .subcommand(ClapCommand::new("lock-status"))
 }
 
 /// Write the completion script for `shell_name` to `out`.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -130,5 +130,14 @@ pub enum Command {
 
 /// First-argument keywords that select a data-plane subcommand handled by [`crate::commands`]
 /// rather than the lifecycle commands parsed here. Kept in sync with the clap subcommands.
-pub(crate) const DATA_COMMANDS: &[&str] = &["routines", "schedule", "agents", "enable", "disable"];
+pub(crate) const DATA_COMMANDS: &[&str] = &[
+    "routines",
+    "schedule",
+    "agents",
+    "enable",
+    "disable",
+    "lock",
+    "unlock",
+    "lock-status",
+];
 include!("wants_json.rs");

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,8 +1,9 @@
 //! Data-plane CLI subcommands.
 //!
 //! These mirror the daemon's `/api/v1` REST routes (and the MCP tools) so most actions are
-//! reachable from the command line too — routine flags and the global routine lock are
-//! REST/MCP-only for now. Each subcommand is a thin client: it serializes its flags into the
+//! reachable from the command line too — routine flags and per-routine snooze are REST/MCP-only
+//! for now (#1516 tracks closing that gap). The global routine lock (`lock`/`unlock`/
+//! `lock-status`) has full CLI parity below. Each subcommand is a thin client: it serializes its flags into the
 //! same JSON the REST API expects, sends it to the running server over the loopback HTTP client in
 //! [`crate::cli`], and prints the server's response. The daemon must already be running
 //! (`moadim` / `moadim -i`); when it is not, these commands report that and exit
@@ -75,6 +76,22 @@ pub(crate) enum DataCommand {
     },
     /// List the available agent registry keys.
     Agents,
+    /// Create a lock sentinel, halting all routine scheduling and triggers without touching any
+    /// individual routine's `enabled` state (the "pause everything" escape hatch, #683).
+    Lock {
+        /// Which sentinel to create: `shared` (committed `.lock`, shareable via git) or `local`
+        /// (gitignored `.local.lock`, machine-local).
+        #[arg(long, default_value = "shared")]
+        scope: String,
+    },
+    /// Remove lock sentinel(s), restoring prior routine scheduling.
+    Unlock {
+        /// Which sentinel(s) to remove: `shared`, `local`, or `all` (both, the default).
+        #[arg(long, default_value = "all")]
+        scope: String,
+    },
+    /// Show the current global lock status (whether the shared and/or local sentinel is present).
+    LockStatus,
 }
 
 /// Schedule operations driven by the OS crontab, keyed only by ID.

--- a/src/every_subcommand_succeeds_against_a_2xx_server_tests.rs
+++ b/src/every_subcommand_succeeds_against_a_2xx_server_tests.rs
@@ -101,6 +101,12 @@ fn every_subcommand_succeeds_against_a_2xx_server() {
         &["sched", "trigger", "sid"],
         // top-level
         &["agents"],
+        // global routine lock
+        &["lock"],
+        &["lock", "--scope", "local"],
+        &["unlock"],
+        &["unlock", "--scope", "shared"],
+        &["lock-status"],
     ];
     for call in calls {
         assert_eq!(run(argv(call)), 0, "call {call:?}");
@@ -162,5 +168,15 @@ fn no_server_returns_not_running_exit_code() {
         run(argv(&["schedule", "trigger", "sid"])),
         crate::cli::EXIT_NOT_RUNNING
     );
+    // `lock-status` reaches the same not-running path.
+    assert_eq!(run(argv(&["lock-status"])), crate::cli::EXIT_NOT_RUNNING);
+}
+
+#[test]
+fn lock_rejects_unknown_scope() {
+    // The server validates `scope` and answers 400; the CLI just surfaces the non-2xx as exit 1.
+    let server = FakeServer::start(400, "{\"error\":\"unknown scope\"}");
+    let _addr = EnvGuard::set(BIND_ENV, &server.addr);
+    assert_eq!(run(argv(&["lock", "--scope", "bogus"])), 1);
 }
 include!("enable_disable_report_server_echoed_state_tests.rs");

--- a/src/run.rs
+++ b/src/run.rs
@@ -34,5 +34,16 @@ pub(crate) fn dispatch(command: DataCommand) -> i32 {
             json,
         } => set_routine_enabled(&routine, false, reason, json),
         DataCommand::Agents => request("GET", "/api/v1/agents", None),
+        DataCommand::Lock { scope } => request(
+            "POST",
+            "/api/v1/routines/lock",
+            Some(&serde_json::json!({ "scope": scope }).to_string()),
+        ),
+        DataCommand::Unlock { scope } => request(
+            "DELETE",
+            &format!("/api/v1/routines/lock?scope={scope}"),
+            None,
+        ),
+        DataCommand::LockStatus => request("GET", "/api/v1/routines/lock", None),
     }
 }


### PR DESCRIPTION
## Summary

Partially addresses #1516 (scoped down — see below; issue should stay open for the snooze/flags follow-up).

The global routine lock (`GET`/`POST`/`DELETE /api/v1/routines/lock`) was REST/MCP-only and unreachable from the terminal — exactly where an operator SSH'd into a misbehaving host would want the "pause everything" escape hatch. This adds:

- `moadim lock [--scope shared|local]` (defaults to `shared`) → `POST /api/v1/routines/lock`
- `moadim unlock [--scope shared|local|all]` (defaults to `all`) → `DELETE /api/v1/routines/lock?scope=...`
- `moadim lock-status` → `GET /api/v1/routines/lock`

These follow the file's established thin-HTTP-client pattern exactly (same `request()`/`print_body()` helpers `routines list/get/delete` already use, `EXIT_NOT_RUNNING` on a down daemon, the server's own JSON response as the machine-readable output — the same convention already used by every other pure-passthrough subcommand in `src/commands.rs`, which is why these don't need their own `--json` flag: the printed body already is the JSON `LockStatus` object). Also wired into shell completions (`src/cli/completions.rs`), `docs/moadim.1`, and `DATA_COMMANDS` so `moadim lock`/`unlock`/`lock-status` route correctly, and updated the module doc comment that used to call out the lock as a REST/MCP-only gap.

## Scoped down from the full issue

The issue asked for three subcommand groups (snooze, flags, and the global lock). While investigating, two of the three turned out not to match the "mirror an existing REST route" premise the issue was built on:

- **Snooze** has **no REST route at all** — `snooze_routine` only exists as an MCP tool (`src/routes/preview_routine_prompt.rs`), calling `routines::svc_snooze` directly with no HTTP handler in `build_app_with_shutdown.rs`. Adding CLI snooze would mean designing and adding a brand-new REST endpoint first, not just wiring the CLI to something that exists.
- **Flags** has a REST route, but not the shape the acceptance criteria assumed: `GET /routines/{id}/flags` requires a routine ID (there's no cross-routine "list all flags" endpoint to back an optional `--routine` filter), and flags have no resolved/open status field at all (per `src/routines/flags.rs`: "There is no status field: an 'open' flag is simply a file that exists. Resolving a flag means deleting it.") — so `--open`/`--resolved` don't correspond to anything the backend can answer.

Both would require real REST API design decisions rather than a mechanical CLI mirror, so per the task's guidance I scoped this PR down to the lock group — the one that matches an existing REST route exactly — and left snooze and flags for follow-up issues. **This PR does not close #1516 on merge** — the issue should stay open (or be split) until snooze/flags parity is addressed.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (1324 passed, 0 failed)
- [x] Added `lock`/`unlock`/`lock-status` cases to `every_subcommand_succeeds_against_a_2xx_server_tests.rs` (2xx success, non-2xx→1, not-running→`EXIT_NOT_RUNNING`)

---

This PR was opened automatically by the moadim routine "Open issues → fix PRs (owned repos + my orgs)".