### PR TITLE
feat(cli): add offline `moadim export` / `moadim import` for config backup and migration

### DIFF
--- a/.changeset/cli-export-import.md
+++ b/.changeset/cli-export-import.md
@@ -1,0 +1,5 @@
+---
+"moadim": minor
+---
+
+Add offline `moadim export` / `moadim import` CLI commands to back up and restore the tracked config (routines, agents, `notifications.toml`, `user_prompt.md`) as a single portable JSON bundle, excluding gitignored runtime/local files. Import validates paths and `routine.toml` syntax before writing, writes atomically, skips existing files unless `--force`, and supports `--dry-run`.

--- a/README.md
+++ b/README.md
@@ -589,12 +589,26 @@ moadim routines delete <id>
 moadim enable <routine>       # set enabled = true
 moadim disable <routine>      # set enabled = false  (--json for a {routine,enabled} object)
 
+# Backup / migration (offline — works without a running daemon)
+moadim export                          # print a JSON bundle of every tracked config file
+moadim export --out moadim-backup.json # write the bundle to a file instead
+moadim import moadim-backup.json --dry-run  # preview what would be created/overwritten/skipped
+moadim import moadim-backup.json       # restore; existing files are skipped unless --force
+
 # Misc
 moadim agents                 # list available agent keys
 moadim machine show           # print this install's resolved machine name + where it came from
 moadim machine set <name>     # persist a machine name to machine.local.toml
 moadim machine list           # list distinct machine names referenced by any routine's `machines`
 ```
+
+`moadim export` captures the tracked config only — per-routine `routine.toml`, `schedule.cron`,
+`disabled.json`, and `prompts/prompt.pure.md`, the agent registry's `agents/*.toml`, plus
+`notifications.toml` and `user_prompt.md`. Gitignored runtime files (`*.local.*` sidecars —
+including secret env overrides — `*.pid`, `*.log`, compiled cron/prompt outputs) are never
+exported. `moadim import` validates the bundle (paths and `routine.toml` syntax) before writing
+anything, writes atomically, and skips existing files unless `--force` is given; run
+`moadim restart` afterwards so imported routines are resynced into the crontab.
 
 Pass `--help` to any subcommand (e.g. `moadim routines create --help`) for the full flag list.
 `--repositories` (routines) takes raw JSON. Optional flags map to a PATCH so

--- a/src/cli/completions.rs
+++ b/src/cli/completions.rs
@@ -86,7 +86,8 @@ pub(super) fn build_cli() -> ClapCommand {
                         .required(true),
                 ),
         )
-        // Data-plane subcommands (`routines`, `agents`, `enable`, `disable`, `schedule`) are a
+        // Data-plane subcommands (`routines`, `agents`, `enable`, `disable`, `schedule`,
+        // `export`, `import`) are a
         // separate clap parser already (`crate::commands::DataCli`); listing their bare names
         // here (with no further flag detail) is enough for top-level tab-completion to find them.
         .subcommand(ClapCommand::new("routines").visible_alias("routine"))
@@ -94,6 +95,8 @@ pub(super) fn build_cli() -> ClapCommand {
         .subcommand(ClapCommand::new("enable").arg(Arg::new("routine")))
         .subcommand(ClapCommand::new("disable").arg(Arg::new("routine")))
         .subcommand(ClapCommand::new("agents"))
+        .subcommand(ClapCommand::new("export"))
+        .subcommand(ClapCommand::new("import").arg(Arg::new("file")))
 }
 
 /// Write the completion script for `shell_name` to `out`.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -130,5 +130,7 @@ pub enum Command {
 
 /// First-argument keywords that select a data-plane subcommand handled by [`crate::commands`]
 /// rather than the lifecycle commands parsed here. Kept in sync with the clap subcommands.
-pub(crate) const DATA_COMMANDS: &[&str] = &["routines", "schedule", "agents", "enable", "disable"];
+pub(crate) const DATA_COMMANDS: &[&str] = &[
+    "routines", "schedule", "agents", "enable", "disable", "export", "import",
+];
 include!("wants_json.rs");

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -75,6 +75,30 @@ pub(crate) enum DataCommand {
     },
     /// List the available agent registry keys.
     Agents,
+    /// Export every tracked routine, agent, and global config file as one portable JSON bundle.
+    ///
+    /// Runs offline against the config directory — no daemon needed. Gitignored runtime files
+    /// (`*.local.*`, `*.pid`, `*.log`, compiled outputs) are excluded, so the bundle is safe to
+    /// share or commit.
+    Export {
+        /// Write the bundle to this file (atomically) instead of stdout.
+        #[arg(long)]
+        out: Option<std::path::PathBuf>,
+    },
+    /// Restore a bundle produced by `moadim export` into the config directory.
+    ///
+    /// Runs offline; existing files are skipped unless `--force` is given. Run `moadim restart`
+    /// afterwards so the imported routines are resynced into the crontab.
+    Import {
+        /// Path of the bundle file to import.
+        file: std::path::PathBuf,
+        /// Print what would be created/overwritten/skipped without writing anything.
+        #[arg(long)]
+        dry_run: bool,
+        /// Overwrite files that already exist (default: skip them).
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 /// Schedule operations driven by the OS crontab, keyed only by ID.

--- a/src/export_import/bundle.rs
+++ b/src/export_import/bundle.rs
@@ -1,0 +1,73 @@
+//! The portable bundle format shared by `moadim export` and `moadim import`, plus the predicate
+//! deciding which config-dir-relative paths belong in a bundle.
+
+use std::collections::BTreeMap;
+use std::path::{Component, Path};
+
+use serde::{Deserialize, Serialize};
+
+/// Version stamp written into every exported bundle so a future format change can be detected on
+/// import instead of silently misreading old or new bundles.
+pub(crate) const BUNDLE_VERSION: u32 = 1;
+
+/// A portable snapshot of the tracked moadim config: a map from config-dir-relative POSIX path
+/// (`/`-separated on every platform) to that file's UTF-8 contents.
+#[derive(Serialize, Deserialize)]
+pub(crate) struct Bundle {
+    /// Bundle format version; import rejects bundles whose version is not [`BUNDLE_VERSION`].
+    pub(crate) version: u32,
+    /// Config-dir-relative path → file contents. A `BTreeMap` keeps export output deterministic.
+    pub(crate) files: BTreeMap<String, String>,
+}
+
+/// True when `rel` (a config-dir-relative path) is one of the tracked files export backs up and
+/// import is allowed to write.
+///
+/// This doubles as import's safety gate: any path with a non-plain component (absolute, `..`, a
+/// prefix, or non-UTF-8) is rejected, so a hostile bundle cannot escape the config directory, and
+/// gitignored runtime files (`*.local.*`, logs, pids, compiled outputs) are never written because
+/// they simply aren't in the allow-list.
+pub(crate) fn is_tracked_rel_path(rel: &Path) -> bool {
+    let Some(parts) = plain_components(rel) else {
+        return false;
+    };
+    match parts.as_slice() {
+        ["notifications.toml" | "user_prompt.md"] => true,
+        ["agents", file] => {
+            Path::new(file).extension() == Some(std::ffi::OsStr::new("toml"))
+                && !file.contains(".local.")
+        }
+        ["routines", middle @ .., file] => is_tracked_routine_file(middle, file),
+        _ => false,
+    }
+}
+
+/// True when `file`, nested under `routines/` behind the intermediate directories `middle`
+/// (routine folders, and optionally the grouping folders of a foldered routine), is one of the
+/// tracked per-routine files.
+fn is_tracked_routine_file(middle: &[&str], file: &str) -> bool {
+    match file {
+        // Tracked routine metadata lives directly in a routine directory, so at least one
+        // intermediate directory (the routine's folder) must be present.
+        "routine.toml" | "schedule.cron" | "disabled.json" => !middle.is_empty(),
+        // The pure prompt lives in the routine directory's `prompts/` subfolder.
+        "prompt.pure.md" => middle.len() >= 2 && middle.last() == Some(&"prompts"),
+        _ => false,
+    }
+}
+
+/// Split `rel` into its plain ([`Component::Normal`]) UTF-8 components, or `None` when any
+/// component is something else (root, prefix, `.`/`..`) or not valid UTF-8 — i.e. when the path
+/// cannot be treated as a safe config-dir-relative path.
+fn plain_components(rel: &Path) -> Option<Vec<&str>> {
+    rel.components()
+        .map(|component| match component {
+            Component::Normal(part) => part.to_str(),
+            _ => None,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+#[path = "bundle_tests.rs"]
+mod bundle_tests;

--- a/src/export_import/bundle_tests.rs
+++ b/src/export_import/bundle_tests.rs
@@ -1,0 +1,94 @@
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and cases do not need doc comments"
+)]
+
+use std::path::Path;
+
+use super::{is_tracked_rel_path, Bundle, BUNDLE_VERSION};
+
+fn tracked(rel: &str) -> bool {
+    is_tracked_rel_path(Path::new(rel))
+}
+
+#[test]
+fn tracked_global_files_are_accepted() {
+    assert!(tracked("notifications.toml"));
+    assert!(tracked("user_prompt.md"));
+}
+
+#[test]
+fn untracked_global_files_are_rejected() {
+    assert!(!tracked("machine.local.toml"));
+    assert!(!tracked("daemon.log"));
+    assert!(!tracked("moadim.pid"));
+    assert!(!tracked("README.md"));
+    assert!(!tracked(".gitignore"));
+}
+
+#[test]
+fn agent_tomls_are_accepted_but_local_and_readme_are_not() {
+    assert!(tracked("agents/claude.toml"));
+    assert!(!tracked("agents/claude.local.toml"));
+    assert!(!tracked("agents/README.md"));
+    assert!(!tracked("agents/nested/claude.toml"));
+}
+
+#[test]
+fn tracked_routine_files_are_accepted() {
+    assert!(tracked("routines/my-routine/routine.toml"));
+    assert!(tracked("routines/my-routine/schedule.cron"));
+    assert!(tracked("routines/my-routine/disabled.json"));
+    assert!(tracked("routines/my-routine/prompts/prompt.pure.md"));
+    // Foldered routines nest the routine directory under grouping folders.
+    assert!(tracked("routines/team/ops/nightly/routine.toml"));
+    assert!(tracked("routines/team/ops/nightly/prompts/prompt.pure.md"));
+}
+
+#[test]
+fn routine_runtime_sidecars_are_rejected() {
+    assert!(!tracked("routines/my-routine/state.local.toml"));
+    assert!(!tracked("routines/my-routine/routine.local.toml"));
+    assert!(!tracked("routines/my-routine/schedule.compailed.cron"));
+    assert!(!tracked("routines/my-routine/runs.log"));
+    assert!(!tracked(
+        "routines/my-routine/prompts/prompt.compiled.local.md"
+    ));
+    assert!(!tracked("routines/README.md"));
+}
+
+#[test]
+fn misplaced_tracked_names_are_rejected() {
+    // Tracked file names only count in their expected position.
+    assert!(!tracked("routines/routine.toml"));
+    assert!(!tracked("routine.toml"));
+    assert!(!tracked("routines/my-routine/prompt.pure.md"));
+    assert!(!tracked("routines/prompts/prompt.pure.md"));
+}
+
+#[test]
+fn unsafe_paths_are_rejected() {
+    assert!(!tracked("../outside/routine.toml"));
+    assert!(!tracked("routines/../../etc/passwd"));
+    assert!(!tracked("/etc/passwd"));
+    // `.` segments are normalized away by `Path::components()`, which is harmless: the
+    // resolved path still lands on the same tracked file inside the config dir.
+    assert!(tracked("routines/./my-routine/routine.toml"));
+}
+
+#[test]
+fn bundle_round_trips_through_json() {
+    let mut files = std::collections::BTreeMap::new();
+    files.insert("notifications.toml".to_string(), "[]".to_string());
+    let bundle = Bundle {
+        version: BUNDLE_VERSION,
+        files,
+    };
+    let json = serde_json::to_string(&bundle).unwrap();
+    let parsed: Bundle = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed.version, BUNDLE_VERSION);
+    assert_eq!(
+        parsed.files.get("notifications.toml").map(String::as_str),
+        Some("[]")
+    );
+}

--- a/src/export_import/export.rs
+++ b/src/export_import/export.rs
@@ -1,0 +1,96 @@
+//! `moadim export`: snapshot the tracked config tree into a single portable JSON bundle.
+
+use std::collections::BTreeMap;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use super::bundle::{is_tracked_rel_path, Bundle, BUNDLE_VERSION};
+
+/// Run `moadim export`: collect every tracked file under the config directory into a
+/// [`Bundle`] and write it as pretty-printed JSON to `out` (atomically), or to stdout when `out`
+/// is `None`. Returns the process exit code (`0` on success, `1` on failure).
+pub(crate) fn run_export(out: Option<PathBuf>) -> i32 {
+    let root = crate::paths::config_dir();
+    let bundle = match collect_bundle(&root) {
+        Ok(bundle) => bundle,
+        Err(err) => {
+            eprintln!("export failed: cannot read {}: {err}", root.display());
+            return 1;
+        }
+    };
+    let count = bundle.files.len();
+    let json = to_json(&bundle);
+    let Some(path) = out else {
+        println!("{json}");
+        return 0;
+    };
+    match crate::utils::atomic::atomic_write(&path, json.as_bytes()) {
+        Ok(()) => {
+            println!("exported {count} tracked file(s) to {}", path.display());
+            0
+        }
+        Err(err) => {
+            eprintln!("export failed: cannot write {}: {err}", path.display());
+            1
+        }
+    }
+}
+
+/// Serialize `bundle` as pretty-printed JSON.
+///
+/// Serializing a struct of a `u32` and a string→string map cannot fail, so the error arm maps to
+/// an empty string rather than threading an impossible `Result` to the caller.
+fn to_json(bundle: &Bundle) -> String {
+    serde_json::to_string_pretty(bundle).unwrap_or_default()
+}
+
+/// Walk the config tree rooted at `root` and collect every tracked, UTF-8 file into a [`Bundle`].
+fn collect_bundle(root: &Path) -> io::Result<Bundle> {
+    let mut files = BTreeMap::new();
+    collect_dir(root, Path::new(""), &mut files)?;
+    Ok(Bundle {
+        version: BUNDLE_VERSION,
+        files,
+    })
+}
+
+/// Recursively walk `dir` (which sits at `rel` relative to the config root), adding every tracked
+/// file to `files`.
+fn collect_dir(dir: &Path, rel: &Path, files: &mut BTreeMap<String, String>) -> io::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let child_rel = rel.join(entry.file_name());
+        let path = entry.path();
+        if path.is_dir() {
+            collect_dir(&path, &child_rel, files)?;
+        } else if is_tracked_rel_path(&child_rel) {
+            insert_file(&path, &child_rel, files);
+        }
+    }
+    Ok(())
+}
+
+/// Read `path` and store its contents under the POSIX form of `rel`. A tracked file that cannot
+/// be read (or is not valid UTF-8) is skipped with a warning rather than aborting the whole
+/// export, so one bad file doesn't block backing up everything else.
+fn insert_file(path: &Path, rel: &Path, files: &mut BTreeMap<String, String>) {
+    match std::fs::read_to_string(path) {
+        Ok(content) => {
+            files.insert(rel_key(rel), content);
+        }
+        Err(err) => eprintln!("skipping {}: {err}", path.display()),
+    }
+}
+
+/// Render `rel` with `/` separators so bundle keys are identical across platforms.
+fn rel_key(rel: &Path) -> String {
+    let parts: Vec<&str> = rel
+        .components()
+        .filter_map(|component| component.as_os_str().to_str())
+        .collect();
+    parts.join("/")
+}
+
+#[cfg(test)]
+#[path = "export_tests.rs"]
+mod export_tests;

--- a/src/export_import/export_tests.rs
+++ b/src/export_import/export_tests.rs
@@ -1,0 +1,136 @@
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and cases do not need doc comments"
+)]
+
+use std::path::{Path, PathBuf};
+
+use super::super::bundle::Bundle;
+use super::run_export;
+
+fn scratch_dir(tag: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("moadim-export-{tag}-{}", uuid::Uuid::new_v4()))
+}
+
+/// Point `MOADIM_HOME_OVERRIDE` at a fresh tempdir home for the duration of `body`.
+fn with_override_home(body: impl FnOnce(&Path)) {
+    let home = scratch_dir("home");
+    std::fs::create_dir_all(&home).unwrap();
+    let previous = std::env::var_os("MOADIM_HOME_OVERRIDE");
+    // SAFETY: tests in this crate run single-threaded per binary (RUST_TEST_THREADS=1).
+    unsafe {
+        std::env::set_var("MOADIM_HOME_OVERRIDE", &home);
+    }
+    body(&home);
+    // SAFETY: single-threaded test execution.
+    unsafe {
+        match previous {
+            Some(value) => std::env::set_var("MOADIM_HOME_OVERRIDE", value),
+            None => std::env::remove_var("MOADIM_HOME_OVERRIDE"),
+        }
+    }
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+fn write(root: &Path, rel: &str, content: &[u8]) {
+    let path = root.join(rel);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, content).unwrap();
+}
+
+fn seed_config_tree(home: &Path) -> PathBuf {
+    let root = home.join(".config").join("moadim");
+    write(&root, "notifications.toml", b"[[on_failure_webhook]]\n");
+    write(&root, "machine.local.toml", b"name = 'secret-host'\n");
+    write(&root, "daemon.log", b"log line\n");
+    write(&root, "agents/claude.toml", b"command = 'claude'\n");
+    write(&root, "agents/README.md", b"registry docs\n");
+    write(&root, "routines/daily/routine.toml", b"title = 'Daily'\n");
+    write(&root, "routines/daily/schedule.cron", b"@daily\n");
+    write(&root, "routines/daily/state.local.toml", b"snoozed = 1\n");
+    write(&root, "routines/daily/prompts/prompt.pure.md", b"do work\n");
+    write(
+        &root,
+        "routines/daily/prompts/prompt.compiled.local.md",
+        b"compiled\n",
+    );
+    root
+}
+
+#[test]
+fn export_to_file_includes_tracked_and_excludes_local_files() {
+    with_override_home(|home| {
+        seed_config_tree(home);
+        let out = home.join("bundle.json");
+        assert_eq!(run_export(Some(out.clone())), 0);
+        let bundle: Bundle = serde_json::from_str(&std::fs::read_to_string(&out).unwrap()).unwrap();
+        assert_eq!(bundle.version, 1);
+        let keys: Vec<&str> = bundle.files.keys().map(String::as_str).collect();
+        assert_eq!(
+            keys,
+            vec![
+                "agents/claude.toml",
+                "notifications.toml",
+                "routines/daily/prompts/prompt.pure.md",
+                "routines/daily/routine.toml",
+                "routines/daily/schedule.cron",
+            ]
+        );
+        assert_eq!(
+            bundle.files.get("routines/daily/routine.toml").unwrap(),
+            "title = 'Daily'\n"
+        );
+    });
+}
+
+#[test]
+fn export_to_stdout_succeeds() {
+    with_override_home(|home| {
+        seed_config_tree(home);
+        assert_eq!(run_export(None), 0);
+    });
+}
+
+#[test]
+fn export_skips_non_utf8_tracked_files() {
+    with_override_home(|home| {
+        let root = seed_config_tree(home);
+        write(&root, "routines/bad/routine.toml", &[0xff, 0xfe, 0x00]);
+        let out = home.join("bundle.json");
+        assert_eq!(run_export(Some(out.clone())), 0);
+        let bundle: Bundle = serde_json::from_str(&std::fs::read_to_string(&out).unwrap()).unwrap();
+        assert!(!bundle.files.contains_key("routines/bad/routine.toml"));
+        assert!(bundle.files.contains_key("routines/daily/routine.toml"));
+    });
+}
+
+#[test]
+fn export_subcommand_dispatches_through_the_data_cli() {
+    with_override_home(|home| {
+        seed_config_tree(home);
+        let out = home.join("bundle.json");
+        let args = vec!["export".to_string(), "--out".to_string(), display(&out)];
+        assert_eq!(crate::commands::run(args), 0);
+        assert!(out.exists());
+    });
+}
+
+fn display(path: &Path) -> String {
+    path.display().to_string()
+}
+
+#[test]
+fn export_fails_when_config_dir_is_missing() {
+    with_override_home(|_home| {
+        assert_eq!(run_export(None), 1);
+    });
+}
+
+#[test]
+fn export_fails_when_out_file_is_unwritable() {
+    with_override_home(|home| {
+        seed_config_tree(home);
+        let out = home.join("missing-dir").join("bundle.json");
+        assert_eq!(run_export(Some(out)), 1);
+    });
+}

--- a/src/export_import/import.rs
+++ b/src/export_import/import.rs
@@ -1,0 +1,149 @@
+//! `moadim import`: validate a bundle produced by `moadim export` and restore its files into the
+//! config tree.
+
+use std::path::Path;
+
+use super::bundle::{is_tracked_rel_path, Bundle, BUNDLE_VERSION};
+
+/// What import would do (or did) with one bundled file, decided by whether the target already
+/// exists and whether `--force` was given.
+enum Action {
+    /// The target does not exist yet and will be written.
+    Create,
+    /// The target exists and `--force` replaces it.
+    Overwrite,
+    /// The target exists and is left untouched (the default collision behavior).
+    Skip,
+}
+
+impl Action {
+    /// The plan/summary verb printed for this action.
+    const fn verb(&self) -> &'static str {
+        match self {
+            Self::Create => "create",
+            Self::Overwrite => "overwrite",
+            Self::Skip => "skip (exists)",
+        }
+    }
+}
+
+/// Run `moadim import`: read the bundle at `file`, validate it in full (version, path safety,
+/// `routine.toml` parseability) before touching disk, then restore its files under the config
+/// directory. Existing files are skipped unless `force` is set; `dry_run` prints the plan and
+/// writes nothing. Returns the process exit code (`0` success, `1` write failure, `2` invalid
+/// bundle).
+pub(crate) fn run_import(file: &Path, dry_run: bool, force: bool) -> i32 {
+    let bundle = match read_bundle(file) {
+        Ok(bundle) => bundle,
+        Err(message) => {
+            eprintln!("import failed: {message}");
+            return 2;
+        }
+    };
+    let root = crate::paths::config_dir();
+    let plan = plan_actions(&root, &bundle, force);
+    if dry_run {
+        for (rel, _content, action) in &plan {
+            println!("{} {rel}", action.verb());
+        }
+        println!("dry run: nothing written");
+        return 0;
+    }
+    apply(&root, &plan)
+}
+
+/// Read and fully validate the bundle at `file`, returning a human-readable error message when
+/// anything is off. Validation happens before any write, so a bad bundle leaves the config tree
+/// untouched.
+fn read_bundle(file: &Path) -> Result<Bundle, String> {
+    let raw = std::fs::read_to_string(file)
+        .map_err(|err| format!("cannot read {}: {err}", file.display()))?;
+    let bundle: Bundle = serde_json::from_str(&raw)
+        .map_err(|err| format!("{} is not a moadim export bundle: {err}", file.display()))?;
+    if bundle.version != BUNDLE_VERSION {
+        return Err(format!(
+            "unsupported bundle version {} (this moadim understands version {BUNDLE_VERSION})",
+            bundle.version
+        ));
+    }
+    for (rel, content) in &bundle.files {
+        validate_entry(rel, content)?;
+    }
+    Ok(bundle)
+}
+
+/// Validate one bundle entry: the path must be a tracked config-dir-relative path (which also
+/// rules out traversal outside the config dir), and a `routine.toml` payload must at least be
+/// valid TOML so import can't plant files the routine loader immediately chokes on.
+fn validate_entry(rel: &str, content: &str) -> Result<(), String> {
+    if !is_tracked_rel_path(Path::new(rel)) {
+        return Err(format!("bundle entry {rel} is not a tracked config path"));
+    }
+    if rel.ends_with("routine.toml") {
+        toml::from_str::<toml::Value>(content)
+            .map_err(|err| format!("bundle entry {rel} is not valid TOML: {err}"))?;
+    }
+    Ok(())
+}
+
+/// Pair every bundled file with the [`Action`] import will take on it: create missing targets,
+/// and overwrite or skip existing ones depending on `force`.
+fn plan_actions<'bundle>(
+    root: &Path,
+    bundle: &'bundle Bundle,
+    force: bool,
+) -> Vec<(&'bundle str, &'bundle str, Action)> {
+    bundle
+        .files
+        .iter()
+        .map(|(rel, content)| {
+            let action = if root.join(rel).exists() {
+                if force {
+                    Action::Overwrite
+                } else {
+                    Action::Skip
+                }
+            } else {
+                Action::Create
+            };
+            (rel.as_str(), content.as_str(), action)
+        })
+        .collect()
+}
+
+/// Write every planned `Create`/`Overwrite` entry through the atomic-write primitive the storage
+/// layer uses, then print a summary. Returns `0` on success, `1` on the first write failure.
+fn apply(root: &Path, plan: &[(&str, &str, Action)]) -> i32 {
+    let mut written = 0_usize;
+    let mut skipped = 0_usize;
+    for (rel, content, action) in plan {
+        if matches!(action, Action::Skip) {
+            println!("{} {rel}", action.verb());
+            skipped += 1;
+            continue;
+        }
+        if let Err(err) = write_file(&root.join(rel), content) {
+            eprintln!("import failed: cannot write {rel}: {err}");
+            return 1;
+        }
+        println!("{} {rel}", action.verb());
+        written += 1;
+    }
+    println!(
+        "imported {written} file(s), skipped {skipped} — run `moadim restart` to resync the crontab"
+    );
+    0
+}
+
+/// Create `target`'s parent directories and write `content` atomically.
+///
+/// Every import target is `config_dir().join(rel)` with a non-empty relative path, so `parent()`
+/// is always present; the `.` fallback only guards against a bare-filename `target`.
+fn write_file(target: &Path, content: &str) -> std::io::Result<()> {
+    std::fs::create_dir_all(target.parent().unwrap_or(Path::new(".")))?;
+    crate::utils::atomic::atomic_write(target, content.as_bytes())
+}
+
+#[cfg(test)]
+#[path = "import_tests.rs"]
+mod import_tests;

--- a/src/export_import/import_tests.rs
+++ b/src/export_import/import_tests.rs
@@ -1,0 +1,192 @@
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and cases do not need doc comments"
+)]
+
+use std::path::{Path, PathBuf};
+
+use super::run_import;
+
+fn scratch_dir(tag: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("moadim-import-{tag}-{}", uuid::Uuid::new_v4()))
+}
+
+/// Point `MOADIM_HOME_OVERRIDE` at a fresh tempdir home for the duration of `body`.
+fn with_override_home(body: impl FnOnce(&Path)) {
+    let home = scratch_dir("home");
+    std::fs::create_dir_all(&home).unwrap();
+    let previous = std::env::var_os("MOADIM_HOME_OVERRIDE");
+    // SAFETY: tests in this crate run single-threaded per binary (RUST_TEST_THREADS=1).
+    unsafe {
+        std::env::set_var("MOADIM_HOME_OVERRIDE", &home);
+    }
+    body(&home);
+    // SAFETY: single-threaded test execution.
+    unsafe {
+        match previous {
+            Some(value) => std::env::set_var("MOADIM_HOME_OVERRIDE", value),
+            None => std::env::remove_var("MOADIM_HOME_OVERRIDE"),
+        }
+    }
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+fn config_root(home: &Path) -> PathBuf {
+    home.join(".config").join("moadim")
+}
+
+/// Write a version-1 bundle holding `files` to a fresh path under `home` and return that path.
+fn write_bundle(home: &Path, files: &[(&str, &str)]) -> PathBuf {
+    let map: serde_json::Map<String, serde_json::Value> = files
+        .iter()
+        .map(|(rel, content)| ((*rel).to_string(), serde_json::Value::from(*content)))
+        .collect();
+    let bundle = serde_json::json!({ "version": 1, "files": map });
+    let path = home.join(format!("bundle-{}.json", uuid::Uuid::new_v4()));
+    std::fs::write(&path, serde_json::to_string(&bundle).unwrap()).unwrap();
+    path
+}
+
+#[test]
+fn import_creates_files_through_the_config_root() {
+    with_override_home(|home| {
+        let bundle = write_bundle(
+            home,
+            &[
+                ("routines/daily/routine.toml", "title = 'Daily'\n"),
+                ("routines/daily/schedule.cron", "@daily\n"),
+                ("routines/daily/prompts/prompt.pure.md", "do work\n"),
+                ("agents/claude.toml", "command = 'claude'\n"),
+            ],
+        );
+        assert_eq!(run_import(&bundle, false, false), 0);
+        let root = config_root(home);
+        let toml = std::fs::read_to_string(root.join("routines/daily/routine.toml")).unwrap();
+        assert_eq!(toml, "title = 'Daily'\n");
+        let prompt =
+            std::fs::read_to_string(root.join("routines/daily/prompts/prompt.pure.md")).unwrap();
+        assert_eq!(prompt, "do work\n");
+    });
+}
+
+#[test]
+fn import_skips_existing_files_by_default_and_overwrites_with_force() {
+    with_override_home(|home| {
+        let root = config_root(home);
+        let target = root.join("routines/daily/routine.toml");
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+        std::fs::write(&target, "title = 'Original'\n").unwrap();
+        let bundle = write_bundle(home, &[("routines/daily/routine.toml", "title = 'New'\n")]);
+        assert_eq!(run_import(&bundle, false, false), 0);
+        assert_eq!(
+            std::fs::read_to_string(&target).unwrap(),
+            "title = 'Original'\n"
+        );
+        assert_eq!(run_import(&bundle, false, true), 0);
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "title = 'New'\n");
+    });
+}
+
+#[test]
+fn dry_run_reports_the_plan_without_writing() {
+    with_override_home(|home| {
+        let root = config_root(home);
+        let existing = root.join("agents").join("claude.toml");
+        std::fs::create_dir_all(existing.parent().unwrap()).unwrap();
+        std::fs::write(&existing, "command = 'claude'\n").unwrap();
+        let bundle = write_bundle(
+            home,
+            &[
+                ("agents/claude.toml", "command = 'changed'\n"),
+                ("routines/daily/routine.toml", "title = 'Daily'\n"),
+            ],
+        );
+        assert_eq!(run_import(&bundle, true, false), 0);
+        assert_eq!(run_import(&bundle, true, true), 0);
+        assert!(!root.join("routines/daily/routine.toml").exists());
+        assert_eq!(
+            std::fs::read_to_string(&existing).unwrap(),
+            "command = 'claude'\n"
+        );
+    });
+}
+
+#[test]
+fn import_subcommand_dispatches_through_the_data_cli() {
+    with_override_home(|home| {
+        let bundle = write_bundle(
+            home,
+            &[("routines/daily/routine.toml", "title = 'Daily'\n")],
+        );
+        let args = vec![
+            "import".to_string(),
+            bundle.display().to_string(),
+            "--dry-run".to_string(),
+        ];
+        assert_eq!(crate::commands::run(args), 0);
+        assert!(!config_root(home)
+            .join("routines/daily/routine.toml")
+            .exists());
+    });
+}
+
+#[test]
+fn import_rejects_a_missing_or_malformed_bundle_file() {
+    with_override_home(|home| {
+        assert_eq!(run_import(&home.join("absent.json"), false, false), 2);
+        let not_json = home.join("not-json.txt");
+        std::fs::write(&not_json, "not a bundle").unwrap();
+        assert_eq!(run_import(&not_json, false, false), 2);
+    });
+}
+
+#[test]
+fn import_rejects_an_unsupported_bundle_version() {
+    with_override_home(|home| {
+        let path = home.join("v9.json");
+        std::fs::write(&path, r#"{"version": 9, "files": {}}"#).unwrap();
+        assert_eq!(run_import(&path, false, false), 2);
+    });
+}
+
+#[test]
+fn import_rejects_untracked_and_traversal_paths_before_writing() {
+    with_override_home(|home| {
+        let sneaky = write_bundle(
+            home,
+            &[
+                ("routines/daily/routine.toml", "title = 'Daily'\n"),
+                ("routines/daily/state.local.toml", "snoozed = 1\n"),
+            ],
+        );
+        assert_eq!(run_import(&sneaky, false, false), 2);
+        assert!(!config_root(home)
+            .join("routines/daily/routine.toml")
+            .exists());
+        let traversal = write_bundle(home, &[("routines/../../../evil.toml", "boom = 1\n")]);
+        assert_eq!(run_import(&traversal, false, false), 2);
+    });
+}
+
+#[test]
+fn import_rejects_a_routine_toml_that_is_not_valid_toml() {
+    with_override_home(|home| {
+        let bundle = write_bundle(home, &[("routines/daily/routine.toml", "not [valid toml")]);
+        assert_eq!(run_import(&bundle, false, false), 2);
+    });
+}
+
+#[test]
+fn import_reports_a_write_failure() {
+    with_override_home(|home| {
+        let root = config_root(home);
+        std::fs::create_dir_all(&root).unwrap();
+        // A plain file where the `routines/` directory should go makes `create_dir_all` fail.
+        std::fs::write(root.join("routines"), "in the way").unwrap();
+        let bundle = write_bundle(
+            home,
+            &[("routines/daily/routine.toml", "title = 'Daily'\n")],
+        );
+        assert_eq!(run_import(&bundle, false, false), 1);
+    });
+}

--- a/src/export_import/mod.rs
+++ b/src/export_import/mod.rs
@@ -1,0 +1,25 @@
+//! Offline `moadim export` / `moadim import`: back up and restore the tracked moadim config.
+//!
+//! `moadim export` snapshots every *tracked* config file — per-routine `routine.toml`,
+//! `schedule.cron`, `disabled.json`, and `prompts/prompt.pure.md`, the agent registry's
+//! `agents/*.toml`, plus the global `notifications.toml` and `user_prompt.md` — into a single
+//! portable JSON bundle ([`bundle::Bundle`]). Gitignored runtime sidecars (`*.local.*`, `*.pid`,
+//! `*.log`, compiled cron/prompt outputs) are excluded, mirroring the tracked-vs-local split the
+//! config `.gitignore` already encodes, so secrets and machine-local state never leak into a
+//! bundle.
+//!
+//! `moadim import` restores such a bundle into the config tree through the same atomic-write
+//! primitive the storage layer uses ([`crate::utils::atomic::atomic_write`]), skipping files that
+//! already exist unless `--force` is given, and validating every path and `routine.toml` payload
+//! before touching disk. Both commands run offline against the filesystem — no daemon required —
+//! so they work for backup/migration even when the server is stopped (issue #368).
+
+/// The portable bundle format and the tracked-path predicate shared by export and import.
+mod bundle;
+/// `moadim export`: walk the config tree and serialize the tracked files into a bundle.
+mod export;
+/// `moadim import`: validate a bundle and restore its files into the config tree.
+mod import;
+
+pub(crate) use export::run_export;
+pub(crate) use import::run_import;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,8 @@ mod cli;
 /// Data-plane CLI subcommands (clap) that drive the running server over HTTP.
 mod commands;
 mod error;
+/// Offline `moadim export`/`import`: back up and restore the tracked config as a JSON bundle.
+mod export_import;
 /// Server filesystem location helpers.
 mod filesystem;
 /// Global lock sentinel that halts all routine scheduling and triggers without modifying routine

--- a/src/run.rs
+++ b/src/run.rs
@@ -34,5 +34,11 @@ pub(crate) fn dispatch(command: DataCommand) -> i32 {
             json,
         } => set_routine_enabled(&routine, false, reason, json),
         DataCommand::Agents => request("GET", "/api/v1/agents", None),
+        DataCommand::Export { out } => crate::export_import::run_export(out),
+        DataCommand::Import {
+            file,
+            dry_run,
+            force,
+        } => crate::export_import::run_import(&file, dry_run, force),
     }
 }


### PR DESCRIPTION
Closes #368

## What

Two new offline data-plane subcommands (no running daemon required):

- `moadim export [--out <file>]` — snapshot every **tracked** config file into a single portable JSON bundle (`{"version": 1, "files": {"<rel path>": "<contents>"}}`), written atomically to `--out` or printed to stdout.
- `moadim import <file> [--dry-run] [--force]` — validate the bundle in full **before touching disk** (version, path safety, `routine.toml` TOML syntax), then restore its files under the config dir via the existing `atomic_write` primitive. Existing files are **skipped** by default; `--force` overwrites; `--dry-run` prints the create/overwrite/skip plan and writes nothing. Prints a `moadim restart` hint so imported routines get resynced into the crontab.

## What's in a bundle

Tracked files only, mirroring the config `.gitignore`'s tracked-vs-local split: per-routine `routine.toml`, `schedule.cron`, `disabled.json`, `prompts/prompt.pure.md` (foldered routines included), `agents/*.toml`, `notifications.toml`, `user_prompt.md`. Runtime/local files (`*.local.*` — including secret env overrides — `*.pid`, `*.log`, compiled cron/prompt outputs, READMEs) are never exported, and the same allow-list predicate doubles as import's safety gate, so a hostile bundle can't write outside the config dir or plant untracked files.

## Notes vs. the issue

- The bundle is plain JSON (`serde_json`, already a dependency) rather than tar/zip — no new dependency, human-diffable, still one portable artifact.
- The issue also mentions cron jobs (`jobs/`/`handlers/`); that concept no longer exists in the codebase (the `DataCommand` docs note the cron-job subcommand is gone), so the bundle covers routines + agents + global config files.
- Collision semantics (skip by default / `--force` overwrite / `--dry-run` preview) are documented in the README.

## Checks

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`: clean
- `cargo test`: 1346 passed
- `cargo llvm-cov --fail-under-lines 100` (repo's exclude regex): **100.00% line coverage**
- `linecheck --max-lines 200`, `typos`: clean
- Changeset included (`minor`)

---
Opened by the moadim routine **“Open issues → fix PRs (owned repos + my orgs)”**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)