### PR TITLE
lint: deny clippy::iter_over_hash_type for deterministic hash-map iteration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -552,3 +552,12 @@ assigning_clones = "deny"
 # compiler validates, with the failure path made explicit via `Result`. The codebase is already
 # clean, so `deny` locks that in.
 checked_conversions = "deny"
+# Reject `for` loops over `HashMap`/`HashSet`: their iteration order is unspecified and varies
+# between runs, so any ordering-sensitive work inside such a loop (rendering output, writing a
+# file, choosing which validation error to report first) silently becomes nondeterministic. Each
+# site must either iterate deterministically (sort the keys first, or use a `BTreeMap`/`BTreeSet`)
+# or carry an `#[allow]` whose reason explains why order genuinely cannot matter there. Fixed the
+# one order-sensitive violation this surfaced (`routines::validate_repositories::validate_env`
+# reported a nondeterministic *first* error when several env entries were invalid); the two
+# remaining sites only feed a `BTreeSet` and are allowed with reasons.
+iter_over_hash_type = "deny"

--- a/src/machine/write_machine_toml.rs
+++ b/src/machine/write_machine_toml.rs
@@ -51,6 +51,10 @@ pub fn set_max_concurrent_runs_override(value: Option<usize>) -> std::io::Result
 pub fn referenced_machines() -> std::collections::BTreeSet<String> {
     let mut names = std::collections::BTreeSet::new();
     let routines = crate::routine_storage::load_store();
+    #[allow(
+        clippy::iter_over_hash_type,
+        reason = "every name lands in the sorted BTreeSet, so hash-map iteration order is irrelevant"
+    )]
     for routine in routines.lock_recover().values() {
         names.extend(routine.machines.iter().cloned());
     }

--- a/src/routes/http_settings_routes.rs
+++ b/src/routes/http_settings_routes.rs
@@ -168,6 +168,10 @@ pub async fn list_machines(State(state): State<AppState>) -> Json<Vec<String>> {
     use crate::utils::lock::LockRecover;
     let mut names = std::collections::BTreeSet::new();
     names.insert(crate::machine::current_machine());
+    #[allow(
+        clippy::iter_over_hash_type,
+        reason = "every name lands in the sorted BTreeSet, so hash-map iteration order is irrelevant"
+    )]
     for routine in state.routines.lock_recover().values() {
         names.extend(routine.machines.iter().cloned());
     }

--- a/src/routines/validate_repositories.rs
+++ b/src/routines/validate_repositories.rs
@@ -76,7 +76,11 @@ pub(super) fn validate_tags(tags: &[String]) -> Result<Vec<String>, AppError> {
 pub(super) fn validate_env(
     env: &std::collections::HashMap<String, String>,
 ) -> Result<(), AppError> {
-    for (key, value) in env {
+    // Iterate in sorted key order so the *first* error reported is deterministic when several
+    // entries are invalid (`HashMap` iteration order varies between runs).
+    let mut entries: Vec<_> = env.iter().collect();
+    entries.sort_by_key(|&(key, _)| key);
+    for (key, value) in entries {
         if !is_valid_env_key(key) {
             return Err(AppError::BadRequest(format!(
                 "env key {key:?} is invalid; keys must match [A-Za-z_][A-Za-z0-9_]*"


### PR DESCRIPTION
Closes #1540

## What

Enables one new Clippy lint — [`clippy::iter_over_hash_type`](https://rust-lang.github.io/rust-clippy/master/index.html#iter_over_hash_type) (`deny`, matching the crate's existing `[lints.clippy]` style) — and resolves the three sites it surfaces.

`HashMap`/`HashSet` iteration order is unspecified and varies between runs, so ordering-sensitive work inside a `for` loop over a hash type is silently nondeterministic. With this lint denied, every future hash-iteration site must either be made deterministic or carry an `#[allow]` with a written reason (kept honest by the already-enabled `allow_attributes_without_reason = "deny"`).

## Changes

- **`Cargo.toml`** — add `iter_over_hash_type = "deny"` with a rationale comment in the established style.
- **`src/routines/validate_repositories.rs`** (`validate_env`) — the one real fix: the loop returns on the first invalid env entry, so with multiple invalid entries the reported error changed from run to run. Now iterates in sorted key order, making the first-reported error stable.
- **`src/machine/write_machine_toml.rs`** (`referenced_machines`) and **`src/routes/http_settings_routes.rs`** (`list_machines`) — both loops only feed a sorted `BTreeSet`, so order genuinely cannot matter; annotated with `#[allow(clippy::iter_over_hash_type, reason = ...)]`.

## Verification

- `cargo clippy --all-targets` — clean
- `cargo build` — clean
- `cargo test` — 1319 passed; the 4 failures (`svc_create_trims_and_stores_tags` etc.) are pre-existing on `main` on this machine (collisions with a live local moadim install's on-disk routine state) and unrelated to this change

---

*This PR was opened automatically by the moadim routine "Clippy lint improvements → issue + PR (Rust repos) → Slack" on behalf of @tupe12334.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)