### PR TITLE
fix: keep Hermes model and provider configurable

### DIFF
--- a/.changeset/hermes-configurable-provider.md
+++ b/.changeset/hermes-configurable-provider.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Keep Hermes model and provider selection configurable while retaining headless-safe routine launches.

--- a/src/routines/agents/agents_tests.rs
+++ b/src/routines/agents/agents_tests.rs
@@ -60,11 +60,7 @@ fn hermes_default_config_uses_oneshot_prompt_argument() {
             "-z".to_string(),
             "{prompt}".to_string(),
             "--ignore-rules".to_string(),
-            "--safe-mode".to_string(),
-            "--model".to_string(),
-            "gpt-5.6-luna".to_string(),
-            "--provider".to_string(),
-            "openai-codex".to_string()
+            "--safe-mode".to_string()
         ]
     );
 }

--- a/src/routines/agents/hermes/setup.rs
+++ b/src/routines/agents/hermes/setup.rs
@@ -7,9 +7,9 @@ pub const NAME: &str = "hermes";
 ///
 /// Runs Hermes headless in one-shot mode with the composed prompt passed as an argument
 /// (`{prompt}`). Safe mode prevents interactive customizations and MCP startup from blocking an
-/// unattended routine; the explicit model/provider keep the invocation independent of the caller's
-/// interactive Hermes defaults. Users can override the file under
-/// `~/.config/moadim/agents/hermes.toml` if their Hermes CLI expects a different invocation.
+/// unattended routine while leaving Hermes's configured model and provider unchanged. Users can
+/// override the file under `~/.config/moadim/agents/hermes.toml` if their Hermes CLI expects a
+/// different invocation.
 pub const CONFIG: &str = r#"command = "hermes"
-args = ["-z", "{prompt}", "--ignore-rules", "--safe-mode", "--model", "gpt-5.6-luna", "--provider", "openai-codex"]
+args = ["-z", "{prompt}", "--ignore-rules", "--safe-mode"]
 "#;

--- a/src/routines/ensure_default_agents_writes_parsable_configs_tests.rs
+++ b/src/routines/ensure_default_agents_writes_parsable_configs_tests.rs
@@ -30,11 +30,7 @@ fn ensure_default_agents_writes_parsable_configs() {
             "-z".to_string(),
             "{prompt}".to_string(),
             "--ignore-rules".to_string(),
-            "--safe-mode".to_string(),
-            "--model".to_string(),
-            "gpt-5.6-luna".to_string(),
-            "--provider".to_string(),
-            "openai-codex".to_string()
+            "--safe-mode".to_string()
         ]
     );
 


### PR DESCRIPTION
## Summary
- Keep Hermes routine launches headless and safe.
- Remove hardcoded model and provider flags so each installation uses its configured Hermes defaults.

## Verification
- `cargo fmt --all -- --check`
- Hermes default-config tests passed
- `cargo clippy --all-targets -- -D warnings` passed
- Full local pre-push gate passed: 1323 Rust tests, client typecheck/lint, 535 client tests, linecheck, and Changeset validation.

This follow-up corrects PR #1555 by preserving model/provider configurability.