### PR TITLE
fix(scheduler): persist scheduled fire evidence before launch

### DIFF
--- a/.changeset/durable-scheduled-fire-evidence.md
+++ b/.changeset/durable-scheduled-fire-evidence.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Persist explicit scheduled-fire evidence before in-process scheduler launch attempts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+Record every accepted in-process scheduled routine fire in the durable per-routine
+`scheduled.log` before attempting its detached launcher. This gives macOS scheduler runs explicit
+evidence that survives daemon restarts even when shell or agent setup fails.
+
 ## [3.2.5] - 2026-08-27
 
 Run routine cron schedules inside the daemon with `tokio-cron-scheduler` across platforms, preserving the existing scheduled-trigger safety policies.

--- a/src/append_manual_trigger_log.rs
+++ b/src/append_manual_trigger_log.rs
@@ -20,6 +20,29 @@ pub fn append_manual_trigger_log(slug: &str, ts: u64) {
     }
 }
 
+/// Append a Unix-timestamp entry to a routine's `scheduled.log`, recording an accepted scheduled
+/// fire before its launcher process is attempted.
+///
+/// The in-process scheduler cannot rely on the detached launcher to leave this evidence: an agent
+/// setup or shell failure would otherwise make a real scheduler fire indistinguishable from a
+/// missed tick. Best-effort like [`append_manual_trigger_log`], so a disk hiccup never blocks the
+/// scheduler from attempting the routine.
+pub fn append_scheduled_trigger_log(slug: &str, ts: u64) {
+    let path = crate::paths::routine_scheduled_log_path(slug);
+    let line = format!("{ts}\n");
+    if let Err(err) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .and_then(|mut file| std::io::Write::write_all(&mut file, line.as_bytes()))
+    {
+        log::warn!(
+            "append_scheduled_trigger_log: failed to write {}: {err}",
+            path.display()
+        );
+    }
+}
+
 /// Append a `{ts}\t{reason}` entry to a routine's `skip.log`, recording why a trigger did not
 /// spawn a workbench.
 ///

--- a/src/routines/command.rs
+++ b/src/routines/command.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use crate::paths::{routine_compiled_prompt_path, routine_scheduled_log_path};
+use crate::paths::routine_compiled_prompt_path;
 use crate::routine_storage::read_local_env;
 
 use super::agents::AgentCommand;

--- a/src/routines/command_builder.rs
+++ b/src/routines/command_builder.rs
@@ -5,22 +5,20 @@
 /// reaches the agent as a process argument (not keystrokes), so there is no readiness race. The
 /// command is `;`-joined (no newlines) so it fits one crontab line.
 ///
-/// `source` controls whether the script records a scheduled firing: a [`TriggerSource::Scheduled`]
-/// run (the crontab) appends to `scheduled.log`, while a [`TriggerSource::Manual`] run omits the
-/// append so an on-demand trigger never clobbers `last_scheduled_trigger_at`.
+/// The trigger service records durable manual or scheduled-fire evidence before invoking this
+/// launcher. `source` remains part of the command contract so callers explicitly declare why a
+/// run was requested, while both paths share the same launcher mechanics.
 pub(crate) fn build_routine_command(
     routine: &Routine,
     agent: &AgentCommand,
-    source: TriggerSource,
+    _source: TriggerSource,
 ) -> String {
     let rel_dir = crate::routine_storage::routine_rel_dir(routine);
     let slug = crate::routine_storage::routine_slug(routine);
     let prompt_path = routine_compiled_prompt_path(&rel_dir)
         .to_string_lossy()
         .into_owned();
-    let scheduled_log_path = routine_scheduled_log_path(&rel_dir)
-        .to_string_lossy()
-        .into_owned();
+
     // Resolve through the same seam the reaper (`cleanup/mod.rs`) and the LOGS view
     // (`routines/service.rs`) use, rather than hardcoding `$HOME/.moadim/workbenches`: honoring
     // `MOADIM_HOME_OVERRIDE` here keeps the path a run is launched at in sync with the paths those
@@ -78,22 +76,7 @@ pub(crate) fn build_routine_command(
     // shell environment.
     stmts.extend(env_export_stmts(routine));
     stmts.push(r#"TS="$(date +%s)""#.to_string());
-    if source == TriggerSource::Scheduled {
-        // Record this scheduled firing. Appends the Unix timestamp as one line to the routine's
-        // gitignored `scheduled.log`; the daemon reads the last line back as
-        // `last_scheduled_trigger_at` on load. Using `>>` (append) preserves the full run history.
-        // Written before the prompt-copy guard below so an aborted run still records that the
-        // schedule fired, and best-effort (`|| true`) so a log write failure never blocks launching.
-        //
-        // A manual ([`TriggerSource::Manual`]) trigger deliberately omits this append: it shares
-        // the exact same launch script but is tracked via `last_manual_trigger_at` (recorded
-        // in-process by `svc_trigger`), so appending here would conflate an on-demand "run now"
-        // with a genuine scheduled fire.
-        stmts.push(format!(
-            r#"printf '%s\n' "$TS" >> {} || true"#,
-            shell_quote(&scheduled_log_path)
-        ));
-    }
+
     stmts.extend([
         format!("SLUG={}", shell_quote(&slug)),
         // Collision-resistant run id. `$TS` alone has one-second granularity, so two runs of the

--- a/src/routines/command_trigger_source_tests.rs
+++ b/src/routines/command_trigger_source_tests.rs
@@ -6,10 +6,10 @@
 use super::*;
 
 #[test]
-fn build_routine_command_appends_scheduled_trigger_log() {
-    // The generated launch script records each scheduled firing by appending `$TS` to the
-    // routine's `scheduled.log` (best-effort, before the prompt-copy guard), since the OS crontab
-    // runs this script directly without the daemon observing the fire.
+fn build_routine_command_does_not_duplicate_scheduled_trigger_evidence() {
+    // The trigger service records a scheduled fire before this detached launcher is attempted.
+    // Keeping the launcher free of a second append yields exactly one durable record per accepted
+    // in-process scheduler fire.
     let routine = make_routine("Cmd Scheduled Stamp Routine");
     let agent = AgentCommand {
         command: "claude".to_string(),
@@ -22,16 +22,9 @@ fn build_routine_command_appends_scheduled_trigger_log() {
         .to_string_lossy()
         .into_owned();
     assert!(
-        cmd.contains(&format!(
-            r#"printf '%s\n' "$TS" >> {} || true"#,
-            shell_quote(&log)
-        )),
-        "expected scheduled-trigger log append in: {cmd}"
+        !cmd.contains(&log),
+        "trigger service, not launcher, must record the scheduled fire: {cmd}"
     );
-    // It must run before the prompt-copy guard so an aborted run still records the firing.
-    let stamp = cmd.find("scheduled.log").unwrap();
-    let copy = cmd.find("/prompt.md\"").unwrap();
-    assert!(stamp < copy, "log append must precede the prompt copy");
 }
 
 #[test]

--- a/src/routines/service_trigger.rs
+++ b/src/routines/service_trigger.rs
@@ -2,7 +2,9 @@
 
 use crate::error::AppError;
 use crate::paths::workbenches_dir;
-use crate::routine_storage::{append_manual_trigger_log, append_skip_log, write_routine};
+use crate::routine_storage::{
+    append_manual_trigger_log, append_scheduled_trigger_log, append_skip_log, write_routine,
+};
 use crate::utils::lock::LockRecover;
 use crate::utils::time::now_secs;
 
@@ -64,9 +66,10 @@ pub fn svc_trigger(store: &RoutineStore, id: &str) -> Result<Routine, AppError> 
 ///
 /// This is the daemon-side endpoint that the generated crontab line drives
 /// (`moadim schedule trigger <id>`). Unlike [`svc_trigger`] it leaves `last_manual_trigger_at`
-/// untouched — the spawned command appends the timestamp to the routine's `scheduled.log` itself,
-/// which the daemon reads back on the next load. Keeping the two paths distinct preserves the
-/// manual-vs-scheduled distinction the timestamps exist to capture.
+/// untouched. Before the detached launcher is attempted, this service appends an accepted-fire
+/// timestamp to the routine's `scheduled.log`, which survives a daemon restart even when the
+/// launcher subsequently fails. Keeping the two paths distinct preserves the manual-vs-scheduled
+/// distinction the timestamps exist to capture.
 ///
 /// A routine snoozed via [`svc_snooze`] (`snoozed_until` in the future, or `skip_runs` above zero)
 /// is skipped here instead of spawned: `snoozed_until` clears itself once elapsed (that fire then
@@ -136,11 +139,19 @@ pub fn svc_trigger_scheduled(store: &RoutineStore, id: &str) -> Result<Routine, 
     // Same-minute claim (#795): multiple crontab lines can target the same routine when a
     // multi-schedule routine has overlapping expressions. Claim the current minute while holding the
     // store mutex so a second scheduled-trigger request observes the in-memory timestamp and no-ops
-    // instead of launching a duplicate workbench. The spawned scheduled command still appends the
-    // durable `scheduled.log` entry for load-after-restart history.
+    // instead of launching a duplicate workbench. Append the durable `scheduled.log` evidence
+    // before attempting the detached launcher, so macOS in-process scheduler fires remain visible
+    // even if its shell or agent setup fails.
     routine.last_scheduled_trigger_at = Some(ts);
     let routine = routine.clone();
     drop(lock);
+    let rel_dir = crate::routine_storage::routine_rel_dir(&routine);
+    append_scheduled_trigger_log(&rel_dir, ts);
+    log::info!(
+        "routine scheduled fire accepted: id={:?}, timestamp={ts}, evidence={}",
+        routine.id,
+        crate::paths::routine_scheduled_log_path(&rel_dir).display()
+    );
     spawn_routine_command(&routine, TriggerSource::Scheduled);
     Ok(routine)
 }

--- a/src/routines/spawn_routine_command.rs
+++ b/src/routines/spawn_routine_command.rs
@@ -14,9 +14,8 @@ use super::*;
 ///
 /// `sh -lc` sources the user's `~/.profile`, so the agent inherits their environment (`GH_TOKEN`,
 /// API keys, …) regardless of the minimal environment the daemon (or cron) runs under. Shared by the
-/// manual ([`svc_trigger`]) and scheduled ([`svc_trigger_scheduled`]) paths, which pass `source`
-/// through to [`build_routine_command`] so only a genuine scheduled fire appends to
-/// `scheduled.log` — a manual "run now" must never masquerade as one (#478).
+/// manual ([`svc_trigger`]) and scheduled ([`svc_trigger_scheduled`]) paths. Those services record
+/// their durable trigger evidence before reaching this best-effort detached launcher.
 pub(crate) fn spawn_routine_command(routine: &Routine, source: TriggerSource) {
     match load_agent_command(&routine.agent) {
         Ok(agent) => {

--- a/src/routines/svc_trigger_scheduled_skips_duplicate_fire_in_same_minute_tests.rs
+++ b/src/routines/svc_trigger_scheduled_skips_duplicate_fire_in_same_minute_tests.rs
@@ -53,6 +53,14 @@ fn svc_trigger_scheduled_spawns_without_recording_manual_trigger() {
     with_empty_path(|| {
         let triggered = svc_trigger_scheduled(&store, "trig-sched-id").unwrap();
         assert!(triggered.last_manual_trigger_at.is_none());
+        let scheduled_log = crate::paths::routine_scheduled_log_path(&slugify(title));
+        let timestamp = std::fs::read_to_string(&scheduled_log)
+            .expect("accepted scheduled fire is durable even when launch fails");
+        assert!(
+            timestamp.trim().parse::<u64>().is_ok(),
+            "expected a Unix timestamp in {}: {timestamp:?}",
+            scheduled_log.display()
+        );
     });
 }
 

--- a/src/snooze_fields_round_trip_through_sidecar_not_routine_toml_tests.rs
+++ b/src/snooze_fields_round_trip_through_sidecar_not_routine_toml_tests.rs
@@ -107,6 +107,27 @@ fn append_manual_trigger_log_warns_on_write_failure() {
 }
 
 #[test]
+fn append_scheduled_trigger_log_warns_on_write_failure() {
+    // A scheduler must still attempt the launcher when its best-effort evidence write fails.
+    let dir = scratch_dir("scheduled-log-fail");
+    let slug = "rs-scheduled-log-fail-routine";
+    let blocker = dir.join(slug).join("scheduled.log");
+    std::fs::create_dir_all(&blocker).unwrap();
+    let previous = std::env::var_os("MOADIM_HOME_OVERRIDE");
+    // SAFETY: single-threaded test execution.
+    unsafe { std::env::set_var("MOADIM_HOME_OVERRIDE", &dir) };
+    append_scheduled_trigger_log(slug, 42);
+    // SAFETY: restore the process-wide test seam.
+    unsafe {
+        match previous {
+            Some(value) => std::env::set_var("MOADIM_HOME_OVERRIDE", value),
+            None => std::env::remove_var("MOADIM_HOME_OVERRIDE"),
+        }
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn append_skip_log_creates_and_appends() {
     // Each call appends one `{ts}\t{reason}` line; the log grows across calls (#1145).
     with_override_home(|_home| {


### PR DESCRIPTION
## Summary
- persist one timestamp in each routine scheduled.log before the detached scheduled launcher is attempted
- emit an explicit accepted-fire daemon log with routine id, timestamp, and evidence path
- remove the launcher-side duplicate stamp so each accepted in-process fire has one durable record

## Verification
- cargo test (1,329 tests)
- cargo clippy --all-targets -- -D warnings
- cargo fmt --all -- --check
- cargo llvm-cov --fail-under-lines 100 (repository gate)
- .githooks/pre-push: Rust checks, coverage, linecheck, and client typecheck/lint/tests (536 tests)

The first full hook run exposed a base-suite race in sync::routines::routines_sync_status_tests::successful_routine_sync_clears_previous_crontab_sync_error; the same test passed from a clean origin/main worktree and the complete hook rerun passed.