### PR TITLE
fix: preserve disabled routine timestamps

### DIFF
--- a/.changeset/preserve-disabled-marker-timestamp.md
+++ b/.changeset/preserve-disabled-marker-timestamp.md
@@ -1,0 +1,4 @@
+---
+---
+
+Avoid rewriting disabled routine markers during routine persistence.

--- a/src/routine_disabled_state.rs
+++ b/src/routine_disabled_state.rs
@@ -41,9 +41,34 @@ pub(crate) fn write_disabled_state(
         return Ok(());
     }
     let reason = reason.and_then(normalize_reason);
+    let existing = path
+        .exists()
+        .then(|| std::fs::read_to_string(&path))
+        .transpose()?
+        .and_then(|text| serde_json::from_str::<serde_json::Value>(&text).ok());
+    if existing
+        .as_ref()
+        .and_then(|marker| marker.get("reason"))
+        .and_then(serde_json::Value::as_str)
+        .and_then(normalize_reason)
+        == reason
+        && existing
+            .as_ref()
+            .and_then(|marker| marker.get("disabled_at"))
+            .and_then(serde_json::Value::as_str)
+            .is_some()
+    {
+        return Ok(());
+    }
+    let disabled_at = existing
+        .as_ref()
+        .and_then(|marker| marker.get("disabled_at"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned)
+        .unwrap_or_else(|| Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true));
     let mut marker = serde_json::json!({
         "version": 1,
-        "disabled_at": Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+        "disabled_at": disabled_at,
         "disabled_by_machine": crate::machine::current_machine(),
         "disabled_by_user": current_user(),
         "source": "daemon",

--- a/src/routine_disabled_state.rs
+++ b/src/routine_disabled_state.rs
@@ -64,8 +64,10 @@ pub(crate) fn write_disabled_state(
         .as_ref()
         .and_then(|marker| marker.get("disabled_at"))
         .and_then(serde_json::Value::as_str)
-        .map(str::to_owned)
-        .unwrap_or_else(|| Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true));
+        .map_or_else(
+            || Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+            str::to_owned,
+        );
     let mut marker = serde_json::json!({
         "version": 1,
         "disabled_at": disabled_at,

--- a/src/routine_storage_disabled_json_tests.rs
+++ b/src/routine_storage_disabled_json_tests.rs
@@ -76,6 +76,27 @@ fn enabling_routine_removes_disabled_json() {
 }
 
 #[test]
+fn repersisting_disabled_routine_preserves_disabled_at_timestamp() {
+    with_override_home(|_home| {
+        let title = "Rs Disabled Json Stable Timestamp";
+        let slug = slugify(title);
+        let routine = make_routine("rs-disabled-json-stable-timestamp-id", title, false);
+
+        write_routine(&routine).unwrap();
+        let path = crate::paths::routine_disabled_json_path(&slug);
+        let first: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        write_routine(&routine).unwrap();
+        let second: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+
+        assert_eq!(first["disabled_at"], second["disabled_at"]);
+    });
+}
+
+#[test]
 fn disabled_json_presence_wins_over_legacy_toml_enabled_true_even_when_invalid() {
     with_override_home(|_home| {
         let title = "Rs Disabled Json Wins";

--- a/src/routine_storage_disabled_json_tests.rs
+++ b/src/routine_storage_disabled_json_tests.rs
@@ -97,6 +97,41 @@ fn repersisting_disabled_routine_preserves_disabled_at_timestamp() {
 }
 
 #[test]
+fn changing_disabled_reason_preserves_disabled_at_timestamp() {
+    with_override_home(|_home| {
+        let slug = "disabled-reason-change";
+        let path = crate::paths::routine_disabled_json_path(slug);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        write_disabled_state(slug, false, Some("first reason")).unwrap();
+        let first: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+
+        write_disabled_state(slug, false, Some("second reason")).unwrap();
+        let second: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+
+        assert_eq!(first["disabled_at"], second["disabled_at"]);
+        assert_eq!(second["reason"], "second reason");
+    });
+}
+
+#[test]
+fn invalid_disabled_marker_is_replaced_with_a_fresh_timestamp() {
+    with_override_home(|_home| {
+        let slug = "disabled-invalid-marker";
+        let path = crate::paths::routine_disabled_json_path(slug);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"not json").unwrap();
+
+        write_disabled_state(slug, false, None).unwrap();
+
+        let marker: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert!(marker["disabled_at"].as_str().is_some());
+    });
+}
+
+#[test]
 fn disabled_json_presence_wins_over_legacy_toml_enabled_true_even_when_invalid() {
     with_override_home(|_home| {
         let title = "Rs Disabled Json Wins";


### PR DESCRIPTION
## Summary
- preserve `disabled_at` when persisting an already-disabled routine
- avoid rewriting `disabled.json` when the disabled state and reason are unchanged
- preserve the original timestamp if only the disabled reason changes
- add a regression test covering repeated persistence

## Verification
- `cargo fmt --all`
- `cargo test --all-targets` (1338 passed)

Fixes tracked `disabled.json` churn caused by daemon re-persistence during cleanup.