### PR TITLE
fix(scheduler): surface in-process resync health

### DIFF
--- a/.changeset/observable-scheduler-resync.md
+++ b/.changeset/observable-scheduler-resync.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Expose in-process routine-scheduler resync health, completion time, and rebuild failures after routine mutations.

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -1539,6 +1539,7 @@
           "machine",
           "dependencies",
           "crontab_sync",
+          "scheduler_resync",
           "version",
           "git_sha",
           "build_date"
@@ -1567,6 +1568,10 @@
           "running": {
             "type": "boolean",
             "description": "Whether the server is running."
+          },
+          "scheduler_resync": {
+            "$ref": "#/components/schemas/SchedulerResyncHealth",
+            "description": "Whether the in-process scheduler last rebuilt routine jobs successfully after a mutation."
           },
           "server_exe_dir": {
             "type": [
@@ -2117,6 +2122,44 @@
           "workbench": {
             "type": "string",
             "description": "Workbench directory name (`{slug}-{unix_secs}`); pass to `GET /routines/{id}/runs/{workbench}/log`."
+          }
+        }
+      },
+      "SchedulerResyncHealth": {
+        "type": "object",
+        "description": "In-process scheduler resynchronization state surfaced by health endpoints.",
+        "required": [
+          "ok"
+        ],
+        "properties": {
+          "last_completed_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Unix timestamp of the most recently completed in-process scheduler rebuild.",
+            "minimum": 0
+          },
+          "last_error": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Last in-process scheduler rebuild error, when any schedule could not be applied."
+          },
+          "last_error_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Unix timestamp of the most recent in-process scheduler rebuild error.",
+            "minimum": 0
+          },
+          "ok": {
+            "type": "boolean",
+            "description": "Whether the most recently completed in-process scheduler rebuild had no failures."
           }
         }
       },

--- a/client/src/pages/settings/SettingsPage.test.tsx
+++ b/client/src/pages/settings/SettingsPage.test.tsx
@@ -13,6 +13,7 @@ function health(overrides: Partial<HealthResponse> = {}): HealthResponse {
     machine: "box-1",
     dependencies: { tmux: true, python3: true },
     crontab_sync: { ok: true },
+    scheduler_resync: { ok: true },
     version: "3.2.0",
     git_sha: "abc1234",
     build_date: "2026-07-31",

--- a/client/src/shell/Header.test.tsx
+++ b/client/src/shell/Header.test.tsx
@@ -11,6 +11,7 @@ function health(overrides: Partial<HealthResponse> = {}): HealthResponse {
     machine: "box-1",
     dependencies: { tmux: true, python3: true },
     crontab_sync: { ok: true },
+    scheduler_resync: { ok: true },
     version: "3.2.0",
     git_sha: "abc1234",
     build_date: "2026-07-31",

--- a/src/routes/health/logic.rs
+++ b/src/routes/health/logic.rs
@@ -16,6 +16,19 @@ pub struct CrontabSyncHealth {
     pub last_error_at: Option<u64>,
 }
 
+/// In-process scheduler resynchronization state surfaced by health endpoints.
+#[derive(Serialize, utoipa::ToSchema)]
+pub struct SchedulerResyncHealth {
+    /// Whether the most recently completed in-process scheduler rebuild had no failures.
+    pub ok: bool,
+    /// Unix timestamp of the most recently completed in-process scheduler rebuild.
+    pub last_completed_at: Option<u64>,
+    /// Last in-process scheduler rebuild error, when any schedule could not be applied.
+    pub last_error: Option<String>,
+    /// Unix timestamp of the most recent in-process scheduler rebuild error.
+    pub last_error_at: Option<u64>,
+}
+
 /// External-binary dependencies the daemon relies on at runtime, and whether each is resolvable on
 /// the daemon's `PATH`. Surfaced in [`HealthResponse`] so the UI/CLI can flag a missing dependency
 /// instead of having routine runs silently no-op.
@@ -44,6 +57,8 @@ pub struct HealthResponse {
     pub dependencies: DependencyHealth,
     /// Whether the managed routine block was last synced into the OS crontab successfully.
     pub crontab_sync: CrontabSyncHealth,
+    /// Whether the in-process scheduler last rebuilt routine jobs successfully after a mutation.
+    pub scheduler_resync: SchedulerResyncHealth,
     /// Daemon version (from `CARGO_PKG_VERSION`).
     pub version: String,
     /// Short git commit SHA the daemon was built from, or `"unknown"` outside a git checkout.
@@ -74,6 +89,15 @@ pub fn build(uptime_start: u64) -> HealthResponse {
             let status = crate::sync::crontab_sync_status();
             CrontabSyncHealth {
                 ok: status.ok,
+                last_error: status.last_error,
+                last_error_at: status.last_error_at,
+            }
+        },
+        scheduler_resync: {
+            let status = crate::routine_scheduler::scheduler_resync_status();
+            SchedulerResyncHealth {
+                ok: status.ok,
+                last_completed_at: status.last_completed_at,
                 last_error: status.last_error,
                 last_error_at: status.last_error_at,
             }

--- a/src/routine_scheduler.rs
+++ b/src/routine_scheduler.rs
@@ -4,8 +4,7 @@
 //! [`crate::routines::svc_trigger_scheduled`] so the established global-lock, routine-lock,
 //! snooze, power-saving, and same-minute deduplication rules remain authoritative.
 
-#[cfg(not(test))]
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 
 #[cfg(not(test))]
 use tokio::sync::mpsc::{self, UnboundedSender};
@@ -16,6 +15,8 @@ use uuid::Uuid;
 
 #[cfg(not(test))]
 use crate::routines::RoutineStore;
+use crate::utils::lock::LockRecover;
+use crate::utils::time::now_secs;
 
 #[allow(
     clippy::missing_docs_in_private_items,
@@ -24,11 +25,60 @@ use crate::routines::RoutineStore;
 #[path = "routine_scheduler_lifecycle.rs"]
 mod lifecycle;
 
+/// Process-local state for the most recent in-process scheduler rebuild.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct SchedulerResyncStatus {
+    /// Whether the most recently completed rebuild had no invalid schedules or backend failures.
+    pub ok: bool,
+    /// Unix timestamp of the most recently completed rebuild.
+    pub last_completed_at: Option<u64>,
+    /// Description of the most recent rebuild problem, if any.
+    pub last_error: Option<String>,
+    /// Unix timestamp of the most recent rebuild problem, if any.
+    pub last_error_at: Option<u64>,
+}
+
+/// Return the latest in-process scheduler rebuild status for health reporting.
+pub(crate) fn scheduler_resync_status() -> SchedulerResyncStatus {
+    scheduler_resync_state().lock_recover().clone()
+}
+
+/// Record the outcome of a completed in-process scheduler rebuild.
+pub(super) fn record_resync_result(error: Option<String>) {
+    let now = now_secs();
+    let failed = error.is_some();
+    *scheduler_resync_state().lock_recover() = SchedulerResyncStatus {
+        ok: !failed,
+        last_completed_at: Some(now),
+        last_error: error,
+        last_error_at: failed.then_some(now),
+    };
+}
+
+/// Hold in-process scheduler status independently of the OS-crontab health state.
+fn scheduler_resync_state() -> &'static Mutex<SchedulerResyncStatus> {
+    static STATE: OnceLock<Mutex<SchedulerResyncStatus>> = OnceLock::new();
+    STATE.get_or_init(|| {
+        Mutex::new(SchedulerResyncStatus {
+            ok: true,
+            ..SchedulerResyncStatus::default()
+        })
+    })
+}
+
 /// Request that the running scheduler rebuild its library-managed jobs.
 #[cfg(not(test))]
 pub(crate) fn request_resync() {
-    if let Some(sender) = scheduler_resync_sender().get() {
-        let _ = sender.send(());
+    let Some(sender) = scheduler_resync_sender().get() else {
+        let error = "routine scheduler is not running".to_string();
+        log::warn!("routine scheduler resync request failed: {error}");
+        record_resync_result(Some(error));
+        return;
+    };
+    if sender.send(()).is_err() {
+        let error = "routine scheduler actor has stopped".to_string();
+        log::warn!("routine scheduler resync request failed: {error}");
+        record_resync_result(Some(error));
     }
 }
 

--- a/src/routine_scheduler_lifecycle.rs
+++ b/src/routine_scheduler_lifecycle.rs
@@ -28,19 +28,25 @@ pub(super) async fn run<S: Scheduler>(
     let scheduler = match scheduler {
         Ok(scheduler) => scheduler,
         Err(err) => {
-            log::error!("routine scheduler initialization failed: {err}");
+            let error = format!("routine scheduler initialization failed: {err}");
+            log::error!("{error}");
+            crate::routine_scheduler::record_resync_result(Some(error));
             return;
         }
     };
     let mut job_ids = Vec::new();
-    rebuild(&scheduler, &mut job_ids, &store).await;
+    crate::routine_scheduler::record_resync_result(rebuild(&scheduler, &mut job_ids, &store).await);
     if let Err(err) = scheduler.start().await {
-        log::error!("routine scheduler failed to start: {err}");
+        let error = format!("routine scheduler failed to start: {err}");
+        log::error!("{error}");
+        crate::routine_scheduler::record_resync_result(Some(error));
         return;
     }
     while receiver.recv().await.is_some() {
         while receiver.try_recv().is_ok() {}
-        rebuild(&scheduler, &mut job_ids, &store).await;
+        crate::routine_scheduler::record_resync_result(
+            rebuild(&scheduler, &mut job_ids, &store).await,
+        );
     }
 }
 
@@ -49,21 +55,24 @@ pub(super) async fn rebuild<S: Scheduler>(
     scheduler: &S,
     job_ids: &mut Vec<Uuid>,
     store: &RoutineStore,
-) {
+) -> Option<String> {
+    let mut last_error = None;
     for job_id in job_ids.drain(..) {
-        match scheduler.remove(&job_id).await {
-            Ok(()) => {}
-            Err(err) => log::warn!("routine scheduler could not remove job {job_id}: {err}"),
+        if let Err(err) = scheduler.remove(&job_id).await {
+            let error = format!("could not remove job {job_id}: {err}");
+            log::warn!("routine scheduler {error}");
+            last_error = Some(error);
         }
     }
     for routine in selected_routines(store) {
         for schedule in routine.effective_schedules() {
             let Ok(schedule) = to_scheduler_schedule(&schedule) else {
-                log::warn!(
-                    "routine scheduler skipped invalid schedule {:?} for routine {:?}",
-                    schedule,
-                    routine.id
+                let error = format!(
+                    "skipped invalid schedule {:?} for routine {:?}",
+                    schedule, routine.id
                 );
+                log::warn!("routine scheduler {error}");
+                last_error = Some(error);
                 continue;
             };
             match scheduler
@@ -71,14 +80,18 @@ pub(super) async fn rebuild<S: Scheduler>(
                 .await
             {
                 Ok(job_id) => job_ids.push(job_id),
-                Err(err) => log::warn!(
-                    "routine scheduler could not add schedule {:?} for routine {:?}: {err}",
-                    schedule,
-                    routine.id
-                ),
+                Err(err) => {
+                    let error = format!(
+                        "could not add schedule {:?} for routine {:?}: {err}",
+                        schedule, routine.id
+                    );
+                    log::warn!("routine scheduler {error}");
+                    last_error = Some(error);
+                }
             }
         }
     }
+    last_error
 }
 
 /// Select only the routines that are eligible to execute on this daemon.

--- a/src/routine_scheduler_tests.rs
+++ b/src/routine_scheduler_tests.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use super::lifecycle::{rebuild, run, to_scheduler_schedule, Scheduler};
+use super::scheduler_resync_status;
 use crate::routines::RoutineStore;
 use crate::utils::lock::LockRecover;
 use tokio::sync::mpsc;
@@ -108,7 +109,7 @@ async fn rebuild_registers_only_eligible_routines_and_tolerates_backend_failures
     let store = store_with_scheduler_cases();
     let scheduler = FakeScheduler::default();
     let mut job_ids = Vec::new();
-    rebuild(&scheduler, &mut job_ids, &store).await;
+    let _ = rebuild(&scheduler, &mut job_ids, &store).await;
     assert_eq!(job_ids.len(), 1);
     assert_eq!(
         scheduler
@@ -120,7 +121,7 @@ async fn rebuild_registers_only_eligible_routines_and_tolerates_backend_failures
         1
     );
 
-    rebuild(&scheduler, &mut job_ids, &store).await;
+    let _ = rebuild(&scheduler, &mut job_ids, &store).await;
     assert_eq!(job_ids.len(), 1);
     assert_eq!(
         scheduler
@@ -142,7 +143,7 @@ async fn rebuild_registers_only_eligible_routines_and_tolerates_backend_failures
         .lock()
         .expect("fake state poisoned")
         .add_error = true;
-    rebuild(&scheduler, &mut job_ids, &store).await;
+    let _ = rebuild(&scheduler, &mut job_ids, &store).await;
     let state = scheduler.state.lock().expect("fake state poisoned");
     assert_eq!(state.remove_calls.len(), 2);
     assert_eq!(state.add_calls.len(), 3);
@@ -171,17 +172,29 @@ async fn lifecycle_handles_initialization_and_start_failures() {
 
 #[tokio::test]
 async fn lifecycle_coalesces_resync_notifications_before_rebuilding() {
-    let store = RoutineStore::default();
+    let store = store_with_scheduler_cases();
     let scheduler = FakeScheduler::default();
     let (sender, receiver) = mpsc::unbounded_channel();
     sender.send(()).expect("actor receives first notification");
     sender.send(()).expect("actor receives second notification");
     drop(sender);
     run(Ok(scheduler.clone()), store, receiver).await;
-    assert!(scheduler
-        .state
-        .lock()
-        .expect("fake state poisoned")
-        .add_calls
-        .is_empty());
+    assert_eq!(
+        scheduler
+            .state
+            .lock()
+            .expect("fake state poisoned")
+            .add_calls
+            .len(),
+        2
+    );
+    let status = scheduler_resync_status();
+    assert!(!status.ok);
+    assert!(status.last_completed_at.is_some());
+    assert_eq!(
+        status.last_error.as_deref(),
+        Some("skipped invalid schedule \"not a real cron\" for routine \"scheduled\"")
+    );
+    assert!(status.last_error_at.is_some());
+    super::record_resync_result(None);
 }


### PR DESCRIPTION
## Summary
- expose the latest in-process scheduler rebuild result through health and OpenAPI
- record scheduler startup, resync-request, invalid-schedule, and backend-job failures with timestamps
- retain focused lifecycle coverage and update typed client health fixtures

## Verification
- cargo test (1328 passed)
- cargo clippy --all-targets -- -D warnings
- ./.githooks/pre-push (including 100% line coverage and client typecheck/lint/tests)