### PR TITLE
chore: add missing changeset

### DIFF
--- a/.changeset/docs-fix-validation-findings.md
+++ b/.changeset/docs-fix-validation-findings.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Fix validation findings in docs (#1534).


### PR DESCRIPTION
Opened by the **Changesets keeper (owned repos + my orgs)** moadim routine.

Adds a pending changeset for a merged PR that shipped without one:

- #1534 docs: fix validation findings

All other merged PRs since v3.2.3 (routine disable-reason work, Run Detail
page, Runs page, CLI regression guard, fixture centralization, failure
notification hooks) already have pending changesets. Dependabot bumps and
internal lint-only chores were excluded as noise.