### PR TITLE
chore: release internal scheduler change

### DIFF
--- a/.changeset/internal-library-scheduler.md
+++ b/.changeset/internal-library-scheduler.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Run routine cron schedules inside the daemon with `tokio-cron-scheduler` across platforms, preserving the existing scheduled-trigger safety policies.


### PR DESCRIPTION
Add the missing patch changeset for the merged cross-platform tokio-cron-scheduler implementation.