### PR TITLE
chore(release): version packages

### DIFF
--- a/.changeset/scheduled-trigger-dedupe-claim.md
+++ b/.changeset/scheduled-trigger-dedupe-claim.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-Keep scheduled-fire deduplication process-local so reloaded current-minute execution history does not suppress the scheduler's current fire.

--- a/.changeset/ui-multi-cron-editor.md
+++ b/.changeset/ui-multi-cron-editor.md
@@ -1,5 +1,0 @@
----
-"moadim": patch
----
-
-Expose each routine cron expression as an independently editable UI field, with per-expression validation, removal, and appendable presets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Versions map to the `v*` git tags that drive the crates.io publish workflow.
 
 ## [Unreleased]
 
+## [3.2.6] - 2026-08-29
+
+Keep scheduled-fire deduplication process-local so reloaded current-minute execution history does not suppress the scheduler's current fire.
+
+Expose each routine cron expression as an independently editable UI field, with per-expression validation, removal, and appendable presets.
+
 ## [3.2.5] - 2026-08-27
 
 Run routine cron schedules inside the daemon with `tokio-cron-scheduler` across platforms, preserving the existing scheduled-trigger safety policies.
@@ -5057,7 +5063,8 @@ Enable `clippy::match_same_arms` and merge the two duplicate-body arms it flagge
 - Ship the prebuilt UI in the published crate.
 - Rename the binary to `moadim` and add install docs.
 
-[Unreleased]: https://github.com/moadim-io/daemon/compare/v3.2.5...HEAD
+[Unreleased]: https://github.com/moadim-io/daemon/compare/v3.2.6...HEAD
+[3.2.6]: https://github.com/moadim-io/daemon/compare/v3.2.5...v3.2.6
 [3.2.5]: https://github.com/moadim-io/daemon/compare/v3.2.4...v3.2.5
 [3.2.4]: https://github.com/moadim-io/daemon/compare/v3.2.3...v3.2.4
 [3.2.3]: https://github.com/moadim-io/daemon/compare/v3.2.2...v3.2.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "moadim"
-version = "3.2.5"
+version = "3.2.6"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moadim"
-version = "3.2.5"
+version = "3.2.6"
 edition = "2021"
 # Floor set by the transitive proc-macro build dependency `darling 0.23`
 # (pulled in via `rmcp-macros` <- `rmcp`), which itself declares

--- a/apis/openapi.json
+++ b/apis/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "3.2.5"
+    "version": "3.2.6"
   },
   "servers": [
     {

--- a/docs/moadim.1
+++ b/docs/moadim.1
@@ -1,7 +1,7 @@
 .\" Man page for moadim.
 .\" Mirrors the built-in `moadim --help` output (src/cli/mod.rs::print_help).
 .\" View with:  man ./docs/moadim.1   or install into share/man/man1/.
-.TH MOADIM 1 "2026-07-31" "moadim 3.2.5" "Moadim Manual"
+.TH MOADIM 1 "2026-07-31" "moadim 3.2.6" "Moadim Manual"
 .SH NAME
 moadim \- routine scheduler with an MCP/REST API and a web control panel
 .SH SYNOPSIS

--- a/npm/moadim/package.json
+++ b/npm/moadim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moadim",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "description": "Moadim daemon CLI binary distributed through npm platform packages",
   "license": "MIT",
   "repository": {
@@ -24,9 +24,9 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@moadim/daemon-darwin-arm64": "3.2.5",
-    "@moadim/daemon-darwin-x64": "3.2.5",
-    "@moadim/daemon-linux-x64-gnu": "3.2.5"
+    "@moadim/daemon-darwin-arm64": "3.2.6",
+    "@moadim/daemon-darwin-x64": "3.2.6",
+    "@moadim/daemon-linux-x64-gnu": "3.2.6"
   },
   "publishConfig": {
     "access": "public",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moadim",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "scripts": {


### PR DESCRIPTION
Release moadim v3.2.6.

Includes the multi-cron routine editor and scheduled-fire deduplication fix. Generated version, package metadata, OpenAPI, man page, and changelog updates come from the verified release workflow.