### PR TITLE
fix(routines): materialize overlap policies

### DIFF
--- a/.changeset/materialize-overlap-policy.md
+++ b/.changeset/materialize-overlap-policy.md
@@ -1,0 +1,5 @@
+---
+"moadim": patch
+---
+
+Create a disabled `overlap.json` sidecar for every persisted routine.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ install -Dm644 docs/moadim.1 "$HOME/.local/share/man/man1/moadim.1"
 │   └── nightly-triage/
 │       ├── routine.toml       # tracked — schedule, agent, repositories, [env], …
 │       ├── schedule.cron      # tracked — cron-entry mirror, not functional yet
-│       ├── overlap.json       # tracked, optional — permits concurrent fires when enabled
+│       ├── overlap.json       # tracked — explicit overlap policy, default disabled
 │       ├── routine.local.toml # gitignored, optional — secret/local env var overrides
 │       └── prompts/
 │           ├── prompt.pure.md      # tracked — the raw, user-authored prompt
@@ -198,6 +198,7 @@ git-trackable:
 └── nightly-triage/
     ├── routine.toml       # tracked — schedule, agent, repositories, [env], …
     ├── schedule.cron      # tracked — cron-entry mirror, not functional yet
+    ├── overlap.json       # tracked — explicit overlap policy, default disabled
     ├── routine.local.toml # gitignored, optional — secret/local env var overrides
     └── prompts/
         ├── prompt.pure.md      # tracked — the raw, user-authored prompt
@@ -210,17 +211,25 @@ whole tree — routine directories don't carry their own.
 
 ### Overlap policy
 
-By default, a fire is skipped and recorded in `skip.log` when a previous run of the same routine
-is still alive. To explicitly allow independent manual or scheduled fires to overlap, commit this
-optional sibling file (not a `routine.toml` field):
+The daemon creates this sibling file (not a `routine.toml` field) whenever it persists a routine,
+including startup repair of existing routine directories. Its default content denies overlap:
+
+```json
+{"version":1,"allow_overlapping_runs":false}
+```
+
+When this value is `false`, a fire is skipped and recorded in `skip.log` when a previous run of the
+same routine is still alive. To explicitly allow independent manual or scheduled fires to overlap,
+change the boolean to `true`:
 
 ```json
 {"version":1,"allow_overlapping_runs":true}
 ```
 
-Save it as `routines/<slug>/overlap.json`. Deleting the file, or setting the boolean to `false`,
-restores the default. Invalid JSON or an unsupported version fails closed: the daemon records the
-policy error in `skip.log` and does not start the new run. This opt-in bypasses only the
+Save it as `routines/<slug>/overlap.json`. If a legacy directory is missing the file, the daemon
+recreates it with the default on its next persistence. Invalid JSON or an unsupported version fails
+closed: the daemon records the policy error in `skip.log` and does not start the new run. This
+opt-in bypasses only the
 per-routine overlap guard; global locks, snoozes, power-saving rules, same-minute schedule
 deduplication, and the fleet-wide concurrency cap remain in force.
 

--- a/src/read_runtime_state.rs
+++ b/src/read_runtime_state.rs
@@ -84,6 +84,7 @@ pub(crate) fn write_routine_to_rel_dir(routine: &Routine, rel_dir: &str) -> std:
     }
     crate::utils::fs_perms::create_private_dir_all(&dir)?;
     crate::utils::fs_perms::create_private_dir_all(&routine_prompts_dir(rel_dir))?;
+    crate::routine_storage::routine_overlap_policy::ensure_overlap_policy(rel_dir)?;
     if !routine.enabled {
         write_disabled_state(rel_dir, false, routine.disabled_reason.as_deref())?;
     }

--- a/src/routine_overlap_policy.rs
+++ b/src/routine_overlap_policy.rs
@@ -1,9 +1,7 @@
 //! Read/write support for a routine's tracked overlap policy sidecar.
 
-use serde::{Deserialize, Serialize};
-
-#[cfg(test)]
 use crate::utils::atomic::atomic_write;
+use serde::{Deserialize, Serialize};
 
 /// Current on-disk schema version for a routine overlap policy.
 const OVERLAP_POLICY_VERSION: u32 = 1;
@@ -40,10 +38,34 @@ pub(crate) fn read_overlap_policy(rel_dir: &str) -> Result<bool, String> {
     Ok(policy.allow_overlapping_runs)
 }
 
+/// Create a missing policy sidecar with the safe default without replacing an explicit policy.
+///
+/// Routine writes run on creation, updates, and startup re-persistence, so this also materializes
+/// the policy file for routines created by older daemon versions.
+pub(crate) fn ensure_overlap_policy(rel_dir: &str) -> std::io::Result<()> {
+    let path = crate::paths::routine_overlap_json_path(rel_dir);
+    if path.exists() {
+        return Ok(());
+    }
+    write_overlap_policy_file(&path, false)
+}
+
+/// Serialize and atomically replace one explicit overlap policy file.
+fn write_overlap_policy_file(
+    path: &std::path::Path,
+    allow_overlapping_runs: bool,
+) -> std::io::Result<()> {
+    let policy = OverlapPolicy {
+        version: OVERLAP_POLICY_VERSION,
+        allow_overlapping_runs,
+    };
+    let bytes = serde_json::to_vec(&policy).map_err(std::io::Error::other)?;
+    atomic_write(path, &bytes)
+}
+
 /// Persist the overlap policy for a routine directory.
 ///
-/// `false` removes the optional sidecar, retaining the default-deny behavior without durable
-/// configuration churn.
+/// `false` removes the sidecar only in tests that need to exercise the legacy missing-file path.
 #[cfg(test)]
 pub(crate) fn write_overlap_policy(
     rel_dir: &str,
@@ -56,10 +78,5 @@ pub(crate) fn write_overlap_policy(
         }
         return Ok(());
     }
-    let policy = OverlapPolicy {
-        version: OVERLAP_POLICY_VERSION,
-        allow_overlapping_runs,
-    };
-    let bytes = serde_json::to_vec(&policy).map_err(std::io::Error::other)?;
-    atomic_write(&path, &bytes)
+    write_overlap_policy_file(&path, allow_overlapping_runs)
 }

--- a/src/routine_storage_tests.rs
+++ b/src/routine_storage_tests.rs
@@ -64,6 +64,11 @@ fn write_then_load_round_trips() {
         assert!(crate::paths::routine_cron_path(&slug).exists());
         assert!(crate::paths::routine_pure_prompt_path(&slug).exists());
         assert!(crate::paths::routine_compiled_prompt_path(&slug).exists());
+        assert_eq!(
+            std::fs::read_to_string(crate::paths::routine_overlap_json_path(&slug)).unwrap(),
+            "{\"version\":1,\"allow_overlapping_runs\":false}",
+            "every persisted routine must carry an explicit disabled overlap policy"
+        );
         assert!(
             !crate::paths::routine_gitignore_path(&slug).exists(),
             "per-routine .gitignore is no longer generated"


### PR DESCRIPTION
## Summary
- materialize a versioned, disabled `overlap.json` whenever the daemon persists a routine
- preserve any existing overlap policy, including an explicit opt-in
- let startup re-persistence backfill missing sidecars for existing routine directories
- document the generated default and add a patch changeset

## Safety
The generated policy is:

```json
{"version":1,"allow_overlapping_runs":false}
```

It preserves default-deny overlap behavior. Existing `overlap.json` files are never overwritten.

## Verification
- `cargo test write_then_load_round_trips -- --nocapture` (red before implementation, green after)
- `cargo fmt && cargo test overlap_policy -- --nocapture && cargo test write_then_load_round_trips -- --nocapture`
- `./.githooks/pre-commit && ./.githooks/pre-push` (including Rust tests, 100% coverage floor, Clippy, linecheck, client API generation/typecheck/lint/Vitest, and changeset check)
