### PR TITLE
fix(routines): scope scheduled duplicate claims to process

### DIFF
--- a/.changeset/scheduled-trigger-dedupe-claim.md
+++ b/.changeset/scheduled-trigger-dedupe-claim.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Keep scheduled-fire deduplication process-local so reloaded current-minute execution history does not suppress the scheduler's current fire.

--- a/src/routines/scheduled_trigger_claim.rs
+++ b/src/routines/scheduled_trigger_claim.rs
@@ -1,0 +1,31 @@
+//! In-memory claims used to deduplicate simultaneous scheduled fires.
+//!
+//! Durable `scheduled.log` entries describe execution history and survive daemon restarts. They
+//! must not act as scheduler claims: a new scheduler fire in the same minute can otherwise be
+//! rejected solely because the daemon reloaded that history. These process-local claims instead
+//! cover only competing scheduled-trigger requests handled by this daemon instance.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+use crate::utils::lock::LockRecover;
+
+/// Return whether this daemon instance can claim `id`'s current scheduled-fire minute.
+pub(super) fn claim_current_minute(id: &str, now: u64) -> bool {
+    let mut claims = scheduled_trigger_claims().lock_recover();
+    claims.retain(|_, claimed_at| *claimed_at / 60 == now / 60);
+    if claims
+        .get(id)
+        .is_some_and(|claimed_at| claimed_at / 60 == now / 60)
+    {
+        return false;
+    }
+    claims.insert(id.to_string(), now);
+    true
+}
+
+/// Hold the current-minute scheduled-fire claims for this daemon process.
+fn scheduled_trigger_claims() -> &'static Mutex<HashMap<String, u64>> {
+    static CLAIMS: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+    CLAIMS.get_or_init(Mutex::default)
+}

--- a/src/routines/service.rs
+++ b/src/routines/service.rs
@@ -97,6 +97,8 @@ pub(crate) use service_log_tail::{read_log_tail, strip_ansi_noise, MAX_LOG_TAIL_
 #[path = "service_log_tail_tests.rs"]
 mod service_log_tail_tests;
 
+#[path = "scheduled_trigger_claim.rs"]
+mod scheduled_trigger_claim;
 #[path = "service_trigger.rs"]
 mod service_trigger;
 #[cfg(test)]

--- a/src/routines/service_trigger.rs
+++ b/src/routines/service_trigger.rs
@@ -18,6 +18,7 @@ use crate::routines::command::{
 use crate::routines::model::{CleanupResponse, Routine, RoutineStore};
 use crate::routines::{max_concurrent_runs, MAX_CONCURRENT_RUNS_ENV};
 
+use super::scheduled_trigger_claim::claim_current_minute;
 use super::service_log_tail::{read_log_tail_with_meta, LogWithMeta};
 
 #[allow(
@@ -123,21 +124,18 @@ pub fn svc_trigger_scheduled(store: &RoutineStore, id: &str) -> Result<Routine, 
     }
 
     let ts = now_secs();
-    if routine
-        .last_scheduled_trigger_at
-        .is_some_and(|last| last / 60 == ts / 60)
-    {
+    if !claim_current_minute(id, ts) {
         let reason = "routine already fired this minute; skipping duplicate scheduled trigger";
         let rel_dir = crate::routine_storage::routine_rel_dir(routine);
         drop(lock);
         append_skip_log(&rel_dir, ts, reason);
         return Err(AppError::Locked(reason.into()));
     }
-    // Same-minute claim (#795): multiple crontab lines can target the same routine when a
-    // multi-schedule routine has overlapping expressions. Claim the current minute while holding the
-    // store mutex so a second scheduled-trigger request observes the in-memory timestamp and no-ops
-    // instead of launching a duplicate workbench. The spawned scheduled command still appends the
-    // durable `scheduled.log` entry for load-after-restart history.
+    // Same-minute claim (#795): multiple scheduler jobs can target the same routine when a
+    // multi-schedule routine has overlapping expressions. Claim the current minute in process while
+    // holding the store mutex so a second scheduled-trigger request observes the claim and no-ops
+    // instead of launching a duplicate workbench. The durable scheduled timestamp remains execution
+    // history, and the spawned scheduled command still appends its entry to `scheduled.log`.
     routine.last_scheduled_trigger_at = Some(ts);
     let routine = routine.clone();
     drop(lock);

--- a/src/routines/svc_trigger_scheduled_skips_duplicate_fire_in_same_minute_tests.rs
+++ b/src/routines/svc_trigger_scheduled_skips_duplicate_fire_in_same_minute_tests.rs
@@ -14,12 +14,16 @@ fn svc_trigger_scheduled_skips_duplicate_fire_in_same_minute() {
     }
     let _home = TempHome::set();
     let store = new_store();
-    let mut routine = make_routine("trig-sched-dedupe-id", "Trig Sched Dedupe ZZZ", 1, 1);
-    routine.last_scheduled_trigger_at = Some(now_secs());
+    let routine = make_routine("trig-sched-dedupe-id", "Trig Sched Dedupe ZZZ", 1, 1);
     store
         .lock()
         .unwrap()
         .insert("trig-sched-dedupe-id".into(), routine);
+    let first = svc_trigger_scheduled(&store, "trig-sched-dedupe-id");
+    assert!(
+        first.is_ok(),
+        "first scheduled fire should claim the minute: {first:?}"
+    );
 
     let result = svc_trigger_scheduled(&store, "trig-sched-dedupe-id");
 
@@ -27,6 +31,36 @@ fn svc_trigger_scheduled_skips_duplicate_fire_in_same_minute() {
         matches!(result, Err(AppError::Locked(ref msg)) if msg.contains("already fired this minute")),
         "expected same-minute scheduled fire dedupe, got {result:?}"
     );
+}
+
+#[test]
+fn svc_trigger_scheduled_allows_a_new_fire_after_reloading_current_minute_history() {
+    let _home = TempHome::set();
+    let agent_name = "svc-trigger-scheduled-history-agent-zzz";
+    std::fs::create_dir_all(crate::paths::agents_dir()).unwrap();
+    std::fs::write(
+        crate::paths::agent_toml_path(agent_name),
+        "command = \"true\"\nargs = []\n",
+    )
+    .unwrap();
+
+    let store = new_store();
+    let mut routine = make_routine("trig-sched-history-id", "Trig Sched History ZZZ", 1, 1);
+    routine.agent = agent_name.into();
+    // `last_scheduled_trigger_at` is durable execution history loaded from scheduled.log. A daemon
+    // restart in the same minute must not confuse that completed/current record with an in-process
+    // duplicate claim for this scheduler fire.
+    routine.last_scheduled_trigger_at = Some(now_secs());
+    crate::routine_storage::write_routine(&routine).unwrap();
+    store
+        .lock()
+        .unwrap()
+        .insert("trig-sched-history-id".into(), routine);
+
+    with_empty_path(|| {
+        let triggered = svc_trigger_scheduled(&store, "trig-sched-history-id").unwrap();
+        assert!(triggered.last_manual_trigger_at.is_none());
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- keep scheduled-fire history (`last_scheduled_trigger_at`) separate from duplicate detection
- track same-minute scheduled-trigger claims only in the running daemon process
- preserve duplicate suppression for overlapping scheduler jobs and cover reloaded current-minute history

## Verification
- `RUST_TEST_THREADS=1 cargo test svc_trigger_scheduled_ -- --nocapture` (24 passed)
- `.githooks/pre-push` (passed: fmt, clippy, 1,329 Rust tests, 100% coverage gate, linecheck, client typecheck/lint, 536 client tests, changeset check)
- `git diff --check`

