### PR TITLE
docs: fix validation findings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ pnpm --filter client test
 
 `cargo llvm-cov` runs the test suite with instrumentation and enforces 100%
 line coverage (excluding `main.rs`). `linecheck` keeps any single `.rs` file
-under `src/` from growing past 500 lines — a convention two independently
+under `src/` from growing past 200 lines — a convention two independently
 green PRs can each respect yet still blow past together, since it isn't a
 required branch-protection check (see the `linecheck` job in
 [`lint.yml`](.github/workflows/lint.yml)). `client/` isn't a Cargo workspace

--- a/README.md
+++ b/README.md
@@ -390,7 +390,8 @@ agent run. The web Notification Center turns that field into a persistent bell
 notification so the operator can review the routine and choose `Run now`
 manually if appropriate.
 
-Blank or unset `MOADIM_API_TOKEN` disables auth.
+Blank or unset `MOADIM_API_TOKEN` disables auth. A non-loopback bind address
+(see [Bind address](#bind-address)) is refused at startup
 unless either `MOADIM_API_TOKEN` is set (protected remote use) or
 `MOADIM_ALLOW_REMOTE=1` is set (explicit unauthenticated override; logs a loud
 RCE warning). Prefer a token plus firewall/VPN/reverse-proxy restrictions for
@@ -659,8 +660,8 @@ MOADIM_BIND_ADDR=127.0.0.1:7000 moadim
 MOADIM_BIND_ADDR=127.0.0.1:7000 moadim status
 ```
 
-> **⚠️ Keep the bind address on loopback.** The REST API and the MCP endpoint are
-> **unauthenticated** — there is no token, password, or per-client check. Anyone who
+> **⚠️ Keep the bind address on loopback.** Unless `MOADIM_API_TOKEN` is set, the REST
+> API and the MCP endpoint are **unauthenticated** — no token, password, or per-client check. Anyone who
 > can reach the bind address can create, edit, and trigger routines, and a triggered
 > routine launches an agent on your machine with your credentials. Binding to a
 > routable interface therefore hands that control surface — effectively remote code
@@ -673,14 +674,15 @@ MOADIM_BIND_ADDR=127.0.0.1:7000 moadim status
 
 Because that risk is easy to hit by accident (a copy-pasted `0.0.0.0` to "just get it
 working" on a container/VM), the daemon **refuses to start** if `MOADIM_BIND_ADDR` resolves
-to a non-loopback address, unless you explicitly opt in:
+to a non-loopback address, unless `MOADIM_API_TOKEN` is set or you explicitly opt in:
 
 ```sh
-# Refused at startup — 0.0.0.0 is not loopback and MOADIM_ALLOW_REMOTE isn't set:
+# Refused at startup — 0.0.0.0 is not loopback, and neither MOADIM_API_TOKEN nor
+# MOADIM_ALLOW_REMOTE is set:
 MOADIM_BIND_ADDR=0.0.0.0:5784 moadim
-# moadim: refusing to bind to 0.0.0.0:5784: it is not loopback-only, and the REST/MCP API
-# has no authentication — ... Set MOADIM_ALLOW_REMOTE=1 to start anyway if you understand
-# and accept that risk.
+# moadim: refusing to bind to 0.0.0.0:5784: it is not loopback-only and MOADIM_API_TOKEN
+# is not set. Set MOADIM_API_TOKEN to protect REST/MCP with a bearer token, or set
+# MOADIM_ALLOW_REMOTE=1 to start without auth if you understand and accept the RCE risk.
 
 # Starts, but logs a prominent warning every time, because you opted in:
 MOADIM_ALLOW_REMOTE=1 MOADIM_BIND_ADDR=0.0.0.0:5784 moadim


### PR DESCRIPTION
- README.md:393-397 — garbled paragraph in the API-authentication section (dangling fragment "unless either `MOADIM_API_TOKEN` is set …") — completed the sentence to state that a non-loopback bind is refused unless a token or the explicit override is set.
- README.md:662-663 — bind-address warning claimed the REST/MCP API is unconditionally unauthenticated ("there is no token, password, or per-client check"); out of date since `MOADIM_API_TOKEN` support landed — now says "unless `MOADIM_API_TOKEN` is set".
- README.md:675-684 — claimed a non-loopback bind is refused unless `MOADIM_ALLOW_REMOTE=1`; per `src/cli/bind.rs` (`validated_bind_addr`), a configured `MOADIM_API_TOKEN` also allows it, and the quoted refusal message no longer matched the actual error text — both updated.
- CONTRIBUTING.md:51 — said the per-file gate stops files "growing past 500 lines"; the actual gate (same doc, pre-push hook, and CI) is `linecheck --max-lines 200`.

🤖 This PR was opened automatically by the moadim routine "Weekly docs validation + fix PRs for repos I worked on".

🤖 Generated with [Claude Code](https://claude.com/claude-code)