### PR TITLE
fix(macos): schedule routines in daemon

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,8 @@ mod paths;
 mod restart;
 /// HTTP and MCP route definitions.
 mod routes;
+/// macOS-native in-process routine scheduler.
+mod routine_scheduler;
 /// TOML-backed routine persistence.
 mod routine_storage;
 /// Routine (agent-driven job) data model, service layer, and handlers.

--- a/src/routes/http_listener.rs
+++ b/src/routes/http_listener.rs
@@ -157,6 +157,10 @@ pub async fn run_with_listener_until(
             .await;
         }
     });
+    // macOS blocks crontab mutation behind TCC in some installations. Schedule directly from the
+    // long-lived daemon instead; the scheduler reuses `svc_trigger_scheduled` for deduplication.
+    #[cfg(target_os = "macos")]
+    let routine_scheduler_task = crate::routine_scheduler::spawn(routines.clone());
     let app = build_app_with_shutdown(routines, signal.clone());
     crate::utils::startup_print::print(&addr);
     // Fires the instant a shutdown is requested, so the grace watchdog below can start its clock
@@ -180,6 +184,8 @@ pub async fn run_with_listener_until(
     watchdog_task.abort();
     version_task.abort();
     log_rotation_task.abort();
+    #[cfg(target_os = "macos")]
+    routine_scheduler_task.abort();
     // Drain routine agents still running in their own detached tmux sessions (#320): without this,
     // `moadim stop` only stopped the daemon's HTTP/MCP server, leaving launched agents free to keep
     // acting with no watchdog until they finished or a later daemon start reaped them. This shells

--- a/src/routine_scheduler.rs
+++ b/src/routine_scheduler.rs
@@ -1,0 +1,81 @@
+//! macOS-native, in-process dispatch of routine cron schedules.
+//!
+//! macOS does not use the OS crontab for routines. The daemon checks every 15 seconds and passes
+//! due routine IDs through [`crate::routines::svc_trigger_scheduled`], preserving its existing
+//! locking, snooze, power-saving, and same-minute deduplication behavior.
+
+use chrono::{DateTime, Duration, Local};
+use croner::Cron;
+
+use crate::routines::{Routine, RoutineStore};
+use crate::utils::lock::LockRecover;
+
+/// How often the macOS daemon checks routine schedules.
+pub(crate) const ROUTINE_SCHEDULER_INTERVAL: std::time::Duration =
+    std::time::Duration::from_secs(15);
+
+/// How far back a scheduler tick searches for a cron fire.
+const ROUTINE_SCHEDULER_LOOKBACK: Duration = Duration::seconds(90);
+
+/// Start the macOS routine scheduler as a daemon-owned background task.
+#[cfg(target_os = "macos")]
+pub(crate) fn spawn(store: RoutineStore) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(ROUTINE_SCHEDULER_INTERVAL);
+        loop {
+            tick.tick().await;
+            let store = store.clone();
+            let joined = tokio::task::spawn_blocking(move || trigger_due_routines(&store)).await;
+            if let Err(err) = joined {
+                log::warn!("macOS routine scheduler task failed: {err}");
+            }
+        }
+    })
+}
+
+/// Identify then trigger every enabled routine whose local cron schedule fired recently.
+#[cfg(target_os = "macos")]
+fn trigger_due_routines(store: &RoutineStore) {
+    let now = Local::now();
+    let machine = crate::machine::current_machine();
+    let routines: Vec<Routine> = store.lock_recover().values().cloned().collect();
+    for id in due_routine_ids(&routines, now - ROUTINE_SCHEDULER_LOOKBACK, now, &machine) {
+        if let Err(err) = crate::routines::svc_trigger_scheduled(store, &id) {
+            log::debug!("macOS routine scheduler skipped {id:?}: {err}");
+        }
+    }
+}
+
+/// Return IDs of enabled local routines with a fire in `(window_start, now]`.
+///
+/// Croner evaluates against [`Local`], matching the OS-crontab timezone semantics this scheduler
+/// replaces. Each matching routine contributes only one ID even when its schedules overlap; the
+/// trigger service supplies the durable cross-tick same-minute deduplication.
+fn due_routine_ids(
+    routines: &[Routine],
+    window_start: DateTime<Local>,
+    now: DateTime<Local>,
+    machine: &str,
+) -> Vec<String> {
+    routines
+        .iter()
+        .filter(|routine| {
+            routine.source == "managed"
+                && routine.enabled
+                && crate::machine::targets(&routine.machines, machine)
+        })
+        .filter(|routine| {
+            routine.effective_schedules().iter().any(|schedule| {
+                schedule
+                    .parse::<Cron>()
+                    .ok()
+                    .is_some_and(|cron| cron.iter_after(window_start).any(|fire| fire <= now))
+            })
+        })
+        .map(|routine| routine.id.clone())
+        .collect()
+}
+
+#[cfg(test)]
+#[path = "routine_scheduler_tests.rs"]
+mod routine_scheduler_tests;

--- a/src/routine_scheduler_tests.rs
+++ b/src/routine_scheduler_tests.rs
@@ -1,0 +1,55 @@
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and fixtures do not need doc comments"
+)]
+
+use chrono::{Duration, Local, Timelike};
+
+use super::due_routine_ids;
+
+#[test]
+fn due_routine_ids_selects_enabled_local_machine_routines_in_recent_window() {
+    let now = Local::now()
+        .with_second(30)
+        .and_then(|time| time.with_nanosecond(0))
+        .expect("valid local timestamp");
+    let mut due = crate::test_fixtures::routine_fixture("due", "Due").build();
+    due.schedule = "* * * * *".into();
+    let mut disabled = crate::test_fixtures::routine_fixture("disabled", "Disabled")
+        .enabled(false)
+        .build();
+    disabled.schedule = "* * * * *".into();
+    let mut other_machine = crate::test_fixtures::routine_fixture("other", "Other").build();
+    other_machine.schedule = "* * * * *".into();
+    other_machine.machines = vec!["another-machine".into()];
+    let mut not_due = crate::test_fixtures::routine_fixture("not-due", "Not due").build();
+    not_due.schedule = "0 0 1 1 *".into();
+
+    let due_ids = due_routine_ids(
+        &[due, disabled, other_machine, not_due],
+        now - Duration::seconds(90),
+        now,
+        &crate::machine::current_machine(),
+    );
+
+    assert_eq!(due_ids, vec!["due"]);
+}
+
+#[test]
+fn due_routine_ids_deduplicates_overlapping_schedules_for_one_routine() {
+    let now = Local::now()
+        .with_second(30)
+        .and_then(|time| time.with_nanosecond(0))
+        .expect("valid local timestamp");
+    let mut routine = crate::test_fixtures::routine_fixture("once", "Once").build();
+    routine.schedules = vec!["* * * * *".into(), "* * * * *".into()];
+
+    let due_ids = due_routine_ids(
+        &[routine],
+        now - Duration::seconds(90),
+        now,
+        &crate::machine::current_machine(),
+    );
+
+    assert_eq!(due_ids, vec!["once"]);
+}

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -20,6 +20,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::utils::lock::LockRecover;
+#[cfg(any(not(target_os = "macos"), test))]
 use crate::utils::time::now_secs;
 
 #[allow(
@@ -67,6 +68,7 @@ pub(crate) fn record_crontab_sync_success() {
 }
 
 /// Mark the OS crontab sync state unhealthy after a failed sync attempt.
+#[cfg(any(not(target_os = "macos"), test))]
 pub(crate) fn record_crontab_sync_failure(err: &SyncError) {
     *crontab_sync_state().lock_recover() = CrontabSyncStatus {
         ok: false,

--- a/src/sync/sync_routines_to_crontab.rs
+++ b/src/sync/sync_routines_to_crontab.rs
@@ -33,6 +33,23 @@ pub(crate) const ROUTINE_LINE_MARKER: &str = "# moadim-routine:";
 /// with none running), so both are checked first; either falls back to running inline exactly as
 /// before.
 pub fn sync_routines_to_crontab(store: &RoutineStore) -> Result<(), SyncError> {
+    // macOS routines are dispatched by the daemon's in-process scheduler. Do not invoke crontab:
+    // its TCC-protected write path can hang the daemon during otherwise ordinary routine changes.
+    #[cfg(all(target_os = "macos", not(test)))]
+    {
+        let _ = store;
+        crate::sync::record_crontab_sync_success();
+        Ok(())
+    }
+    #[cfg(not(all(target_os = "macos", not(test))))]
+    {
+        sync_routines_to_crontab_with_os_crontab(store)
+    }
+}
+
+/// Synchronize the OS crontab where it is the active routine scheduler.
+#[cfg(not(all(target_os = "macos", not(test))))]
+fn sync_routines_to_crontab_with_os_crontab(store: &RoutineStore) -> Result<(), SyncError> {
     let on_multi_thread_runtime = tokio::runtime::Handle::try_current()
         .is_ok_and(|handle| handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread);
     let result = if on_multi_thread_runtime {

--- a/src/sync/wait_for_crontab_write.rs
+++ b/src/sync/wait_for_crontab_write.rs
@@ -118,7 +118,22 @@ pub(crate) fn replace_block_with(
 ///
 /// Best-effort and idempotent: a crontab with no managed block (or no crontab at all)
 /// removes nothing and returns `0` without rewriting the crontab.
+#[cfg(all(target_os = "macos", not(test)))]
+pub const fn clear_managed_crontab_blocks() -> Result<usize, SyncError> {
+    // Production macOS never installs managed routine crontab lines; leave any legacy user
+    // crontab untouched rather than invoking the TCC-protected crontab command during uninstall.
+    Ok(0)
+}
+
+/// Clear managed routine entries from the OS crontab.
+#[cfg(not(all(target_os = "macos", not(test))))]
 pub fn clear_managed_crontab_blocks() -> Result<usize, SyncError> {
+    clear_managed_os_crontab_blocks()
+}
+
+/// Remove the routine block from the OS crontab where that scheduler is active.
+#[cfg(not(all(target_os = "macos", not(test))))]
+fn clear_managed_os_crontab_blocks() -> Result<usize, SyncError> {
     let current = read_crontab()?;
 
     // Count managed schedule lines before removal for the user-facing report.


### PR DESCRIPTION
Replace macOS routine crontab writes with a daemon-owned 15-second scheduler that uses existing scheduled-trigger dedupe/locks.