### PR TITLE
docs: add Homebrew installation

### DIFF
--- a/Formula/moadim.rb
+++ b/Formula/moadim.rb
@@ -1,0 +1,19 @@
+class Moadim < Formula
+  desc "Loop engine for AI agents"
+  homepage "https://moadim.io"
+  url "https://github.com/moadim-io/daemon.git", tag: "v3.2.5", revision: "28e3f67994d78e0d94ec6e74216f59051d0ccb5b"
+  license "MIT"
+  head "https://github.com/moadim-io/daemon.git", branch: "main"
+
+  depends_on "rust" => :build
+  depends_on "tmux"
+
+  def install
+    system "cargo", "install", "--locked", "--path", ".", "--root", prefix
+    man1.install "docs/moadim.1"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/moadim --version")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ either is missing, so a misconfigured host is easy to spot. See the built-in
 cargo install --locked moadim
 ```
 
+### Homebrew (from this repository)
+
+To build and install the current `main` branch with Homebrew, add this repository
+as a tap and install its formula with `--HEAD`:
+
+```sh
+brew tap moadim-io/daemon https://github.com/moadim-io/daemon.git
+brew install --build-from-source --HEAD moadim-io/daemon/moadim
+```
+
+The formula installs the `moadim` binary, its `moadim(1)` man page, and the
+required `tmux` runtime dependency. Homebrew builds the Rust binary from the
+repository checkout; it is not a prebuilt package.
+
 `--locked` installs the exact dependency graph published and tested with this
 release (from the crate's `Cargo.lock`) instead of re-resolving every dependency
 to the newest semver-compatible version at install time — so a bad or breaking


### PR DESCRIPTION
## Summary

- add a Homebrew formula that builds Moadim from the pinned release or the current `main` branch
- document the repository-as-tap workflow: `brew tap moadim-io/daemon …` followed by `brew install --build-from-source --HEAD moadim-io/daemon/moadim`
- install `tmux` and the `moadim(1)` man page through the formula

## Verification

- `brew style Formula/moadim.rb`
- Homebrew tap discovery, formula loading, and `brew install --dry-run --build-from-source --HEAD moadim-io/daemon/moadim`
- `.githooks/pre-push` (Rust format, clippy, 1,329 Rust tests, 100% coverage gate, linecheck; client typecheck, lint, and 536 tests)

`brew audit --strict Formula/moadim.rb` could not run because this host's Command Line Tools are older than Homebrew's required version; formula style and dry-run resolution passed.
