### PR TITLE
fix(routines): dedupe live run history

### DIFF
--- a/.changeset/dedupe-live-persisted-runs.md
+++ b/.changeset/dedupe-live-persisted-runs.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Avoid duplicate routine run-history entries when a live workbench already has a persisted cleanup record.

--- a/src/routines/service_runs.rs
+++ b/src/routines/service_runs.rs
@@ -6,6 +6,7 @@ use crate::error::AppError;
 use crate::paths::workbenches_dir;
 use crate::utils::lock::LockRecover;
 use crate::utils::time::format_local;
+use std::collections::HashSet;
 
 use crate::routines::cleanup::{parse_workbench_name, run_session_alive};
 use crate::routines::command::slugify;
@@ -26,6 +27,7 @@ pub fn svc_list_runs(store: &RoutineStore, id: &str) -> Result<Vec<RunSummary>, 
         .ok_or(AppError::NotFound)?;
     let slug = slugify(&routine.title);
     let mut runs = Vec::new();
+    let mut seen_workbenches = HashSet::new();
     if let Ok(entries) = std::fs::read_dir(workbenches_dir()) {
         for entry in entries.flatten() {
             let name = entry.file_name().to_string_lossy().into_owned();
@@ -35,10 +37,14 @@ pub fn svc_list_runs(store: &RoutineStore, id: &str) -> Result<Vec<RunSummary>, 
             if dir_slug != slug {
                 continue;
             }
+            seen_workbenches.insert(name.clone());
             runs.push(run_summary(&name, ts, Some(routine.effective_ttl_secs())));
         }
     }
     for persisted in read_persisted_runs(id) {
+        if !seen_workbenches.insert(persisted.workbench.clone()) {
+            continue;
+        }
         runs.push(RunSummary {
             workbench: persisted.workbench,
             started_at: persisted.started_at,
@@ -80,6 +86,7 @@ pub fn svc_list_all_runs(store: &RoutineStore, limit: Option<usize>) -> Vec<Flee
         .map(|(id, title)| (slugify(title), (id.clone(), title.clone())))
         .collect();
     let mut runs = Vec::new();
+    let mut seen_workbenches = HashSet::new();
     if let Ok(entries) = std::fs::read_dir(workbenches_dir()) {
         for entry in entries.flatten() {
             let name = entry.file_name().to_string_lossy().into_owned();
@@ -89,6 +96,7 @@ pub fn svc_list_all_runs(store: &RoutineStore, limit: Option<usize>) -> Vec<Flee
             let Some((routine_id, routine_title)) = by_slug.get(dir_slug).cloned() else {
                 continue;
             };
+            seen_workbenches.insert(name.clone());
             let run = run_summary(&name, ts, None);
             runs.push(FleetRunSummary {
                 routine_id,
@@ -105,6 +113,9 @@ pub fn svc_list_all_runs(store: &RoutineStore, limit: Option<usize>) -> Vec<Flee
     }
     for (routine_id, routine_title) in &routines {
         for persisted in read_persisted_runs(routine_id) {
+            if !seen_workbenches.insert(persisted.workbench.clone()) {
+                continue;
+            }
             runs.push(FleetRunSummary {
                 routine_id: routine_id.clone(),
                 routine_title: routine_title.clone(),

--- a/src/routines/service_runs_tests.rs
+++ b/src/routines/service_runs_tests.rs
@@ -168,3 +168,6 @@ fn svc_list_runs_derives_status_newest_first() {
     assert!(runs[0].finished_at.is_none());
 }
 include!("svc_list_runs_reports_running_when_session_alive_and_no_exit_code_tests.rs");
+
+#[path = "svc_list_runs_deduplicates_live_persisted_workbenches_tests.rs"]
+mod svc_list_runs_deduplicates_live_persisted_workbenches_tests;

--- a/src/routines/svc_list_runs_deduplicates_live_persisted_workbenches_tests.rs
+++ b/src/routines/svc_list_runs_deduplicates_live_persisted_workbenches_tests.rs
@@ -1,0 +1,59 @@
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "test helpers and fixtures do not need doc comments"
+)]
+
+use super::*;
+
+#[test]
+fn run_history_lists_each_live_manual_or_scheduled_workbench_once() {
+    use crate::routines::run_history::{append_persisted_run, PersistedRun};
+
+    let _home = TempHome::set();
+    let title = "Scheduled Manual History ZZQ";
+    let slug = slugify(title);
+    let store = new_store();
+    store
+        .lock()
+        .unwrap()
+        .insert("id".into(), make_routine("id", title));
+
+    let manual = format!("{slug}-2000_101");
+    let scheduled = format!("{slug}-2000_202");
+    let workbenches = crate::paths::workbenches_dir();
+    std::fs::create_dir_all(workbenches.join(&manual)).unwrap();
+    std::fs::create_dir_all(workbenches.join(&scheduled)).unwrap();
+
+    // Cleanup writes durable history before it removes the workbench. If removal fails, the next
+    // listing sees both representations of this manual run and must not report it twice.
+    append_persisted_run(
+        "id",
+        &PersistedRun {
+            workbench: manual.clone(),
+            started_at: 2000,
+            finished_at: 2001,
+            status: RunStatus::Success,
+            exit_code: Some(0),
+        },
+    );
+
+    let per_routine = svc_list_runs(&store, "id").unwrap();
+    let fleet = svc_list_all_runs(&store, None);
+    for names in [
+        per_routine
+            .iter()
+            .map(|run| run.workbench.as_str())
+            .collect::<std::collections::BTreeSet<_>>(),
+        fleet
+            .iter()
+            .map(|run| run.workbench.as_str())
+            .collect::<std::collections::BTreeSet<_>>(),
+    ] {
+        assert_eq!(
+            names,
+            std::collections::BTreeSet::from([manual.as_str(), scheduled.as_str()])
+        );
+    }
+    assert_eq!(per_routine.len(), 2);
+    assert_eq!(fleet.len(), 2);
+}


### PR DESCRIPTION
## Summary
- keep a live workbench authoritative when cleanup has already written its persisted record
- apply the same deduplication to per-routine and fleet-wide run history
- cover simultaneous manual/scheduled workbenches with a persisted cleanup record

## Verification
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `RUST_TEST_THREADS=1 cargo test` (1329 passed)
- `cargo llvm-cov --fail-under-lines 100 ...`
- `pnpm --filter client typecheck && pnpm --filter client lint && pnpm --filter client test` (536 passed)
- repository pre-push hook passed (including all tests, coverage, linecheck, and client checks)