### PR TITLE
fix(routines): recover from deleted launcher cwd

### DIFF
--- a/.changeset/routine-launcher-fresh-cwd.md
+++ b/.changeset/routine-launcher-fresh-cwd.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Start every routine launcher from its new workbench so a daemon that inherited a deleted workbench directory can still materialize repository checkouts.

--- a/src/routines/command_builder.rs
+++ b/src/routines/command_builder.rs
@@ -112,6 +112,11 @@ pub(crate) fn build_routine_command(
         format!(r#"WB={}/"$SLUG-$RID""#, shell_quote(&workbenches_base)),
         format!(r#"SESS="{TMUX_SESSION_PREFIX}$SLUG-$RID""#),
         r#"mkdir -p "$WB""#.to_string(),
+        // The daemon can outlive a previous workbench that cleanup removed. In that case its
+        // inherited cwd no longer exists, and Git's checkout step fails even though the new
+        // workbench and repository cache are valid. Anchor the launcher in the fresh workbench
+        // before any prompt, repository, or agent setup command runs.
+        r#"cd "$WB" || exit 1"#.to_string(),
     ]);
 
     // Everything from here on runs with stdout/stderr redirected into the workbench itself, so a

--- a/src/routines/command_umask_tests.rs
+++ b/src/routines/command_umask_tests.rs
@@ -24,3 +24,26 @@ fn build_routine_command_sets_owner_only_umask_before_creating_files() {
         "umask must precede the first mkdir so the workbench tree is owner-only: {cmd}"
     );
 }
+
+#[test]
+fn build_routine_command_enters_new_workbench_before_running_setup() {
+    let routine = make_routine("Cmd Workbench Cwd Routine");
+    let agent = AgentCommand {
+        command: "claude".to_string(),
+        args: vec![],
+        instructions_file: "CLAUDE.md".to_string(),
+        setup: None,
+    };
+    let cmd = build_routine_command(&routine, &agent, TriggerSource::Scheduled);
+    let mkdir_at = cmd
+        .find(r#"mkdir -p "$WB""#)
+        .expect("workbench mkdir present");
+    let cd_at = cmd
+        .find(r#"cd "$WB" || exit 1"#)
+        .expect("workbench cd present");
+    let prompt_at = cmd.find("prompt.md").expect("prompt setup present");
+    assert!(
+        mkdir_at < cd_at && cd_at < prompt_at,
+        "the launcher must enter the fresh workbench before setup or repository commands: {cmd}"
+    );
+}


### PR DESCRIPTION
## Summary
- anchor each routine launcher in its freshly created workbench before prompt, repository, or agent setup work
- prevent a daemon inheriting a deleted prior-workbench CWD from breaking `git clone` checkout
- add a command-order regression test

## Root cause
A live failed run showed `getcwd: cannot access parent directories` followed by a local clone whose checkout failed. The daemon process had inherited a CWD inside a stale workbench. Starting the launcher with `cd "$WB"` makes Git operate from the newly created valid workbench instead.

## Verification
- `cargo fmt --check`
- `cargo test command_` (107 passed)
- `cargo clippy --all-targets -- -D warnings`
- reproduced the pre-fix failure from a deleted CWD: `git clone --local -b main` returned 128 with the same `getcwd`/checkout error
