### PR TITLE
fix: launch Hermes routines in headless mode

### DIFF
--- a/.changeset/hermes-headless-agent.md
+++ b/.changeset/hermes-headless-agent.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Run built-in Hermes routines in explicit headless mode with a pinned model/provider, preventing interactive customization and MCP startup from blocking unattended runs.

--- a/src/routines/agents/agents_tests.rs
+++ b/src/routines/agents/agents_tests.rs
@@ -59,7 +59,12 @@ fn hermes_default_config_uses_oneshot_prompt_argument() {
         vec![
             "-z".to_string(),
             "{prompt}".to_string(),
-            "--ignore-rules".to_string()
+            "--ignore-rules".to_string(),
+            "--safe-mode".to_string(),
+            "--model".to_string(),
+            "gpt-5.6-luna".to_string(),
+            "--provider".to_string(),
+            "openai-codex".to_string()
         ]
     );
 }

--- a/src/routines/agents/hermes/setup.rs
+++ b/src/routines/agents/hermes/setup.rs
@@ -6,8 +6,10 @@ pub const NAME: &str = "hermes";
 /// Default `hermes.toml` contents, written on startup when the file is absent.
 ///
 /// Runs Hermes headless in one-shot mode with the composed prompt passed as an argument
-/// (`{prompt}`). Users can override the file under `~/.config/moadim/agents/hermes.toml`
-/// if their Hermes CLI expects a different invocation.
+/// (`{prompt}`). Safe mode prevents interactive customizations and MCP startup from blocking an
+/// unattended routine; the explicit model/provider keep the invocation independent of the caller's
+/// interactive Hermes defaults. Users can override the file under
+/// `~/.config/moadim/agents/hermes.toml` if their Hermes CLI expects a different invocation.
 pub const CONFIG: &str = r#"command = "hermes"
-args = ["-z", "{prompt}", "--ignore-rules"]
+args = ["-z", "{prompt}", "--ignore-rules", "--safe-mode", "--model", "gpt-5.6-luna", "--provider", "openai-codex"]
 "#;

--- a/src/routines/command_path_resolution.rs
+++ b/src/routines/command_path_resolution.rs
@@ -31,9 +31,7 @@ pub(crate) fn tmux_available_in(path: &str) -> bool {
 
 /// Whether `tmux` resolves on the daemon's live `PATH`. Returns `false` when `PATH` is unset.
 pub(crate) fn tmux_available() -> bool {
-    std::env::var("PATH")
-        .ok()
-        .is_some_and(|path| tmux_available_in(&path))
+    std::env::var("PATH").is_ok_and(|path| tmux_available_in(&path))
 }
 
 /// Whether `command` resolves to a file on the given `:`-separated `path` list.
@@ -49,9 +47,7 @@ pub(crate) fn agent_command_available_in(path: &str, command: &str) -> bool {
 
 /// Whether `command` resolves on the daemon's live `PATH`. Returns `false` when `PATH` is unset.
 pub(crate) fn agent_command_available(command: &str) -> bool {
-    std::env::var("PATH")
-        .ok()
-        .is_some_and(|path| agent_command_available_in(&path, command))
+    std::env::var("PATH").is_ok_and(|path| agent_command_available_in(&path, command))
 }
 
 /// The first whitespace-delimited token of an agent's `setup` step — the interpreter or binary it

--- a/src/routines/ensure_default_agents_writes_parsable_configs_tests.rs
+++ b/src/routines/ensure_default_agents_writes_parsable_configs_tests.rs
@@ -29,7 +29,12 @@ fn ensure_default_agents_writes_parsable_configs() {
         vec![
             "-z".to_string(),
             "{prompt}".to_string(),
-            "--ignore-rules".to_string()
+            "--ignore-rules".to_string(),
+            "--safe-mode".to_string(),
+            "--model".to_string(),
+            "gpt-5.6-luna".to_string(),
+            "--provider".to_string(),
+            "openai-codex".to_string()
         ]
     );
 

--- a/src/routines/from_routine_counts_open_flags_tests.rs
+++ b/src/routines/from_routine_counts_open_flags_tests.rs
@@ -1,11 +1,12 @@
 
 #[test]
 fn from_routine_counts_open_flags() {
+    let title = format!("Flag Count Model Test {}", uuid::Uuid::new_v4());
     let routine = Routine {
         id: "rid2".into(),
         schedule: "@daily".into(),
         schedules: vec![],
-        title: "Flag Count Model Test ZZZ".into(),
+        title,
         agent: "claude".into(),
         model: None,
         prompt: "p".into(),

--- a/src/routines/service_model_tests.rs
+++ b/src/routines/service_model_tests.rs
@@ -37,7 +37,7 @@ fn svc_create_trims_and_stores_tags() {
     // Covers the normalize/Ok path of `validate_tags` and the `tags` assignment in
     // `svc_create`: surrounding whitespace is trimmed and the tags are stored.
     crate::routines::ensure_default_agents();
-    let title = "Svc Create Tags ZZZ";
+    let title = format!("Svc Create Tags {}", uuid::Uuid::new_v4());
     let store = new_store();
     let created = svc_create(
         &store,
@@ -46,7 +46,7 @@ fn svc_create_trims_and_stores_tags() {
             model: None,
             power_saving_exempt: false,
             tags: vec!["  triage  ".into(), "nightly".into()],
-            ..create_req_with_title(title)
+            ..create_req_with_title(&title)
         },
     )
     .unwrap();
@@ -56,7 +56,7 @@ fn svc_create_trims_and_stores_tags() {
     );
 
     svc_delete(&store, &created.routine.id).unwrap();
-    let _ = crate::routine_storage::remove_routine_dir(&slugify(title));
+    let _ = crate::routine_storage::remove_routine_dir(&slugify(&title));
 }
 
 #[test]

--- a/src/routines/svc_create_update_delete_lifecycle_tests.rs
+++ b/src/routines/svc_create_update_delete_lifecycle_tests.rs
@@ -2,6 +2,9 @@
 #[test]
 fn svc_create_update_delete_lifecycle() {
     let store = new_store();
+    let suffix = uuid::Uuid::new_v4().to_string();
+    let created_title = format!("Cov Routine {suffix}");
+    let renamed_title = format!("Renamed {suffix}");
     let created = svc_create(
         &store,
         CreateRoutineRequest {
@@ -9,7 +12,7 @@ fn svc_create_update_delete_lifecycle() {
             model: None,
             schedule: "@daily".into(),
             schedules: vec![],
-            title: "Cov Routine".into(),
+            title: created_title.clone(),
             agent: "claude".into(),
             prompt: "p".into(),
             goal: None,
@@ -28,8 +31,9 @@ fn svc_create_update_delete_lifecycle() {
     .unwrap();
     let id = created.routine.id;
     // folder is slug of the title, not the UUID
-    assert!(crate::paths::routine_toml_path("cov-routine").exists());
-    assert!(crate::paths::routine_compiled_prompt_path("cov-routine").exists());
+    let created_slug = slugify(&created_title);
+    assert!(crate::paths::routine_toml_path(&created_slug).exists());
+    assert!(crate::paths::routine_compiled_prompt_path(&created_slug).exists());
 
     let updated = svc_update(
         &store,
@@ -39,7 +43,7 @@ fn svc_create_update_delete_lifecycle() {
             model: None,
             schedule: Some("@weekly".into()),
             schedules: None,
-            title: Some("Renamed".into()),
+            title: Some(renamed_title.clone()),
             agent: Some("codex".into()),
             prompt: Some("p2".into()),
             goal: None,
@@ -61,13 +65,13 @@ fn svc_create_update_delete_lifecycle() {
     )
     .unwrap();
     assert_eq!(updated.routine.schedule, "@weekly");
-    assert_eq!(updated.routine.title, "Renamed");
+    assert_eq!(updated.routine.title, renamed_title);
     assert_eq!(updated.routine.agent, "codex");
     assert!(!updated.routine.enabled);
 
     svc_delete(&store, &id).unwrap();
     // after rename to "Renamed" and delete, the slug dir is gone
-    assert!(!crate::paths::routine_dir("renamed").exists());
+    assert!(!crate::paths::routine_dir(&slugify(&format!("Renamed {suffix}"))).exists());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Run built-in Hermes routines with explicit headless-safe flags.
- Pin the configured model/provider so unattended routine launches do not inherit interactive defaults.
- Make routine filesystem fixtures unique so the full verification suite is isolated from live Moadim state.

## Verification
- `cargo fmt --all -- --check`
- `cargo test --all-targets` — 1323 passed
- client typecheck, lint, and tests — 535 passed
- line-count and Changeset checks
- repository pre-push hook passed

Scope is limited to the Moadim daemon.