### PR TITLE
feat(routines): add an optional per-routine timezone override

### DIFF
--- a/.changeset/routine-timezone-override.md
+++ b/.changeset/routine-timezone-override.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Add an optional per-routine `timezone` (IANA name) so a schedule can pin to a zone instead of always running in the host crontab's own zone. Applied via a `CRON_TZ` directive in the managed crontab block; only accepted on Linux hosts, since BSD `cron` (macOS) does not honor `CRON_TZ`.

--- a/Architecture.md
+++ b/Architecture.md
@@ -183,6 +183,21 @@ At create/update time moadim writes the raw prompt to `prompts/prompt.pure.md` a
 # END MOADIM-ROUTINES
 ```
 
+A routine's `schedule` is interpreted in the host's local system timezone (the OS crontab's own
+zone) by default. An optional per-routine `timezone` (IANA name, e.g. `"Asia/Jerusalem"`, validated
+against the on-disk zoneinfo database) pins it instead, so the schedule keeps firing at the intended
+wall-clock time regardless of what zone the host itself is in or later moves to (issue #405). This
+is emitted as a `CRON_TZ=<tz>` directive immediately ahead of the routine's line(s) in the managed
+block — `crate::sync::routines::cron_tz_line_for` emits one such directive ahead of *every* routine
+(falling back to the host's own resolvable zone when a routine has no override), because `CRON_TZ`
+persists in the crontab file until reassigned and would otherwise leak into the next routine's line.
+`CRON_TZ` is a vixie-cron/cronie (Linux) extension that BSD `cron` (macOS) does not honor, so setting
+`timezone` is rejected outright at create/update time on any non-Linux host
+(`routines::service_validate::validate_timezone`) rather than silently doing nothing. `next_run_at`
+and the `.ics` feed (below) still project fire times in the host's own local timezone regardless of
+a routine's override — only the actual crontab firing (via `CRON_TZ`) honors it; this is a known gap
+tracked for a follow-up.
+
 That crontab line does **not** launch the agent by itself — it invokes the `moadim` binary directly
 (`moadim schedule trigger <id>`, a thin HTTP client), which calls `POST
 /routines/{id}/scheduled-trigger` on the **running daemon**. Scheduled routines therefore require

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -1340,6 +1340,13 @@
             },
             "description": "Free-form labels for the routine (defaults to empty). Each entry is trimmed\nand must be non-blank."
           },
+          "timezone": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "IANA timezone name (e.g. `\"Asia/Jerusalem\"`) to pin the schedule to, or `None` to use the\nhost crontab's own zone (today's behavior). Only accepted on Linux, since `CRON_TZ` is not\nhonored by BSD `cron` (macOS) — see `Routine::timezone`."
+          },
           "title": {
             "type": "string",
             "description": "Human name for the routine."
@@ -1905,6 +1912,13 @@
             },
             "description": "Free-form labels for grouping and filtering routines (e.g. `\"triage\"`, `\"nightly\"`).\nDefaults to empty; each entry is trimmed and must be non-blank."
           },
+          "timezone": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "IANA timezone name (e.g. `\"Asia/Jerusalem\"`) this routine's schedule is interpreted in,\noverriding the host's local system timezone. `None` (the default) preserves today's\nbehavior: the schedule runs in whatever zone the host crontab itself uses, which silently\nchanges if the host's zone ever changes (issue #405).\n\nEmitted as a `CRON_TZ=<tz>` directive ahead of this routine's line(s) in the managed\ncrontab block ([`crate::sync::routines`]). Only vixie-cron/cronie (Linux) honor `CRON_TZ`;\nBSD `cron` (macOS) does not, so setting this field is rejected outright on non-Linux hosts\n(see `service_validate::validate_timezone`) rather than silently doing nothing."
+          },
           "title": {
             "type": "string",
             "description": "Human name; slugified to name the workbench and tmux session."
@@ -2322,6 +2336,13 @@
               "type": "string"
             },
             "description": "New tags list, or `None` to keep the existing value."
+          },
+          "timezone": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "New timezone override, or `None` to keep the existing value. A blank/whitespace-only value\nclears the override back to the host crontab's own zone. See\n[`CreateRoutineRequest::timezone`] for validation rules."
           },
           "title": {
             "type": [

--- a/src/machine/set_machine_rejects_empty_tests.rs
+++ b/src/machine/set_machine_rejects_empty_tests.rs
@@ -79,6 +79,7 @@ fn referenced_machines_unions_routines() {
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     };
     crate::routine_storage::write_routine(&routine).expect("write routine");
 
@@ -157,6 +158,7 @@ fn run_list_with_referenced_machine() {
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     };
     crate::routine_storage::write_routine(&routine).expect("write routine");
     assert_eq!(run(&["list".to_string()]), 0);

--- a/src/read_runtime_state.rs
+++ b/src/read_runtime_state.rs
@@ -116,6 +116,7 @@ pub(crate) fn write_routine_to_rel_dir(routine: &Routine, rel_dir: &str) -> std:
         notifications: routine.notifications.clone(),
         tags: routine.tags.clone(),
         env: routine.env.clone(),
+        timezone: routine.timezone.clone(),
     };
     let text = toml::to_string_pretty(&toml_routine).map_err(std::io::Error::other)?;
     // Atomic write (temp + rename) so any concurrent reader never observes a torn routine.toml —

--- a/src/routes/build_app_serves_machines_tests.rs
+++ b/src/routes/build_app_serves_machines_tests.rs
@@ -44,6 +44,7 @@ async fn build_app_serves_machines() {
             consecutive_failures: 0,
             failure_threshold: None,
         notifications: Default::default(),
+            timezone: None,
         },
     );
     let resp = build_app(routines)

--- a/src/routes/create_flag/mcp_tests.rs
+++ b/src/routes/create_flag/mcp_tests.rs
@@ -37,6 +37,7 @@ fn make_create_routine_req() -> crate::routines::CreateRoutineRequest {
         env: std::collections::HashMap::new(),
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routes/create_routine/logic_tests.rs
+++ b/src/routes/create_routine/logic_tests.rs
@@ -25,6 +25,7 @@ fn make_req() -> CreateRoutineRequest {
         env: std::collections::HashMap::new(),
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routes/create_routine/mcp_tests.rs
+++ b/src/routes/create_routine/mcp_tests.rs
@@ -34,6 +34,7 @@ fn make_create_routine_req() -> crate::routines::CreateRoutineRequest {
         env: std::collections::HashMap::new(),
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routes/list_routine_runs/mcp_tests.rs
+++ b/src/routes/list_routine_runs/mcp_tests.rs
@@ -58,6 +58,7 @@ fn make_create_routine_req() -> crate::routines::CreateRoutineRequest {
         env: std::collections::HashMap::new(),
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routes/mcp_endpoint_triggers_factory_tests.rs
+++ b/src/routes/mcp_endpoint_triggers_factory_tests.rs
@@ -54,6 +54,7 @@ async fn router_serves_routines_ical_feed() {
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     })
     .unwrap();
     let resp = build_app(crate::routines::new_store())

--- a/src/routes/mcp_parity_tests.rs
+++ b/src/routes/mcp_parity_tests.rs
@@ -68,6 +68,7 @@ fn make_create_routine_req() -> crate::routines::CreateRoutineRequest {
         env: std::collections::HashMap::new(),
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routes/mcp_prompt_preview_tests.rs
+++ b/src/routes/mcp_prompt_preview_tests.rs
@@ -90,6 +90,7 @@ fn preview_routine_prompt_success_contains_prompt() {
             env: std::collections::HashMap::new(),
             failure_threshold: None,
         notifications: Default::default(),
+            timezone: None,
         }))
         .unwrap();
     assert!(!create_result.is_error.unwrap_or(false));

--- a/src/routes/mcp_tests.rs
+++ b/src/routes/mcp_tests.rs
@@ -83,6 +83,7 @@ fn make_create_routine_req() -> crate::routines::CreateRoutineRequest {
         env: std::collections::HashMap::new(),
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 
@@ -141,6 +142,7 @@ fn create_get_update_trigger_delete_routine_success() {
             tags: None,
             env: None,
             failure_threshold: None,
+            timezone: None,
         }))
         .unwrap();
     assert!(!result.is_error.unwrap_or(false));

--- a/src/routes/mcp_types.rs
+++ b/src/routes/mcp_types.rs
@@ -138,4 +138,8 @@ pub(super) struct UpdateRoutineInput {
     /// Non-secret only — keys must match `[A-Za-z_][A-Za-z0-9_]*` and values must not contain
     /// newlines. For secrets, edit the gitignored `routine.local.toml` sidecar on disk instead.
     pub(super) env: Option<std::collections::HashMap<String, String>>,
+    /// New timezone override (IANA name, e.g. `"Asia/Jerusalem"`), or `None` to keep the existing
+    /// value. A blank/whitespace-only value clears the override back to the host crontab's own
+    /// zone. Only accepted on Linux hosts — `CRON_TZ` is not honored by BSD `cron` (macOS).
+    pub(super) timezone: Option<String>,
 }

--- a/src/routes/resolve_flag/mcp_tests.rs
+++ b/src/routes/resolve_flag/mcp_tests.rs
@@ -37,6 +37,7 @@ fn make_create_routine_req() -> crate::routines::CreateRoutineRequest {
         env: std::collections::HashMap::new(),
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routes/router_serves_per_routine_ical_feed_via_query_tests.rs
+++ b/src/routes/router_serves_per_routine_ical_feed_via_query_tests.rs
@@ -44,6 +44,7 @@ async fn router_serves_per_routine_ical_feed_via_query() {
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     };
     crate::routine_storage::write_routine(&mk("a", "Routine A")).unwrap();
     crate::routine_storage::write_routine(&mk("b", "Routine B")).unwrap();

--- a/src/routes/trigger_routine/mcp_tests.rs
+++ b/src/routes/trigger_routine/mcp_tests.rs
@@ -58,6 +58,7 @@ fn make_create_routine_req() -> crate::routines::CreateRoutineRequest {
         env: std::collections::HashMap::new(),
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routes/update_routine/logic_tests.rs
+++ b/src/routes/update_routine/logic_tests.rs
@@ -25,6 +25,7 @@ fn make_update_req() -> UpdateRoutineRequest {
         env: None,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routes/update_routine/mcp.rs
+++ b/src/routes/update_routine/mcp.rs
@@ -36,6 +36,7 @@ impl MoadimMcp {
             power_saving_exempt: input.power_saving_exempt,
             tags: input.tags,
             env: input.env,
+            timezone: input.timezone,
         };
         Ok(match logic::build(&self.routines, &input.id, req) {
             Ok(resp) => ok(resp),

--- a/src/routes/update_routine/mcp_tests.rs
+++ b/src/routes/update_routine/mcp_tests.rs
@@ -39,6 +39,7 @@ fn update_routine_tool_not_found_is_error() {
             tags: None,
             env: None,
             failure_threshold: None,
+            timezone: None,
         }))
         .unwrap();
     assert!(result.is_error.unwrap_or(false));

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -111,6 +111,10 @@ struct RoutineToml {
     /// gitignored `routine.local.toml` sidecar instead ([`RoutineLocalToml`]).
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     env: HashMap<String, String>,
+    /// IANA timezone override the schedule is interpreted in; absent means the host crontab's own
+    /// zone (see [`crate::routines::Routine::timezone`], issue #405).
+    #[serde(default)]
+    timezone: Option<String>,
 }
 
 /// TOML representation of a routine's untracked `routine.local.toml` sidecar: secret or

--- a/src/routine_storage_env_tests.rs
+++ b/src/routine_storage_env_tests.rs
@@ -64,6 +64,7 @@ fn make_routine(id: &str, title: &str) -> Routine {
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routine_storage_load.rs
+++ b/src/routine_storage_load.rs
@@ -116,6 +116,7 @@ fn load_routine_from_base(base: &std::path::Path, dir_name: &str) -> Option<Rout
         notifications: toml.notifications,
         tags: toml.tags,
         env: toml.env,
+        timezone: toml.timezone,
     })
 }
 

--- a/src/routine_storage_more_tests.rs
+++ b/src/routine_storage_more_tests.rs
@@ -64,6 +64,7 @@ fn make_routine(id: &str, title: &str) -> Routine {
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routine_storage_sidecar_state_tests.rs
+++ b/src/routine_storage_sidecar_state_tests.rs
@@ -60,6 +60,7 @@ fn make_routine(id: &str, title: &str) -> Routine {
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routine_storage_snooze_tests.rs
+++ b/src/routine_storage_snooze_tests.rs
@@ -39,6 +39,7 @@ fn make_routine(id: &str, title: &str) -> Routine {
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routines/cleanup/circuit_breaker_tests.rs
+++ b/src/routines/cleanup/circuit_breaker_tests.rs
@@ -68,6 +68,7 @@ fn make_routine(
         failure_threshold,
         notifications: Default::default(),
         env: std::collections::HashMap::new(),
+        timezone: None,
     }
 }
 

--- a/src/routines/cleanup/cleanup_run_history_tests.rs
+++ b/src/routines/cleanup/cleanup_run_history_tests.rs
@@ -40,6 +40,7 @@ fn make_routine(id: &str, title: &str) -> super::super::model::Routine {
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routines/cleanup/reap_dir_counts_zero_when_remove_fails_tests.rs
+++ b/src/routines/cleanup/reap_dir_counts_zero_when_remove_fails_tests.rs
@@ -78,6 +78,7 @@ fn routine_with(schedule: &str, ttl_secs: Option<u64>) -> super::super::model::R
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routines/cleanup/snapshot_tests.rs
+++ b/src/routines/cleanup/snapshot_tests.rs
@@ -40,6 +40,7 @@ fn routine_with(title: &str, schedule: &str, ttl_secs: Option<u64>) -> Routine {
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routines/command_tests.rs
+++ b/src/routines/command_tests.rs
@@ -38,6 +38,7 @@ fn make_routine(title: &str) -> Routine {
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routines/defaults/mod.rs
+++ b/src/routines/defaults/mod.rs
@@ -105,6 +105,7 @@ fn materialize(spec: &DefaultRoutine, now: u64) -> Routine {
         notifications: Default::default(),
         tags: Vec::new(),
         env: std::collections::HashMap::new(),
+        timezone: None,
     }
 }
 include!("reconcile.rs");

--- a/src/routines/defaults/reconcile.rs
+++ b/src/routines/defaults/reconcile.rs
@@ -75,6 +75,8 @@ fn reconcile(spec: &DefaultRoutine, cur: &Routine, now: u64) -> Option<Routine> 
         tags: cur.tags.clone(),
         // Env vars are user-owned, like `tags`: never overridden by the spec.
         env: cur.env.clone(),
+        // Timezone is user-owned, like `tags`/`env`: never overridden by the spec.
+        timezone: cur.timezone.clone(),
     })
 }
 

--- a/src/routines/describe_schedule_appends_timezone_when_present_tests.rs
+++ b/src/routines/describe_schedule_appends_timezone_when_present_tests.rs
@@ -91,6 +91,7 @@ fn from_routine_populates_derived_fields() {
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     };
     let resp = RoutineResponse::from_routine(routine);
     assert!(resp.schedule_description.is_some());

--- a/src/routines/failure_notify_tests.rs
+++ b/src/routines/failure_notify_tests.rs
@@ -73,6 +73,7 @@ fn routine(config: FailureNotificationConfig) -> Routine {
         notifications: config,
         tags: vec![],
         env: std::collections::HashMap::new(),
+        timezone: None,
     }
 }
 

--- a/src/routines/from_routine_counts_open_flags_tests.rs
+++ b/src/routines/from_routine_counts_open_flags_tests.rs
@@ -31,6 +31,7 @@ fn from_routine_counts_open_flags() {
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     };
     let slug = slugify(&routine.title);
     crate::routines::flags::create_flag(

--- a/src/routines/ical_tests.rs
+++ b/src/routines/ical_tests.rs
@@ -38,6 +38,7 @@ fn routine_with(id: &str, schedule: &str, enabled: bool) -> Routine {
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routines/local_timezone.rs
+++ b/src/routines/local_timezone.rs
@@ -173,6 +173,17 @@ pub struct Routine {
     /// `service_validate::validate_env`).
     #[serde(default, skip_serializing)]
     pub env: std::collections::HashMap<String, String>,
+    /// IANA timezone name (e.g. `"Asia/Jerusalem"`) this routine's schedule is interpreted in,
+    /// overriding the host's local system timezone. `None` (the default) preserves today's
+    /// behavior: the schedule runs in whatever zone the host crontab itself uses, which silently
+    /// changes if the host's zone ever changes (issue #405).
+    ///
+    /// Emitted as a `CRON_TZ=<tz>` directive ahead of this routine's line(s) in the managed
+    /// crontab block ([`crate::sync::routines`]). Only vixie-cron/cronie (Linux) honor `CRON_TZ`;
+    /// BSD `cron` (macOS) does not, so setting this field is rejected outright on non-Linux hosts
+    /// (see `service_validate::validate_timezone`) rather than silently doing nothing.
+    #[serde(default)]
+    pub timezone: Option<String>,
 }
 
 /// The IANA name of the host's local timezone (e.g. `"Asia/Jerusalem"`).

--- a/src/routines/missed_run_alert_tests.rs
+++ b/src/routines/missed_run_alert_tests.rs
@@ -31,6 +31,7 @@ fn routine(overrides: impl FnOnce(&mut Routine)) -> Routine {
         notifications: Default::default(),
         tags: vec![],
         env: std::collections::HashMap::new(),
+        timezone: None,
     };
     overrides(&mut routine);
     routine

--- a/src/routines/mod_agents_reload_tests.rs
+++ b/src/routines/mod_agents_reload_tests.rs
@@ -42,6 +42,7 @@ fn make_routine(id: &str) -> Routine {
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routines/mod_agents_tests.rs
+++ b/src/routines/mod_agents_tests.rs
@@ -40,6 +40,7 @@ fn make_routine(id: &str) -> Routine {
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 
@@ -132,6 +133,7 @@ fn svc_create_invalid_cron_rejected() {
         env: std::collections::HashMap::new(),
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     };
     assert!(svc_create(&store, req).is_err());
 }

--- a/src/routines/mod_tests.rs
+++ b/src/routines/mod_tests.rs
@@ -40,6 +40,7 @@ fn make_routine(id: &str) -> Routine {
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routines/model_requests.rs
+++ b/src/routines/model_requests.rs
@@ -73,6 +73,11 @@ pub struct CreateRoutineRequest {
     /// over the API.
     #[serde(default)]
     pub env: std::collections::HashMap<String, String>,
+    /// IANA timezone name (e.g. `"Asia/Jerusalem"`) to pin the schedule to, or `None` to use the
+    /// host crontab's own zone (today's behavior). Only accepted on Linux, since `CRON_TZ` is not
+    /// honored by BSD `cron` (macOS) — see `Routine::timezone`.
+    #[serde(default)]
+    pub timezone: Option<String>,
 }
 
 /// Request body for partially updating an existing routine.
@@ -124,4 +129,8 @@ pub struct UpdateRoutineRequest {
     /// merged); send the full desired set. See [`CreateRoutineRequest::env`] for validation rules
     /// and the `routine.local.toml` secrets sidecar.
     pub env: Option<std::collections::HashMap<String, String>>,
+    /// New timezone override, or `None` to keep the existing value. A blank/whitespace-only value
+    /// clears the override back to the host crontab's own zone. See
+    /// [`CreateRoutineRequest::timezone`] for validation rules.
+    pub timezone: Option<String>,
 }

--- a/src/routines/model_tests.rs
+++ b/src/routines/model_tests.rs
@@ -85,6 +85,7 @@ fn make_routine(agent: &str) -> Routine {
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 
@@ -168,5 +169,31 @@ fn from_routine_agent_setup_available_true_when_no_setup_step() {
     let resp = RoutineResponse::from_routine(make_routine("model-test-no-setup"));
     assert!(resp.agent_registered);
     assert!(resp.agent_setup_available);
+}
+
+#[test]
+fn from_routine_timezone_reports_the_routine_override_not_the_host_zone() {
+    // Issue #405: `RoutineResponse.timezone` must reflect the routine's own override when set,
+    // not always the host's zone — otherwise a client has no way to see the effective zone a
+    // pinned routine actually fires in.
+    let _home = TempHome::set();
+    let mut routine = make_routine("model-test-tz-override");
+    routine.timezone = Some("Asia/Jerusalem".to_string());
+    let resp = RoutineResponse::from_routine(routine);
+    assert_eq!(resp.timezone.as_deref(), Some("Asia/Jerusalem"));
+    // The schedule description is annotated with the *effective* (overridden) zone too.
+    assert!(resp
+        .schedule_description
+        .as_deref()
+        .is_some_and(|desc| desc.contains("Asia/Jerusalem")));
+}
+
+#[test]
+fn from_routine_timezone_falls_back_to_host_zone_when_unset() {
+    // The pre-#405 behavior — no override — is unchanged: an unset `Routine::timezone` still
+    // reports whatever the host's own zone resolves to (`None` on a host where it can't be named).
+    let _home = TempHome::set();
+    let resp = RoutineResponse::from_routine(make_routine("model-test-tz-default"));
+    assert_eq!(resp.timezone, crate::routines::local_timezone());
 }
 include!("from_routine_agent_setup_available_true_when_setup_interpreter_resolve_tests.rs");

--- a/src/routines/next_run_at.rs
+++ b/src/routines/next_run_at.rs
@@ -11,6 +11,13 @@ use super::*;
 /// crontab semantics), reusing the same compiled schedule path as the TTL sweep
 /// (`cleanup::ttl::cron_interval_secs`).
 ///
+/// **Known gap (#405):** this always projects against the host's own zone via [`Local::now`],
+/// even for a routine with a [`Routine::timezone`] override — unlike the actual crontab firing
+/// (`crate::sync::routines::cron_tz_line_for`), which does honor it via `CRON_TZ`. Projecting a
+/// preview in an arbitrary IANA zone correctly (DST-aware, not just a fixed UTC offset) needs a
+/// zone database this crate does not depend on; left as a follow-up rather than risking a
+/// DST-wrong "next fire" preview shipping alongside the real (correct) crontab behavior.
+///
 /// `None` when `enabled` is `false`, the daemon is globally locked (see [`crate::global_lock`]),
 /// `schedule` cannot be parsed (e.g. `@reboot`), or it has no upcoming fire.
 pub(crate) fn next_run_at(schedules: &[String], enabled: bool) -> Option<u64> {
@@ -58,7 +65,10 @@ impl RoutineResponse {
             .join("routine.toml")
             .to_string_lossy()
             .into_owned();
-        let timezone = local_timezone();
+        // The routine's own override, when set, is the *effective* zone its schedule is
+        // interpreted in (see `Routine::timezone`); only fall back to the host's zone when unset,
+        // so this reflects reality instead of always reporting the host's zone (issue #405).
+        let timezone = routine.timezone.clone().or_else(local_timezone);
         let schedules = routine.effective_schedules();
         let schedule_description = schedules
             .first()

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -42,7 +42,7 @@ use service_validate::MAX_TITLE_LEN;
 use service_validate::{
     map_write_routine_err, normalize_model, reject_blank, reject_over_ceiling, reject_zero_secs,
     validate_agent, validate_env, validate_goal, validate_machines, validate_prompt,
-    validate_repositories, validate_tags, validate_title,
+    validate_repositories, validate_tags, validate_timezone, validate_title,
 };
 
 /// Validate and normalize all schedules, requiring at least one non-blank expression.

--- a/src/routines/service_ceiling_tests.rs
+++ b/src/routines/service_ceiling_tests.rs
@@ -70,6 +70,7 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 
@@ -103,6 +104,7 @@ fn valid_create_request() -> CreateRoutineRequest {
         env: std::collections::HashMap::new(),
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 
@@ -127,6 +129,7 @@ fn empty_update_request() -> UpdateRoutineRequest {
         env: None,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routines/service_coverage_tests.rs
+++ b/src/routines/service_coverage_tests.rs
@@ -64,6 +64,7 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 
@@ -99,6 +100,7 @@ fn valid_create_request() -> CreateRoutineRequest {
         env: std::collections::HashMap::new(),
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 
@@ -122,6 +124,7 @@ fn empty_update_request() -> UpdateRoutineRequest {
         env: None,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routines/service_field_validation_create_tests.rs
+++ b/src/routines/service_field_validation_create_tests.rs
@@ -62,6 +62,7 @@ pub(super) fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 
@@ -86,6 +87,7 @@ pub(super) fn create_req_with_title(title: &str) -> CreateRoutineRequest {
         env: std::collections::HashMap::new(),
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 
@@ -146,10 +148,97 @@ fn svc_create_rejects_unknown_agent() {
             env: std::collections::HashMap::new(),
             failure_threshold: None,
             notifications: Default::default(),
+            timezone: None,
         },
     );
     assert!(matches!(result, Err(AppError::BadRequest(_))));
     // Nothing should have been persisted.
+    assert!(store.lock().unwrap().is_empty());
+}
+
+/// Build a create request with the given title and `timezone`, otherwise valid.
+fn create_req_with_timezone(title: &str, timezone: Option<&str>) -> CreateRoutineRequest {
+    CreateRoutineRequest {
+        timezone: timezone.map(str::to_string),
+        ..create_req_with_title(title)
+    }
+}
+
+#[test]
+fn svc_create_rejects_an_unknown_timezone_name() {
+    let _home = TempHome::set();
+    // Covers `validate_timezone`'s IANA-lookup reject branch: a string that merely looks like a
+    // zone name, but is not present in the on-disk zoneinfo database, 400s rather than being
+    // persisted and silently never applied (issue #405).
+    let store = new_store();
+    let result = svc_create(
+        &store,
+        create_req_with_timezone(
+            "Svc Create Unknown Timezone ZZZ",
+            Some("Definitely/Not_A_Zone"),
+        ),
+    );
+    assert!(matches!(result, Err(AppError::BadRequest(_))));
+    assert!(store.lock().unwrap().is_empty());
+}
+
+#[test]
+fn svc_create_rejects_a_path_traversal_timezone_value() {
+    let _home = TempHome::set();
+    // A crafted value must not reach the filesystem check at all (issue #405).
+    let store = new_store();
+    let result = svc_create(
+        &store,
+        create_req_with_timezone(
+            "Svc Create Traversal Timezone ZZZ",
+            Some("../../etc/passwd"),
+        ),
+    );
+    assert!(matches!(result, Err(AppError::BadRequest(_))));
+    assert!(store.lock().unwrap().is_empty());
+}
+
+#[test]
+fn svc_create_treats_a_blank_timezone_as_unset() {
+    let _home = TempHome::set();
+    // Mirrors `model`: a blank/whitespace-only value is not an error, it just means "no override".
+    let store = new_store();
+    let result = svc_create(
+        &store,
+        create_req_with_timezone("Svc Create Blank Timezone ZZZ", Some("   ")),
+    )
+    .expect("blank timezone should not be rejected");
+    assert_eq!(result.routine.timezone, None);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn svc_create_accepts_a_valid_iana_timezone_on_linux() {
+    let _home = TempHome::set();
+    // The accept path only runs on Linux — `CRON_TZ` is a vixie-cron/cronie (Linux) extension,
+    // so the same request must 400 on any other host (see
+    // `svc_create_rejects_timezone_override_on_non_linux_hosts` below).
+    let store = new_store();
+    let result = svc_create(
+        &store,
+        create_req_with_timezone("Svc Create Valid Timezone ZZZ", Some("Asia/Jerusalem")),
+    )
+    .expect("a real IANA zone name should be accepted on Linux");
+    assert_eq!(result.routine.timezone.as_deref(), Some("Asia/Jerusalem"));
+}
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn svc_create_rejects_timezone_override_on_non_linux_hosts() {
+    let _home = TempHome::set();
+    // `CRON_TZ` is not honored by BSD `cron` (macOS); even a real IANA zone name must be rejected
+    // outright here rather than accepted and then silently ignored at crontab-sync time.
+    let store = new_store();
+    let result = svc_create(
+        &store,
+        create_req_with_timezone("Svc Create Timezone Non-Linux ZZZ", Some("Asia/Jerusalem")),
+    );
+    assert!(matches!(result, Err(AppError::BadRequest(_))));
     assert!(store.lock().unwrap().is_empty());
 }
 include!("svc_create_accepts_builtin_agent_tests.rs");

--- a/src/routines/service_flag_tests.rs
+++ b/src/routines/service_flag_tests.rs
@@ -56,6 +56,7 @@ fn create_req_with_title(title: &str) -> CreateRoutineRequest {
         env: std::collections::HashMap::new(),
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routines/service_list_tests.rs
+++ b/src/routines/service_list_tests.rs
@@ -72,6 +72,7 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routines/service_logs_tests.rs
+++ b/src/routines/service_logs_tests.rs
@@ -62,6 +62,7 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routines/service_model_tests.rs
+++ b/src/routines/service_model_tests.rs
@@ -27,6 +27,7 @@ fn create_req_with_title(title: &str) -> CreateRoutineRequest {
         env: std::collections::HashMap::new(),
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routines/service_move_tests.rs
+++ b/src/routines/service_move_tests.rs
@@ -114,6 +114,7 @@ fn make_routine(id: &str, title: &str) -> Routine {
         notifications: Default::default(),
         tags: Vec::new(),
         env: std::collections::HashMap::new(),
+        timezone: None,
     }
 }
 

--- a/src/routines/service_multi_schedule_tests.rs
+++ b/src/routines/service_multi_schedule_tests.rs
@@ -80,6 +80,7 @@ fn valid_create_request() -> CreateRoutineRequest {
         env: std::collections::HashMap::new(),
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 
@@ -103,6 +104,7 @@ fn empty_update_request() -> UpdateRoutineRequest {
         env: None,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routines/service_overlap_guard_tests.rs
+++ b/src/routines/service_overlap_guard_tests.rs
@@ -62,6 +62,7 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routines/service_power_saving_tests.rs
+++ b/src/routines/service_power_saving_tests.rs
@@ -62,6 +62,7 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routines/service_prompt_preview_tests.rs
+++ b/src/routines/service_prompt_preview_tests.rs
@@ -37,6 +37,7 @@ fn make_routine(id: &str, repositories: Vec<Repository>) -> Routine {
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routines/service_prompt_tests.rs
+++ b/src/routines/service_prompt_tests.rs
@@ -38,6 +38,7 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 
@@ -67,6 +68,7 @@ fn svc_create_rejects_empty_prompt() {
             env: std::collections::HashMap::new(),
             failure_threshold: None,
         notifications: Default::default(),
+            timezone: None,
         },
     );
     assert!(matches!(result, Err(AppError::BadRequest(_))));
@@ -99,6 +101,7 @@ fn svc_create_rejects_whitespace_prompt() {
             env: std::collections::HashMap::new(),
             failure_threshold: None,
         notifications: Default::default(),
+            timezone: None,
         },
     );
     assert!(matches!(result, Err(AppError::BadRequest(_))));
@@ -141,6 +144,7 @@ fn svc_update_rejects_clearing_prompt_to_empty() {
             env: None,
             failure_threshold: None,
         notifications: Default::default(),
+            timezone: None,
         },
     );
     assert!(matches!(result, Err(AppError::BadRequest(_))));

--- a/src/routines/service_rename_machine_tests.rs
+++ b/src/routines/service_rename_machine_tests.rs
@@ -63,6 +63,7 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routines/service_runs_tests.rs
+++ b/src/routines/service_runs_tests.rs
@@ -83,6 +83,7 @@ fn make_routine(id: &str, title: &str) -> Routine {
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routines/service_slug_tests.rs
+++ b/src/routines/service_slug_tests.rs
@@ -69,6 +69,7 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 
@@ -102,6 +103,7 @@ fn valid_create_request() -> CreateRoutineRequest {
         env: std::collections::HashMap::new(),
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 
@@ -126,6 +128,7 @@ fn empty_update_request() -> UpdateRoutineRequest {
         env: None,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routines/service_snooze_tests.rs
+++ b/src/routines/service_snooze_tests.rs
@@ -63,6 +63,7 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routines/service_sync_tests.rs
+++ b/src/routines/service_sync_tests.rs
@@ -63,6 +63,7 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 
@@ -112,6 +113,7 @@ fn svc_create_warns_when_crontab_sync_fails() {
                 env: std::collections::HashMap::new(),
                 failure_threshold: None,
                 notifications: Default::default(),
+                timezone: None,
             },
         )
         .unwrap();
@@ -146,6 +148,7 @@ fn svc_create_rejects_goal_over_five_lines() {
             env: std::collections::HashMap::new(),
             failure_threshold: None,
             notifications: Default::default(),
+            timezone: None,
         },
     );
     match result {

--- a/src/routines/service_tests.rs
+++ b/src/routines/service_tests.rs
@@ -70,6 +70,7 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 
@@ -103,6 +104,7 @@ fn valid_create_request() -> CreateRoutineRequest {
         env: std::collections::HashMap::new(),
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 
@@ -127,6 +129,7 @@ fn empty_update_request() -> UpdateRoutineRequest {
         env: None,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routines/service_trigger_tests.rs
+++ b/src/routines/service_trigger_tests.rs
@@ -63,6 +63,7 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routines/service_update.rs
+++ b/src/routines/service_update.rs
@@ -4,8 +4,9 @@ use super::{
     map_write_routine_err, max_runtime_ceiling_secs, min_schedule_ceiling, normalize_model,
     now_secs, reject_blank, reject_over_ceiling, reject_zero_secs, slugify, ttl_ceiling_secs,
     validate_agent, validate_and_normalize_schedules, validate_env, validate_goal,
-    validate_machines, validate_prompt, validate_repositories, validate_tags, validate_title,
-    write_routine, AppError, LockRecover, RoutineResponse, RoutineStore, UpdateRoutineRequest,
+    validate_machines, validate_prompt, validate_repositories, validate_tags, validate_timezone,
+    validate_title, write_routine, AppError, LockRecover, RoutineResponse, RoutineStore,
+    UpdateRoutineRequest,
 };
 
 /// Apply non-`None` fields from `req` to the routine identified by `id`.
@@ -58,6 +59,13 @@ pub fn svc_update(
     if let Some(ref env) = req.env {
         validate_env(env)?;
     }
+    // `Some(_)` (even a blank string) applies the change, clearing the override back to the host
+    // zone on blank input; `None` (the field omitted) leaves the existing value untouched —
+    // mirrors `model`, not the `Some(None)`-clears convention `goal` uses.
+    let timezone = match req.timezone {
+        Some(ref timezone) => Some(validate_timezone(Some(timezone))?),
+        None => None,
+    };
     let mut lock = store.lock_recover();
     let old_slug = slugify(&lock.get(id).ok_or(AppError::NotFound)?.title);
     // Check slug conflict before mutating.
@@ -174,6 +182,9 @@ pub fn svc_update(
     }
     if let Some(env) = req.env {
         routine.env = env;
+    }
+    if let Some(timezone) = timezone {
+        routine.timezone = timezone;
     }
     routine.updated_at = now_secs();
     let routine = routine.clone();

--- a/src/routines/service_update_apply_tests.rs
+++ b/src/routines/service_update_apply_tests.rs
@@ -62,6 +62,7 @@ fn make_routine(id: &str, title: &str, created_at: u64, updated_at: u64) -> Rout
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 
@@ -85,6 +86,7 @@ fn empty_update_request() -> UpdateRoutineRequest {
         env: None,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 
@@ -141,10 +143,86 @@ fn svc_update_sets_ttl_secs() {
                 env: None,
                 failure_threshold: None,
         notifications: Default::default(),
+                timezone: None,
             },
         )
         .unwrap();
         assert_eq!(updated.routine.ttl_secs, Some(1800));
+    });
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn svc_update_sets_timezone_override() {
+    let _home = TempHome::set();
+    let title = "Svc Update Timezone Set ZZZ";
+    let store = new_store();
+    let routine = make_routine("tz-set-id", title, 1, 1);
+    crate::routine_storage::write_routine(&routine).unwrap();
+    store.lock().unwrap().insert("tz-set-id".into(), routine);
+
+    with_empty_path(|| {
+        let updated = svc_update(
+            &store,
+            "tz-set-id",
+            UpdateRoutineRequest {
+                timezone: Some("Asia/Jerusalem".to_string()),
+                ..empty_update_request()
+            },
+        )
+        .unwrap();
+        assert_eq!(updated.routine.timezone.as_deref(), Some("Asia/Jerusalem"));
+    });
+}
+
+#[test]
+fn svc_update_clears_an_existing_timezone_override_via_blank_string() {
+    let _home = TempHome::set();
+    // Mirrors `model`'s clear-on-blank convention. Sets the override directly on the persisted
+    // routine (bypassing create-time platform validation) so this exercises the *clear* path on
+    // every host, not just Linux.
+    let title = "Svc Update Timezone Clear ZZZ";
+    let store = new_store();
+    let mut routine = make_routine("tz-clear-id", title, 1, 1);
+    routine.timezone = Some("Asia/Jerusalem".to_string());
+    crate::routine_storage::write_routine(&routine).unwrap();
+    store.lock().unwrap().insert("tz-clear-id".into(), routine);
+
+    with_empty_path(|| {
+        let updated = svc_update(
+            &store,
+            "tz-clear-id",
+            UpdateRoutineRequest {
+                timezone: Some("   ".to_string()),
+                ..empty_update_request()
+            },
+        )
+        .unwrap();
+        assert_eq!(updated.routine.timezone, None);
+    });
+}
+
+#[test]
+fn svc_update_leaves_timezone_unchanged_when_the_field_is_omitted() {
+    let _home = TempHome::set();
+    let title = "Svc Update Timezone Untouched ZZZ";
+    let store = new_store();
+    let mut routine = make_routine("tz-untouched-id", title, 1, 1);
+    routine.timezone = Some("Asia/Jerusalem".to_string());
+    crate::routine_storage::write_routine(&routine).unwrap();
+    store.lock().unwrap().insert("tz-untouched-id".into(), routine);
+
+    with_empty_path(|| {
+        let updated = svc_update(
+            &store,
+            "tz-untouched-id",
+            UpdateRoutineRequest {
+                ttl_secs: Some(1800),
+                ..empty_update_request()
+            },
+        )
+        .unwrap();
+        assert_eq!(updated.routine.timezone.as_deref(), Some("Asia/Jerusalem"));
     });
 }
 

--- a/src/routines/service_update_not_found_tests.rs
+++ b/src/routines/service_update_not_found_tests.rs
@@ -61,6 +61,7 @@ fn empty_update_request() -> UpdateRoutineRequest {
         env: None,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/routines/service_validate.rs
+++ b/src/routines/service_validate.rs
@@ -158,4 +158,56 @@ pub(super) fn validate_title(title: &str) -> Result<(), AppError> {
     }
     Ok(())
 }
+
+/// Directory containing the system IANA timezone database, used to check a submitted `timezone`
+/// name actually exists rather than accepting any string that merely looks plausible. Present on
+/// every mainstream Linux distribution.
+#[cfg(target_os = "linux")]
+const ZONEINFO_DIR: &str = "/usr/share/zoneinfo";
+
+/// Validate and normalize an optional routine `timezone` override (issue #405): a
+/// blank/whitespace-only value clears it back to the host crontab's own zone (`None`), mirroring
+/// `normalize_model`; a non-blank value must name a real IANA zone, checked against the on-disk
+/// zoneinfo database rather than any hand-rolled list, so the accepted set always matches what the
+/// host's own `cron`/`libc` would resolve.
+///
+/// `#[cfg(target_os = "linux")]`, not a runtime check: `CRON_TZ` (the mechanism
+/// `crate::sync::routines` uses to apply the override) is a vixie-cron/cronie extension that BSD
+/// `cron` (macOS) does not honor, so a non-Linux build never even offers the accept path — see the
+/// sibling `#[cfg(not(target_os = "linux"))]` definition below, which rejects unconditionally.
+#[cfg(target_os = "linux")]
+pub(super) fn validate_timezone(timezone: Option<&str>) -> Result<Option<String>, AppError> {
+    let Some(trimmed) = timezone.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+    // Reject path traversal / absolute-path-looking input before it ever touches the filesystem
+    // (e.g. `"../../etc/passwd"`) — a valid IANA name never contains `..` or starts with `/`.
+    if trimmed.starts_with('/') || trimmed.split('/').any(|segment| segment == "..") {
+        return Err(AppError::BadRequest(format!(
+            "unknown timezone {trimmed:?}"
+        )));
+    }
+    if !std::path::Path::new(ZONEINFO_DIR).join(trimmed).is_file() {
+        return Err(AppError::BadRequest(format!(
+            "unknown timezone {trimmed:?}; expected an IANA name (e.g. \"Asia/Jerusalem\")"
+        )));
+    }
+    Ok(Some(trimmed.to_string()))
+}
+
+/// Non-Linux counterpart of [`validate_timezone`]: a blank/whitespace-only value is still a no-op
+/// (`Ok(None)`), but any real value is rejected outright — `CRON_TZ` is not honored by BSD `cron`
+/// (macOS), so silently accepting and then never applying it would be worse than refusing it.
+#[cfg(not(target_os = "linux"))]
+pub(super) fn validate_timezone(timezone: Option<&str>) -> Result<Option<String>, AppError> {
+    if timezone.map(str::trim).is_none_or(str::is_empty) {
+        return Ok(None);
+    }
+    Err(AppError::BadRequest(
+        "routine timezone is only supported on Linux hosts: CRON_TZ is not honored by BSD cron \
+         (macOS)"
+            .to_string(),
+    ))
+}
+
 include!("validate_repositories.rs");

--- a/src/routines/svc_create.rs
+++ b/src/routines/svc_create.rs
@@ -31,6 +31,7 @@ pub fn svc_create(
     let goal = validate_goal(req.goal.as_deref())?;
     let machines = validate_machines(&req.machines)?;
     validate_env(&req.env)?;
+    let timezone = validate_timezone(req.timezone.as_deref())?;
     let slug = slugify(&req.title);
     {
         let lock = store.lock_recover();
@@ -79,6 +80,7 @@ pub fn svc_create(
         notifications: req.notifications,
         tags,
         env: req.env,
+        timezone,
     };
     write_routine(&routine).map_err(|err| map_write_routine_err(&err))?;
     store

--- a/src/routines/svc_create_accepts_builtin_agent_tests.rs
+++ b/src/routines/svc_create_accepts_builtin_agent_tests.rs
@@ -28,6 +28,7 @@ fn svc_create_accepts_builtin_agent() {
             env: std::collections::HashMap::new(),
             failure_threshold: None,
         notifications: Default::default(),
+            timezone: None,
         },
     )
     .unwrap();
@@ -69,6 +70,7 @@ fn svc_create_rejects_blank_repository_url() {
                 env: std::collections::HashMap::new(),
                 failure_threshold: None,
         notifications: Default::default(),
+                timezone: None,
             },
         );
         assert!(matches!(result, Err(AppError::BadRequest(_))));
@@ -108,6 +110,7 @@ fn svc_create_rejects_blank_repository_branch() {
             env: std::collections::HashMap::new(),
             failure_threshold: None,
         notifications: Default::default(),
+            timezone: None,
         },
     );
     assert!(matches!(result, Err(AppError::BadRequest(_))));

--- a/src/routines/svc_create_rejects_duplicate_slug_tests.rs
+++ b/src/routines/svc_create_rejects_duplicate_slug_tests.rs
@@ -30,6 +30,7 @@ fn svc_create_rejects_duplicate_slug() {
                 env: std::collections::HashMap::new(),
                 failure_threshold: None,
         notifications: Default::default(),
+                timezone: None,
             },
         )
         .unwrap();
@@ -56,6 +57,7 @@ fn svc_create_rejects_duplicate_slug() {
                 env: std::collections::HashMap::new(),
                 failure_threshold: None,
         notifications: Default::default(),
+                timezone: None,
             },
         );
         assert!(matches!(conflict, Err(AppError::Conflict(_))));

--- a/src/routines/svc_create_rejects_malformed_agent_config_tests.rs
+++ b/src/routines/svc_create_rejects_malformed_agent_config_tests.rs
@@ -39,6 +39,7 @@ fn svc_create_rejects_malformed_agent_config() {
             env: std::collections::HashMap::new(),
             failure_threshold: None,
         notifications: Default::default(),
+            timezone: None,
         },
     );
     match result {
@@ -79,6 +80,7 @@ fn svc_create_rejects_unreadable_agent_config() {
             env: std::collections::HashMap::new(),
             failure_threshold: None,
         notifications: Default::default(),
+            timezone: None,
         },
     );
     match result {
@@ -126,6 +128,7 @@ fn svc_update_rejects_malformed_agent_config() {
             env: None,
             failure_threshold: None,
         notifications: Default::default(),
+            timezone: None,
         },
     );
     match result {

--- a/src/routines/svc_create_syncs_crontab_on_success_tests.rs
+++ b/src/routines/svc_create_syncs_crontab_on_success_tests.rs
@@ -28,6 +28,7 @@ fn svc_create_syncs_crontab_on_success() {
                 env: std::collections::HashMap::new(),
                 failure_threshold: None,
         notifications: Default::default(),
+                timezone: None,
             },
         )
         .unwrap();
@@ -69,6 +70,7 @@ fn svc_update_syncs_crontab_on_success() {
                 env: None,
                 failure_threshold: None,
         notifications: Default::default(),
+                timezone: None,
             },
         )
         .unwrap();

--- a/src/routines/svc_create_trims_and_persists_goal_tests.rs
+++ b/src/routines/svc_create_trims_and_persists_goal_tests.rs
@@ -27,6 +27,7 @@ fn svc_create_trims_and_persists_goal() {
                 env: std::collections::HashMap::new(),
                 failure_threshold: None,
         notifications: Default::default(),
+                timezone: None,
             },
         )
         .unwrap();
@@ -79,6 +80,7 @@ fn svc_update_clears_goal_with_empty_string() {
                 env: None,
                 failure_threshold: None,
         notifications: Default::default(),
+                timezone: None,
             },
         )
         .unwrap();
@@ -118,6 +120,7 @@ fn svc_update_warns_when_crontab_sync_fails() {
                 env: None,
                 failure_threshold: None,
         notifications: Default::default(),
+                timezone: None,
             },
         )
         .unwrap();

--- a/src/routines/svc_create_trims_repository_entries_tests.rs
+++ b/src/routines/svc_create_trims_repository_entries_tests.rs
@@ -40,6 +40,7 @@ fn svc_create_trims_repository_entries() {
             env: std::collections::HashMap::new(),
             failure_threshold: None,
         notifications: Default::default(),
+            timezone: None,
         },
     )
     .unwrap();

--- a/src/routines/svc_create_update_delete_lifecycle_tests.rs
+++ b/src/routines/svc_create_update_delete_lifecycle_tests.rs
@@ -23,6 +23,7 @@ fn svc_create_update_delete_lifecycle() {
             env: std::collections::HashMap::new(),
             failure_threshold: None,
         notifications: Default::default(),
+            timezone: None,
         },
     )
     .unwrap();
@@ -57,6 +58,7 @@ fn svc_create_update_delete_lifecycle() {
             env: None,
             failure_threshold: None,
         notifications: Default::default(),
+            timezone: None,
         },
     )
     .unwrap();
@@ -91,6 +93,7 @@ fn svc_update_not_found() {
         env: None,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     };
     assert!(svc_update(&new_store(), "missing", req).is_err());
 }
@@ -121,6 +124,7 @@ fn svc_update_invalid_cron_rejected() {
         env: None,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     };
     assert!(svc_update(&store, "id", req).is_err());
 }

--- a/src/routines/svc_update_rejects_renaming_into_existing_slug_tests.rs
+++ b/src/routines/svc_update_rejects_renaming_into_existing_slug_tests.rs
@@ -44,6 +44,7 @@ fn svc_update_rejects_renaming_into_existing_slug() {
                 env: None,
                 failure_threshold: None,
         notifications: Default::default(),
+                timezone: None,
             },
         );
         assert!(matches!(conflict, Err(AppError::Conflict(_))));

--- a/src/routines/svc_update_sets_max_runtime_secs_tests.rs
+++ b/src/routines/svc_update_sets_max_runtime_secs_tests.rs
@@ -37,6 +37,7 @@ fn svc_update_sets_max_runtime_secs() {
                 env: None,
                 failure_threshold: None,
         notifications: Default::default(),
+                timezone: None,
             },
         )
         .unwrap();

--- a/src/sync/build_block.rs
+++ b/src/sync/build_block.rs
@@ -41,10 +41,13 @@ fn build_block(store: &RoutineStore) -> String {
                 let pure_schedules = pure_schedules_for_crontab(routine);
                 let compailed_schedules = compailed_schedules_for_crontab(routine, &pure_schedules);
                 write_compailed_cron_sidecar(routine, &compailed_schedules);
-                compailed_schedules
-                    .iter()
-                    .map(|schedule| format_routine_line_for_schedule(routine, schedule))
-                    .collect::<Vec<_>>()
+                let mut group: Vec<String> = cron_tz_line_for(routine).into_iter().collect();
+                group.extend(
+                    compailed_schedules
+                        .iter()
+                        .map(|schedule| format_routine_line_for_schedule(routine, schedule)),
+                );
+                group
             }),
             Err(err) => {
                 log::warn!(

--- a/src/sync/cron_tz_directive_tests.rs
+++ b/src/sync/cron_tz_directive_tests.rs
@@ -1,0 +1,88 @@
+#[test]
+fn cron_tz_line_for_reflects_host_zone_when_no_override() {
+    // The pre-#405 fallback: no per-routine override still emits the host's own resolvable zone
+    // (or nothing, on a host where it can't be named), never leaving the previous routine's
+    // directive to bleed into a routine with no override of its own.
+    let routine = make_routine("no-tz", "No Timezone Override Routine", "claude");
+    assert_eq!(
+        cron_tz_line_for(&routine),
+        crate::routines::local_timezone().map(|tz| format!("CRON_TZ={tz}"))
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn cron_tz_line_for_emits_the_override_on_linux() {
+    let mut routine = make_routine("tz-override", "Timezone Override Routine", "claude");
+    routine.timezone = Some("Asia/Jerusalem".to_string());
+    assert_eq!(
+        cron_tz_line_for(&routine),
+        Some("CRON_TZ=Asia/Jerusalem".to_string())
+    );
+}
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn cron_tz_line_for_drops_an_override_on_a_non_linux_host() {
+    // `CRON_TZ` is a Linux-only mechanism; an override that somehow reached this host (e.g. a
+    // routine.toml synced from a Linux machine sharing the config repo) must not be emitted where
+    // BSD `cron` (macOS) would silently ignore it — fall back to the host's own zone instead,
+    // exactly like the no-override case.
+    let mut routine = make_routine("tz-override-non-linux", "Non-Linux Override Routine", "claude");
+    routine.timezone = Some("Asia/Jerusalem".to_string());
+    assert_eq!(
+        cron_tz_line_for(&routine),
+        crate::routines::local_timezone().map(|tz| format!("CRON_TZ={tz}"))
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn build_block_scopes_cron_tz_per_routine_without_bleeding() {
+    // Two enabled routines back to back, only the first with an override: the second must carry
+    // its own `CRON_TZ` directive (the host's zone) rather than silently inheriting the first
+    // routine's `Asia/Jerusalem` — crontab's `CRON_TZ` otherwise persists until reassigned.
+    let agent_name = "test-sync-agent-cron-tz-scope";
+    std::fs::create_dir_all(crate::paths::agents_dir()).unwrap();
+    let cfg = crate::paths::agent_toml_path(agent_name);
+    std::fs::write(&cfg, "command = \"claude\"\nargs = []\n").unwrap();
+
+    let title_a = "Cron Tz Scope Alpha Routine";
+    let title_b = "Cron Tz Scope Beta Routine";
+    let slug_a = slugify(title_a);
+    let slug_b = slugify(title_b);
+
+    let store = new_store();
+    let mut routine_a = make_routine("tz-scope-a", title_a, agent_name);
+    routine_a.created_at = 0;
+    routine_a.timezone = Some("Asia/Jerusalem".to_string());
+    let mut routine_b = make_routine("tz-scope-b", title_b, agent_name);
+    routine_b.created_at = 1;
+    store.lock().unwrap().insert("tz-scope-a".into(), routine_a);
+    store.lock().unwrap().insert("tz-scope-b".into(), routine_b);
+
+    let block = build_block(&store);
+    let directive_before_a = block
+        .lines()
+        .take_while(|line| !line.contains("# moadim-routine:tz-scope-a"))
+        .last()
+        .expect("routine a's line must be preceded by another line");
+    assert_eq!(directive_before_a, "CRON_TZ=Asia/Jerusalem");
+
+    let host_tz_directive = crate::routines::local_timezone().map(|tz| format!("CRON_TZ={tz}"));
+    let directive_before_b = block
+        .lines()
+        .take_while(|line| !line.contains("# moadim-routine:tz-scope-b"))
+        .last()
+        .expect("routine b's line must be preceded by another line");
+    if let Some(expected) = &host_tz_directive {
+        assert_eq!(directive_before_b, expected);
+    }
+    // However the host resolves (or fails to), routine b must not have inherited routine a's
+    // `Asia/Jerusalem` directive.
+    assert_ne!(directive_before_b, "CRON_TZ=Asia/Jerusalem");
+
+    std::fs::remove_file(&cfg).unwrap();
+    let _ = std::fs::remove_dir_all(crate::paths::routine_dir(&slug_a));
+    let _ = std::fs::remove_dir_all(crate::paths::routine_dir(&slug_b));
+}

--- a/src/sync/routines.rs
+++ b/src/sync/routines.rs
@@ -86,6 +86,43 @@ pub(crate) fn format_routine_line_for_schedule(routine: &Routine, schedule: &str
     )
 }
 
+/// Build the `CRON_TZ=<tz>` directive line to place immediately ahead of `routine`'s crontab
+/// line(s), or `None` when nothing needs to be emitted (issue #405).
+///
+/// Emitted unconditionally ahead of *every* routine's line group — rather than only on a
+/// zone change from the previous routine — because `CRON_TZ` persists in the crontab file until
+/// reassigned: without a directive of its own, a routine with no override would silently inherit
+/// whatever zone the previous routine in the (deterministically sorted) block happened to set.
+///
+/// - On Linux, a routine with a (validated — see `service_validate::validate_timezone`) override
+///   emits that zone.
+/// - Otherwise (no override, or a non-Linux build where an override can never be set in the first
+///   place) emits the host's own resolvable local zone, making the otherwise implicit "runs in the
+///   host's zone" explicit and immune to the previous routine's directive. Emits nothing when the
+///   host zone can't be named ([`crate::routines::local_timezone`] returns `None`), exactly
+///   preserving pre-#405 behavior (no `CRON_TZ` line at all) for that case.
+///
+/// `#[cfg(target_os = "linux")]`-gated below, not a runtime check: `CRON_TZ` is a vixie-cron/cronie
+/// (Linux) extension that BSD `cron` (macOS) does not honor, so a non-Linux build has no accept
+/// path for `Routine::timezone` to begin with (`service_validate::validate_timezone` rejects it at
+/// create/update time) and this function's non-Linux definition never looks at the field at all.
+#[cfg(target_os = "linux")]
+fn cron_tz_line_for(routine: &Routine) -> Option<String> {
+    match routine.timezone.as_deref() {
+        Some(tz) => Some(format!("CRON_TZ={tz}")),
+        None => crate::routines::local_timezone().map(|host_tz| format!("CRON_TZ={host_tz}")),
+    }
+}
+
+/// Non-Linux counterpart of [`cron_tz_line_for`]: `Routine::timezone` can never be set on this
+/// platform (rejected at create/update time), so this always emits the host's own zone — see the
+/// `#[cfg(target_os = "linux")]` definition above for the override-aware behavior.
+#[cfg(not(target_os = "linux"))]
+fn cron_tz_line_for(routine: &Routine) -> Option<String> {
+    let _ = routine;
+    crate::routines::local_timezone().map(|host_tz| format!("CRON_TZ={host_tz}"))
+}
+
 /// Format a single routine using its public schedule field.
 #[cfg(test)]
 pub(crate) fn format_routine_line(routine: &Routine) -> String {

--- a/src/sync/routines_sync_multi_cron_tests.rs
+++ b/src/sync/routines_sync_multi_cron_tests.rs
@@ -37,6 +37,7 @@ fn make_routine(id: &str, title: &str, agent: &str) -> Routine {
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/sync/routines_sync_status_tests.rs
+++ b/src/sync/routines_sync_status_tests.rs
@@ -37,6 +37,7 @@ fn make_routine(id: &str, title: &str, agent: &str) -> Routine {
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 

--- a/src/sync/routines_sync_tests.rs
+++ b/src/sync/routines_sync_tests.rs
@@ -37,6 +37,7 @@ fn make_routine(id: &str, title: &str, agent: &str) -> Routine {
         consecutive_failures: 0,
         failure_threshold: None,
         notifications: Default::default(),
+        timezone: None,
     }
 }
 
@@ -136,3 +137,4 @@ struct CronShim {
     previous: Option<std::ffi::OsString>,
 }
 include!("new_with_write_delay_tests.rs");
+include!("cron_tz_directive_tests.rs");

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -91,6 +91,7 @@ impl RoutineFixture {
             consecutive_failures: 0,
             failure_threshold: None,
             notifications: Default::default(),
+            timezone: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #405.

- `Routine.timezone`: optional IANA name (e.g. `Asia/Jerusalem`), validated against the on-disk zoneinfo database on create/update. `None`/blank preserves today's behavior (schedule runs in the host crontab's own zone).
- Applied by emitting a `CRON_TZ=<tz>` directive ahead of every routine's line(s) in the managed crontab block (`# BEGIN MOADIM-ROUTINES` … `# END MOADIM-ROUTINES`) — emitted unconditionally per routine (not just on a zone change) because `CRON_TZ` persists in the crontab file until reassigned, so a routine with no override still gets its own directive (the host's zone) rather than silently inheriting the previous routine's override.
- `CRON_TZ` is a vixie-cron/cronie (Linux) extension that BSD `cron` (macOS) does not honor. `Routine::timezone` is only accepted on Linux — via `#[cfg(target_os = "linux")]`, not a runtime check, so the accept path doesn't even exist in a non-Linux build — and rejected outright (400) elsewhere, per the issue's "pick one and state it" guidance.
- `RoutineResponse.timezone` now reports the *effective* zone (the routine's own override, falling back to the host's) instead of always the host's zone, so `schedule_description` is annotated correctly for a pinned routine too.
- Exposed on `CreateRoutineRequest`/`UpdateRoutineRequest` (REST + the `create_routine`/`update_routine` MCP tools, which already share those types) and documented in `Architecture.md`.

### Known, documented gap

`next_run_at` (the `next_run_at` API field) and the `.ics` feed still project upcoming fire times in the host's own local timezone regardless of a routine's override — only the actual crontab firing (via `CRON_TZ`) honors it. Projecting an arbitrary IANA zone's wall-clock time correctly (DST-aware, not just a fixed UTC offset) needs a timezone database this crate doesn't currently depend on (only `iana-time-zone`, which resolves the *current system* zone, not arbitrary named zones). Rather than ship a DST-incorrect preview alongside a correct crontab mechanism, this is called out explicitly in the doc comments and `Architecture.md` as a follow-up.

## Test plan

- [x] `cargo test` — 1333 passed, including new coverage for `validate_timezone` (accept/reject/blank-clears, Linux-only accept path gated `#[cfg(target_os = "linux")]`), `cron_tz_line_for` (per-routine directive, no bleed between routines), and `RoutineResponse::from_routine` (effective timezone surfacing).
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `.changeset/routine-timezone-override.md` added (patch, matching this repo's existing feature-changeset convention).

---
This PR was opened by the moadim routine **"Open issues → fix PRs (owned repos + my orgs)"**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)