### PR TITLE
feat(routines): add NanoClaw agent

### DIFF
--- a/.changeset/add-nanoclaw-agent.md
+++ b/.changeset/add-nanoclaw-agent.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Add a built-in NanoClaw agent bridge for queuing routine work in an agent group.

--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ built-in `claude` agent.
 Each agent is a single TOML file at `~/.config/moadim/agents/<name>.toml`, where
 `<name>` is the registry key a routine's `agent` field references (the filename
 stem, e.g. `claude.toml` → `claude`). On startup the daemon seeds the built-in
-defaults (`claude`, `codex`, `hermes`, `pi`) into this directory **only if the file is
+defaults (`claude`, `codex`, `hermes`, `nanoclaw`, `pi`) into this directory **only if the file is
 absent** — your edits are never overwritten — so you can both tweak a default and
 register a brand-new agent by dropping in another `<name>.toml`.
 
@@ -507,6 +507,22 @@ args = ["--permission-mode", "auto", "{prompt}"]
 command = "pi"
 args = ["--approve", "-p", "@{prompt_file}"]
 ```
+
+```toml
+# ~/.config/moadim/agents/nanoclaw.toml
+# Queue a one-shot NanoClaw task. Set NANOCLAW_AGENT_GROUP_ID in the routine's
+# environment to the NanoClaw group that should own the task.
+command = "sh"
+args = ["-c", "exec ncl tasks create --group \"${NANOCLAW_AGENT_GROUP_ID:?set NANOCLAW_AGENT_GROUP_ID}\" --name moadim --process-after \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\" --prompt \"$(cat {prompt_file})\""]
+```
+
+The built-in `nanoclaw` agent requires the NanoClaw `ncl` launcher on `PATH`
+and a routine environment value such as
+`NANOCLAW_AGENT_GROUP_ID = "<agent-group-id>"`. It queues a one-shot task in
+that NanoClaw group; NanoClaw then executes and delivers the task asynchronously.
+Moadim records successful queueing, not the later NanoClaw task result. Omit a
+routine-level `model` override: NanoClaw selects the provider and model from the
+target agent group's own configuration.
 
 A routine whose `agent` names a file that is missing or whose TOML is malformed
 fails to launch; `GET /routines` reports `agent_registered: false` for the former

--- a/src/routines/agents/agents_tests.rs
+++ b/src/routines/agents/agents_tests.rs
@@ -24,6 +24,7 @@ fn available_agents_in_falls_back_when_dir_has_no_toml() {
             "claude".to_string(),
             "codex".to_string(),
             "hermes".to_string(),
+            "nanoclaw".to_string(),
             "pi".to_string()
         ]
     );
@@ -63,6 +64,21 @@ fn hermes_default_config_uses_oneshot_prompt_argument() {
             "--safe-mode".to_string()
         ]
     );
+}
+
+#[test]
+fn nanoclaw_default_config_queues_a_one_shot_task_for_the_configured_group() {
+    let cmd: AgentCommand = toml::from_str(super::nanoclaw::CONFIG)
+        .expect("nanoclaw default config must be valid TOML");
+    assert_eq!(cmd.command, "sh");
+    assert_eq!(
+        cmd.args,
+        vec![
+            "-c".to_string(),
+            "exec ncl tasks create --group \"${NANOCLAW_AGENT_GROUP_ID:?set NANOCLAW_AGENT_GROUP_ID}\" --name moadim --process-after \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\" --prompt \"$(cat {prompt_file})\"".to_string()
+        ]
+    );
+    assert_eq!(cmd.instructions_file, DEFAULT_INSTRUCTIONS_FILE);
 }
 
 #[test]

--- a/src/routines/agents/mod.rs
+++ b/src/routines/agents/mod.rs
@@ -27,6 +27,8 @@ mod claude_code;
 mod codex;
 #[path = "hermes/setup.rs"]
 mod hermes;
+#[path = "nanoclaw/setup.rs"]
+mod nanoclaw;
 #[path = "pi/setup.rs"]
 mod pi;
 
@@ -111,6 +113,7 @@ const DEFAULT_AGENT_CONFIGS: &[(&str, &str)] = &[
     (claude_code::NAME, claude_code::CONFIG),
     (codex::NAME, codex::CONFIG),
     (hermes::NAME, hermes::CONFIG),
+    (nanoclaw::NAME, nanoclaw::CONFIG),
     (pi::NAME, pi::CONFIG),
 ];
 

--- a/src/routines/agents/nanoclaw/setup.rs
+++ b/src/routines/agents/nanoclaw/setup.rs
@@ -1,0 +1,13 @@
+//! Built-in default agent config for `NanoClaw`.
+
+/// Registry key for this agent; also the config filename stem (`nanoclaw.toml`).
+pub const NAME: &str = "nanoclaw";
+
+/// Default `nanoclaw.toml` contents, written on startup when the file is absent.
+///
+/// `NanoClaw` accepts host-created work through `ncl tasks create`, rather than a direct one-shot
+/// agent command. This bridge queues a one-shot task for the configured `NanoClaw` agent group; the
+/// `NanoClaw` host owns execution and delivery after `ncl` accepts the task.
+pub const CONFIG: &str = r#"command = "sh"
+args = ["-c", "exec ncl tasks create --group \"${NANOCLAW_AGENT_GROUP_ID:?set NANOCLAW_AGENT_GROUP_ID}\" --name moadim --process-after \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\" --prompt \"$(cat {prompt_file})\""]
+"#;

--- a/src/routines/ensure_default_agents_writes_parsable_configs_tests.rs
+++ b/src/routines/ensure_default_agents_writes_parsable_configs_tests.rs
@@ -34,6 +34,19 @@ fn ensure_default_agents_writes_parsable_configs() {
         ]
     );
 
+    // NanoClaw queues the one-shot task in the agent group supplied at runtime.
+    let nanoclaw: AgentCommand =
+        toml::from_str(&std::fs::read_to_string(dir.join("nanoclaw.toml")).unwrap()).unwrap();
+    assert_eq!(nanoclaw.command, "sh");
+    assert!(nanoclaw.args.iter().any(|arg| arg.contains("ncl tasks create")));
+    assert!(
+        nanoclaw
+            .args
+            .iter()
+            .any(|arg| arg.contains("NANOCLAW_AGENT_GROUP_ID"))
+    );
+    assert!(nanoclaw.args.iter().any(|arg| arg.contains("{prompt_file}")));
+
     // pi default parses and runs print mode against the composed prompt file
     let pi: AgentCommand =
         toml::from_str(&std::fs::read_to_string(dir.join("pi.toml")).unwrap()).unwrap();
@@ -60,6 +73,7 @@ fn ensure_default_agents_does_not_overwrite_existing() {
         "command = \"mine\"\nargs = []\n"
     );
     assert!(dir.join("codex.toml").exists());
+    assert!(dir.join("nanoclaw.toml").exists());
     assert!(dir.join("pi.toml").exists());
 
     let _ = std::fs::remove_dir_all(&dir);

--- a/src/routines/mod_agents_tests.rs
+++ b/src/routines/mod_agents_tests.rs
@@ -72,6 +72,7 @@ fn available_agents_falls_back_to_builtins_when_missing() {
             "claude".to_string(),
             "codex".to_string(),
             "hermes".to_string(),
+            "nanoclaw".to_string(),
             "pi".to_string()
         ]
     );


### PR DESCRIPTION
## Summary
- add `nanoclaw` to Moadim's built-in agent registry
- queue routine prompts as immediate one-shot NanoClaw tasks using the routine's `NANOCLAW_AGENT_GROUP_ID`
- document NanoClaw's asynchronous ownership and model-selection boundary

## Verification
- `.githooks/pre-push` (Rust format, Clippy, tests, 100% line coverage, linecheck; client typecheck/lint/tests: 537 passed)
