### PR TITLE
feat(routines): allow opt-in overlapping fires

### DIFF
--- a/.changeset/allow-routine-overlap.md
+++ b/.changeset/allow-routine-overlap.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Add opt-in `overlap.json` sidecars so a routine can allow concurrent fires.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ install -Dm644 docs/moadim.1 "$HOME/.local/share/man/man1/moadim.1"
 │   └── nightly-triage/
 │       ├── routine.toml       # tracked — schedule, agent, repositories, [env], …
 │       ├── schedule.cron      # tracked — cron-entry mirror, not functional yet
+│       ├── overlap.json       # tracked, optional — permits concurrent fires when enabled
 │       ├── routine.local.toml # gitignored, optional — secret/local env var overrides
 │       └── prompts/
 │           ├── prompt.pure.md      # tracked — the raw, user-authored prompt
@@ -206,6 +207,22 @@ git-trackable:
 The gitignored files are covered by the single generated `.gitignore` at the
 config-dir root (`~/.config/moadim/.gitignore`), whose patterns apply to the
 whole tree — routine directories don't carry their own.
+
+### Overlap policy
+
+By default, a fire is skipped and recorded in `skip.log` when a previous run of the same routine
+is still alive. To explicitly allow independent manual or scheduled fires to overlap, commit this
+optional sibling file (not a `routine.toml` field):
+
+```json
+{"version":1,"allow_overlapping_runs":true}
+```
+
+Save it as `routines/<slug>/overlap.json`. Deleting the file, or setting the boolean to `false`,
+restores the default. Invalid JSON or an unsupported version fails closed: the daemon records the
+policy error in `skip.log` and does not start the new run. This opt-in bypasses only the
+per-routine overlap guard; global locks, snoozes, power-saving rules, same-minute schedule
+deduplication, and the fleet-wide concurrency cap remain in force.
 
 | Field          | Type   | Required | Description                                                                                  |
 | -------------- | ------ | -------- | -------------------------------------------------------------------------------------------- |

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -115,6 +115,13 @@ pub fn routine_disabled_json_path(id: &str) -> PathBuf {
     routine_dir(id).join("disabled.json")
 }
 
+/// Returns the path to `{routines_dir}/{id}/overlap.json`, the tracked policy that controls
+/// whether a routine may launch while one of its earlier fires is still running.
+#[must_use]
+pub fn routine_overlap_json_path(id: &str) -> PathBuf {
+    routine_dir(id).join("overlap.json")
+}
+
 /// Returns the path to `{routines_dir}/{id}/schedule.compailed.cron`, the gitignored cron-union output.
 ///
 /// `schedule.cron` stays the human-authored source; this derived file is rewritten by crontab

--- a/src/routine_overlap_policy.rs
+++ b/src/routine_overlap_policy.rs
@@ -1,0 +1,65 @@
+//! Read/write support for a routine's tracked overlap policy sidecar.
+
+use serde::{Deserialize, Serialize};
+
+#[cfg(test)]
+use crate::utils::atomic::atomic_write;
+
+/// Current on-disk schema version for a routine overlap policy.
+const OVERLAP_POLICY_VERSION: u32 = 1;
+
+/// Serialized, versioned opt-in that lives beside a routine's TOML.
+#[derive(Deserialize, Serialize)]
+struct OverlapPolicy {
+    /// Schema version, used to fail closed on a future incompatible policy.
+    version: u32,
+    /// Whether the daemon may launch another fire while a prior fire is live.
+    allow_overlapping_runs: bool,
+}
+
+/// Read the effective overlap policy for a routine directory.
+///
+/// An absent sidecar preserves the safe default of denying overlapping fires. A malformed sidecar
+/// is returned as an error so callers can fail closed instead of accidentally permitting overlap.
+pub(crate) fn read_overlap_policy(rel_dir: &str) -> Result<bool, String> {
+    let path = crate::paths::routine_overlap_json_path(rel_dir);
+    let text = match std::fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(format!("cannot read {}: {error}", path.display())),
+    };
+    let policy: OverlapPolicy = serde_json::from_str(&text)
+        .map_err(|error| format!("invalid overlap policy {}: {error}", path.display()))?;
+    if policy.version != OVERLAP_POLICY_VERSION {
+        return Err(format!(
+            "unsupported overlap policy version {} in {}",
+            policy.version,
+            path.display()
+        ));
+    }
+    Ok(policy.allow_overlapping_runs)
+}
+
+/// Persist the overlap policy for a routine directory.
+///
+/// `false` removes the optional sidecar, retaining the default-deny behavior without durable
+/// configuration churn.
+#[cfg(test)]
+pub(crate) fn write_overlap_policy(
+    rel_dir: &str,
+    allow_overlapping_runs: bool,
+) -> std::io::Result<()> {
+    let path = crate::paths::routine_overlap_json_path(rel_dir);
+    if !allow_overlapping_runs {
+        if path.exists() {
+            std::fs::remove_file(path)?;
+        }
+        return Ok(());
+    }
+    let policy = OverlapPolicy {
+        version: OVERLAP_POLICY_VERSION,
+        allow_overlapping_runs,
+    };
+    let bytes = serde_json::to_vec(&policy).map_err(std::io::Error::other)?;
+    atomic_write(&path, &bytes)
+}

--- a/src/routine_overlap_policy_tests.rs
+++ b/src/routine_overlap_policy_tests.rs
@@ -1,0 +1,59 @@
+#![allow(clippy::missing_docs_in_private_items, reason = "test helpers")]
+
+struct TempHome;
+
+impl TempHome {
+    fn set() -> Self {
+        let dir =
+            std::env::temp_dir().join(format!("moadim-overlap-policy-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        // SAFETY: this crate's tests serialize environment mutations.
+        unsafe { std::env::set_var("MOADIM_HOME_OVERRIDE", dir) };
+        Self
+    }
+}
+
+impl Drop for TempHome {
+    fn drop(&mut self) {
+        // SAFETY: this crate's tests serialize environment mutations.
+        unsafe { std::env::remove_var("MOADIM_HOME_OVERRIDE") };
+    }
+}
+
+use super::{read_overlap_policy, write_overlap_policy};
+
+#[test]
+fn overlap_policy_defaults_false_and_round_trips_true_then_false() {
+    let _home = TempHome::set();
+    std::fs::create_dir_all(crate::paths::routine_dir("overlap-policy")).unwrap();
+    assert!(!read_overlap_policy("overlap-policy").unwrap());
+
+    write_overlap_policy("overlap-policy", true).unwrap();
+    assert!(read_overlap_policy("overlap-policy").unwrap());
+
+    write_overlap_policy("overlap-policy", false).unwrap();
+    assert!(!read_overlap_policy("overlap-policy").unwrap());
+
+    write_overlap_policy("overlap-policy", false).unwrap();
+    assert!(!read_overlap_policy("overlap-policy").unwrap());
+}
+
+#[test]
+fn overlap_policy_rejects_malformed_and_unsupported_sidecars() {
+    let _home = TempHome::set();
+    let path = crate::paths::routine_overlap_json_path("broken-overlap-policy");
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, "not json").unwrap();
+    assert!(read_overlap_policy("broken-overlap-policy").is_err());
+
+    std::fs::write(&path, r#"{"version":2,"allow_overlapping_runs":true}"#).unwrap();
+    assert!(read_overlap_policy("broken-overlap-policy").is_err());
+}
+
+#[test]
+fn overlap_policy_reports_an_unreadable_sidecar() {
+    let _home = TempHome::set();
+    let path = crate::paths::routine_overlap_json_path("directory-overlap-policy");
+    std::fs::create_dir_all(&path).unwrap();
+    assert!(read_overlap_policy("directory-overlap-policy").is_err());
+}

--- a/src/routine_storage.rs
+++ b/src/routine_storage.rs
@@ -13,6 +13,12 @@ pub(crate) use read_runtime_state::*;
 #[path = "routine_disabled_state.rs"]
 mod routine_disabled_state;
 pub(crate) use routine_disabled_state::*;
+#[path = "routine_overlap_policy.rs"]
+mod routine_overlap_policy;
+pub(crate) use routine_overlap_policy::*;
+#[cfg(test)]
+#[path = "routine_overlap_policy_tests.rs"]
+mod routine_overlap_policy_tests;
 
 // Re-exported (as `super::routines_dir`) for `routine_storage_migrations`; not called directly
 // in this file since `load_store`/`load_store_from_dir` moved to `routine_storage_load`.

--- a/src/routines/service_2.rs
+++ b/src/routines/service_2.rs
@@ -20,6 +20,10 @@ mod service_update_apply_tests;
 mod service_overlap_guard_tests;
 
 #[cfg(test)]
+#[path = "service_overlap_policy_error_tests.rs"]
+mod service_overlap_policy_error_tests;
+
+#[cfg(test)]
 #[path = "service_update_not_found_tests.rs"]
 mod service_update_not_found_tests;
 

--- a/src/routines/service_overlap_guard_tests.rs
+++ b/src/routines/service_overlap_guard_tests.rs
@@ -134,3 +134,54 @@ fn svc_trigger_skips_spawn_when_a_previous_run_is_still_alive() {
     }
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+#[test]
+fn svc_trigger_spawns_when_overlap_policy_allows_a_live_previous_run() {
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let _home = TempHome::set();
+    let title = "Svc Trigger Allow Overlap ZZZ";
+    let slug = slugify(title);
+    let agent_name = "svc-trigger-allow-overlap-agent-zzz";
+    std::fs::create_dir_all(crate::paths::agents_dir()).unwrap();
+    std::fs::write(
+        crate::paths::agent_toml_path(agent_name),
+        "command = \"true\"\nargs = []\n",
+    )
+    .unwrap();
+    let dir = std::env::temp_dir().join(format!("moadim-svc-allow-overlap-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let tmux = dir.join("tmux");
+    std::fs::write(
+        &tmux,
+        format!("#!/bin/sh\nprintf 'moadim-{slug}-1730000000_4821\\n'\n"),
+    )
+    .unwrap();
+    #[cfg(unix)]
+    std::fs::set_permissions(&tmux, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let mut routine = make_routine("trig-allow-overlap-id", title, 1, 1);
+    routine.agent = agent_name.into();
+    crate::routine_storage::write_routine(&routine).unwrap();
+    crate::routine_storage::write_overlap_policy(&slug, true).unwrap();
+    let store = new_store();
+    store.lock().unwrap().insert(routine.id.clone(), routine);
+    let old_tmux = std::env::var_os("MOADIM_TMUX_BIN");
+    let old_shell = std::env::var_os("MOADIM_SH_BIN");
+    // SAFETY: tests in this crate run single-threaded.
+    unsafe {
+        std::env::set_var("MOADIM_TMUX_BIN", &tmux);
+        std::env::set_var("MOADIM_SH_BIN", "/usr/bin/true");
+    }
+    svc_trigger(&store, "trig-allow-overlap-id").unwrap();
+    assert!(
+        !crate::paths::routine_skip_log_path(&slug).exists(),
+        "allow-overlap policy must bypass the per-routine overlap skip"
+    );
+    // SAFETY: restore the process-wide test seams.
+    unsafe {
+        match old_tmux { Some(value) => std::env::set_var("MOADIM_TMUX_BIN", value), None => std::env::remove_var("MOADIM_TMUX_BIN") }
+        match old_shell { Some(value) => std::env::set_var("MOADIM_SH_BIN", value), None => std::env::remove_var("MOADIM_SH_BIN") }
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/src/routines/service_overlap_policy_error_tests.rs
+++ b/src/routines/service_overlap_policy_error_tests.rs
@@ -1,0 +1,81 @@
+#![allow(clippy::missing_docs_in_private_items, reason = "test fixtures")]
+
+use super::*;
+
+use crate::routines::new_store;
+
+struct TempHome(std::path::PathBuf);
+
+impl TempHome {
+    fn set() -> Self {
+        let dir = std::env::temp_dir().join(format!("moadim-overlap-error-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        // SAFETY: this crate's tests serialize environment mutations.
+        unsafe { std::env::set_var("MOADIM_HOME_OVERRIDE", &dir) };
+        Self(dir)
+    }
+}
+
+impl Drop for TempHome {
+    fn drop(&mut self) {
+        // SAFETY: this crate's tests serialize environment mutations.
+        unsafe { std::env::remove_var("MOADIM_HOME_OVERRIDE") };
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn svc_trigger_fails_closed_when_overlap_policy_cannot_be_read() {
+    let _home = TempHome::set();
+    let agent_name = "overlap-policy-error-agent";
+    std::fs::create_dir_all(crate::paths::agents_dir()).unwrap();
+    std::fs::write(
+        crate::paths::agent_toml_path(agent_name),
+        "command = \"true\"\nargs = []\n",
+    )
+    .unwrap();
+    let routine = Routine {
+        id: "overlap-policy-error".into(),
+        title: "Overlap Policy Error".into(),
+        agent: agent_name.into(),
+        schedule: "@daily".into(),
+        schedules: vec![],
+        prompt: "test".into(),
+        enabled: true,
+        source: "managed".into(),
+        machines: vec![crate::machine::current_machine()],
+        model: None,
+        goal: None,
+        repositories: vec![],
+        disabled_reason: None,
+        created_at: 1,
+        updated_at: 1,
+        last_manual_trigger_at: None,
+        last_scheduled_trigger_at: None,
+        snoozed_until: None,
+        skip_runs: None,
+        power_saving: false,
+        power_saving_exempt: false,
+        tags: vec![],
+        ttl_secs: None,
+        max_runtime_secs: None,
+        env: Default::default(),
+        auto_disabled_reason: None,
+        consecutive_failures: 0,
+        failure_threshold: None,
+        notifications: Default::default(),
+    };
+    let rel_dir = crate::routine_storage::routine_rel_dir(&routine);
+    let policy_path = crate::paths::routine_overlap_json_path(&rel_dir);
+    std::fs::create_dir_all(policy_path.parent().unwrap()).unwrap();
+    std::fs::write(&policy_path, "not json").unwrap();
+    crate::routine_storage::write_routine(&routine).unwrap();
+
+    let store = new_store();
+    store.lock().unwrap().insert(routine.id.clone(), routine.clone());
+    let triggered = svc_trigger(&store, &routine.id).unwrap();
+
+    assert!(triggered.last_manual_trigger_at.is_some());
+    let skip_log = std::fs::read_to_string(crate::paths::routine_skip_log_path(&rel_dir)).unwrap();
+    assert!(skip_log.contains("invalid overlap policy"), "skip.log: {skip_log}");
+}

--- a/src/routines/spawn_routine_command.rs
+++ b/src/routines/spawn_routine_command.rs
@@ -45,9 +45,18 @@ pub(crate) fn spawn_routine_command(routine: &Routine, source: TriggerSource) {
             // all acting on the same target — duplicate PRs/issues, racing pushes. Every fire's tmux
             // session name shares the same `moadim-{slug}-` prefix (see `build_routine_command`); if
             // any of them is still alive, skip this fire instead of launching a second one.
+            let rel_dir = crate::routine_storage::routine_rel_dir(routine);
+            let allows_overlap = match crate::routine_storage::read_overlap_policy(&rel_dir) {
+                Ok(allows_overlap) => allows_overlap,
+                Err(reason) => {
+                    log::warn!("trigger: routine {:?} skipped — {reason}", routine.id);
+                    append_skip_log(&rel_dir, now_secs(), &reason);
+                    return;
+                }
+            };
             let session_prefix =
                 tmux_session_prefix(&crate::routine_storage::routine_slug(routine));
-            if tmux_session_prefix_alive(&session_prefix) {
+            if !allows_overlap && tmux_session_prefix_alive(&session_prefix) {
                 let reason = format!(
                     "a previous run (tmux session prefix {session_prefix:?}) is still active \
                      (overlap guard)"


### PR DESCRIPTION
## Summary
- add an opt-in, tracked `routines/<slug>/overlap.json` sidecar for allowing same-routine overlapping fires
- retain default skip-and-log behavior when the sidecar is absent or disabled; malformed or unsupported policies fail closed
- preserve the global concurrency cap and all other trigger safeguards

## Policy
```json
{"version":1,"allow_overlapping_runs":true}
```

## Verification
- `./.githooks/pre-commit`
- `./.githooks/pre-push`
  - Rust tests and 100% required line coverage
  - linecheck
  - client API generation, typecheck, lint, and 537 tests
