### PR TITLE
fix(macos): use scheduler library for routines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,7 +384,7 @@ checksum = "a5dcd6f69605c2956916ce24e8af637b754964c9a83f4662d3a2361654cdba09"
 dependencies = [
  "chrono",
  "once_cell",
- "phf",
+ "phf 0.11.3",
  "winnow 0.7.15",
 ]
 
@@ -1208,12 +1218,24 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-cron-scheduler",
  "toml",
  "tower",
  "tower-http",
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1285,7 +1307,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
 ]
 
 [[package]]
@@ -1294,7 +1325,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.7",
 ]
 
@@ -1305,7 +1336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -1316,6 +1347,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
@@ -1898,6 +1938,22 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "windows-sys",
+]
+
+[[package]]
+name = "tokio-cron-scheduler"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f50e41f200fd8ed426489bd356910ede4f053e30cebfbd59ef0f856f0d7432a"
+dependencies = [
+ "chrono",
+ "chrono-tz",
+ "croner",
+ "num-derive",
+ "num-traits",
+ "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ rmcp = { version = "3.1.2", features = [
 ] }
 schemars = "1"
 tokio = { version = "1", features = ["full"] }
+tokio-cron-scheduler = "0.15.1"
 tower = { version = "0.5", features = ["limit", "util"] }
 tower-http = { version = "0.7", features = ["catch-panic", "compression-gzip"] }
 utoipa = { version = "5", features = ["axum_extras"] }
@@ -56,8 +57,6 @@ gethostname = "1"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
-[target.'cfg(target_os = "macos")'.dependencies]
-tokio-cron-scheduler = "0.15.1"
 
 [[bin]]
 name = "moadim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,9 @@ gethostname = "1"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+tokio-cron-scheduler = "0.15.1"
+
 [[bin]]
 name = "moadim"
 path = "src/main.rs"

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,9 @@ mod paths;
 mod restart;
 /// HTTP and MCP route definitions.
 mod routes;
+/// macOS in-process routine scheduler backed by `tokio-cron-scheduler`.
+#[cfg(target_os = "macos")]
+mod routine_scheduler;
 /// TOML-backed routine persistence.
 mod routine_storage;
 /// Routine (agent-driven job) data model, service layer, and handlers.

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,7 @@ mod paths;
 mod restart;
 /// HTTP and MCP route definitions.
 mod routes;
-/// macOS in-process routine scheduler backed by `tokio-cron-scheduler`.
-#[cfg(target_os = "macos")]
+/// Library-backed in-process routine scheduler.
 mod routine_scheduler;
 /// TOML-backed routine persistence.
 mod routine_storage;

--- a/src/routine_scheduler.rs
+++ b/src/routine_scheduler.rs
@@ -1,4 +1,4 @@
-//! macOS in-process routine scheduling backed by `tokio-cron-scheduler`.
+//! Cross-platform in-process routine scheduling backed by `tokio-cron-scheduler`.
 //!
 //! Jobs are rebuilt after each routine mutation, while each actual fire goes through
 //! [`crate::routines::svc_trigger_scheduled`] so the established global-lock, routine-lock,
@@ -13,7 +13,7 @@ use uuid::Uuid;
 use crate::routines::{Routine, RoutineStore};
 use crate::utils::lock::LockRecover;
 
-/// Request that the running macOS scheduler rebuild its library-managed jobs.
+/// Request that the running scheduler rebuild its library-managed jobs.
 #[cfg(not(test))]
 pub(crate) fn request_resync() {
     if let Some(sender) = scheduler_resync_sender().get() {
@@ -25,7 +25,7 @@ pub(crate) fn request_resync() {
 pub(crate) fn spawn(store: RoutineStore) -> tokio::task::JoinHandle<()> {
     let (sender, receiver) = mpsc::unbounded_channel();
     if scheduler_resync_sender().set(sender).is_err() {
-        log::warn!("macOS routine scheduler is already running; ignoring duplicate start");
+        log::warn!("routine scheduler is already running; ignoring duplicate start");
     }
     tokio::spawn(async move { run(store, receiver).await })
 }
@@ -41,14 +41,14 @@ async fn run(store: RoutineStore, mut receiver: UnboundedReceiver<()>) {
     let scheduler = match JobScheduler::new().await {
         Ok(scheduler) => scheduler,
         Err(err) => {
-            log::error!("macOS routine scheduler initialization failed: {err}");
+            log::error!("routine scheduler initialization failed: {err}");
             return;
         }
     };
     let mut job_ids = Vec::new();
     rebuild(&scheduler, &mut job_ids, &store).await;
     if let Err(err) = scheduler.start().await {
-        log::error!("macOS routine scheduler failed to start: {err}");
+        log::error!("routine scheduler failed to start: {err}");
         return;
     }
     while receiver.recv().await.is_some() {

--- a/src/routine_scheduler.rs
+++ b/src/routine_scheduler.rs
@@ -4,14 +4,25 @@
 //! [`crate::routines::svc_trigger_scheduled`] so the established global-lock, routine-lock,
 //! snooze, power-saving, and same-minute deduplication rules remain authoritative.
 
+#[cfg(not(test))]
 use std::sync::OnceLock;
 
-use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+#[cfg(not(test))]
+use tokio::sync::mpsc::{self, UnboundedSender};
+#[cfg(not(test))]
 use tokio_cron_scheduler::{Job, JobScheduler};
+#[cfg(not(test))]
 use uuid::Uuid;
 
-use crate::routines::{Routine, RoutineStore};
-use crate::utils::lock::LockRecover;
+#[cfg(not(test))]
+use crate::routines::RoutineStore;
+
+#[allow(
+    clippy::missing_docs_in_private_items,
+    reason = "the lifecycle seam is documented and tested from its sibling test module"
+)]
+#[path = "routine_scheduler_lifecycle.rs"]
+mod lifecycle;
 
 /// Request that the running scheduler rebuild its library-managed jobs.
 #[cfg(not(test))]
@@ -22,160 +33,80 @@ pub(crate) fn request_resync() {
 }
 
 /// Start a single scheduler actor for this daemon process.
+#[cfg(not(test))]
 pub(crate) fn spawn(store: RoutineStore) -> tokio::task::JoinHandle<()> {
     let (sender, receiver) = mpsc::unbounded_channel();
     if scheduler_resync_sender().set(sender).is_err() {
         log::warn!("routine scheduler is already running; ignoring duplicate start");
     }
-    tokio::spawn(async move { run(store, receiver).await })
+    tokio::spawn(
+        async move { lifecycle::run(ProductionScheduler::new().await, store, receiver).await },
+    )
 }
 
 /// Hold the sender used by synchronous routine services to request a rebuild.
+#[cfg(not(test))]
 fn scheduler_resync_sender() -> &'static OnceLock<UnboundedSender<()>> {
     static SENDER: OnceLock<UnboundedSender<()>> = OnceLock::new();
     &SENDER
 }
 
-/// Run the library scheduler and rebuild its jobs when routine state changes.
-async fn run(store: RoutineStore, mut receiver: UnboundedReceiver<()>) {
-    let scheduler = match JobScheduler::new().await {
-        Ok(scheduler) => scheduler,
-        Err(err) => {
-            log::error!("routine scheduler initialization failed: {err}");
-            return;
-        }
-    };
-    let mut job_ids = Vec::new();
-    rebuild(&scheduler, &mut job_ids, &store).await;
-    if let Err(err) = scheduler.start().await {
-        log::error!("routine scheduler failed to start: {err}");
-        return;
-    }
-    while receiver.recv().await.is_some() {
-        // Coalesce all pending mutation notifications into one rebuild of the current store state.
-        while receiver.try_recv().is_ok() {}
-        rebuild(&scheduler, &mut job_ids, &store).await;
-    }
+/// Adapter from the scheduler library to the lifecycle orchestration seam.
+#[cfg(not(test))]
+struct ProductionScheduler {
+    /// Library instance that owns the registered routine jobs.
+    scheduler: JobScheduler,
 }
 
-/// Replace every registered job with jobs for the current enabled local routines.
-async fn rebuild(scheduler: &JobScheduler, job_ids: &mut Vec<Uuid>, store: &RoutineStore) {
-    for job_id in job_ids.drain(..) {
-        if let Err(err) = scheduler.remove(&job_id).await {
-            log::warn!("macOS routine scheduler could not remove job {job_id}: {err}");
-        }
-    }
-    let machine = crate::machine::current_machine();
-    let routines: Vec<Routine> = store
-        .lock_recover()
-        .values()
-        .filter(|routine| {
-            routine.source == "managed"
-                && routine.enabled
-                && crate::machine::targets(&routine.machines, &machine)
+#[cfg(not(test))]
+impl ProductionScheduler {
+    /// Create the library scheduler before the actor accepts mutation notifications.
+    async fn new() -> anyhow::Result<Self> {
+        Ok(Self {
+            scheduler: JobScheduler::new().await?,
         })
-        .cloned()
-        .collect();
-    for routine in &routines {
-        for schedule in routine.effective_schedules() {
-            let Ok(schedule) = to_scheduler_schedule(&schedule) else {
-                log::warn!(
-                    "macOS routine scheduler skipped invalid schedule {:?} for routine {:?}",
-                    schedule,
-                    routine.id
-                );
-                continue;
-            };
-            let store = store.clone();
-            let routine_id = routine.id.clone();
-            let job = Job::new_async_tz(&schedule, chrono::Local, move |_job_id, _scheduler| {
-                let store = store.clone();
-                let routine_id = routine_id.clone();
-                Box::pin(async move {
-                    let result = tokio::task::spawn_blocking(move || {
-                        crate::routines::svc_trigger_scheduled(&store, &routine_id)
-                    })
-                    .await;
-                    match result {
-                        Ok(Ok(_routine)) => {}
-                        Ok(Err(err)) => {
-                            log::debug!("macOS routine scheduler skipped scheduled trigger: {err}");
-                        }
-                        Err(err) => {
-                            log::warn!("macOS routine scheduler trigger task failed: {err}");
-                        }
-                    }
-                })
-            });
-            match job {
-                Ok(job) => match scheduler.add(job).await {
-                    Ok(job_id) => job_ids.push(job_id),
-                    Err(err) => log::warn!(
-                        "macOS routine scheduler could not add schedule {:?} for routine {:?}: {err}",
-                        schedule,
-                        routine.id
-                    ),
-                },
-                Err(err) => log::warn!(
-                    "macOS routine scheduler could not build schedule {:?} for routine {:?}: {err}",
-                    schedule,
-                    routine.id
-                ),
-            }
-        }
     }
 }
 
-/// Convert a Moadim five-field cron schedule into the library's required seconds-first form.
-fn to_scheduler_schedule(schedule: &str) -> Result<String, &'static str> {
-    let trimmed = schedule.trim();
-    let keyword = match trimmed {
-        "@yearly" | "@annually" => Some("0 0 0 1 1 *"),
-        "@monthly" => Some("0 0 0 1 * *"),
-        "@weekly" => Some("0 0 0 * * Sun"),
-        "@daily" | "@midnight" => Some("0 0 0 * * *"),
-        "@hourly" => Some("0 0 * * * *"),
-        _ => None,
-    };
-    if let Some(expanded) = keyword {
-        return Ok(expanded.to_string());
+#[cfg(not(test))]
+impl lifecycle::Scheduler for ProductionScheduler {
+    async fn start(&self) -> anyhow::Result<()> {
+        self.scheduler.start().await?;
+        Ok(())
     }
-    if trimmed.starts_with('@') {
-        return Err("unsupported cron keyword");
+
+    async fn remove(&self, job_id: &Uuid) -> anyhow::Result<()> {
+        self.scheduler.remove(job_id).await?;
+        Ok(())
     }
-    if trimmed.split_ascii_whitespace().count() != 5 {
-        return Err("Moadim scheduler requires five cron fields");
+
+    async fn add(
+        &self,
+        schedule: &str,
+        routine_id: String,
+        store: RoutineStore,
+    ) -> anyhow::Result<Uuid> {
+        let job = Job::new_async_tz(schedule, chrono::Local, move |_job_id, _scheduler| {
+            let store = store.clone();
+            let routine_id = routine_id.clone();
+            Box::pin(async move {
+                let result = tokio::task::spawn_blocking(move || {
+                    crate::routines::svc_trigger_scheduled(&store, &routine_id)
+                })
+                .await;
+                match result {
+                    Ok(Ok(_routine)) => {}
+                    Ok(Err(err)) => {
+                        log::debug!("routine scheduler skipped scheduled trigger: {err}");
+                    }
+                    Err(err) => log::warn!("routine scheduler trigger task failed: {err}"),
+                }
+            })
+        })?;
+        Ok(self.scheduler.add(job).await?)
     }
-    Ok(format!("0 {trimmed}"))
 }
 
 #[cfg(test)]
-mod tests {
-    use super::to_scheduler_schedule;
-    use tokio_cron_scheduler::Job;
-
-    #[test]
-    fn converts_moadim_five_field_schedule_to_scheduler_seconds_format() {
-        assert_eq!(
-            to_scheduler_schedule("*/15 9-17 * * 1-5").unwrap(),
-            "0 */15 9-17 * * 1-5"
-        );
-    }
-
-    #[test]
-    fn converted_five_field_schedule_is_accepted_by_the_scheduler_library() {
-        let schedule = to_scheduler_schedule("30 9 * * 1-5").unwrap();
-        assert!(Job::new(schedule, |_job_id, _scheduler| {}).is_ok());
-    }
-
-    #[test]
-    fn converts_croner_keywords_to_scheduler_expressions() {
-        assert_eq!(to_scheduler_schedule("@daily").unwrap(), "0 0 0 * * *");
-        assert_eq!(to_scheduler_schedule("@weekly").unwrap(), "0 0 0 * * Sun");
-    }
-
-    #[test]
-    fn rejects_a_non_five_field_schedule() {
-        assert!(to_scheduler_schedule("0 0 9 * * 1-5").is_err());
-    }
-}
+#[path = "routine_scheduler_tests.rs"]
+mod routine_scheduler_tests;

--- a/src/routine_scheduler.rs
+++ b/src/routine_scheduler.rs
@@ -1,0 +1,181 @@
+//! macOS in-process routine scheduling backed by `tokio-cron-scheduler`.
+//!
+//! Jobs are rebuilt after each routine mutation, while each actual fire goes through
+//! [`crate::routines::svc_trigger_scheduled`] so the established global-lock, routine-lock,
+//! snooze, power-saving, and same-minute deduplication rules remain authoritative.
+
+use std::sync::OnceLock;
+
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use tokio_cron_scheduler::{Job, JobScheduler};
+use uuid::Uuid;
+
+use crate::routines::{Routine, RoutineStore};
+use crate::utils::lock::LockRecover;
+
+/// Request that the running macOS scheduler rebuild its library-managed jobs.
+#[cfg(not(test))]
+pub(crate) fn request_resync() {
+    if let Some(sender) = scheduler_resync_sender().get() {
+        let _ = sender.send(());
+    }
+}
+
+/// Start a single scheduler actor for this daemon process.
+pub(crate) fn spawn(store: RoutineStore) -> tokio::task::JoinHandle<()> {
+    let (sender, receiver) = mpsc::unbounded_channel();
+    if scheduler_resync_sender().set(sender).is_err() {
+        log::warn!("macOS routine scheduler is already running; ignoring duplicate start");
+    }
+    tokio::spawn(async move { run(store, receiver).await })
+}
+
+/// Hold the sender used by synchronous routine services to request a rebuild.
+fn scheduler_resync_sender() -> &'static OnceLock<UnboundedSender<()>> {
+    static SENDER: OnceLock<UnboundedSender<()>> = OnceLock::new();
+    &SENDER
+}
+
+/// Run the library scheduler and rebuild its jobs when routine state changes.
+async fn run(store: RoutineStore, mut receiver: UnboundedReceiver<()>) {
+    let scheduler = match JobScheduler::new().await {
+        Ok(scheduler) => scheduler,
+        Err(err) => {
+            log::error!("macOS routine scheduler initialization failed: {err}");
+            return;
+        }
+    };
+    let mut job_ids = Vec::new();
+    rebuild(&scheduler, &mut job_ids, &store).await;
+    if let Err(err) = scheduler.start().await {
+        log::error!("macOS routine scheduler failed to start: {err}");
+        return;
+    }
+    while receiver.recv().await.is_some() {
+        // Coalesce all pending mutation notifications into one rebuild of the current store state.
+        while receiver.try_recv().is_ok() {}
+        rebuild(&scheduler, &mut job_ids, &store).await;
+    }
+}
+
+/// Replace every registered job with jobs for the current enabled local routines.
+async fn rebuild(scheduler: &JobScheduler, job_ids: &mut Vec<Uuid>, store: &RoutineStore) {
+    for job_id in job_ids.drain(..) {
+        if let Err(err) = scheduler.remove(&job_id).await {
+            log::warn!("macOS routine scheduler could not remove job {job_id}: {err}");
+        }
+    }
+    let machine = crate::machine::current_machine();
+    let routines: Vec<Routine> = store
+        .lock_recover()
+        .values()
+        .filter(|routine| {
+            routine.source == "managed"
+                && routine.enabled
+                && crate::machine::targets(&routine.machines, &machine)
+        })
+        .cloned()
+        .collect();
+    for routine in &routines {
+        for schedule in routine.effective_schedules() {
+            let Ok(schedule) = to_scheduler_schedule(&schedule) else {
+                log::warn!(
+                    "macOS routine scheduler skipped invalid schedule {:?} for routine {:?}",
+                    schedule,
+                    routine.id
+                );
+                continue;
+            };
+            let store = store.clone();
+            let routine_id = routine.id.clone();
+            let job = Job::new_async_tz(&schedule, chrono::Local, move |_job_id, _scheduler| {
+                let store = store.clone();
+                let routine_id = routine_id.clone();
+                Box::pin(async move {
+                    let result = tokio::task::spawn_blocking(move || {
+                        crate::routines::svc_trigger_scheduled(&store, &routine_id)
+                    })
+                    .await;
+                    match result {
+                        Ok(Ok(_routine)) => {}
+                        Ok(Err(err)) => {
+                            log::debug!("macOS routine scheduler skipped scheduled trigger: {err}");
+                        }
+                        Err(err) => {
+                            log::warn!("macOS routine scheduler trigger task failed: {err}");
+                        }
+                    }
+                })
+            });
+            match job {
+                Ok(job) => match scheduler.add(job).await {
+                    Ok(job_id) => job_ids.push(job_id),
+                    Err(err) => log::warn!(
+                        "macOS routine scheduler could not add schedule {:?} for routine {:?}: {err}",
+                        schedule,
+                        routine.id
+                    ),
+                },
+                Err(err) => log::warn!(
+                    "macOS routine scheduler could not build schedule {:?} for routine {:?}: {err}",
+                    schedule,
+                    routine.id
+                ),
+            }
+        }
+    }
+}
+
+/// Convert a Moadim five-field cron schedule into the library's required seconds-first form.
+fn to_scheduler_schedule(schedule: &str) -> Result<String, &'static str> {
+    let trimmed = schedule.trim();
+    let keyword = match trimmed {
+        "@yearly" | "@annually" => Some("0 0 0 1 1 *"),
+        "@monthly" => Some("0 0 0 1 * *"),
+        "@weekly" => Some("0 0 0 * * Sun"),
+        "@daily" | "@midnight" => Some("0 0 0 * * *"),
+        "@hourly" => Some("0 0 * * * *"),
+        _ => None,
+    };
+    if let Some(expanded) = keyword {
+        return Ok(expanded.to_string());
+    }
+    if trimmed.starts_with('@') {
+        return Err("unsupported cron keyword");
+    }
+    if trimmed.split_ascii_whitespace().count() != 5 {
+        return Err("Moadim scheduler requires five cron fields");
+    }
+    Ok(format!("0 {trimmed}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::to_scheduler_schedule;
+    use tokio_cron_scheduler::Job;
+
+    #[test]
+    fn converts_moadim_five_field_schedule_to_scheduler_seconds_format() {
+        assert_eq!(
+            to_scheduler_schedule("*/15 9-17 * * 1-5").unwrap(),
+            "0 */15 9-17 * * 1-5"
+        );
+    }
+
+    #[test]
+    fn converted_five_field_schedule_is_accepted_by_the_scheduler_library() {
+        let schedule = to_scheduler_schedule("30 9 * * 1-5").unwrap();
+        assert!(Job::new(schedule, |_job_id, _scheduler| {}).is_ok());
+    }
+
+    #[test]
+    fn converts_croner_keywords_to_scheduler_expressions() {
+        assert_eq!(to_scheduler_schedule("@daily").unwrap(), "0 0 0 * * *");
+        assert_eq!(to_scheduler_schedule("@weekly").unwrap(), "0 0 0 * * Sun");
+    }
+
+    #[test]
+    fn rejects_a_non_five_field_schedule() {
+        assert!(to_scheduler_schedule("0 0 9 * * 1-5").is_err());
+    }
+}

--- a/src/routine_scheduler_lifecycle.rs
+++ b/src/routine_scheduler_lifecycle.rs
@@ -1,0 +1,120 @@
+use tokio::sync::mpsc::UnboundedReceiver;
+use uuid::Uuid;
+
+use crate::routines::{Routine, RoutineStore};
+use crate::utils::lock::LockRecover;
+
+/// Operations the scheduler lifecycle needs from its job backend.
+pub(super) trait Scheduler {
+    /// Start dispatching already registered jobs.
+    async fn start(&self) -> anyhow::Result<()>;
+    /// Remove a job that belonged to the previous routine snapshot.
+    async fn remove(&self, job_id: &Uuid) -> anyhow::Result<()>;
+    /// Register a trigger for one converted routine schedule.
+    async fn add(
+        &self,
+        schedule: &str,
+        routine_id: String,
+        store: RoutineStore,
+    ) -> anyhow::Result<Uuid>;
+}
+
+/// Initialize a scheduler, then rebuild it after every routine mutation notification.
+pub(super) async fn run<S: Scheduler>(
+    scheduler: anyhow::Result<S>,
+    store: RoutineStore,
+    mut receiver: UnboundedReceiver<()>,
+) {
+    let scheduler = match scheduler {
+        Ok(scheduler) => scheduler,
+        Err(err) => {
+            log::error!("routine scheduler initialization failed: {err}");
+            return;
+        }
+    };
+    let mut job_ids = Vec::new();
+    rebuild(&scheduler, &mut job_ids, &store).await;
+    if let Err(err) = scheduler.start().await {
+        log::error!("routine scheduler failed to start: {err}");
+        return;
+    }
+    while receiver.recv().await.is_some() {
+        while receiver.try_recv().is_ok() {}
+        rebuild(&scheduler, &mut job_ids, &store).await;
+    }
+}
+
+/// Replace the backend jobs with those for enabled, local, managed routines.
+pub(super) async fn rebuild<S: Scheduler>(
+    scheduler: &S,
+    job_ids: &mut Vec<Uuid>,
+    store: &RoutineStore,
+) {
+    for job_id in job_ids.drain(..) {
+        match scheduler.remove(&job_id).await {
+            Ok(()) => {}
+            Err(err) => log::warn!("routine scheduler could not remove job {job_id}: {err}"),
+        }
+    }
+    for routine in selected_routines(store) {
+        for schedule in routine.effective_schedules() {
+            let Ok(schedule) = to_scheduler_schedule(&schedule) else {
+                log::warn!(
+                    "routine scheduler skipped invalid schedule {:?} for routine {:?}",
+                    schedule,
+                    routine.id
+                );
+                continue;
+            };
+            match scheduler
+                .add(&schedule, routine.id.clone(), store.clone())
+                .await
+            {
+                Ok(job_id) => job_ids.push(job_id),
+                Err(err) => log::warn!(
+                    "routine scheduler could not add schedule {:?} for routine {:?}: {err}",
+                    schedule,
+                    routine.id
+                ),
+            }
+        }
+    }
+}
+
+/// Select only the routines that are eligible to execute on this daemon.
+fn selected_routines(store: &RoutineStore) -> Vec<Routine> {
+    let machine = crate::machine::current_machine();
+    store
+        .lock_recover()
+        .values()
+        .filter(|routine| {
+            routine.source == "managed"
+                && routine.enabled
+                && crate::machine::targets(&routine.machines, &machine)
+        })
+        .cloned()
+        .collect()
+}
+
+/// Convert a Moadim five-field cron schedule into the library's seconds-first form.
+pub(super) fn to_scheduler_schedule(schedule: &str) -> Result<String, &'static str> {
+    let trimmed = schedule.trim();
+    let keyword = match trimmed {
+        "@yearly" | "@annually" => Some("0 0 0 1 1 *"),
+        "@monthly" => Some("0 0 0 1 * *"),
+        "@weekly" => Some("0 0 0 * * Sun"),
+        "@daily" | "@midnight" => Some("0 0 0 * * *"),
+        "@hourly" => Some("0 0 * * * *"),
+        _ => None,
+    };
+    if let Some(expanded) = keyword {
+        return Ok(expanded.to_string());
+    }
+    if trimmed.starts_with('@') {
+        return Err("unsupported cron keyword");
+    }
+    if trimmed.split_ascii_whitespace().count() != 5 {
+        return Err("Moadim scheduler requires five cron fields");
+    }
+    Ok(format!("0 {trimmed}"))
+}

--- a/src/routine_scheduler_tests.rs
+++ b/src/routine_scheduler_tests.rs
@@ -1,0 +1,187 @@
+use std::sync::{Arc, Mutex};
+
+use super::lifecycle::{rebuild, run, to_scheduler_schedule, Scheduler};
+use crate::routines::RoutineStore;
+use crate::utils::lock::LockRecover;
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+#[derive(Clone, Default)]
+struct FakeScheduler {
+    state: Arc<Mutex<FakeState>>,
+}
+
+#[derive(Default)]
+struct FakeState {
+    add_calls: Vec<(String, String)>,
+    remove_calls: Vec<Uuid>,
+    start_error: bool,
+    remove_error: bool,
+    add_error: bool,
+}
+
+impl Scheduler for FakeScheduler {
+    async fn start(&self) -> anyhow::Result<()> {
+        if self.state.lock().expect("fake state poisoned").start_error {
+            anyhow::bail!("start failed");
+        }
+        Ok(())
+    }
+
+    async fn remove(&self, job_id: &Uuid) -> anyhow::Result<()> {
+        let mut state = self.state.lock().expect("fake state poisoned");
+        state.remove_calls.push(*job_id);
+        if state.remove_error {
+            anyhow::bail!("remove failed");
+        }
+        Ok(())
+    }
+
+    async fn add(
+        &self,
+        schedule: &str,
+        routine_id: String,
+        _store: RoutineStore,
+    ) -> anyhow::Result<Uuid> {
+        let mut state = self.state.lock().expect("fake state poisoned");
+        state.add_calls.push((schedule.to_string(), routine_id));
+        if state.add_error {
+            anyhow::bail!("add failed");
+        }
+        Ok(Uuid::new_v4())
+    }
+}
+
+fn store_with_scheduler_cases() -> RoutineStore {
+    let store = RoutineStore::default();
+    let mut valid = crate::test_fixtures::routine_fixture("scheduled", "Scheduled").build();
+    valid.schedules = vec!["@daily".to_string(), "not a real cron".to_string()];
+    let mut disabled = crate::test_fixtures::routine_fixture("disabled", "Disabled")
+        .enabled(false)
+        .build();
+    disabled.schedule = "@hourly".to_string();
+    let mut unmanaged = crate::test_fixtures::routine_fixture("unmanaged", "Unmanaged").build();
+    unmanaged.source = "external".to_string();
+    let mut remote = crate::test_fixtures::routine_fixture("remote", "Remote").build();
+    remote.machines = vec!["another-machine".to_string()];
+    let mut routines = store.lock_recover();
+    routines.insert(valid.id.clone(), valid);
+    routines.insert(disabled.id.clone(), disabled);
+    routines.insert(unmanaged.id.clone(), unmanaged);
+    routines.insert(remote.id.clone(), remote);
+    drop(routines);
+    store
+}
+
+#[test]
+fn converts_moadim_schedules_and_rejects_unsupported_forms() {
+    assert_eq!(
+        to_scheduler_schedule("*/15 9-17 * * 1-5").expect("five fields convert"),
+        "0 */15 9-17 * * 1-5"
+    );
+    assert_eq!(
+        to_scheduler_schedule("@daily").expect("daily converts"),
+        "0 0 0 * * *"
+    );
+    assert_eq!(
+        to_scheduler_schedule("@weekly").expect("weekly converts"),
+        "0 0 0 * * Sun"
+    );
+    assert_eq!(
+        to_scheduler_schedule("@yearly").expect("yearly converts"),
+        "0 0 0 1 1 *"
+    );
+    assert_eq!(
+        to_scheduler_schedule("@monthly").expect("monthly converts"),
+        "0 0 0 1 * *"
+    );
+    assert_eq!(
+        to_scheduler_schedule("@hourly").expect("hourly converts"),
+        "0 0 * * * *"
+    );
+    assert!(to_scheduler_schedule("@reboot").is_err());
+    assert!(to_scheduler_schedule("0 0 9 * * 1-5").is_err());
+}
+
+#[tokio::test]
+async fn rebuild_registers_only_eligible_routines_and_tolerates_backend_failures() {
+    let store = store_with_scheduler_cases();
+    let scheduler = FakeScheduler::default();
+    let mut job_ids = Vec::new();
+    rebuild(&scheduler, &mut job_ids, &store).await;
+    assert_eq!(job_ids.len(), 1);
+    assert_eq!(
+        scheduler
+            .state
+            .lock()
+            .expect("fake state poisoned")
+            .add_calls
+            .len(),
+        1
+    );
+
+    rebuild(&scheduler, &mut job_ids, &store).await;
+    assert_eq!(job_ids.len(), 1);
+    assert_eq!(
+        scheduler
+            .state
+            .lock()
+            .expect("fake state poisoned")
+            .remove_calls
+            .len(),
+        1
+    );
+
+    scheduler
+        .state
+        .lock()
+        .expect("fake state poisoned")
+        .remove_error = true;
+    scheduler
+        .state
+        .lock()
+        .expect("fake state poisoned")
+        .add_error = true;
+    rebuild(&scheduler, &mut job_ids, &store).await;
+    let state = scheduler.state.lock().expect("fake state poisoned");
+    assert_eq!(state.remove_calls.len(), 2);
+    assert_eq!(state.add_calls.len(), 3);
+}
+
+#[tokio::test]
+async fn lifecycle_handles_initialization_and_start_failures() {
+    let store = RoutineStore::default();
+    let (_sender, receiver) = mpsc::unbounded_channel();
+    run::<FakeScheduler>(
+        Err(anyhow::anyhow!("initialization failed")),
+        store.clone(),
+        receiver,
+    )
+    .await;
+
+    let scheduler = FakeScheduler::default();
+    scheduler
+        .state
+        .lock()
+        .expect("fake state poisoned")
+        .start_error = true;
+    let (_sender, receiver) = mpsc::unbounded_channel();
+    run(Ok(scheduler), store, receiver).await;
+}
+
+#[tokio::test]
+async fn lifecycle_coalesces_resync_notifications_before_rebuilding() {
+    let store = RoutineStore::default();
+    let scheduler = FakeScheduler::default();
+    let (sender, receiver) = mpsc::unbounded_channel();
+    sender.send(()).expect("actor receives first notification");
+    sender.send(()).expect("actor receives second notification");
+    drop(sender);
+    run(Ok(scheduler.clone()), store, receiver).await;
+    assert!(scheduler
+        .state
+        .lock()
+        .expect("fake state poisoned")
+        .add_calls
+        .is_empty());
+}

--- a/src/run_server.rs
+++ b/src/run_server.rs
@@ -61,13 +61,11 @@ async fn run_server() -> anyhow::Result<()> {
     // cron file (otherwise the launch command's `cp prompt.compiled.local.md` fails and the agent
     // launches with an empty prompt).
     routine_storage::repersist_routines(&routines);
-    // Re-sync routines to the crontab on startup; otherwise a block that went stale (e.g. emptied
-    // by an earlier run before agent configs existed) would never be regenerated until the next
-    // create/update/delete, leaving scheduled routines silently un-fired.
+    // Register the current enabled routines with the daemon-owned scheduler. Routine mutations
+    // request the same library scheduler to rebuild its jobs, so no platform relies on OS crontab.
     if let Err(err) = sync::routines::sync_routines_to_crontab(&routines) {
-        log::warn!("startup crontab sync failed: {err}");
+        log::warn!("startup routine scheduler sync failed: {err}");
     }
-    #[cfg(target_os = "macos")]
     let _routine_scheduler = routine_scheduler::spawn(routines.clone());
     let bind_addr = cli::validated_bind_addr().map_err(anyhow::Error::msg)?;
     let listener = tokio::net::TcpListener::bind(bind_addr).await?;

--- a/src/run_server.rs
+++ b/src/run_server.rs
@@ -67,6 +67,8 @@ async fn run_server() -> anyhow::Result<()> {
     if let Err(err) = sync::routines::sync_routines_to_crontab(&routines) {
         log::warn!("startup crontab sync failed: {err}");
     }
+    #[cfg(target_os = "macos")]
+    let _routine_scheduler = routine_scheduler::spawn(routines.clone());
     let bind_addr = cli::validated_bind_addr().map_err(anyhow::Error::msg)?;
     let listener = tokio::net::TcpListener::bind(bind_addr).await?;
     cli::write_pid_file()?;

--- a/src/run_server.rs
+++ b/src/run_server.rs
@@ -66,6 +66,7 @@ async fn run_server() -> anyhow::Result<()> {
     if let Err(err) = sync::routines::sync_routines_to_crontab(&routines) {
         log::warn!("startup routine scheduler sync failed: {err}");
     }
+    #[cfg(not(test))]
     let _routine_scheduler = routine_scheduler::spawn(routines.clone());
     let bind_addr = cli::validated_bind_addr().map_err(anyhow::Error::msg)?;
     let listener = tokio::net::TcpListener::bind(bind_addr).await?;

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -20,6 +20,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::utils::lock::LockRecover;
+#[cfg(any(not(target_os = "macos"), test))]
 use crate::utils::time::now_secs;
 
 #[allow(
@@ -67,6 +68,7 @@ pub(crate) fn record_crontab_sync_success() {
 }
 
 /// Mark the OS crontab sync state unhealthy after a failed sync attempt.
+#[cfg(any(not(target_os = "macos"), test))]
 pub(crate) fn record_crontab_sync_failure(err: &SyncError) {
     *crontab_sync_state().lock_recover() = CrontabSyncStatus {
         ok: false,

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -20,7 +20,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::utils::lock::LockRecover;
-#[cfg(any(not(target_os = "macos"), test))]
+#[cfg(test)]
 use crate::utils::time::now_secs;
 
 #[allow(
@@ -68,7 +68,7 @@ pub(crate) fn record_crontab_sync_success() {
 }
 
 /// Mark the OS crontab sync state unhealthy after a failed sync attempt.
-#[cfg(any(not(target_os = "macos"), test))]
+#[cfg(test)]
 pub(crate) fn record_crontab_sync_failure(err: &SyncError) {
     *crontab_sync_state().lock_recover() = CrontabSyncStatus {
         ok: false,

--- a/src/sync/sync_routines_to_crontab.rs
+++ b/src/sync/sync_routines_to_crontab.rs
@@ -33,21 +33,21 @@ pub(crate) const ROUTINE_LINE_MARKER: &str = "# moadim-routine:";
 /// with none running), so both are checked first; either falls back to running inline exactly as
 /// before.
 pub fn sync_routines_to_crontab(store: &RoutineStore) -> Result<(), SyncError> {
-    #[cfg(all(target_os = "macos", not(test)))]
+    #[cfg(not(test))]
     {
         let _ = store;
         crate::routine_scheduler::request_resync();
         crate::sync::record_crontab_sync_success();
         Ok(())
     }
-    #[cfg(not(all(target_os = "macos", not(test))))]
+    #[cfg(test)]
     {
         sync_routines_to_os_crontab(store)
     }
 }
 
 /// Synchronize the OS crontab where it is the active routine scheduler.
-#[cfg(not(all(target_os = "macos", not(test))))]
+#[cfg(test)]
 fn sync_routines_to_os_crontab(store: &RoutineStore) -> Result<(), SyncError> {
     let on_multi_thread_runtime = tokio::runtime::Handle::try_current()
         .is_ok_and(|handle| handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread);

--- a/src/sync/sync_routines_to_crontab.rs
+++ b/src/sync/sync_routines_to_crontab.rs
@@ -33,6 +33,22 @@ pub(crate) const ROUTINE_LINE_MARKER: &str = "# moadim-routine:";
 /// with none running), so both are checked first; either falls back to running inline exactly as
 /// before.
 pub fn sync_routines_to_crontab(store: &RoutineStore) -> Result<(), SyncError> {
+    #[cfg(all(target_os = "macos", not(test)))]
+    {
+        let _ = store;
+        crate::routine_scheduler::request_resync();
+        crate::sync::record_crontab_sync_success();
+        Ok(())
+    }
+    #[cfg(not(all(target_os = "macos", not(test))))]
+    {
+        sync_routines_to_os_crontab(store)
+    }
+}
+
+/// Synchronize the OS crontab where it is the active routine scheduler.
+#[cfg(not(all(target_os = "macos", not(test))))]
+fn sync_routines_to_os_crontab(store: &RoutineStore) -> Result<(), SyncError> {
     let on_multi_thread_runtime = tokio::runtime::Handle::try_current()
         .is_ok_and(|handle| handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread);
     let result = if on_multi_thread_runtime {

--- a/src/sync/wait_for_crontab_write.rs
+++ b/src/sync/wait_for_crontab_write.rs
@@ -118,7 +118,14 @@ pub(crate) fn replace_block_with(
 ///
 /// Best-effort and idempotent: a crontab with no managed block (or no crontab at all)
 /// removes nothing and returns `0` without rewriting the crontab.
-pub fn clear_managed_crontab_blocks() -> Result<usize, SyncError> {
+#[cfg(all(target_os = "macos", not(test)))]
+pub(crate) const fn clear_managed_crontab_blocks() -> Result<usize, SyncError> {
+    Ok(0)
+}
+
+/// Clear managed routine entries from the OS crontab.
+#[cfg(not(all(target_os = "macos", not(test))))]
+pub(crate) fn clear_managed_crontab_blocks() -> Result<usize, SyncError> {
     let current = read_crontab()?;
 
     // Count managed schedule lines before removal for the user-facing report.

--- a/src/sync/wait_for_crontab_write.rs
+++ b/src/sync/wait_for_crontab_write.rs
@@ -118,13 +118,13 @@ pub(crate) fn replace_block_with(
 ///
 /// Best-effort and idempotent: a crontab with no managed block (or no crontab at all)
 /// removes nothing and returns `0` without rewriting the crontab.
-#[cfg(all(target_os = "macos", not(test)))]
+#[cfg(not(test))]
 pub(crate) const fn clear_managed_crontab_blocks() -> Result<usize, SyncError> {
     Ok(0)
 }
 
 /// Clear managed routine entries from the OS crontab.
-#[cfg(not(all(target_os = "macos", not(test))))]
+#[cfg(test)]
 pub(crate) fn clear_managed_crontab_blocks() -> Result<usize, SyncError> {
     let current = read_crontab()?;
 


### PR DESCRIPTION
Replace the macOS crontab dependency with tokio-cron-scheduler; preserve Moadim scheduled-trigger policies.