### PR TITLE
Fix test routine storage leakage

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,5 @@
 [env]
-# Test isolation: several tests mutate process-global state — the `PATH`, the `MOADIM_*` env
-# seams (home/bind-address/crontab overrides), and the crontab binary — to exercise the
-# daemon, crontab, and config-path code against tempdirs and ephemeral ports. Pin the test
-# harness to a single thread so those mutations cannot leak across concurrently-running tests.
-# Only the test harness honors `RUST_TEST_THREADS`; the shipped binary ignores it.
-RUST_TEST_THREADS = "1"
+# Moadim tests intentionally exercise process-wide environment seams such as
+# `MOADIM_HOME_OVERRIDE` and `MOADIM_CRONTAB_BIN`. Run Rust test cases serially
+# so one fixture cannot leak a transient override into another.
+RUST_TEST_THREADS = { value = "1", force = true }

--- a/.changeset/isolate-test-home-paths.md
+++ b/.changeset/isolate-test-home-paths.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Keep test routine storage under isolated temporary homes when a fixture omits its explicit home override.

--- a/src/paths/default_home.rs
+++ b/src/paths/default_home.rs
@@ -1,0 +1,23 @@
+/// Resolve the default home directory, using an isolated per-test root in test builds.
+#[cfg(not(test))]
+pub(crate) fn default_home() -> Option<std::path::PathBuf> {
+    dirs::home_dir()
+}
+
+/// Resolve an isolated per-test home directory when no fixture override is installed.
+#[cfg(test)]
+pub(crate) fn default_home() -> Option<std::path::PathBuf> {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = DefaultHasher::new();
+    std::thread::current()
+        .name()
+        .unwrap_or("unnamed-test-thread")
+        .hash(&mut hasher);
+    Some(
+        std::env::temp_dir()
+            .join(format!("moadim-test-home-{}", std::process::id()))
+            .join(format!("{:016x}", hasher.finish())),
+    )
+}

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -9,6 +9,9 @@ use std::path::PathBuf;
 )]
 mod agent_toml_path;
 pub(crate) use agent_toml_path::*;
+/// Default-home resolution with a per-test temporary fallback.
+mod default_home;
+pub(crate) use default_home::*;
 
 /// Environment variable that, when set, overrides the home directory all moadim paths resolve
 /// under. Used by tests to redirect config/routines/jobs/agents/workbenches into a tempdir so they
@@ -27,33 +30,6 @@ pub(crate) fn home() -> Option<PathBuf> {
         Some(dir) => Some(PathBuf::from(dir)),
         None => default_home(),
     }
-}
-
-/// Resolve the process's real home directory outside test builds.
-#[cfg(not(test))]
-fn default_home() -> Option<PathBuf> {
-    dirs::home_dir()
-}
-
-/// Isolate every test from the developer's home even when an individual fixture forgets to install
-/// `MOADIM_HOME_OVERRIDE`. The Rust harness names each test thread, so the fallback also prevents
-/// one unisolated fixture from leaving state that changes another test. Explicit overrides still
-/// take precedence for tests that need a custom root or a failure-injection path.
-#[cfg(test)]
-fn default_home() -> Option<PathBuf> {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-
-    let mut hasher = DefaultHasher::new();
-    std::thread::current()
-        .name()
-        .unwrap_or("unnamed-test-thread")
-        .hash(&mut hasher);
-    Some(
-        std::env::temp_dir()
-            .join(format!("moadim-test-home-{}", std::process::id()))
-            .join(format!("{:016x}", hasher.finish())),
-    )
 }
 
 /// Resolve the config root the moadim config tree nests under, honoring the XDG Base Directory

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -25,8 +25,35 @@ const XDG_CONFIG_HOME_ENV: &str = "XDG_CONFIG_HOME";
 pub(crate) fn home() -> Option<PathBuf> {
     match std::env::var_os(HOME_OVERRIDE_ENV) {
         Some(dir) => Some(PathBuf::from(dir)),
-        None => dirs::home_dir(),
+        None => default_home(),
     }
+}
+
+/// Resolve the process's real home directory outside test builds.
+#[cfg(not(test))]
+fn default_home() -> Option<PathBuf> {
+    dirs::home_dir()
+}
+
+/// Isolate every test from the developer's home even when an individual fixture forgets to install
+/// `MOADIM_HOME_OVERRIDE`. The Rust harness names each test thread, so the fallback also prevents
+/// one unisolated fixture from leaving state that changes another test. Explicit overrides still
+/// take precedence for tests that need a custom root or a failure-injection path.
+#[cfg(test)]
+fn default_home() -> Option<PathBuf> {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = DefaultHasher::new();
+    std::thread::current()
+        .name()
+        .unwrap_or("unnamed-test-thread")
+        .hash(&mut hasher);
+    Some(
+        std::env::temp_dir()
+            .join(format!("moadim-test-home-{}", std::process::id()))
+            .join(format!("{:016x}", hasher.finish())),
+    )
 }
 
 /// Resolve the config root the moadim config tree nests under, honoring the XDG Base Directory

--- a/src/paths/mod_tests.rs
+++ b/src/paths/mod_tests.rs
@@ -34,6 +34,16 @@ fn routines_dir_ends_with_routines() {
 }
 
 #[test]
+fn default_test_config_dir_stays_under_the_system_temp_directory() {
+    let config_dir = config_dir();
+    assert!(
+        config_dir.starts_with(std::env::temp_dir()),
+        "test config dir must not resolve under the developer home: {}",
+        config_dir.display()
+    );
+}
+
+#[test]
 fn routine_dir_is_child_of_routines_dir() {
     assert_eq!(routine_dir("xyz").parent().unwrap(), routines_dir());
 }

--- a/src/paths/mod_tests.rs
+++ b/src/paths/mod_tests.rs
@@ -35,12 +35,14 @@ fn routines_dir_ends_with_routines() {
 
 #[test]
 fn default_test_config_dir_stays_under_the_system_temp_directory() {
-    let config_dir = config_dir();
-    assert!(
-        config_dir.starts_with(std::env::temp_dir()),
-        "test config dir must not resolve under the developer home: {}",
-        config_dir.display()
-    );
+    if std::env::var_os("MOADIM_HOME_OVERRIDE").is_none() {
+        let config_dir = config_dir();
+        assert!(
+            config_dir.starts_with(std::env::temp_dir()),
+            "test config dir must not resolve under the developer home: {}",
+            config_dir.display()
+        );
+    }
 }
 
 #[test]

--- a/src/paths/mod_tests.rs
+++ b/src/paths/mod_tests.rs
@@ -35,14 +35,12 @@ fn routines_dir_ends_with_routines() {
 
 #[test]
 fn default_test_config_dir_stays_under_the_system_temp_directory() {
-    if std::env::var_os("MOADIM_HOME_OVERRIDE").is_none() {
-        let config_dir = config_dir();
-        assert!(
-            config_dir.starts_with(std::env::temp_dir()),
-            "test config dir must not resolve under the developer home: {}",
-            config_dir.display()
-        );
-    }
+    let home = default_home().expect("test fallback home");
+    assert!(
+        home.starts_with(std::env::temp_dir()),
+        "test fallback home must not resolve under the developer home: {}",
+        home.display()
+    );
 }
 
 #[test]

--- a/src/routines/shell_quote_wraps_and_escapes_tests.rs
+++ b/src/routines/shell_quote_wraps_and_escapes_tests.rs
@@ -21,10 +21,11 @@ fn build_routine_command_contains_expected_pieces() {
     assert!(cmd.contains("tmux new-session -d -s \"$SESS\" -c \"$WB\""));
     // bakes a PATH export so cron's minimal PATH does not hide tmux/claude
     assert!(cmd.contains("export PATH="));
-    // sanity-check: command must stay in a reasonable range; the PATH export and system-prompt
-    // setup add several hundred chars, so the limit is higher than the raw cron-line minimum
+    // The managed preamble and explicit failure diagnostics make the command longer than the old
+    // 3 KiB budget; retain a conservative bound that catches accidental command bloat while
+    // accommodating the current complete launch contract.
     assert!(
-        cmd.len() < 3000,
+        cmd.len() < 4_000,
         "crontab line unexpectedly long: {} chars",
         cmd.len()
     );


### PR DESCRIPTION
## Summary
- route test builds without an explicit home override to per-test temporary homes
- prevent test routines and state from reaching the operator config directory
- add regression coverage and align the command-size budget with the current managed preamble

## Verification
- cargo clippy --all-targets -- -D warnings
- cargo test -- --test-threads=1 (1324 passed)
- client typecheck, lint, and tests (535 passed) via the required pre-push hook